### PR TITLE
hal_silabs: patch: Return bool from macro GPIO_PORT_VALID

### DIFF
--- a/gecko/emlib/inc/em_gpio.h
+++ b/gecko/emlib/inc/em_gpio.h
@@ -432,7 +432,7 @@ extern "C" {
     : 0)
 
 /** Validation of port and pin. */
-#define GPIO_PORT_VALID(port)          (_GPIO_PORT_MASK(port) )
+#define GPIO_PORT_VALID(port)          (_GPIO_PORT_MASK(port) != 0)
 #define GPIO_PORT_PIN_VALID(port, pin) (((_GPIO_PORT_MASK(port)) >> (pin)) & 0x1)
 
 #if defined(_GPIO_EXTIPINSELL_MASK)


### PR DESCRIPTION
The macro GPIO_PORT_VALID() is used in boolean operations in
em_gpio.c. In some compiler/ccache configurations this produced the
warning "using integer constants in boolean context
[-Werror=int-in-bool-context]"

See https://github.com/zephyrproject-rtos/zephyr/issues/16968 for more
details.

This patch needs to be reapplied every time SiLabs library version is
updated.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>