### PR TITLE
modules: hal_silabs: Import sleeptimer service

### DIFF
--- a/gecko/CMakeLists.txt
+++ b/gecko/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SILABS_GECKO_PART_NUMBER ${CONFIG_SOC_PART_NUMBER})
 zephyr_include_directories(
   Device/SiliconLabs/${SILABS_GECKO_DEVICE}/Include
   emlib/inc
+  common/inc
   )
 
 # The gecko SDK uses the cpu name to include the matching device header.
@@ -50,3 +51,17 @@ zephyr_sources_ifdef(CONFIG_SOC_SERIES_EFM32PG12B  Device/SiliconLabs/EFM32PG12B
 zephyr_sources_ifdef(CONFIG_SOC_SERIES_EFM32GG11B  Device/SiliconLabs/EFM32GG11B/Source/system_efm32gg11b.c)
 zephyr_sources_ifdef(CONFIG_SOC_SERIES_EFM32JG12B  Device/SiliconLabs/EFM32JG12B/Source/system_efm32jg12b.c)
 zephyr_sources_ifdef(CONFIG_SOC_SERIES_EFR32MG21   Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c)
+
+if(CONFIG_GECKO_SLEEPTIMER)
+  zephyr_include_directories(service/sleeptimer/inc service/sleeptimer/config)
+  zephyr_library()
+  zephyr_library_sources(service/sleeptimer/src/sl_sleeptimer.c)
+  if(CONFIG_GECKO_SLEEPTIMER_RTC)
+    zephyr_library_compile_definitions(SL_SLEEPTIMER_PERIPHERAL=SL_SLEEPTIMER_PERIPHERAL_RTC)
+    zephyr_library_sources(service/sleeptimer/src/sl_sleeptimer_hal_rtc.c)
+  endif()
+  if(CONFIG_GECKO_SLEEPTIMER_RTCC)
+    zephyr_library_compile_definitions(SL_SLEEPTIMER_PERIPHERAL=SL_SLEEPTIMER_PERIPHERAL_RTCC)
+    zephyr_library_sources(service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c)
+  endif()
+endif()

--- a/gecko/README
+++ b/gecko/README
@@ -6,7 +6,7 @@ Origin:
    https://www.silabs.com/products/development-tools/software/simplicity-studio
 
 Version:
-   v2.7.3
+   v2.7.3 (v3.0 used for platform/service and platform/common)
 
 Purpose:
    Add support for Silicon Labs EXX32 SoCs
@@ -21,6 +21,8 @@ Description:
    The following folders are imported:
    platform/Device/SiliconLabs/$(GECKO_DEVICE)
    platform/emlib
+   platform/common
+   platform/service
 
 Dependencies:
    This source code depends on headers and sources from Zephyr:
@@ -47,12 +49,18 @@ How to update
 
 The following folders are used in this HAL:
 
-+-------------------+-----------------------------+--------------------------------------------------------------------+
-| Gecko SDK         | Zephyr                      | Comments                                                           |
-+-------------------+-----------------------------+--------------------------------------------------------------------+
-| platform/Device/  | ext/hal/silabs/gecko/Device | Contains the device specific files in SiliconLabs/$(GECKO_DEVICE). |
-|                   |                             | The files are not modified.                                        |
-+-------------------+-----------------------------+--------------------------------------------------------------------+
-| platform/emlib/   | ext/hal/silabs/gecko/emlib  | Contains the Silabs Peripheral Support library for the EXX32 SoCs. |
-|                   |                             | All files are copied over. The files are not modified.             |
-+-------------------+-----------------------------+--------------------------------------------------------------------+
++-------------------+------------------------------+--------------------------------------------------------------------+
+| Gecko SDK         | Zephyr                       | Comments                                                           |
++-------------------+------------------------------+--------------------------------------------------------------------+
+| platform/Device/  | ext/hal/silabs/gecko/Device  | Contains the device specific files in SiliconLabs/$(GECKO_DEVICE). |
+|                   |                              | The files are not modified.                                        |
++-------------------+------------------------------+--------------------------------------------------------------------+
+| platform/emlib/   | ext/hal/silabs/gecko/emlib   | Contains the Silabs Peripheral Support library for the EXX32 SoCs. |
+|                   |                              | All files are copied over. The files are not modified.             |
++-------------------+------------------------------+--------------------------------------------------------------------+
+| platform/common/  | ext/hal/silabs/gecko/common  | Contains the Silabs common header files.                           |
+|                   |                              | The files are not modified.                                        |
++-------------------+------------------------------+--------------------------------------------------------------------+
+| platform/service/ | ext/hal/silabs/gecko/service | Contains the Silabs services                                       |
+|                   |                              | The files are not modified.                                        |
++-------------------+------------------------------+--------------------------------------------------------------------+

--- a/gecko/common/inc/sl_atomic.h
+++ b/gecko/common/inc/sl_atomic.h
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * @file
+ * @brief Implementation of atomic operations.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#ifndef SL_ATOMIC_H
+#define SL_ATOMIC_H
+
+/*******************************************************************************
+ * @addtogroup atomic Atomic Operations
+ * @brief Atomic operations
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @brief         Perform an atomic load. Use when a variable must be read from
+ *                RAM.
+ *
+ * @param dest    Variable where to copy the loaded value.
+ *
+ * @param source  Variable from where to load the value.
+ *
+ * @note          Does only support native types <= 32 bits.
+ *
+ * @note          Load operation on 32 bit value is atomic on ARM architecture.
+ ******************************************************************************/
+#define sl_atomic_load(dest, source)     ((dest) = (source))
+
+/*******************************************************************************
+ * @brief         Perform an atomic store. Use when a value must be stored in
+ *                RAM.
+ *
+ * @param dest    Variable where to store the value.
+ *
+ * @param source  Variable that contains the value to store in 'dest'.
+ *
+ * @note          Does only support native types <= 32 bits.
+ *
+ * @note          Store operation on 32 bit value is atomic on ARM architecture.
+ ******************************************************************************/
+#define sl_atomic_store(dest, source)    ((dest) = (source))
+
+/** @} (end addtogroup atomic) */
+
+#endif /* SL_ATOMIC_H */

--- a/gecko/common/inc/sl_status.h
+++ b/gecko/common/inc/sl_status.h
@@ -1,0 +1,421 @@
+/*******************************************************************************
+ * @file
+ * @brief SL Status Codes.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_STATUS_H
+#define SL_STATUS_H
+
+#include <stdint.h>
+
+/*******************************************************************************
+ * @addtogroup status Status Codes
+ * @brief Status codes
+ * @{
+ ******************************************************************************/
+
+// -----------------------------------------------------------------------------
+// Space Defines
+
+#define SL_STATUS_SPACE_MASK              ((sl_status_t)0xFF00)
+
+#define SL_STATUS_GENERIC_SPACE           ((sl_status_t)0x0000)
+
+#define SL_STATUS_PLATFORM_1_SPACE        ((sl_status_t)0x0100)
+#define SL_STATUS_PLATFORM_2_SPACE        ((sl_status_t)0x0200)
+#define SL_STATUS_HARDWARE_SPACE          ((sl_status_t)0x0300)
+
+#define SL_STATUS_BLUETOOTH_SPACE         ((sl_status_t)0x0400)
+#define SL_STATUS_BLUETOOTH_MESH_SPACE    ((sl_status_t)0x0500)
+#define SL_STATUS_CAN_CANOPEN_SPACE       ((sl_status_t)0x0600)
+#define SL_STATUS_CONNECT_SPACE           ((sl_status_t)0x0700)
+#define SL_STATUS_NET_SUITE_SPACE         ((sl_status_t)0x0800)
+#define SL_STATUS_THREAD_SPACE            ((sl_status_t)0x0900)
+#define SL_STATUS_USB_SPACE               ((sl_status_t)0x0A00)
+#define SL_STATUS_WIFI_SPACE              ((sl_status_t)0x0B00)
+#define SL_STATUS_ZIGBEE_SPACE            ((sl_status_t)0x0C00)
+#define SL_STATUS_Z_WAVE_SPACE            ((sl_status_t)0x0D00)
+
+#define SL_STATUS_GECKO_OS_1_SPACE        ((sl_status_t)0x0E00)
+#define SL_STATUS_GECKO_OS_2_SPACE        ((sl_status_t)0x0F00)
+
+#define SL_STATUS_BLUETOOTH_CTRL_SPACE    ((sl_status_t)0x1000)
+#define SL_STATUS_BLUETOOTH_ATT_SPACE     ((sl_status_t)0x1100)
+#define SL_STATUS_BLUETOOTH_SMP_SPACE     ((sl_status_t)0x1200)
+#define SL_STATUS_BLUETOOTH_MESH_FOUNDATION_SPACE     ((sl_status_t)0x1300)
+
+// -----------------------------------------------------------------------------
+// Status Defines
+
+// -----------------------------------------------------------------------------
+// Generic Errors
+
+#define SL_STATUS_OK    ((sl_status_t)0x0000)  ///< No error.
+#define SL_STATUS_FAIL  ((sl_status_t)0x0001)  ///< Generic error.
+
+// State Errors
+#define SL_STATUS_INVALID_STATE         ((sl_status_t)0x0002)  ///< Generic invalid state error.
+#define SL_STATUS_NOT_READY             ((sl_status_t)0x0003)  ///< Module is not ready for requested operation.
+#define SL_STATUS_BUSY                  ((sl_status_t)0x0004)  ///< Module is busy and cannot carry out requested operation.
+#define SL_STATUS_IN_PROGRESS           ((sl_status_t)0x0005)  ///< Operation is in progress and not yet complete (pass or fail).
+#define SL_STATUS_ABORT                 ((sl_status_t)0x0006)  ///< Operation aborted.
+#define SL_STATUS_TIMEOUT               ((sl_status_t)0x0007)  ///< Operation timed out.
+#define SL_STATUS_PERMISSION            ((sl_status_t)0x0008)  ///< Operation not allowed per permissions.
+#define SL_STATUS_WOULD_BLOCK           ((sl_status_t)0x0009)  ///< Non-blocking operation would block.
+#define SL_STATUS_IDLE                  ((sl_status_t)0x000A)  ///< Operation/module is Idle, cannot carry requested operation.
+#define SL_STATUS_IS_WAITING            ((sl_status_t)0x000B)  ///< Operation cannot be done while construct is waiting.
+#define SL_STATUS_NONE_WAITING          ((sl_status_t)0x000C)  ///< No task/construct waiting/pending for that action/event.
+#define SL_STATUS_SUSPENDED             ((sl_status_t)0x000D)  ///< Operation cannot be done while construct is suspended.
+#define SL_STATUS_NOT_AVAILABLE         ((sl_status_t)0x000E)  ///< Feature not available due to software configuration.
+#define SL_STATUS_NOT_SUPPORTED         ((sl_status_t)0x000F)  ///< Feature not supported.
+#define SL_STATUS_INITIALIZATION        ((sl_status_t)0x0010)  ///< Initialization failed.
+#define SL_STATUS_NOT_INITIALIZED       ((sl_status_t)0x0011)  ///< Module has not been initialized.
+#define SL_STATUS_ALREADY_INITIALIZED   ((sl_status_t)0x0012)  ///< Module has already been initialized.
+#define SL_STATUS_DELETED               ((sl_status_t)0x0013)  ///< Object/construct has been deleted.
+#define SL_STATUS_ISR                   ((sl_status_t)0x0014)  ///< Illegal call from ISR.
+#define SL_STATUS_NETWORK_UP            ((sl_status_t)0x0015)  ///< Illegal call because network is up.
+#define SL_STATUS_NETWORK_DOWN          ((sl_status_t)0x0016)  ///< Illegal call because network is down.
+#define SL_STATUS_NOT_JOINED            ((sl_status_t)0x0017)  ///< Failure due to not being joined in a network.
+#define SL_STATUS_NO_BEACONS            ((sl_status_t)0x0018)  ///< Invalid operation as there are no beacons.
+
+// Allocation/ownership Errors
+#define SL_STATUS_ALLOCATION_FAILED   ((sl_status_t)0x0019)  ///< Generic allocation error.
+#define SL_STATUS_NO_MORE_RESOURCE    ((sl_status_t)0x001A)  ///< No more resource available to perform the operation.
+#define SL_STATUS_EMPTY               ((sl_status_t)0x001B)  ///< Item/list/queue is empty.
+#define SL_STATUS_FULL                ((sl_status_t)0x001C)  ///< Item/list/queue is full.
+#define SL_STATUS_WOULD_OVERFLOW      ((sl_status_t)0x001D)  ///< Item would overflow.
+#define SL_STATUS_HAS_OVERFLOWED      ((sl_status_t)0x001E)  ///< Item/list/queue has been overflowed.
+#define SL_STATUS_OWNERSHIP           ((sl_status_t)0x001F)  ///< Generic ownership error.
+#define SL_STATUS_IS_OWNER            ((sl_status_t)0x0020)  ///< Already/still owning resource.
+
+// Invalid Parameters Errors
+#define SL_STATUS_INVALID_PARAMETER       ((sl_status_t)0x0021)  ///< Generic invalid argument or consequence of invalid argument.
+#define SL_STATUS_NULL_POINTER            ((sl_status_t)0x0022)  ///< Invalid null pointer received as argument.
+#define SL_STATUS_INVALID_CONFIGURATION   ((sl_status_t)0x0023)  ///< Invalid configuration provided.
+#define SL_STATUS_INVALID_MODE            ((sl_status_t)0x0024)  ///< Invalid mode.
+#define SL_STATUS_INVALID_HANDLE          ((sl_status_t)0x0025)  ///< Invalid handle.
+#define SL_STATUS_INVALID_TYPE            ((sl_status_t)0x0026)  ///< Invalid type for operation.
+#define SL_STATUS_INVALID_INDEX           ((sl_status_t)0x0027)  ///< Invalid index.
+#define SL_STATUS_INVALID_RANGE           ((sl_status_t)0x0028)  ///< Invalid range.
+#define SL_STATUS_INVALID_KEY             ((sl_status_t)0x0029)  ///< Invalid key.
+#define SL_STATUS_INVALID_CREDENTIALS     ((sl_status_t)0x002A)  ///< Invalid credentials.
+#define SL_STATUS_INVALID_COUNT           ((sl_status_t)0x002B)  ///< Invalid count.
+#define SL_STATUS_INVALID_SIGNATURE       ((sl_status_t)0x002C)  ///< Invalid signature / verification failed.
+#define SL_STATUS_NOT_FOUND               ((sl_status_t)0x002D)  ///< Item could not be found.
+#define SL_STATUS_ALREADY_EXISTS          ((sl_status_t)0x002E)  ///< Item already exists.
+
+// IO/Communication Errors
+#define SL_STATUS_IO                    ((sl_status_t)0x002F)  ///< Generic I/O failure.
+#define SL_STATUS_IO_TIMEOUT            ((sl_status_t)0x0030)  ///< I/O failure due to timeout.
+#define SL_STATUS_TRANSMIT              ((sl_status_t)0x0031)  ///< Generic transmission error.
+#define SL_STATUS_TRANSMIT_UNDERFLOW    ((sl_status_t)0x0032)  ///< Transmit underflowed.
+#define SL_STATUS_TRANSMIT_INCOMPLETE   ((sl_status_t)0x0033)  ///< Transmit is incomplete.
+#define SL_STATUS_TRANSMIT_BUSY         ((sl_status_t)0x0034)  ///< Transmit is busy.
+#define SL_STATUS_RECEIVE               ((sl_status_t)0x0035)  ///< Generic reception error.
+#define SL_STATUS_OBJECT_READ           ((sl_status_t)0x0036)  ///< Failed to read on/via given object.
+#define SL_STATUS_OBJECT_WRITE          ((sl_status_t)0x0037)  ///< Failed to write on/via given object.
+#define SL_STATUS_MESSAGE_TOO_LONG      ((sl_status_t)0x0038)  ///< Message is too long.
+
+// EEPROM/Flash Errors
+#define SL_STATUS_EEPROM_MFG_VERSION_MISMATCH     ((sl_status_t)0x0039)  ///<
+#define SL_STATUS_EEPROM_STACK_VERSION_MISMATCH   ((sl_status_t)0x003A)  ///<
+#define SL_STATUS_FLASH_WRITE_INHIBITED           ((sl_status_t)0x003B)  ///< Flash write is inhibited.
+#define SL_STATUS_FLASH_VERIFY_FAILED             ((sl_status_t)0x003C)  ///< Flash verification failed.
+#define SL_STATUS_FLASH_PROGRAM_FAILED            ((sl_status_t)0x003D)  ///< Flash programming failed.
+#define SL_STATUS_FLASH_ERASE_FAILED              ((sl_status_t)0x003E)  ///< Flash erase failed.
+
+// MAC Errors
+#define SL_STATUS_MAC_NO_DATA                   ((sl_status_t)0x003F)  ///<
+#define SL_STATUS_MAC_NO_ACK_RECEIVED           ((sl_status_t)0x0040)  ///<
+#define SL_STATUS_MAC_INDIRECT_TIMEOUT          ((sl_status_t)0x0041)  ///<
+#define SL_STATUS_MAC_UNKNOWN_HEADER_TYPE       ((sl_status_t)0x0042)  ///<
+#define SL_STATUS_MAC_ACK_HEADER_TYPE           ((sl_status_t)0x0043)  ///<
+#define SL_STATUS_MAC_COMMAND_TRANSMIT_FAILURE  ((sl_status_t)0x0044)  ///<
+
+// CLI_STORAGE Errors
+#define SL_STATUS_CLI_STORAGE_NVM_OPEN_ERROR    ((sl_status_t)0x0045)  ///< Error in open NVM
+
+// Security status codes
+#define SL_STATUS_SECURITY_IMAGE_CHECKSUM_ERROR ((sl_status_t)0x0046)  ///< Image checksum is not valid.
+#define SL_STATUS_SECURITY_DECRYPT_ERROR        ((sl_status_t)0x0047)  ///< Decryption failed
+
+// Command status codes
+#define SL_STATUS_COMMAND_IS_INVALID            ((sl_status_t)0x0048)  ///< Command was not recognized
+#define SL_STATUS_COMMAND_TOO_LONG              ((sl_status_t)0x0049)  ///< Command maximum length exceeded
+#define SL_STATUS_COMMAND_INCOMPLETE            ((sl_status_t)0x004A)  ///< Data received does not form a complete command
+
+// Misc Errors
+#define SL_STATUS_BUS_ERROR                     ((sl_status_t)0x004B)  ///< Bus error, e.g. invalid DMA address
+
+// Unified MAC Errors
+#define SL_STATUS_CCA_FAILURE                   ((sl_status_t)0x004C)  ///<
+
+// Scan errors
+#define SL_STATUS_MAC_SCANNING                  ((sl_status_t)0x004D)  ///<
+#define SL_STATUS_MAC_INCORRECT_SCAN_TYPE       ((sl_status_t)0x004E)  ///<
+#define SL_STATUS_INVALID_CHANNEL_MASK          ((sl_status_t)0x004F)  ///<
+#define SL_STATUS_BAD_SCAN_DURATION             ((sl_status_t)0x0050)  ///<
+
+// Bluetooth status codes
+#define SL_STATUS_BT_OUT_OF_BONDS                                                                        ((sl_status_t)0x0402)        ///< Bonding procedure can't be started because device has no space left for bond.
+#define SL_STATUS_BT_UNSPECIFIED                                                                         ((sl_status_t)0x0403)        ///< Unspecified error
+#define SL_STATUS_BT_HARDWARE                                                                            ((sl_status_t)0x0404)        ///< Hardware failure
+#define SL_STATUS_BT_NO_BONDING                                                                          ((sl_status_t)0x0406)        ///< The bonding does not exist.
+#define SL_STATUS_BT_CRYPTO                                                                              ((sl_status_t)0x0407)        ///< Error using crypto functions
+#define SL_STATUS_BT_DATA_CORRUPTED                                                                      ((sl_status_t)0x0408)        ///< Data was corrupted.
+#define SL_STATUS_BT_INVALID_SYNC_HANDLE                                                                 ((sl_status_t)0x040A)        ///< Invalid periodic advertising sync handle
+#define SL_STATUS_BT_INVALID_MODULE_ACTION                                                               ((sl_status_t)0x040B)        ///< Bluetooth cannot be used on this hardware
+#define SL_STATUS_BT_RADIO                                                                               ((sl_status_t)0x040C)        ///< Error received from radio
+#define SL_STATUS_BT_L2CAP_REMOTE_DISCONNECTED                                                           ((sl_status_t)0x040D)        ///< Returned when remote disconnects the connection-oriented channel by sending disconnection request.
+#define SL_STATUS_BT_L2CAP_LOCAL_DISCONNECTED                                                            ((sl_status_t)0x040E)        ///< Returned when local host disconnect the connection-oriented channel by sending disconnection request.
+#define SL_STATUS_BT_L2CAP_CID_NOT_EXIST                                                                 ((sl_status_t)0x040F)        ///< Returned when local host did not find a connection-oriented channel with given destination CID.
+#define SL_STATUS_BT_L2CAP_LE_DISCONNECTED                                                               ((sl_status_t)0x0410)        ///< Returned when connection-oriented channel disconnected due to LE connection is dropped.
+#define SL_STATUS_BT_L2CAP_FLOW_CONTROL_VIOLATED                                                         ((sl_status_t)0x0412)        ///< Returned when connection-oriented channel disconnected due to remote end send data even without credit.
+#define SL_STATUS_BT_L2CAP_FLOW_CONTROL_CREDIT_OVERFLOWED                                                ((sl_status_t)0x0413)        ///< Returned when connection-oriented channel disconnected due to remote end send flow control credits exceed 65535.
+#define SL_STATUS_BT_L2CAP_NO_FLOW_CONTROL_CREDIT                                                        ((sl_status_t)0x0414)        ///< Returned when connection-oriented channel has run out of flow control credit and local application still trying to send data.
+#define SL_STATUS_BT_L2CAP_CONNECTION_REQUEST_TIMEOUT                                                    ((sl_status_t)0x0415)        ///< Returned when connection-oriented channel has not received connection response message within maximum timeout.
+#define SL_STATUS_BT_L2CAP_INVALID_CID                                                                   ((sl_status_t)0x0416)        ///< Returned when local host received a connection-oriented channel connection response with an invalid destination CID.
+#define SL_STATUS_BT_L2CAP_WRONG_STATE                                                                   ((sl_status_t)0x0417)        ///< Returned when local host application tries to send a command which is not suitable for L2CAP channel's current state.
+#define SL_STATUS_BT_PS_STORE_FULL                                                                       ((sl_status_t)0x041B)        ///< Flash reserved for PS store is full
+#define SL_STATUS_BT_PS_KEY_NOT_FOUND                                                                    ((sl_status_t)0x041C)        ///< PS key not found
+#define SL_STATUS_BT_APPLICATION_MISMATCHED_OR_INSUFFICIENT_SECURITY                                     ((sl_status_t)0x041D)        ///< Mismatched or insufficient security level
+#define SL_STATUS_BT_APPLICATION_ENCRYPTION_DECRYPTION_ERROR                                             ((sl_status_t)0x041E)        ///< Encrypion/decryption operation failed.
+
+// Bluetooth controller status codes
+#define SL_STATUS_BT_CTRL_UNKNOWN_CONNECTION_IDENTIFIER                                                  ((sl_status_t)0x1002)      ///< Connection does not exist, or connection open request was cancelled.
+#define SL_STATUS_BT_CTRL_AUTHENTICATION_FAILURE                                                         ((sl_status_t)0x1005)      ///< Pairing or authentication failed due to incorrect results in the pairing or authentication procedure. This could be due to an incorrect PIN or Link Key
+#define SL_STATUS_BT_CTRL_PIN_OR_KEY_MISSING                                                             ((sl_status_t)0x1006)      ///< Pairing failed because of missing PIN, or authentication failed because of missing Key
+#define SL_STATUS_BT_CTRL_MEMORY_CAPACITY_EXCEEDED                                                       ((sl_status_t)0x1007)      ///< Controller is out of memory.
+#define SL_STATUS_BT_CTRL_CONNECTION_TIMEOUT                                                             ((sl_status_t)0x1008)      ///< Link supervision timeout has expired.
+#define SL_STATUS_BT_CTRL_CONNECTION_LIMIT_EXCEEDED                                                      ((sl_status_t)0x1009)      ///< Controller is at limit of connections it can support.
+#define SL_STATUS_BT_CTRL_SYNCHRONOUS_CONNECTIONTION_LIMIT_EXCEEDED                                      ((sl_status_t)0x100A)     ///< The Synchronous Connection Limit to a Device Exceeded error code indicates that the Controller has reached the limit to the number of synchronous connections that can be achieved to a device.
+#define SL_STATUS_BT_CTRL_ACL_CONNECTION_ALREADY_EXISTS                                                  ((sl_status_t)0x100B)     ///< The ACL Connection Already Exists error code indicates that an attempt to create a new ACL Connection to a device when there is already a connection to this device.
+#define SL_STATUS_BT_CTRL_COMMAND_DISALLOWED                                                             ((sl_status_t)0x100C)     ///< Command requested cannot be executed because the Controller is in a state where it cannot process this command at this time.
+#define SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_LIMITED_RESOURCES                                   ((sl_status_t)0x100D)     ///< The Connection Rejected Due To Limited Resources error code indicates that an incoming connection was rejected due to limited resources.
+#define SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_SECURITY_REASONS                                    ((sl_status_t)0x100E)     ///< The Connection Rejected Due To Security Reasons error code indicates that a connection was rejected due to security requirements not being fulfilled, like authentication or pairing.
+#define SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_UNACCEPTABLE_BD_ADDR                                ((sl_status_t)0x100F)     ///< The Connection was rejected because this device does not accept the BD_ADDR. This may be because the device will only accept connections from specific BD_ADDRs.
+#define SL_STATUS_BT_CTRL_CONNECTION_ACCEPT_TIMEOUT_EXCEEDED                                             ((sl_status_t)0x1010)     ///< The Connection Accept Timeout has been exceeded for this connection attempt.
+#define SL_STATUS_BT_CTRL_UNSUPPORTED_FEATURE_OR_PARAMETER_VALUE                                         ((sl_status_t)0x1011)     ///< A feature or parameter value in the HCI command is not supported.
+#define SL_STATUS_BT_CTRL_INVALID_COMMAND_PARAMETERS                                                     ((sl_status_t)0x1012)     ///< Command contained invalid parameters.
+#define SL_STATUS_BT_CTRL_REMOTE_USER_TERMINATED                                                         ((sl_status_t)0x1013)     ///< User on the remote device terminated the connection.
+#define SL_STATUS_BT_CTRL_REMOTE_DEVICE_TERMINATED_CONNECTION_DUE_TO_LOW_RESOURCES                       ((sl_status_t)0x1014)     ///< The remote device terminated the connection because of low resources
+#define SL_STATUS_BT_CTRL_REMOTE_POWERING_OFF                                                            ((sl_status_t)0x1015)     ///< Remote Device Terminated Connection due to Power Off
+#define SL_STATUS_BT_CTRL_CONNECTION_TERMINATED_BY_LOCAL_HOST                                            ((sl_status_t)0x1016)     ///< Local device terminated the connection.
+#define SL_STATUS_BT_CTRL_REPEATED_ATTEMPTS                                                              ((sl_status_t)0x1017)     ///< The Controller is disallowing an authentication or pairing procedure because too little time has elapsed since the last authentication or pairing attempt failed.
+#define SL_STATUS_BT_CTRL_PAIRING_NOT_ALLOWED                                                            ((sl_status_t)0x1018)     ///< The device does not allow pairing. This can be for example, when a device only allows pairing during a certain time window after some user input allows pairing
+#define SL_STATUS_BT_CTRL_UNSUPPORTED_REMOTE_FEATURE                                                     ((sl_status_t)0x101A)     ///< The remote device does not support the feature associated with the issued command.
+#define SL_STATUS_BT_CTRL_UNSPECIFIED_ERROR                                                              ((sl_status_t)0x101F)     ///< No other error code specified is appropriate to use.
+#define SL_STATUS_BT_CTRL_LL_RESPONSE_TIMEOUT                                                            ((sl_status_t)0x1022)     ///< Connection terminated due to link-layer procedure timeout.
+#define SL_STATUS_BT_CTRL_LL_PROCEDURE_COLLISION                                                         ((sl_status_t)0x1023)     ///< LL procedure has collided with the same transaction or procedure that is already in progress.
+#define SL_STATUS_BT_CTRL_ENCRYPTION_MODE_NOT_ACCEPTABLE                                                 ((sl_status_t)0x1025)     ///< The requested encryption mode is not acceptable at this time.
+#define SL_STATUS_BT_CTRL_LINK_KEY_CANNOT_BE_CHANGED                                                     ((sl_status_t)0x1026)     ///< Link key cannot be changed because a fixed unit key is being used.
+#define SL_STATUS_BT_CTRL_INSTANT_PASSED                                                                 ((sl_status_t)0x1028)     ///< LMP PDU or LL PDU that includes an instant cannot be performed because the instant when this would have occurred has passed.
+#define SL_STATUS_BT_CTRL_PAIRING_WITH_UNIT_KEY_NOT_SUPPORTED                                            ((sl_status_t)0x1029)     ///< It was not possible to pair as a unit key was requested and it is not supported.
+#define SL_STATUS_BT_CTRL_DIFFERENT_TRANSACTION_COLLISION                                                ((sl_status_t)0x102A)     ///< LMP transaction was started that collides with an ongoing transaction.
+#define SL_STATUS_BT_CTRL_CHANNEL_ASSESSMENT_NOT_SUPPORTED                                               ((sl_status_t)0x102E)     ///< The Controller cannot perform channel assessment because it is not supported.
+#define SL_STATUS_BT_CTRL_INSUFFICIENT_SECURITY                                                          ((sl_status_t)0x102F)     ///< The HCI command or LMP PDU sent is only possible on an encrypted link.
+#define SL_STATUS_BT_CTRL_PARAMETER_OUT_OF_MANDATORY_RANGE                                               ((sl_status_t)0x1030)     ///< A parameter value requested is outside the mandatory range of parameters for the given HCI command or LMP PDU.
+#define SL_STATUS_BT_CTRL_SIMPLE_PAIRING_NOT_SUPPORTED_BY_HOST                                           ((sl_status_t)0x1037)     ///< The IO capabilities request or response was rejected because the sending Host does not support Secure Simple Pairing even though the receiving Link Manager does.
+#define SL_STATUS_BT_CTRL_HOST_BUSY_PAIRING                                                              ((sl_status_t)0x1038)     ///< The Host is busy with another pairing operation and unable to support the requested pairing. The receiving device should retry pairing again later.
+#define SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_NO_SUITABLE_CHANNEL_FOUND                           ((sl_status_t)0x1039)     ///< The Controller could not calculate an appropriate value for the Channel selection operation.
+#define SL_STATUS_BT_CTRL_CONTROLLER_BUSY                                                                ((sl_status_t)0x103A)     ///< Operation was rejected because the controller is busy and unable to process the request.
+#define SL_STATUS_BT_CTRL_UNACCEPTABLE_CONNECTION_INTERVAL                                               ((sl_status_t)0x103B)     ///< Remote device terminated the connection because of an unacceptable connection interval.
+#define SL_STATUS_BT_CTRL_ADVERTISING_TIMEOUT                                                            ((sl_status_t)0x103C)     ///< Ddvertising for a fixed duration completed or, for directed advertising, that advertising completed without a connection being created.
+#define SL_STATUS_BT_CTRL_CONNECTION_TERMINATED_DUE_TO_MIC_FAILURE                                       ((sl_status_t)0x103D)     ///< Connection was terminated because the Message Integrity Check (MIC) failed on a received packet.
+#define SL_STATUS_BT_CTRL_CONNECTION_FAILED_TO_BE_ESTABLISHED                                            ((sl_status_t)0x103E)     ///< LL initiated a connection but the connection has failed to be established. Controller did not receive any packets from remote end.
+#define SL_STATUS_BT_CTRL_MAC_CONNECTION_FAILED                                                          ((sl_status_t)0x103F)     ///< The MAC of the 802.11 AMP was requested to connect to a peer, but the connection failed.
+#define SL_STATUS_BT_CTRL_COARSE_CLOCK_ADJUSTMENT_REJECTED_BUT_WILL_TRY_TO_ADJUST_USING_CLOCK_DRAGGING   ((sl_status_t)0x1040)     ///< The master, at this time, is unable to make a coarse adjustment to the piconet clock, using the supplied parameters. Instead the master will attempt to move the clock using clock dragging.
+#define SL_STATUS_BT_CTRL_UNKNOWN_ADVERTISING_IDENTIFIER                                                 ((sl_status_t)0x1042)     ///< A command was sent from the Host that should identify an Advertising or Sync handle, but the Advertising or Sync handle does not exist.
+#define SL_STATUS_BT_CTRL_LIMIT_REACHED                                                                  ((sl_status_t)0x1043)     ///< Number of operations requested has been reached and has indicated the completion of the activity (e.g., advertising or scanning).
+#define SL_STATUS_BT_CTRL_OPERATION_CANCELLED_BY_HOST                                                    ((sl_status_t)0x1044)     ///< A request to the Controller issued by the Host and still pending was successfully canceled.
+#define SL_STATUS_BT_CTRL_PACKET_TOO_LONG                                                                ((sl_status_t)0x1045)     ///< An attempt was made to send or receive a packet that exceeds the maximum allowed packet l
+
+// Bluetooth attribute status codes
+#define SL_STATUS_BT_ATT_INVALID_HANDLE                                                                  ((sl_status_t)0x1101)      ///< The attribute handle given was not valid on this server
+#define SL_STATUS_BT_ATT_READ_NOT_PERMITTED                                                              ((sl_status_t)0x1102)      ///< The attribute cannot be read
+#define SL_STATUS_BT_ATT_WRITE_NOT_PERMITTED                                                             ((sl_status_t)0x1103)      ///< The attribute cannot be written
+#define SL_STATUS_BT_ATT_INVALID_PDU                                                                     ((sl_status_t)0x1104)      ///< The attribute PDU was invalid
+#define SL_STATUS_BT_ATT_INSUFFICIENT_AUTHENTICATION                                                     ((sl_status_t)0x1105)      ///< The attribute requires authentication before it can be read or written.
+#define SL_STATUS_BT_ATT_REQUEST_NOT_SUPPORTED                                                           ((sl_status_t)0x1106)      ///< Attribute Server does not support the request received from the client.
+#define SL_STATUS_BT_ATT_INVALID_OFFSET                                                                  ((sl_status_t)0x1107)      ///< Offset specified was past the end of the attribute
+#define SL_STATUS_BT_ATT_INSUFFICIENT_AUTHORIZATION                                                      ((sl_status_t)0x1108)      ///< The attribute requires authorization before it can be read or written.
+#define SL_STATUS_BT_ATT_PREPARE_QUEUE_FULL                                                              ((sl_status_t)0x1109)      ///< Too many prepare writes have been queueud
+#define SL_STATUS_BT_ATT_ATT_NOT_FOUND                                                                   ((sl_status_t)0x110A)     ///< No attribute found within the given attribute handle range.
+#define SL_STATUS_BT_ATT_ATT_NOT_LONG                                                                    ((sl_status_t)0x110B)     ///< The attribute cannot be read or written using the Read Blob Request
+#define SL_STATUS_BT_ATT_INSUFFICIENT_ENC_KEY_SIZE                                                       ((sl_status_t)0x110C)     ///< The Encryption Key Size used for encrypting this link is insufficient.
+#define SL_STATUS_BT_ATT_INVALID_ATT_LENGTH                                                              ((sl_status_t)0x110D)     ///< The attribute value length is invalid for the operation
+#define SL_STATUS_BT_ATT_UNLIKELY_ERROR                                                                  ((sl_status_t)0x110E)     ///< The attribute request that was requested has encountered an error that was unlikely, and therefore could not be completed as requested.
+#define SL_STATUS_BT_ATT_INSUFFICIENT_ENCRYPTION                                                         ((sl_status_t)0x110F)     ///< The attribute requires encryption before it can be read or written.
+#define SL_STATUS_BT_ATT_UNSUPPORTED_GROUP_TYPE                                                          ((sl_status_t)0x1110)     ///< The attribute type is not a supported grouping attribute as defined by a higher layer specification.
+#define SL_STATUS_BT_ATT_INSUFFICIENT_RESOURCES                                                          ((sl_status_t)0x1111)     ///< Insufficient Resources to complete the request
+#define SL_STATUS_BT_ATT_OUT_OF_SYNC                                                                     ((sl_status_t)0x1112)     ///< The server requests the client to rediscover the database.
+#define SL_STATUS_BT_ATT_VALUE_NOT_ALLOWED                                                               ((sl_status_t)0x1113)     ///< The attribute parameter value was not allowed.
+#define SL_STATUS_BT_ATT_APPLICATION                                                                     ((sl_status_t)0x1180)    ///< When this is returned in a BGAPI response, the application tried to read or write the value of a user attribute from the GATT databa
+
+// Bluetooth Security Manager Protocol status codes
+#define SL_STATUS_BT_SMP_PASSKEY_ENTRY_FAILED                                                            ((sl_status_t)0x1201)      ///< The user input of passkey failed, for example, the user cancelled the operation
+#define SL_STATUS_BT_SMP_OOB_NOT_AVAILABLE                                                               ((sl_status_t)0x1202)      ///< Out of Band data is not available for authentication
+#define SL_STATUS_BT_SMP_AUTHENTICATION_REQUIREMENTS                                                     ((sl_status_t)0x1203)      ///< The pairing procedure cannot be performed as authentication requirements cannot be met due to IO capabilities of one or both devices
+#define SL_STATUS_BT_SMP_CONFIRM_VALUE_FAILED                                                            ((sl_status_t)0x1204)      ///< The confirm value does not match the calculated compare value
+#define SL_STATUS_BT_SMP_PAIRING_NOT_SUPPORTED                                                           ((sl_status_t)0x1205)      ///< Pairing is not supported by the device
+#define SL_STATUS_BT_SMP_ENCRYPTION_KEY_SIZE                                                             ((sl_status_t)0x1206)      ///< The resultant encryption key size is insufficient for the security requirements of this device
+#define SL_STATUS_BT_SMP_COMMAND_NOT_SUPPORTED                                                           ((sl_status_t)0x1207)      ///< The SMP command received is not supported on this device
+#define SL_STATUS_BT_SMP_UNSPECIFIED_REASON                                                              ((sl_status_t)0x1208)      ///< Pairing failed due to an unspecified reason
+#define SL_STATUS_BT_SMP_REPEATED_ATTEMPTS                                                               ((sl_status_t)0x1209)      ///< Pairing or authentication procedure is disallowed because too little time has elapsed since last pairing request or security request
+#define SL_STATUS_BT_SMP_INVALID_PARAMETERS                                                              ((sl_status_t)0x120A)     ///< The Invalid Parameters error code indicates: the command length is invalid or a parameter is outside of the specified range.
+#define SL_STATUS_BT_SMP_DHKEY_CHECK_FAILED                                                              ((sl_status_t)0x120B)     ///< Indicates to the remote device that the DHKey Check value received doesn't match the one calculated by the local device.
+#define SL_STATUS_BT_SMP_NUMERIC_COMPARISON_FAILED                                                       ((sl_status_t)0x120C)     ///< Indicates that the confirm values in the numeric comparison protocol do not match.
+#define SL_STATUS_BT_SMP_BREDR_PAIRING_IN_PROGRESS                                                       ((sl_status_t)0x120D)     ///< Indicates that the pairing over the LE transport failed due to a Pairing Request sent over the BR/EDR transport in process.
+#define SL_STATUS_BT_SMP_CROSS_TRANSPORT_KEY_DERIVATION_GENERATION_NOT_ALLOWED                           ((sl_status_t)0x120E)     ///< Indicates that the BR/EDR Link Key generated on the BR/EDR transport cannot be used to derive and distribute keys for the LE transport.
+
+// Bluetooth Mesh status codes
+#define SL_STATUS_BT_MESH_ALREADY_EXISTS                                                                 ((sl_status_t)0x0501)      ///< Returned when trying to add a key or some other unique resource with an ID which already exists
+#define SL_STATUS_BT_MESH_DOES_NOT_EXIST                                                                 ((sl_status_t)0x0502)      ///< Returned when trying to manipulate a key or some other resource with an ID which does not exist
+#define SL_STATUS_BT_MESH_LIMIT_REACHED                                                                  ((sl_status_t)0x0503)      ///< Returned when an operation cannot be executed because a pre-configured limit for keys, key bindings, elements, models, virtual addresses, provisioned devices, or provisioning sessions is reached
+#define SL_STATUS_BT_MESH_INVALID_ADDRESS                                                                ((sl_status_t)0x0504)      ///< Returned when trying to use a reserved address or add a "pre-provisioned" device using an address already used by some other device
+#define SL_STATUS_BT_MESH_MALFORMED_DATA                                                                 ((sl_status_t)0x0505)      ///< In a BGAPI response, the user supplied malformed data; in a BGAPI event, the remote end responded with malformed or unrecognized data
+#define SL_STATUS_BT_MESH_ALREADY_INITIALIZED                                                            ((sl_status_t)0x0506)      ///< An attempt was made to initialize a subsystem that was already initialized.
+#define SL_STATUS_BT_MESH_NOT_INITIALIZED                                                                ((sl_status_t)0x0507)      ///< An attempt was made to use a subsystem that wasn't initialized yet. Call the subsystem's init function first.
+#define SL_STATUS_BT_MESH_NO_FRIEND_OFFER                                                                ((sl_status_t)0x0508)      ///< Returned when trying to establish a friendship as a Low Power Node, but no acceptable friend offer message was received.
+#define SL_STATUS_BT_MESH_PROV_LINK_CLOSED                                                               ((sl_status_t)0x0509)      ///< Provisioning link was unexpectedly closed before provisioning was complete.
+#define SL_STATUS_BT_MESH_PROV_INVALID_PDU                                                               ((sl_status_t)0x050A)     ///< An unrecognized provisioning PDU was received.
+#define SL_STATUS_BT_MESH_PROV_INVALID_PDU_FORMAT                                                        ((sl_status_t)0x050B)     ///< A provisioning PDU with wrong length or containing field values that are out of bounds was received.
+#define SL_STATUS_BT_MESH_PROV_UNEXPECTED_PDU                                                            ((sl_status_t)0x050C)     ///< An unexpected (out of sequence) provisioning PDU was received.
+#define SL_STATUS_BT_MESH_PROV_CONFIRMATION_FAILED                                                       ((sl_status_t)0x050D)     ///< The computed confirmation value did not match the expected value.
+#define SL_STATUS_BT_MESH_PROV_OUT_OF_RESOURCES                                                          ((sl_status_t)0x050E)     ///< Provisioning could not be continued due to insufficient resources.
+#define SL_STATUS_BT_MESH_PROV_DECRYPTION_FAILED                                                         ((sl_status_t)0x050F)     ///< The provisioning data block could not be decrypted.
+#define SL_STATUS_BT_MESH_PROV_UNEXPECTED_ERROR                                                          ((sl_status_t)0x0510)     ///< An unexpected error happened during provisioning.
+#define SL_STATUS_BT_MESH_PROV_CANNOT_ASSIGN_ADDR                                                        ((sl_status_t)0x0511)     ///< Device could not assign unicast addresses to all of its elements.
+#define SL_STATUS_BT_MESH_ADDRESS_TEMPORARILY_UNAVAILABLE                                                ((sl_status_t)0x0512)     ///< Returned when trying to reuse an address of a previously deleted device before an IV Index Update has been executed.
+#define SL_STATUS_BT_MESH_ADDRESS_ALREADY_USED                                                           ((sl_status_t)0x0513)     ///< Returned when trying to assign an address that is used by one of the devices in the Device Database, or by the Provisioner itself.
+
+// Bluetooth Mesh foundation status codes
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_ADDRESS                                                     ((sl_status_t)0x1301)      ///< Returned when address in request was not valid
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_MODEL                                                       ((sl_status_t)0x1302)      ///< Returned when model identified is not found for a given element
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_APP_KEY                                                     ((sl_status_t)0x1303)      ///< Returned when the key identified by AppKeyIndex is not stored in the node
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_NET_KEY                                                     ((sl_status_t)0x1304)      ///< Returned when the key identified by NetKeyIndex is not stored in the node
+#define SL_STATUS_BT_MESH_FOUNDATION_INSUFFICIENT_RESOURCES                                              ((sl_status_t)0x1305)      ///< Returned when The node cannot serve the request due to insufficient resources
+#define SL_STATUS_BT_MESH_FOUNDATION_KEY_INDEX_EXISTS                                                    ((sl_status_t)0x1306)      ///< Returned when the key identified is already stored in the node and the new NetKey value is different
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_PUBLISH_PARAMS                                              ((sl_status_t)0x1307)      ///< Returned when the model does not support the publish mechanism
+#define SL_STATUS_BT_MESH_FOUNDATION_NOT_SUBSCRIBE_MODEL                                                 ((sl_status_t)0x1308)      ///< Returned when  the model does not support the subscribe mechanism
+#define SL_STATUS_BT_MESH_FOUNDATION_STORAGE_FAILURE                                                     ((sl_status_t)0x1309)      ///< Returned when storing of the requested parameters failed
+#define SL_STATUS_BT_MESH_FOUNDATION_NOT_SUPPORTED                                                       ((sl_status_t)0x130A)     ///< Returned when requested setting is not supported
+#define SL_STATUS_BT_MESH_FOUNDATION_CANNOT_UPDATE                                                       ((sl_status_t)0x130B)     ///< Returned when the requested update operation cannot be performed due to general constraints
+#define SL_STATUS_BT_MESH_FOUNDATION_CANNOT_REMOVE                                                       ((sl_status_t)0x130C)     ///< Returned when the requested delete operation cannot be performed due to general constraints
+#define SL_STATUS_BT_MESH_FOUNDATION_CANNOT_BIND                                                         ((sl_status_t)0x130D)     ///< Returned when the requested bind operation cannot be performed due to general constraints
+#define SL_STATUS_BT_MESH_FOUNDATION_TEMPORARILY_UNABLE                                                  ((sl_status_t)0x130E)     ///< Returned when The node cannot start advertising with Node Identity or Proxy since the maximum number of parallel advertising is reached
+#define SL_STATUS_BT_MESH_FOUNDATION_CANNOT_SET                                                          ((sl_status_t)0x130F)     ///< Returned when the requested state cannot be set
+#define SL_STATUS_BT_MESH_FOUNDATION_UNSPECIFIED                                                         ((sl_status_t)0x1310)     ///< Returned when an unspecified error took place
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_BINDING                                                     ((sl_status_t)0x1311)     ///< Returned when the NetKeyIndex and AppKeyIndex combination is not valid for a Config AppKey Update
+
+// -----------------------------------------------------------------------------
+// Wi-Fi Errors
+
+#define SL_STATUS_WIFI_INVALID_KEY                         ((sl_status_t)0x0B01)  ///< Invalid firmware keyset
+#define SL_STATUS_WIFI_FIRMWARE_DOWNLOAD_TIMEOUT           ((sl_status_t)0x0B02)  ///< The firmware download took too long
+#define SL_STATUS_WIFI_UNSUPPORTED_MESSAGE_ID              ((sl_status_t)0x0B03)  ///< Unknown request ID or wrong interface ID used
+#define SL_STATUS_WIFI_WARNING                             ((sl_status_t)0x0B04)  ///< The request is successful but some parameters have been ignored
+#define SL_STATUS_WIFI_NO_PACKET_TO_RECEIVE                ((sl_status_t)0x0B05)  ///< No Packets waiting to be received
+#define SL_STATUS_WIFI_SLEEP_GRANTED                       ((sl_status_t)0x0B08)  ///< The sleep mode is granted
+#define SL_STATUS_WIFI_SLEEP_NOT_GRANTED                   ((sl_status_t)0x0B09)  ///< The WFx does not go back to sleep
+#define SL_STATUS_WIFI_SECURE_LINK_MAC_KEY_ERROR           ((sl_status_t)0x0B10)  ///< The SecureLink MAC key was not found
+#define SL_STATUS_WIFI_SECURE_LINK_MAC_KEY_ALREADY_BURNED  ((sl_status_t)0x0B11)  ///< The SecureLink MAC key is already installed in OTP
+#define SL_STATUS_WIFI_SECURE_LINK_RAM_MODE_NOT_ALLOWED    ((sl_status_t)0x0B12)  ///< The SecureLink MAC key cannot be installed in RAM
+#define SL_STATUS_WIFI_SECURE_LINK_FAILED_UNKNOWN_MODE     ((sl_status_t)0x0B13)  ///< The SecureLink MAC key installation failed
+#define SL_STATUS_WIFI_SECURE_LINK_EXCHANGE_FAILED         ((sl_status_t)0x0B14)  ///< SecureLink key (re)negotiation failed
+#define SL_STATUS_WIFI_WRONG_STATE                         ((sl_status_t)0x0B18)  ///< The device is in an inappropriate state to perform the request
+#define SL_STATUS_WIFI_CHANNEL_NOT_ALLOWED                 ((sl_status_t)0x0B19)  ///< The request failed due to regulatory limitations
+#define SL_STATUS_WIFI_NO_MATCHING_AP                      ((sl_status_t)0x0B1A)  ///< The connection request failed because no suitable AP was found
+#define SL_STATUS_WIFI_CONNECTION_ABORTED                  ((sl_status_t)0x0B1B)  ///< The connection request was aborted by host
+#define SL_STATUS_WIFI_CONNECTION_TIMEOUT                  ((sl_status_t)0x0B1C)  ///< The connection request failed because of a timeout
+#define SL_STATUS_WIFI_CONNECTION_REJECTED_BY_AP           ((sl_status_t)0x0B1D)  ///< The connection request failed because the AP rejected the device
+#define SL_STATUS_WIFI_CONNECTION_AUTH_FAILURE             ((sl_status_t)0x0B1E)  ///< The connection request failed because the WPA handshake did not complete successfully
+#define SL_STATUS_WIFI_RETRY_EXCEEDED                      ((sl_status_t)0x0B1F)  ///< The request failed because the retry limit was exceeded
+#define SL_STATUS_WIFI_TX_LIFETIME_EXCEEDED                ((sl_status_t)0x0B20)  ///< The request failed because the MSDU life time was exceeded
+
+// -----------------------------------------------------------------------------
+// Data Types
+
+typedef uint32_t sl_status_t;
+
+// -----------------------------------------------------------------------------
+// Functions
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/********************************************************************************************************
+ *                                      sl_status_get_string_n()
+ *
+ * @brief    Get a copy of the status string associated to the status code passed, up to
+ *           'buffer_length' length, if the string associated to the status code is enabled. If not,
+ *           the error code number, in hex, prefixed by "SL_STATUS_" will be copied in the buffer
+ *           instead.
+ *           For example, the buffer would either contain "SL_STATUS_FAIL" if that status string is
+ *           enabled, or "SL_STATUS_0x0001" if the string is disabled, as SL_STATUS_FAIL's
+ *           value is 0x0001.
+ *
+ * @param    status         The status code from which to obtain the status string.
+ *
+ * @param    buffer         Pointer to a buffer in which the status string will be copied. A terminating
+ *                          null-character will be appended after the copied status string.
+ *
+ * @param    buffer_length  Maximum number of characters that can be written in the buffer, including the
+ *                          terminating null-character. If the status string would be longer than the
+ *                          available length, it will be truncated and a null-terminating character will
+ *                          be the last character contained in the buffer.
+ *
+ * @return                  The number of characters that would have been written if the buffer_length had been
+ *                          sufficiently large, not counting the terminating null character.
+ *                          If the status code is invalid, 0 or a negative number is returned.
+ *                          Notice that only when this returned value is strictly positive and less than
+ *                          buffer_length, the status string has been completely written in the buffer.
+ *******************************************************************************************************/
+int32_t sl_status_get_string_n(sl_status_t status, char *buffer, uint32_t buffer_length);
+
+/********************************************************************************************************
+ *                                         sl_status_print()
+ *
+ * @brief    Print, through printf, the string associated to the passed status code. If the string
+ *           associated to the status code is enabled, the status string will be printed, for example
+ *           "SL_STATUS_OK". If the string associated to the status code is disabled, the status number,
+ *           in hex, prefixed by "SL_STATUS_" will be printed instead, for example "SL_STATUS_0x0000",
+ *           as SL_STATUS_OK's value is 0x0000.
+ *
+ * @param    status         The status code of which to print the status string.
+ *******************************************************************************************************/
+void sl_status_print(sl_status_t status);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} (end addtogroup status) */
+
+#endif /* SL_STATUS_H */

--- a/gecko/service/sleeptimer/config/sl_sleeptimer_config.h
+++ b/gecko/service/sleeptimer/config/sl_sleeptimer_config.h
@@ -1,0 +1,68 @@
+/***************************************************************************//**
+ * @file
+ * @brief Sleep Timer configuration file.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+#ifndef SL_SLEEPTIMER_CONFIG_H
+#define SL_SLEEPTIMER_CONFIG_H
+
+#define SL_SLEEPTIMER_PERIPHERAL_DEFAULT 0
+#define SL_SLEEPTIMER_PERIPHERAL_RTCC    1
+#define SL_SLEEPTIMER_PERIPHERAL_PRORTC  2
+#define SL_SLEEPTIMER_PERIPHERAL_RTC     3
+#define SL_SLEEPTIMER_PERIPHERAL_BURTC   4
+
+// <o SL_SLEEPTIMER_PERIPHERAL> Timer Peripheral Used by Sleeptimer
+//   <SL_SLEEPTIMER_PERIPHERAL_DEFAULT=> Default (auto select)
+//   <SL_SLEEPTIMER_PERIPHERAL_RTCC=> RTCC
+//   <SL_SLEEPTIMER_PERIPHERAL_PRORTC=> Radio internal RTC (PRORTC)
+//   <SL_SLEEPTIMER_PERIPHERAL_RTC=> RTC
+//   <SL_SLEEPTIMER_PERIPHERAL_BURTC=> Back-Up RTC (BURTC)
+// <i> Selection of the Timer Peripheral Used by the Sleeptimer
+#ifndef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL  SL_SLEEPTIMER_PERIPHERAL_DEFAULT
+#endif
+
+// <q SL_SLEEPTIMER_WALLCLOCK_CONFIG> Enable wallclock functionality
+// <i> Enable or disable wallclock functionalities (get_time, get_date, etc).
+// <i> Default: 0
+#define SL_SLEEPTIMER_WALLCLOCK_CONFIG  0
+
+// <o SL_SLEEPTIMER_FREQ_DIVIDER> Timer frequency divider
+// <i> Default: 1
+#define SL_SLEEPTIMER_FREQ_DIVIDER  1
+
+// <q SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER> If Radio internal RTC (PRORTC) HAL is used, determines if it owns the IRQ handler. Enable, if no wireless stack is used.
+// <i> Default: 0
+#define SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER  0
+
+#endif /* SLEEPTIMER_CONFIG_H */
+
+// <<< end of configuration section >>>

--- a/gecko/service/sleeptimer/inc/sl_sleeptimer.h
+++ b/gecko/service/sleeptimer/inc/sl_sleeptimer.h
@@ -1,0 +1,1008 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER API definition.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @addtogroup sleeptimer Sleep Timer
+ * @{
+ ******************************************************************************/
+
+#ifndef SL_SLEEPTIMER_H
+#define SL_SLEEPTIMER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "sl_sleeptimer_config.h"
+#include "em_device.h"
+#include "sl_status.h"
+
+/// @cond DO_NOT_INCLUDE_WITH_DOXYGEN
+#define SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG 0x01
+
+#define SLEEPTIMER_ENUM(name) typedef uint8_t name; enum name##_enum
+/// @endcond
+
+/// Timestamp, wall clock time in seconds.
+typedef uint32_t sl_sleeptimer_timestamp_t;
+
+/// Time zone offset from UTC(second).
+typedef int32_t sl_sleeptimer_time_zone_offset_t;
+
+// Forward declaration
+typedef struct sl_sleeptimer_timer_handle sl_sleeptimer_timer_handle_t;
+
+/***************************************************************************//**
+ * Typedef for the user supplied callback function which is called when
+ * a timer expires.
+ *
+ * @param handle The timer handle.
+ *
+ * @param data An extra parameter for the user application.
+ ******************************************************************************/
+typedef void (*sl_sleeptimer_timer_callback_t)(sl_sleeptimer_timer_handle_t *handle, void *data);
+
+/// @brief Timer structure for sleeptimer
+struct sl_sleeptimer_timer_handle {
+  void *callback_data;                     ///< User data to pass to callback function.
+  uint8_t priority;                        ///< Priority of timer.
+  uint16_t option_flags;                   ///< Option flags.
+  sl_sleeptimer_timer_handle_t *next;      ///< Pointer to next element in list.
+  sl_sleeptimer_timer_callback_t callback; ///< Function to call when timer expires.
+  uint32_t timeout_periodic;               ///< Periodic timeout.
+  uint32_t delta;                          ///< Delay relative to previous element in list.
+};
+
+/// @brief Month enum.
+SLEEPTIMER_ENUM(sl_sleeptimer_month_t) {
+  MONTH_JANUARY = 0,
+  MONTH_FEBRUARY = 1,
+  MONTH_MARCH   = 2,
+  MONTH_APRIL = 3,
+  MONTH_MAY = 4,
+  MONTH_JUNE = 5,
+  MONTH_JULY = 6,
+  MONTH_AUGUST = 7,
+  MONTH_SEPTEMBER = 8,
+  MONTH_OCTOBER = 9,
+  MONTH_NOVEMBER = 10,
+  MONTH_DECEMBER = 11,
+};
+
+/// @brief Week Day enum.
+SLEEPTIMER_ENUM(sl_sleeptimer_weekDay_t) {
+  DAY_SUNDAY = 0,
+  DAY_MONDAY = 1,
+  DAY_TUESDAY = 2,
+  DAY_WEDNESDAY = 3,
+  DAY_THURSDAY = 4,
+  DAY_FRIDAY = 5,
+  DAY_SATURDAY = 6,
+};
+
+/// @brief Time and Date structure.
+typedef  struct  time_date {
+  uint8_t sec;                                ///< Second (0-59)
+  uint8_t min;                                ///< Minute of month (0-59)
+  uint8_t hour;                               ///< Hour (0-23)
+  uint8_t month_day;                          ///< Day of month (1-31)
+  sl_sleeptimer_month_t month;                ///< Month (0-11)
+  uint16_t year;                              ///< Year, based on a 0 Epoch or a 1900 Epoch.
+  sl_sleeptimer_weekDay_t day_of_week;        ///< Day of week (0-6)
+  uint16_t day_of_year;                       ///< Day of year (1-366)
+  sl_sleeptimer_time_zone_offset_t time_zone; ///< Offset, in seconds, from UTC
+} sl_sleeptimer_date_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * Initializes the Sleeptimer.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_init(void);
+
+/***************************************************************************//**
+ * Starts a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer timeout, in timer ticks.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_start_timer(sl_sleeptimer_timer_handle_t *handle,
+                                      uint32_t timeout,
+                                      sl_sleeptimer_timer_callback_t callback,
+                                      void *callback_data,
+                                      uint8_t priority,
+                                      uint16_t option_flags);
+
+/***************************************************************************//**
+ * Restarts a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer timeout, in timer ticks.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_restart_timer(sl_sleeptimer_timer_handle_t *handle,
+                                        uint32_t timeout,
+                                        sl_sleeptimer_timer_callback_t callback,
+                                        void *callback_data,
+                                        uint8_t priority,
+                                        uint16_t option_flags);
+
+/***************************************************************************//**
+ * Starts a 32 bits periodic timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer periodic timeout, in timer ticks.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_start_periodic_timer(sl_sleeptimer_timer_handle_t *handle,
+                                               uint32_t timeout,
+                                               sl_sleeptimer_timer_callback_t callback,
+                                               void *callback_data,
+                                               uint8_t priority,
+                                               uint16_t option_flags);
+
+/***************************************************************************//**
+ * Restarts a 32 bits periodic timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer periodic timeout, in timer ticks.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_restart_periodic_timer(sl_sleeptimer_timer_handle_t *handle,
+                                                 uint32_t timeout,
+                                                 sl_sleeptimer_timer_callback_t callback,
+                                                 void *callback_data,
+                                                 uint8_t priority,
+                                                 uint16_t option_flags);
+
+/***************************************************************************//**
+ * Stops a timer.
+ *
+ * @param handle Pointer to handle to timer.
+ *
+ * @return
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_stop_timer(sl_sleeptimer_timer_handle_t *handle);
+
+/***************************************************************************//**
+ * Gets the status of a timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param running Pointer to the status of the timer.
+ *
+ * @note A non periodic timer is considered not running during its callback.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_is_timer_running(sl_sleeptimer_timer_handle_t *handle,
+                                           bool *running);
+
+/***************************************************************************//**
+ * Gets remaining time until timer expires.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param time Time left in timer ticks.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_get_timer_time_remaining(sl_sleeptimer_timer_handle_t *handle,
+                                                   uint32_t *time);
+
+/**************************************************************************//**
+ * Gets the time remaining until the first timer with the matching set of flags
+ * expires.
+ *
+ * @param option_flags Set of flags to match.
+ *
+ * @param time_remaining Time left in timer ticks.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_get_remaining_time_of_first_timer(uint16_t option_flags,
+                                                            uint32_t *time_remaining);
+
+/***************************************************************************//**
+ * Gets current 32 bits global tick count.
+ *
+ * @return Current tick count.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_tick_count(void);
+
+/***************************************************************************//**
+ * Gets current 64 bits global tick count.
+ *
+ * @return Current tick count.
+ ******************************************************************************/
+uint64_t sl_sleeptimer_get_tick_count64(void);
+
+/***************************************************************************//**
+ * Get timer frequency.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_timer_frequency(void);
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+/***************************************************************************//**
+ * Converts a Unix timestamp into a date.
+ *
+ * @param time Unix timestamp to convert.
+ * @param time_zone Offset from UTC in second.
+ * @param date Pointer to converted date.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_time_to_date(sl_sleeptimer_timestamp_t time,
+                                               sl_sleeptimer_time_zone_offset_t time_zone,
+                                               sl_sleeptimer_date_t *date);
+
+/***************************************************************************//**
+ * Converts a date into a Unix timestamp.
+ *
+ * @param date Pointer to date to convert.
+ * @param time Pointer to converted Unix timestamp.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note Dates are based on the Unix time representation.
+ *       Range of dates supported :
+ *          - January 1, 1970, 00:00:00 to January 19, 2038, 03:14:00
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_date_to_time(sl_sleeptimer_date_t *date,
+                                               sl_sleeptimer_timestamp_t *time);
+
+/***************************************************************************//**
+ * Convert date to string.
+ *
+ * @param str Output string.
+ * @param size Size of the input array.
+ * @param format The format specification character.
+ * @param date Pointer to date structure.
+ *
+ * @return 0 if error. Number of character in the output string.
+ *
+ * @note Refer strftime() from UNIX.
+ *       http://man7.org/linux/man-pages/man3/strftime.3.html
+ ******************************************************************************/
+uint32_t sl_sleeptimer_convert_date_to_str(char *str,
+                                           size_t size,
+                                           const uint8_t *format,
+                                           sl_sleeptimer_date_t *date);
+
+/***************************************************************************//**
+ * Sets time zone offset.
+ *
+ * @param  offset  Time zone offset, in seconds.
+ ******************************************************************************/
+void sl_sleeptimer_set_tz(sl_sleeptimer_time_zone_offset_t offset);
+
+/***************************************************************************//**
+ * Gets time zone offset.
+ *
+ * @return Time zone offset, in seconds.
+ ******************************************************************************/
+sl_sleeptimer_time_zone_offset_t sl_sleeptimer_get_tz(void);
+
+/***************************************************************************//**
+ * Retrieves current time.
+ *
+ * @return Current timestamps in Unix format.
+ ******************************************************************************/
+sl_sleeptimer_timestamp_t sl_sleeptimer_get_time(void);
+
+/***************************************************************************//**
+ * Sets current time.
+ *
+ * @param time Time to set.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_time(sl_sleeptimer_timestamp_t time);
+
+/***************************************************************************//**
+ * Gets current date.
+ *
+ * @param date Pointer to a sl_sleeptimer_date_t structure.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_get_datetime(sl_sleeptimer_date_t *date);
+
+/***************************************************************************//**
+ * Sets current time, in date format.
+ *
+ * @param date Pointer to current date.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_datetime(sl_sleeptimer_date_t *date);
+
+/***************************************************************************//**
+ * Builds a date time structure based on the provided parameters.
+ *
+ * @param date Pointer to the structure to be populated.
+ * @param year Current year. May be provided based on a 0 Epoch or a 1900 Epoch.
+ * @param month Months since January. Expected value: 0-11.
+ * @param month_day Day of the month. Expected value: 1-31.
+ * @param hour Hours since midnight. Expected value: 0-23.
+ * @param min Minutes after the hour. Expected value: 0-59.
+ * @param sec Seconds after the minute. Expected value: 0-59.
+ * @param tzOffset Offset, in seconds, from UTC.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_build_datetime(sl_sleeptimer_date_t *date,
+                                         uint16_t year,
+                                         sl_sleeptimer_month_t month,
+                                         uint8_t month_day,
+                                         uint8_t hour,
+                                         uint8_t min,
+                                         uint8_t sec,
+                                         sl_sleeptimer_time_zone_offset_t tzOffset);
+
+/***************************************************************************//**
+ * Converts Unix timestamp into NTP timestamp.
+ *
+ * @param time Unix timestamp.
+ * @param ntp_time Pointer to NTP Timestamp.
+ *
+ * @note Unix timestamp range supported : 0x0 to 0x7C55 817F
+ *       ie. January 1, 1970, 00:00:00 to February 07, 2036, 06:28:15
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_unix_time_to_ntp(sl_sleeptimer_timestamp_t time,
+                                                   uint32_t *ntp_time);
+
+/***************************************************************************//**
+ * Converts NTP timestamp into Unix timestamp.
+ *
+ * @param ntp_time NTP Timestamp.
+ * @param time Pointer to Unix timestamp.
+ *
+ * @note NTP timestamp range supported : 0x83AA 7E80 to 0xFFFF FFFF
+ *       ie. January 1, 1970, 00:00:00 to February 07, 2036, 06:28:15
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_ntp_time_to_unix(uint32_t ntp_time,
+                                                   sl_sleeptimer_timestamp_t *time);
+
+/***************************************************************************//**
+ * Converts Unix timestamp into Zigbee timestamp.
+ *
+ * @param time Unix timestamp.
+ *
+ * @param zigbee_time Pointer to NTP Timestamp.
+ *
+ * @note Unix timestamp range supported : 0x386D 4380 to 0x7FFF FFFF
+ *       ie. January 1, 2000, 00:00:0 to January 19, 2038, 03:14:00
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_unix_time_to_zigbee(sl_sleeptimer_timestamp_t time,
+                                                      uint32_t *zigbee_time);
+
+/***************************************************************************//**
+ * Converts Zigbee timestamp into Unix timestamp.
+ *
+ * @param zigbee_time NTP Timestamp.
+ * @param time Pointer to Unix timestamp.
+ *
+ * @note ZIGBEE timestamp range supported : 0x0 to 0x4792 BC7F
+ *        ie. January 1, 2000, 00:00:00 to January 19, 2038, 03:14:00
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_zigbee_time_to_unix(uint32_t zigbee_time,
+                                                      sl_sleeptimer_timestamp_t *time);
+
+/***************************************************************************//**
+ * Calculates offset for time zone after UTC-0.
+ *
+ * @param hours Number of hours from UTC-0.
+ * @param minutes Number of minutes from UTC-0.
+ *
+ * @return The time zone offset in seconds.
+ ******************************************************************************/
+__STATIC_INLINE sl_sleeptimer_time_zone_offset_t sl_sleeptimer_set_tz_ahead_utc(uint8_t hours,
+                                                                                uint8_t minutes)
+{
+  return ((hours * 3600u) + (minutes * 60u));
+}
+
+/***************************************************************************//**
+ * Calculates offset for time zone before UTC-0.
+ *
+ * @param hours Number of hours to UTC-0.
+ * @param minutes Number of minutes to UTC-0.
+ *
+ * @return The time zone offset in seconds.
+ ******************************************************************************/
+__STATIC_INLINE sl_sleeptimer_time_zone_offset_t sl_sleeptimer_set_tz_behind_utc(uint8_t hours,
+                                                                                 uint8_t minutes)
+{
+  return -((hours * 3600u) + (minutes * 60u));
+}
+#endif
+
+/***************************************************************************//**
+ * Active delay.
+ *
+ * @param time_ms Delay duration in milliseconds.
+ ******************************************************************************/
+void sl_sleeptimer_delay_millisecond(uint16_t time_ms);
+
+/***************************************************************************//**
+ * Converts milliseconds in ticks.
+ *
+ * @param time_ms Number of milliseconds.
+ *
+ * @return Corresponding ticks number.
+ *
+ * @note The result is "rounded" to the superior tick number.
+ *       This function is light and cannot fail so it should be privilegied to
+ *       perform a millisecond to tick conversion.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_ms_to_tick(uint16_t time_ms);
+
+/***************************************************************************//**
+ * Converts 32-bits milliseconds in ticks.
+ *
+ * @param time_ms Number of milliseconds.
+ * @param tick Pointer to the converted tick number.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  The result is "rounded" to the superior tick number.
+ *        If possible the sl_sleeptimer_ms_to_tick() function should be used.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'time_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'time_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_ms32_to_tick(uint32_t time_ms,
+                                       uint32_t *tick);
+
+/***************************************************************************//**
+ * Gets the maximum value that can be passed to the functions that have a
+ * 32-bits time or timeout argument expressed in milliseconds.
+ *
+ * @return Maximum time or timeout value in milliseconds.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_max_ms32_conversion(void);
+
+/***************************************************************************//**
+ * Converts ticks in milliseconds.
+ *
+ * @param tick Number of tick.
+ *
+ * @return Corresponding milliseconds number.
+ *
+ * @note The result is rounded to the inferior millisecond.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_tick_to_ms(uint32_t tick);
+
+/***************************************************************************//**
+ * Converts 64-bit ticks in milliseconds.
+ *
+ * @param tick Number of tick.
+ * @param ms Pointer to the converted milliseconds number.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note The result is rounded to the inferior millisecond.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_tick64_to_ms(uint64_t tick,
+                                       uint64_t *ms);
+
+/***************************************************************************//**
+ * Allow sleep after ISR exit.
+ *
+ * @return true if sleep is allowed after ISR exit. False otherwise.
+ ******************************************************************************/
+bool sl_sleeptimer_is_power_manager_early_restore_timer_latest_to_expire(void);
+
+/**************************************************************************//**
+ * Starts a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_ms Timer timeout, in milliseconds.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'timeout_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'timeout_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ *****************************************************************************/
+__STATIC_INLINE sl_status_t sl_sleeptimer_start_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                         uint32_t timeout_ms,
+                                                         sl_sleeptimer_timer_callback_t callback,
+                                                         void *callback_data,
+                                                         uint8_t priority,
+                                                         uint16_t option_flags)
+{
+  sl_status_t status;
+  uint32_t timeout_tick;
+
+  status = sl_sleeptimer_ms32_to_tick(timeout_ms, &timeout_tick);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  return sl_sleeptimer_start_timer(handle, timeout_tick, callback, callback_data, priority, option_flags);
+}
+
+/**************************************************************************//**
+ * Restarts a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_ms Timer timeout, in milliseconds.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'timeout_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'timeout_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ *****************************************************************************/
+__STATIC_INLINE sl_status_t sl_sleeptimer_restart_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                           uint32_t timeout_ms,
+                                                           sl_sleeptimer_timer_callback_t callback,
+                                                           void *callback_data,
+                                                           uint8_t priority,
+                                                           uint16_t option_flags)
+{
+  sl_status_t status;
+  uint32_t timeout_tick;
+
+  status = sl_sleeptimer_ms32_to_tick(timeout_ms, &timeout_tick);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  return sl_sleeptimer_restart_timer(handle, timeout_tick, callback, callback_data, priority, option_flags);
+}
+
+/***************************************************************************//**
+ * Starts a 32 bits periodic timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_ms Timer periodic timeout, in milliseconds.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'timeout_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'timeout_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ ******************************************************************************/
+__STATIC_INLINE sl_status_t sl_sleeptimer_start_periodic_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                                  uint32_t timeout_ms,
+                                                                  sl_sleeptimer_timer_callback_t callback,
+                                                                  void *callback_data,
+                                                                  uint8_t priority,
+                                                                  uint16_t option_flags)
+{
+  sl_status_t status;
+  uint32_t timeout_tick;
+
+  status = sl_sleeptimer_ms32_to_tick(timeout_ms, &timeout_tick);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  return sl_sleeptimer_start_periodic_timer(handle, timeout_tick, callback, callback_data, priority, option_flags);
+}
+
+/***************************************************************************//**
+ * Restarts a 32 bits periodic timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_ms Timer periodic timeout, in milliseconds.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'timeout_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'timeout_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ ******************************************************************************/
+__STATIC_INLINE sl_status_t sl_sleeptimer_restart_periodic_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                                    uint32_t timeout_ms,
+                                                                    sl_sleeptimer_timer_callback_t callback,
+                                                                    void *callback_data,
+                                                                    uint8_t priority,
+                                                                    uint16_t option_flags)
+{
+  sl_status_t status;
+  uint32_t timeout_tick;
+
+  status = sl_sleeptimer_ms32_to_tick(timeout_ms, &timeout_tick);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  return sl_sleeptimer_restart_periodic_timer(handle, timeout_tick, callback, callback_data, priority, option_flags);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} (end addtogroup sleeptimer) */
+
+/* *INDENT-OFF* */
+/* THE REST OF THE FILE IS DOCUMENTATION ONLY! */
+/// @addtogroup sleeptimer Sleep Timer
+/// @brief Sleep Timer
+/// @{
+///
+///   @details
+///   The sleeptimer.c and sleeptimer.h source files for the SLEEPTIMER device driver library are in the
+///   service/sleeptimer folder.
+///
+///   @li @ref sleeptimer_intro
+///   @li @ref sleeptimer_functionalities_overview
+///   @li @ref sleeptimer_getting_started
+///   @li @ref sleeptimer_conf
+///   @li @ref sleeptimer_api
+///   @li @ref sleeptimer_example
+///
+///   @n @section sleeptimer_intro Introduction
+///
+///   The Sleeptimer driver provides software timers, delays, timekeeping and date functionalities using a low-frequency real-time clock peripheral.
+///
+///   All Silicon Labs microcontrollers equipped with the RTC or RTCC peripheral are currently supported. Only one instance of this driver can be initialized by the application.
+///
+///   @n @section sleeptimer_functionalities_overview Functionalities overview
+///
+///   @n @subsection software_timers Software Timers
+///
+///   This functionality allows the user to create periodic and one shot timers. A user callback can be associated with a timer and is called when the timer expires.
+///
+///   Timer structures must be allocated by the user. The function is called from within an interrupt handler with interrupts enabled.
+///
+///   @n @subsection timekeeping Timekeeping
+///
+///   A 64-bits tick counter is accessible through the @li uint64_t sl_sleeptimer_get_tick_count64(void) API. It keeps the tick count since the initialization of the driver
+///
+///   The `SL_SLEEPTIMER_WALLCLOCK_CONFIG` configuration enables a UNIX timestamp (seconds count since January 1, 1970, 00:00:00).
+///
+///   This timestamp can be retrieved/modified using the following API:
+///
+///   @li sl_sleeptimer_timestamp_t sl_sleeptimer_get_time(void);
+///   @li sl_status_t sl_sleeptimer_set_time(sl_sleeptimer_timestamp_t time);
+///
+///   Convenience conversion functions are provided to convert UNIX timestamp to/from NTP and Zigbee cluster format :
+///
+///   @li sl_status_t sl_sleeptimer_convert_unix_time_to_ntp(sl_sleeptimer_timestamp_t time, uint32_t *ntp_time);
+///   @li sl_status_t sl_sleeptimer_convert_ntp_time_to_unix(uint32_t ntp_time, sl_sleeptimer_timestamp_t *time);
+///   @li sl_status_t sl_sleeptimer_convert_unix_time_to_zigbee(sl_sleeptimer_timestamp_t time, uint32_t *zigbee_time);
+///   @li sl_status_t sl_sleeptimer_convert_zigbee_time_to_unix(uint32_t zigbee_time, sl_sleeptimer_timestamp_t *time);
+///
+///   @n @subsection date Date
+///
+///   The previously described internal timestamp can also be retrieved/modified in a date format sl_sleeptimer_date_t.
+///
+///   @n <b>API :</b> @n
+///
+///   @li sl_status_t sl_sleeptimer_get_datetime(sl_sleeptimer_date_t *date);
+///   @li sl_status_t sl_sleeptimer_set_datetime(sl_sleeptimer_date_t *date);
+///
+///   @n @subsection frequency_setup Frequency Setup and Tick Count
+///
+///   This driver works with a configurable time unit called tick.
+///
+///   The frequency of the ticks is based on the clock source and the internal frequency divider.
+///
+///   One of the following clock sources must be enabled before initializing the sleeptimer:
+///
+///   @li LFXO: external crystal oscillator. Typically running at 32.768 kHz.
+///   @li LFRCO: internal oscillator running at 32.768 kHz
+///   @li ULFRCO: Ultra low-frequency oscillator running at 1.000 kHz
+///
+///   The frequency divider is selected with the `SL_SLEEPTIMER_FREQ_DIVIDER` configuration. Its value must be a power of two within the range of 1 to 32. The number of ticks per second (sleeptimer frequency) is dictated by the following formula:
+///
+///   Tick (seconds) = 1 / (clock_frequency / frequency_divider)
+///
+///   The highest resolution for a tick is 30.5 us. It is achieved with a 32.768 kHz clock and a divider of 1.
+///
+///   @n @section sleeptimer_getting_started Getting Started
+///
+///   @n @subsection  clock_selection Clock Selection
+///
+///   The sleeptimer relies on the hardware timer to operate. The hardware timer peripheral must be properly clocked from the application. Selecting the appropriate timer is crucial for design considerations. Each timer can potentially be used as a sleeptimer and is also available to the user. However, note that if a timer is used by the sleeptimer, it can't be used by the application and vice versa.
+///
+///   @n @subsection  Clock Selection in a Project without Micrium OS
+///
+///   When RTC, RTCC, or BURTC is selected, the clock source for the peripheral must be configured and enabled in the application before initializing the sleeptimer module or any communication stacks. Most of the time, it consists in enabling the desired oscillators and setting up the clock source for the peripheral, like in the following example:
+///
+///   @code{.c}
+///   CMU_ClockSelectSet(cmuClock_LFE, cmuSelect_LFRCO);
+///   CMU_ClockEnable(cmuClock_RTCC, true);
+///   @endcode
+///
+///   @n @subsection  clock_branch_select Clock Branch Select
+///
+///   | Clock  | Enum                    | Description                       | Frequency |
+///   |--------|-------------------------|-----------------------------------|-----------|
+///   | LFXO   | <b>cmuSelect_LFXO</b>   | Low-frequency crystal oscillator  |32.768 Khz |
+///   | LFRCO  | <b>cmuSelect_LFRCO</b>  | Low-frequency RC oscillator       |32.768 Khz |
+///   | ULFRCO | <b>cmuSelect_ULFRCO</b> | Ultra low-frequency RC oscillator |1 Khz      |
+///
+///   @n @subsection  timer_clock_enable Timer Clock Enable
+///
+///   | Module             | Enum                  | Description                                        |
+///   |--------------------|-----------------------|----------------------------------------------------|
+///   | RTCC               | <b>cmuClock_RTCC</b>  | Real-time counter and calendar clock (LF E branch) |
+///   | RTC                | <b>cmuClock_RTC</b>   | Real time counter clock (LF A branch)              |
+///   | BURTC              | <b>cmuClock_BURTC</b> | BURTC clock (EM4 Group A branch)                   |
+///
+///   When the Radio internal RTC (PRORTC) is selected, it is not necessary to configure the clock source for the peripheral. However, it is important to enable the desired oscillator before initializing the sleeptimer module or any communication stacks. The best oscillator available (LFXO being the first choice) will be used by the sleeptimer at initalization. The following example shows how the desired oscilator should be enabled:
+///
+///   @code{.c}
+///   CMU_OscillatorEnable(cmuSelect_LFXO, true, true);
+///   @endcode
+///
+///   @n @subsection  clock_micrium_os Clock Selection in a Project with Micrium OS
+///
+///   When Micrium OS is used, a BSP (all instances) is provided that sets up some parts of the clock tree. The sleeptimer clock source will be enabled by this bsp. However, the desired oscillator remains configurable from the file <b>bsp_cfg.h</b>.
+///
+///   The configuration `BSP_LF_CLK_SEL` determines which oscillator will be used by the sleeptimer's hardware timer peripheral. It can take the following values:
+///
+///   | Config                   | Description                       | Frequency |
+///   |--------------------------|-----------------------------------|-----------|
+///   | <b>BSP_LF_CLK_LFXO</b>   | Low-frequency crystal oscillator  |32.768 Khz |
+///   | <b>BSP_LF_CLK_LFRCO</b>  | Low-frequency RC oscillator       |32.768 Khz |
+///   | <b>BSP_LF_CLK_ULFRCO</b> | Ultra low-frequency RC oscillator |1 Khz      |
+///
+///   @n @section sleeptimer_conf Configuration Options
+///
+///   `SL_SLEEPTIMER_PERIPHERAL` can be set to one of the following values:
+///
+///   | Config                            | Description                                                                                          |
+///   | --------------------------------- |------------------------------------------------------------------------------------------------------|
+///   | `SL_SLEEPTIMER_PERIPHERAL_DEFAULT`| Selects either RTC or RTCC, depending of what is available on the platform.                          |
+///   | `SL_SLEEPTIMER_PERIPHERAL_RTCC`   | Selects RTCC                                                                                         |
+///   | `SL_SLEEPTIMER_PERIPHERAL_RTC`    | Selects RTC                                                                                          |
+///   | `SL_SLEEPTIMER_PERIPHERAL_PRORTC` | Selects Internal radio RTC. Available only on EFR32XG13, EFR32XG14, EFR32XG21 and EFR32XG22 families.|
+///   | `SL_SLEEPTIMER_PERIPHERAL_BURTC`  | Selects BURTC. Not available on Series 0 devices.                                                    |
+///
+///   `SL_SLEEPTIMER_WALLCLOCK_CONFIG` must be set to 1 to enable timestamp and date functionnalities.
+///
+///   `SL_SLEEPTIMER_FREQ_DIVIDER` must be a power of 2 within the range 1 to 32. When `SL_SLEEPTIMER_PERIPHERAL` is set to `SL_SLEEPTIMER_PERIPHERAL_PRORTC`, `SL_SLEEPTIMER_FREQ_DIVIDER` must be set to 1.
+///
+///   `SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER` is only meaningful when `SL_SLEEPTIMER_PERIPHERAL` is set to `SL_SLEEPTIMER_PERIPHERAL_PRORTC`. Set to 1 if no communication stack is used in your project. Otherwise, must be set to 0.
+///
+///   @n @section sleeptimer_api The API
+///
+///   This section contains brief descriptions of the API functions. For
+///   more information about input and output parameters and return values,
+///   click on the hyperlinked function names. Most functions return an error
+///   code, `SL_STATUS_OK` is returned on success,
+///   see sl_status.h for other error codes.
+///
+///   The application code must include the @em sl_sleeptimer.h header file.
+///
+///   All API functions can be called from within interrupt handlers.
+///
+///   @ref sl_sleeptimer_init() @n
+///    These functions initialize the sleeptimer driver. Typically,
+///    @htmlonly sl_sleeptimer_init() @endhtmlonly is called once in the startup code.
+///
+///   @ref sl_sleeptimer_start_timer() @n
+///    Start a one shot 32 bits timer. When a timer expires, a user-supplied callback function
+///    is called. A pointer to this function is passed to
+///    @htmlonly sl_sleeptimer_start_timer()@endhtmlonly. See @ref callback for
+///    details of the callback prototype.
+///
+///   @ref sl_sleeptimer_restart_timer() @n
+///    Restart a one shot 32 bits timer. When a timer expires, a user-supplied callback function
+///    is called. A pointer to this function is passed to
+///    @htmlonly sl_sleeptimer_start_timer()@endhtmlonly. See @ref callback for
+///    details of the callback prototype.
+///
+///   @ref sl_sleeptimer_start_periodic_timer() @n
+///    Start a periodic 32 bits timer. When a timer expires, a user-supplied callback function
+///    is called. A pointer to this function is passed to
+///    @htmlonly sl_sleeptimer_start_timer()@endhtmlonly. See @ref callback for
+///    details of the callback prototype.
+///
+///   @ref sl_sleeptimer_restart_periodic_timer() @n
+///    Restart a periodic 32 bits timer. When a timer expires, a user-supplied callback function
+///    is called. A pointer to this function is passed to
+///    @htmlonly sl_sleeptimer_start_timer()@endhtmlonly. See @ref callback for
+///    details of the callback prototype.
+///
+///   @ref sl_sleeptimer_stop_timer() @n
+///    Stop a timer.
+///
+///   @ref sl_sleeptimer_get_timer_time_remaining() @n
+///    Get the time remaining before the timer expires.
+///
+///   @ref sl_sleeptimer_delay_millisecond() @n
+///    Delay for the given number of milliseconds. This is an "active wait" delay function.
+///
+///   @ref sl_sleeptimer_is_timer_running() @n
+///    Check if a timer is running.
+///
+///   @ref sl_sleeptimer_get_time(), @ref sl_sleeptimer_set_time() @n
+///    Get or set wallclock time.
+///
+///   @ref sl_sleeptimer_ms_to_tick(), @ref sl_sleeptimer_ms32_to_tick(),
+///   @ref sl_sleeptimer_tick_to_ms(), @ref sl_sleeptimer_tick64_to_ms() @n
+///    Convert between milliseconds and RTC/RTCC
+///    counter ticks.
+///
+///   @n @anchor callback <b>The timer expiry callback function:</b> @n
+///   The callback function, prototyped as @ref sl_sleeptimer_timer_callback_t(), is called from
+///   within the RTC peripheral interrupt handler on timer expiration.
+///   @htmlonly sl_sleeptimer_timer_callback_t(sl_sleeptimer_timer_handle_t *handle, void *data)@endhtmlonly
+///
+///   @n @section sleeptimer_example Example
+///   @code{.c}
+///#include "sl_sleeptimer.h"
+///
+///void my_timer_callback(sl_sleeptimer_timer_handle_t *handle, void *data)
+///{
+///  //Code executed when the timer expire.
+///}
+///
+///int main(void)
+///{
+///  sl_status_t status;
+///  sl_sleeptimer_timer_handle_t my_timer;
+///  uint32_t timer_timeout = 300;
+///
+///  CMU_ClockSelectSet(cmuClock_LFE, cmuSelect_LFRCO);
+///  CMU_ClockEnable(cmuClock_RTCC, true);
+///
+///  status = sl_sleeptimer_init();
+///  if(status != SL_STATUS_OK) {
+///    printf("Sleeptimer init error.\r\n");
+///  }
+///
+///  status = sl_sleeptimer_start_timer(&my_timer,
+///                                     timer_timeout,
+///                                     my_timer_callback,
+///                                     (void *)NULL,
+///                                     0
+///                                     0);
+///  if(status != SL_STATUS_OK) {
+///    printf("Timer not started.\r\n");
+///  }
+///
+///  while(1) {
+///  }
+///
+///  return 0;
+///}
+///   @endcode
+///
+/// @} (end addtogroup sleeptimer)
+
+#endif // SL_SLEEPTIMER_H

--- a/gecko/service/sleeptimer/inc/sli_sleeptimer.h
+++ b/gecko/service/sleeptimer/inc/sli_sleeptimer.h
@@ -1,0 +1,70 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER SDK internal APIs.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SLI_SLEEPTIMER_H
+#define SLI_SLEEPTIMER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "em_device.h"
+
+#define SLEEPTIMER_EVENT_OF (0x01)
+#define SLEEPTIMER_EVENT_COMP (0x02)
+
+#define SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG 0x02
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get interrupt status.
+ *
+ * @param local_flag Internal interrupt flag.
+ *
+ * @return Boolean indicating if specified interrupt is set.
+ ******************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag);
+
+/**************************************************************************//**
+ * Determines if next timer to expire has the option flag
+ * "SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG".
+ *
+ * @return true if power manager will expire at next compare match,
+ *         false otherwise.
+ *****************************************************************************/
+bool sli_sleeptimer_is_power_manager_timer_next_to_expire(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SLI_SLEEPTIMER_H */

--- a/gecko/service/sleeptimer/src/sl_sleeptimer.c
+++ b/gecko/service/sleeptimer/src/sl_sleeptimer.c
@@ -1,0 +1,1423 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER API implementation.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#include <time.h>
+#include <stdlib.h>
+
+#include "em_device.h"
+#include "em_common.h"
+#include "em_core.h"
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "sl_atomic.h"
+
+#define TIME_UNIX_EPOCH                         (1970u)
+#define TIME_NTP_EPOCH                          (1900u)
+#define TIME_ZIGBEE_EPOCH                       (2000u)
+#define TIME_NTP_UNIX_EPOCH_DIFF                (TIME_UNIX_EPOCH - TIME_NTP_EPOCH)
+#define TIME_ZIGBEE_UNIX_EPOCH_DIFF             (TIME_ZIGBEE_EPOCH - TIME_UNIX_EPOCH)
+#define TIME_DAY_COUNT_NTP_TO_UNIX_EPOCH        (TIME_NTP_UNIX_EPOCH_DIFF * 365u + 17u)                  ///< 70 years and 17 leap days
+#define TIME_DAY_COUNT_ZIGBEE_TO_UNIX_EPOCH     (TIME_ZIGBEE_UNIX_EPOCH_DIFF * 365u + 7u)                ///< 30 years and 7 leap days
+#define TIME_SEC_PER_DAY                        (60u * 60u * 24u)
+#define TIME_NTP_EPOCH_OFFSET_SEC               (TIME_DAY_COUNT_NTP_TO_UNIX_EPOCH * TIME_SEC_PER_DAY)
+#define TIME_ZIGBEE_EPOCH_OFFSET_SEC            (TIME_DAY_COUNT_ZIGBEE_TO_UNIX_EPOCH * TIME_SEC_PER_DAY)
+#define TIME_DAY_PER_YEAR                       (365u)
+#define TIME_SEC_PER_YEAR                       (TIME_SEC_PER_DAY * TIME_DAY_PER_YEAR)
+#define TIME_UNIX_TIMESTAMP_MAX                 (0x7FFFFFFF)
+#define TIME_UNIX_YEAR_MAX                      (2038u - TIME_NTP_EPOCH)                                 ///< Max UNIX year based from a 1900 epoch
+
+#define TIME_LEAP_DAYS_UP_TO_YEAR(year)         (((year - 3) / 4) + 1)
+
+/// @brief Time Format.
+SLEEPTIMER_ENUM(sl_sleeptimer_time_format_t) {
+  TIME_FORMAT_UNIX = 0,           ///< Number of seconds since January 1, 1970, 00:00. Type is signed, so represented on 31 bit.
+  TIME_FORMAT_NTP = 1,            ///< Number of seconds since January 1, 1900, 00:00. Type is unsigned, so represented on 32 bit.
+  TIME_FORMAT_ZIGBEE_CLUSTER = 2, ///< Number of seconds since January 1, 2000, 00:00. Type is unsigned, so represented on 32 bit.
+};
+
+// tick_count, it can wrap around.
+typedef uint32_t sl_sleeptimer_tick_count_t;
+
+// Overflow counter used to provide 64-bits tick count.
+static volatile uint16_t overflow_counter;
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+// Current time count.
+static sl_sleeptimer_timestamp_t second_count;
+// Tick rest when the frequency is not a divider of the timer width.
+static uint32_t overflow_tick_rest = 0;
+// Current time zone offset.
+static sl_sleeptimer_time_zone_offset_t tz_offset = 0;
+// Precalculated tick rest in case of overflow.
+static uint32_t calculated_tick_rest = 0;
+// Precalculated timer overflow duration in seconds.
+static uint32_t calculated_sec_count = 0;
+#endif
+
+// Timer frequency in Hz.
+static uint32_t timer_frequency;
+
+// Head of timer list.
+static sl_sleeptimer_timer_handle_t *timer_head;
+
+// Count at last update of delta of first timer.
+static sl_sleeptimer_tick_count_t last_delta_update_count;
+
+// Initialization flag.
+static bool is_sleeptimer_initialized = false;
+
+// Flag that indicates if power manager's timer will expire at next compare match.
+static bool next_timer_to_expire_is_power_manager = false;
+
+// Precalculated value to avoid millisecond to tick conversion overflow.
+static uint32_t max_millisecond_conversion;
+
+// Sleep on ISR exit flag.
+static bool sleep_on_isr_exit = false;
+
+static void delta_list_insert_timer(sl_sleeptimer_timer_handle_t *handle,
+                                    sl_sleeptimer_tick_count_t timeout);
+
+static sl_status_t delta_list_remove_timer(sl_sleeptimer_timer_handle_t *handle);
+
+static void set_comparator_for_next_timer(void);
+
+static void update_first_timer_delta(void);
+
+__STATIC_INLINE uint32_t div_to_log2(uint32_t div);
+
+__STATIC_INLINE bool is_power_of_2(uint32_t nbr);
+
+static sl_status_t create_timer(sl_sleeptimer_timer_handle_t *handle,
+                                sl_sleeptimer_tick_count_t timeout_initial,
+                                sl_sleeptimer_tick_count_t timeout_periodic,
+                                sl_sleeptimer_timer_callback_t callback,
+                                void *callback_data,
+                                uint8_t priority,
+                                uint16_t option_flags);
+
+static void update_next_timer_to_expire_is_power_manager(void);
+
+static void delay_callback(sl_sleeptimer_timer_handle_t *handle,
+                           void *data);
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+static bool is_leap_year(uint16_t year);
+
+static sl_sleeptimer_weekDay_t compute_day_of_week(uint32_t day);
+static uint16_t compute_day_of_year(sl_sleeptimer_month_t month, uint8_t day, bool isLeapYear);
+
+static bool is_valid_time(sl_sleeptimer_timestamp_t time,
+                          sl_sleeptimer_time_format_t format,
+                          sl_sleeptimer_time_zone_offset_t time_zone);
+
+static bool is_valid_date(sl_sleeptimer_date_t *date);
+
+static const uint8_t days_in_month[2u][12] = {
+  /* Jan  Feb  Mar  Apr  May  Jun  Jul  Aug  Sep  Oct  Nov  Dec */
+  { 31u, 28u, 31u, 30u, 31u, 30u, 31u, 31u, 30u, 31u, 30u, 31u },
+  { 31u, 29u, 31u, 30u, 31u, 30u, 31u, 31u, 30u, 31u, 30u, 31u }
+};
+#endif
+
+/**************************************************************************//**
+ * Initializes sleep timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_init(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  if (!is_sleeptimer_initialized) {
+    timer_head  = NULL;
+    last_delta_update_count = 0u;
+    overflow_counter = 0u;
+    sleeptimer_hal_init_timer();
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_OF);
+    timer_frequency = sleeptimer_hal_get_timer_frequency();
+    if (timer_frequency == 0) {
+      return SL_STATUS_INVALID_CONFIGURATION;
+    }
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+    second_count = 0;
+    calculated_tick_rest = ((uint64_t)UINT32_MAX + 1) % (uint64_t)timer_frequency;
+    calculated_sec_count = (((uint64_t)UINT32_MAX + 1) / (uint64_t)timer_frequency);
+#endif
+    max_millisecond_conversion = ((uint64_t)UINT32_MAX * (uint64_t)1000u) / timer_frequency;
+    is_sleeptimer_initialized = true;
+  }
+  CORE_EXIT_ATOMIC();
+
+  return SL_STATUS_OK;
+}
+
+/**************************************************************************//**
+ * Starts a 32 bits timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_start_timer(sl_sleeptimer_timer_handle_t *handle,
+                                      uint32_t timeout,
+                                      sl_sleeptimer_timer_callback_t callback,
+                                      void *callback_data,
+                                      uint8_t priority,
+                                      uint16_t option_flags)
+{
+  bool is_running = false;
+
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  sl_sleeptimer_is_timer_running(handle, &is_running);
+  if (is_running == true) {
+    return SL_STATUS_NOT_READY;
+  }
+
+  return create_timer(handle,
+                      timeout,
+                      0,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Restarts a 32 bits timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_restart_timer(sl_sleeptimer_timer_handle_t *handle,
+                                        uint32_t timeout,
+                                        sl_sleeptimer_timer_callback_t callback,
+                                        void *callback_data,
+                                        uint8_t priority,
+                                        uint16_t option_flags)
+{
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  //Trying to stop the Timer. Failing to do so implies the timer is not running.
+  sl_sleeptimer_stop_timer(handle);
+
+  //Creates the timer in any case.
+  return create_timer(handle,
+                      timeout,
+                      0,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Starts a 32 bits periodic timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_start_periodic_timer(sl_sleeptimer_timer_handle_t *handle,
+                                               uint32_t timeout,
+                                               sl_sleeptimer_timer_callback_t callback,
+                                               void *callback_data,
+                                               uint8_t priority,
+                                               uint16_t option_flags)
+{
+  bool is_running = false;
+
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  sl_sleeptimer_is_timer_running(handle, &is_running);
+  if (is_running == true) {
+    return SL_STATUS_INVALID_STATE;
+  }
+
+  return create_timer(handle,
+                      timeout,
+                      timeout,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Restarts a 32 bits periodic timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_restart_periodic_timer(sl_sleeptimer_timer_handle_t *handle,
+                                                 uint32_t timeout,
+                                                 sl_sleeptimer_timer_callback_t callback,
+                                                 void *callback_data,
+                                                 uint8_t priority,
+                                                 uint16_t option_flags)
+{
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  //Trying to stop the Timer. Failing to do so implies the timer has already been stopped.
+  sl_sleeptimer_stop_timer(handle);
+
+  //Creates the timer in any case.
+  return create_timer(handle,
+                      timeout,
+                      timeout,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Stops a 32 bits timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_stop_timer(sl_sleeptimer_timer_handle_t *handle)
+{
+  CORE_DECLARE_IRQ_STATE;
+  sl_status_t error;
+  bool set_comparator = false;
+
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  CORE_ENTER_ATOMIC();
+  update_first_timer_delta();
+
+  // If first timer in list, update timer comparator.
+  if (timer_head == handle) {
+    set_comparator = true;
+  }
+
+  error = delta_list_remove_timer(handle);
+  if (error != SL_STATUS_OK) {
+    CORE_EXIT_ATOMIC();
+    return error;
+  }
+
+  if (set_comparator && timer_head) {
+    set_comparator_for_next_timer();
+  } else if (!timer_head) {
+    sleeptimer_hal_disable_int(SLEEPTIMER_EVENT_COMP);
+  }
+
+  CORE_EXIT_ATOMIC();
+  return SL_STATUS_OK;
+}
+
+/**************************************************************************//**
+ * Gets the status of a timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_is_timer_running(sl_sleeptimer_timer_handle_t *handle,
+                                           bool *running)
+{
+  CORE_DECLARE_IRQ_STATE;
+  sl_sleeptimer_timer_handle_t *current;
+
+  if (handle == NULL || running == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  } else {
+    *running = false;
+    CORE_ENTER_ATOMIC();
+    current = timer_head;
+    while (current != NULL && !*running) {
+      if (current == handle) {
+        *running = true;
+      } else {
+        current = current->next;
+      }
+    }
+    CORE_EXIT_ATOMIC();
+  }
+  return SL_STATUS_OK;
+}
+
+/**************************************************************************//**
+ * Gets a 32 bits timer's time remaining.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_get_timer_time_remaining(sl_sleeptimer_timer_handle_t *handle,
+                                                   uint32_t *time)
+{
+  CORE_DECLARE_IRQ_STATE;
+  sl_sleeptimer_timer_handle_t *current;
+
+  if (handle == NULL || time == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  CORE_ENTER_ATOMIC();
+
+  update_first_timer_delta();
+  *time  = handle->delta;
+
+  // Retrieve timer in list and add the deltas.
+  current = timer_head;
+  while (current != handle && current != NULL) {
+    *time += current->delta;
+    current = current->next;
+  }
+
+  if (current != handle) {
+    CORE_EXIT_ATOMIC();
+    return SL_STATUS_NOT_READY;
+  }
+
+  // Substract time since last compare match.
+  if (*time > sleeptimer_hal_get_counter() - last_delta_update_count) {
+    *time -= sleeptimer_hal_get_counter() - last_delta_update_count;
+  } else {
+    *time = 0;
+  }
+
+  CORE_EXIT_ATOMIC();
+
+  return SL_STATUS_OK;
+}
+
+/**************************************************************************//**
+ * Gets the time remaining until the first timer with the matching set of flags
+ * expires.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_get_remaining_time_of_first_timer(uint16_t option_flags,
+                                                            uint32_t *time_remaining)
+{
+  CORE_DECLARE_IRQ_STATE;
+  sl_sleeptimer_timer_handle_t *current;
+  uint32_t time = 0;
+
+  CORE_ENTER_ATOMIC();
+  // parse list and retrieve first timer with HF requirement.
+  current = timer_head;
+  while (current != NULL) {
+    // save time remaining for timer.
+    time += current->delta;
+    // Check if the current timer has the flags requested
+    if (current->option_flags == option_flags) {
+      // Substract time since last compare match.
+      if (time > (sleeptimer_hal_get_counter() - last_delta_update_count)) {
+        time -= (sleeptimer_hal_get_counter() - last_delta_update_count);
+      } else {
+        time = 0;
+      }
+      *time_remaining = time;
+      CORE_EXIT_ATOMIC();
+      return SL_STATUS_OK;
+    }
+    current = current->next;
+  }
+  CORE_EXIT_ATOMIC();
+
+  return SL_STATUS_EMPTY;
+}
+
+/**************************************************************************//**
+ * Determines if next timer to expire has the option flag
+ * "SL_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG".
+ *
+ * This function is for internal use only.
+ *****************************************************************************/
+bool sli_sleeptimer_is_power_manager_timer_next_to_expire(void)
+{
+  bool next_timer_is_power_manager;
+
+  sl_atomic_load(next_timer_is_power_manager, next_timer_to_expire_is_power_manager);
+
+  return next_timer_is_power_manager;
+}
+
+/***************************************************************************//**
+* Gets current 32 bits tick count.
+*******************************************************************************/
+uint32_t sl_sleeptimer_get_tick_count(void)
+{
+  uint32_t cnt;
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  cnt = sleeptimer_hal_get_counter();
+  CORE_EXIT_ATOMIC();
+
+  return cnt;
+}
+
+/***************************************************************************//**
+* Gets current 64 bits tick count.
+*******************************************************************************/
+uint64_t sl_sleeptimer_get_tick_count64(void)
+{
+  uint32_t tick_cnt;
+  uint32_t of_cnt;
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  tick_cnt = sleeptimer_hal_get_counter();
+  of_cnt = overflow_counter;
+
+  if (sli_sleeptimer_hal_is_int_status_set(SLEEPTIMER_EVENT_OF)) {
+    tick_cnt = sleeptimer_hal_get_counter();
+    of_cnt++;
+  }
+  CORE_EXIT_ATOMIC();
+
+  return (((uint64_t) of_cnt) << 32) | tick_cnt;
+}
+
+/***************************************************************************//**
+ * Get timer frequency.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_timer_frequency(void)
+{
+  return timer_frequency;
+}
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+/***************************************************************************//**
+ * Retrieves current time.
+ ******************************************************************************/
+sl_sleeptimer_timestamp_t sl_sleeptimer_get_time(void)
+{
+  uint32_t cnt = 0u;
+  uint32_t freq = 0u;
+  sl_sleeptimer_timestamp_t time;
+  CORE_DECLARE_IRQ_STATE;
+
+  cnt = sleeptimer_hal_get_counter();
+  freq = sl_sleeptimer_get_timer_frequency();
+
+  CORE_ENTER_ATOMIC();
+  time = second_count + cnt / freq;
+  if (cnt % freq + overflow_tick_rest >= freq) {
+    time++;
+  }
+  CORE_EXIT_ATOMIC();
+
+  return time;
+}
+
+/***************************************************************************//**
+ * Sets current time.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_time(sl_sleeptimer_timestamp_t time)
+{
+  uint32_t freq = 0u;
+  uint32_t counter_sec = 0u;
+  uint32_t cnt = 0;
+  CORE_DECLARE_IRQ_STATE;
+
+  if (!is_valid_time(time, TIME_FORMAT_UNIX, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  freq = sl_sleeptimer_get_timer_frequency();
+  cnt = sleeptimer_hal_get_counter();
+
+  CORE_ENTER_ATOMIC();
+  second_count = time;
+  overflow_tick_rest = 0;
+  counter_sec = cnt / freq;
+
+  if (second_count >= counter_sec) {
+    second_count -= counter_sec;
+  } else {
+    CORE_EXIT_ATOMIC();
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  CORE_EXIT_ATOMIC();
+
+  return SL_STATUS_OK;
+}
+
+/***************************************************************************//**
+ * Gets current date.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_get_datetime(sl_sleeptimer_date_t *date)
+{
+  sl_sleeptimer_timestamp_t time = 0u;
+  sl_sleeptimer_time_zone_offset_t tz;
+  sl_status_t err_code = SL_STATUS_OK;
+
+  time = sl_sleeptimer_get_time();
+  tz = sl_sleeptimer_get_tz();
+  err_code = sl_sleeptimer_convert_time_to_date(time, tz, date);
+
+  return err_code;
+}
+
+/***************************************************************************//**
+ * Sets current time, in date format.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_datetime(sl_sleeptimer_date_t *date)
+{
+  sl_sleeptimer_timestamp_t time = 0u;
+  sl_status_t err_code = SL_STATUS_OK;
+
+  if (!is_valid_date(date)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  err_code = sl_sleeptimer_convert_date_to_time(date, &time);
+
+  if (err_code != SL_STATUS_OK) {
+    return err_code;
+  }
+
+  err_code = sl_sleeptimer_set_time(time);
+  return err_code;
+}
+
+/***************************************************************************//**
+ * Builds a date time structure based on the provided parameters.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_build_datetime(sl_sleeptimer_date_t *date,
+                                         uint16_t year,
+                                         sl_sleeptimer_month_t month,
+                                         uint8_t month_day,
+                                         uint8_t hour,
+                                         uint8_t min,
+                                         uint8_t sec,
+                                         sl_sleeptimer_time_zone_offset_t tz_offset)
+{
+  if (date == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  // If year is smaller than 1900, assume NTP Epoch is used.
+  date->year = ((year < TIME_NTP_EPOCH) ? year : (year - TIME_NTP_EPOCH));
+  date->month = month;
+  date->month_day = month_day;
+  date->hour = hour;
+  date->min = min;
+  date->sec = sec;
+  date->time_zone = tz_offset;
+
+  // Validate that input parameters are correct before filing the missing fields
+  if (!is_valid_date(date)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  date->day_of_year = compute_day_of_year(date->month, date->month_day, is_leap_year(date->year));
+  date->day_of_week = compute_day_of_week(((date->year - TIME_NTP_UNIX_EPOCH_DIFF)  * TIME_DAY_PER_YEAR)
+                                          + TIME_LEAP_DAYS_UP_TO_YEAR(date->year - TIME_NTP_UNIX_EPOCH_DIFF)
+                                          + date->day_of_year - 1);
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Convert a time stamp into a date structure.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_time_to_date(sl_sleeptimer_timestamp_t time,
+                                               sl_sleeptimer_time_zone_offset_t time_zone,
+                                               sl_sleeptimer_date_t *date)
+{
+  uint8_t full_year = 0;
+  uint8_t leap_day = 0;
+  uint8_t leap_year_flag = 0;
+  uint8_t current_month = 0;
+
+  if (!is_valid_time(time, TIME_FORMAT_UNIX, time_zone)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  date->sec = time % 60;
+  time /= 60;
+  date->min = time % 60;
+  time /= 60;
+  date->hour = time % 24;
+  time /= 24; // time is now the number of days since 1970.
+
+  date->day_of_week = (sl_sleeptimer_weekDay_t)compute_day_of_week(time);
+
+  full_year = time / (TIME_DAY_PER_YEAR); // Approximates the number of full years.
+  if (full_year > 2) {
+    leap_day = TIME_LEAP_DAYS_UP_TO_YEAR(full_year);  // Approximates the number of leap days.
+    full_year = (time - leap_day) / (TIME_DAY_PER_YEAR); // Computes the number of year integrating the leap days.
+    leap_day = TIME_LEAP_DAYS_UP_TO_YEAR(full_year);  // Computes the actual number of leap days of the previous years.
+  }
+  date->year = TIME_NTP_UNIX_EPOCH_DIFF + full_year; // Year in date struct must be based on a 1900 epoch.
+  if (is_leap_year(date->year)) {
+    leap_year_flag = 1;
+  }
+
+  time = (time - leap_day) - (TIME_DAY_PER_YEAR * full_year);  // Subtracts days of previous year.
+  date->day_of_year = time + 1;
+
+  while (time >= days_in_month[leap_year_flag][current_month]) {
+    time -= days_in_month[leap_year_flag][current_month]; // Subtracts the number of days of the passed month.
+    current_month++;
+  }
+  date->month = (sl_sleeptimer_month_t) current_month;
+  date->month_day = time + 1;
+  date->time_zone = time_zone;
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Convert a date structure into a time stamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_date_to_time(sl_sleeptimer_date_t *date,
+                                               sl_sleeptimer_timestamp_t *time)
+{
+  uint16_t month_days = 0;
+  uint8_t  month;
+  uint8_t  full_year = 0;
+  uint8_t  leap_year_flag = 0;
+  uint8_t  leap_days = 0;
+  if (!is_valid_date(date)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  full_year = (date->year - TIME_NTP_UNIX_EPOCH_DIFF);       // Timestamp returned must follow the UNIX epoch.
+  month = (uint8_t)date->month;                              // offset to get months value from 1 to 12.
+
+  *time = full_year * TIME_SEC_PER_YEAR;
+
+  if (full_year > 2) {
+    leap_days = TIME_LEAP_DAYS_UP_TO_YEAR(full_year);
+    month_days = leap_days;
+  }
+
+  if (is_leap_year(date->year)) {
+    leap_year_flag = 1;
+  }
+
+  for (int i = 0; i < month; i++) {
+    month_days += days_in_month[leap_year_flag][i];         // Add the number of days of the month of the year.
+  }
+
+  month_days += (date->month_day - 1);                       // Add full days of the current month.
+  *time += month_days * TIME_SEC_PER_DAY;
+  *time += (3600 * date->hour) + (60 * date->min) + date->sec;
+  *time += date->time_zone;
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Convert a date structure to string.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_convert_date_to_str(char *str,
+                                           size_t size,
+                                           const uint8_t *format,
+                                           sl_sleeptimer_date_t *date)
+{
+  uint32_t  return_size = 0u;
+  if (is_valid_date(date)) {
+    struct tm date_struct;
+
+    date_struct.tm_hour = date->hour;
+    date_struct.tm_mday = date->month_day;
+    date_struct.tm_min = date->min;
+    date_struct.tm_mon = date->month;
+    date_struct.tm_sec = date->sec;
+    date_struct.tm_wday = date->day_of_week;
+    date_struct.tm_yday = date->day_of_year;
+    date_struct.tm_year = date->year;
+
+    return_size = strftime(str,
+                           size,
+                           (const char *)format,
+                           &date_struct);
+  }
+
+  return return_size;
+}
+
+/***************************************************************************//**
+ * Sets time zone offset.
+ *
+ * @param  offset  Time zone offset, in seconds.
+ ******************************************************************************/
+void sl_sleeptimer_set_tz(sl_sleeptimer_time_zone_offset_t offset)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  tz_offset = offset;
+  CORE_EXIT_ATOMIC();
+}
+
+/***************************************************************************//**
+ * Gets time zone offset.
+ *
+ * @return Time zone offset, in seconds.
+ ******************************************************************************/
+sl_sleeptimer_time_zone_offset_t sl_sleeptimer_get_tz(void)
+{
+  sl_sleeptimer_time_zone_offset_t offset;
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  offset = tz_offset;
+  CORE_EXIT_ATOMIC();
+
+  return offset;
+}
+
+/***************************************************************************//**
+ * Converts Unix timestamp into NTP timestamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_unix_time_to_ntp(sl_sleeptimer_timestamp_t time,
+                                                   uint32_t *ntp_time)
+{
+  uint32_t temp_ntp_time;
+  temp_ntp_time = time + TIME_NTP_EPOCH_OFFSET_SEC;
+  if (!is_valid_time(temp_ntp_time, TIME_FORMAT_NTP, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  } else {
+    *ntp_time = temp_ntp_time;
+    return SL_STATUS_OK;
+  }
+}
+
+/***************************************************************************//**
+ * Converts NTP timestamp into Unix timestamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_ntp_time_to_unix(uint32_t ntp_time,
+                                                   sl_sleeptimer_timestamp_t *time)
+{
+  uint32_t temp_time;
+  temp_time = ntp_time - TIME_NTP_EPOCH_OFFSET_SEC;
+  if (!is_valid_time(temp_time, TIME_FORMAT_UNIX, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  } else {
+    *time = temp_time;
+    return SL_STATUS_OK;
+  }
+}
+
+/***************************************************************************//**
+ * Converts Unix timestamp into Zigbee timestamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_unix_time_to_zigbee(sl_sleeptimer_timestamp_t time,
+                                                      uint32_t *zigbee_time)
+{
+  uint32_t temp_zigbee_time;
+  temp_zigbee_time = time - TIME_ZIGBEE_EPOCH_OFFSET_SEC;
+  if (!is_valid_time(temp_zigbee_time, TIME_FORMAT_ZIGBEE_CLUSTER, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  } else {
+    *zigbee_time = temp_zigbee_time;
+    return SL_STATUS_OK;
+  }
+}
+
+/***************************************************************************//**
+ * Converts Zigbee timestamp into Unix timestamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_zigbee_time_to_unix(uint32_t zigbee_time,
+                                                      sl_sleeptimer_timestamp_t *time)
+{
+  uint32_t temp_time;
+  temp_time = zigbee_time + TIME_ZIGBEE_EPOCH_OFFSET_SEC;
+  if (!is_valid_time(temp_time, TIME_FORMAT_UNIX, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  } else {
+    *time = temp_time;
+    return SL_STATUS_OK;
+  }
+}
+
+#endif // SL_SLEEPTIMER_WALLCLOCK_CONFIG
+
+/*******************************************************************************
+ * Active delay of 'time_ms' milliseconds.
+ ******************************************************************************/
+void sl_sleeptimer_delay_millisecond(uint16_t time_ms)
+{
+  volatile bool wait = true;
+  sl_status_t error_code;
+  sl_sleeptimer_timer_handle_t delay_timer;
+  uint32_t delay = sl_sleeptimer_ms_to_tick(time_ms);
+
+  error_code = sl_sleeptimer_start_timer(&delay_timer,
+                                         delay,
+                                         delay_callback,
+                                         (void *)&wait,
+                                         0,
+                                         0);
+  if (error_code == SL_STATUS_OK) {
+    while (wait) { // Active delay loop.
+    }
+  }
+}
+
+/*******************************************************************************
+ * Converts milliseconds in ticks.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_ms_to_tick(uint16_t time_ms)
+{
+  return (uint32_t)((((uint32_t)time_ms * timer_frequency) / 1000) + 1);
+}
+
+/*******************************************************************************
+ * Converts 32-bits milliseconds in ticks.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_ms32_to_tick(uint32_t time_ms,
+                                       uint32_t *tick)
+{
+  if (time_ms <= max_millisecond_conversion) {
+    *tick = (uint32_t)((((uint64_t)time_ms * timer_frequency) / 1000u) + 1);
+    return SL_STATUS_OK;
+  } else {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+}
+
+/***************************************************************************//**
+ * Gets the maximum value that can be passed to the functions that have a
+ * 32-bits time or timeout argument expressed in milliseconds.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_max_ms32_conversion(void)
+{
+  return max_millisecond_conversion;
+}
+
+/*******************************************************************************
+ * Converts ticks in milliseconds.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_tick_to_ms(uint32_t tick)
+{
+  if (is_power_of_2(timer_frequency)) {
+    return (uint32_t)(((uint64_t)tick * (uint64_t)1000u) >> div_to_log2(timer_frequency));
+  } else {
+    return (uint32_t)(((uint64_t)tick * (uint64_t)1000u) / timer_frequency);
+  }
+}
+
+/*******************************************************************************
+ * Converts 64-bits ticks in milliseconds.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_tick64_to_ms(uint64_t tick,
+                                       uint64_t *ms)
+{
+  if (tick <= UINT64_MAX / 1000) {
+    if (is_power_of_2(timer_frequency)) {
+      *ms =  (uint64_t)(((uint64_t)tick * (uint64_t)1000u) >> div_to_log2(timer_frequency));
+      return SL_STATUS_OK;
+    } else {
+      *ms = (uint64_t)(((uint64_t)tick * (uint64_t)1000u) / timer_frequency);
+      return SL_STATUS_OK;
+    }
+  } else {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+}
+/*******************************************************************************
+ * Process timer interrupt.
+ *
+ * @param local_flag Flag indicating the type of timer interrupt.
+ ******************************************************************************/
+void process_timer_irq(uint8_t local_flag)
+{
+  CORE_DECLARE_IRQ_STATE;
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+    uint32_t timer_freq = sl_sleeptimer_get_timer_frequency();
+
+    overflow_tick_rest += calculated_tick_rest;
+    if (overflow_tick_rest >= timer_freq) {
+      second_count++;
+      overflow_tick_rest -= timer_freq;
+    }
+    second_count = second_count + calculated_sec_count;
+#endif
+    overflow_counter++;
+
+    update_first_timer_delta();
+
+    if (timer_head) {
+      set_comparator_for_next_timer();
+    }
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    sl_sleeptimer_tick_count_t delta_tot = 0u;
+    sl_sleeptimer_tick_count_t current_cnt = sleeptimer_hal_get_counter();
+    sl_sleeptimer_timer_handle_t *current = NULL;
+    uint32_t nb_timer_expire = 0u;
+
+    delta_tot = current_cnt - last_delta_update_count;
+
+    CORE_ENTER_ATOMIC();
+    // Process all timers that have expired.
+    while ((timer_head) && (delta_tot >= timer_head->delta)) {
+      sl_sleeptimer_tick_count_t new_cnt;
+      sl_sleeptimer_tick_count_t delta_tot_temp = delta_tot;
+      sl_sleeptimer_timer_handle_t *temp = timer_head;
+      current = timer_head;
+
+      last_delta_update_count = current_cnt;
+
+      while ((temp != NULL) && (delta_tot_temp >= temp->delta)) {
+        if (current->priority > temp->priority) {
+          current = temp;
+        }
+
+        delta_tot_temp -= temp->delta;
+        temp = temp->next;
+      }
+      CORE_EXIT_ATOMIC();
+      delta_tot -= current->delta;
+      current->delta = 0;
+
+      CORE_ENTER_ATOMIC();
+      delta_list_remove_timer(current);
+      CORE_EXIT_ATOMIC();
+
+      if (current->timeout_periodic != 0u) {
+        CORE_ENTER_ATOMIC();
+        delta_list_insert_timer(current, current->timeout_periodic);
+        CORE_EXIT_ATOMIC();
+      }
+
+      if (current->callback != NULL) {
+        current->callback(current, current->callback_data);
+      }
+
+      nb_timer_expire++;
+
+      new_cnt = sleeptimer_hal_get_counter();
+      delta_tot += new_cnt - current_cnt;
+      current_cnt = new_cnt;
+      CORE_ENTER_ATOMIC();
+    }
+
+    if ((nb_timer_expire == 1u)
+        && (current->option_flags == SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG)) {
+      sleep_on_isr_exit = true;
+    } else {
+      sleep_on_isr_exit = false;
+    }
+
+    if (timer_head) {
+      timer_head->delta -= delta_tot;
+      last_delta_update_count = current_cnt;
+
+      set_comparator_for_next_timer();
+    } else {
+      sleeptimer_hal_disable_int(SLEEPTIMER_EVENT_COMP);
+    }
+    CORE_EXIT_ATOMIC();
+  }
+}
+
+/*******************************************************************************
+ * Timer expiration callback for the delay function.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param data Pointer to delay flag.
+ ******************************************************************************/
+static void delay_callback(sl_sleeptimer_timer_handle_t *handle,
+                           void *data)
+{
+  volatile bool *wait_flag = (bool *)data;
+
+  (void)handle;  // Unused parameter.
+
+  *wait_flag = false;
+}
+
+/*******************************************************************************
+ * Inserts a timer in the delta list.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer timeout, in ticks.
+ ******************************************************************************/
+static void delta_list_insert_timer(sl_sleeptimer_timer_handle_t *handle,
+                                    sl_sleeptimer_tick_count_t timeout)
+{
+  sl_sleeptimer_tick_count_t local_handle_delta = timeout;
+
+  handle->delta = local_handle_delta;
+
+  if (timer_head != NULL) {
+    sl_sleeptimer_timer_handle_t *prev = NULL;
+    sl_sleeptimer_timer_handle_t *current = timer_head;
+    // Find timer position taking into accounts the deltas and priority.
+    while (current != NULL
+           && (local_handle_delta >= current->delta || current->delta == 0u
+               || (((local_handle_delta - current->delta) == 0) && (handle->priority > current->priority)))) {
+      local_handle_delta -= current->delta;
+      handle->delta = local_handle_delta;
+      prev = current;
+      current = current->next;
+    }
+
+    // Insert timer in middle of delta list.
+    if (prev != NULL) {
+      prev->next = handle;
+    } else {
+      timer_head = handle;
+    }
+    handle->next = current;
+
+    if (current != NULL) {
+      current->delta -= local_handle_delta;
+    }
+  } else {
+    timer_head = handle;
+    handle->next = NULL;
+  }
+}
+
+/*******************************************************************************
+ * Removes a timer from delta list.
+ *
+ * @param handle Pointer to handle to timer.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+static sl_status_t delta_list_remove_timer(sl_sleeptimer_timer_handle_t *handle)
+{
+  sl_sleeptimer_timer_handle_t *prev = NULL;
+  sl_sleeptimer_timer_handle_t *current = timer_head;
+
+  // Retrieve timer in delta list.
+  while (current != NULL && current != handle) {
+    prev = current;
+    current = current->next;
+  }
+
+  if (current != handle) {
+    return SL_STATUS_INVALID_STATE;
+  }
+
+  if (prev != NULL) {
+    prev->next = handle->next;
+  } else {
+    timer_head = handle->next;
+  }
+
+  // Update delta of next timer
+  if (handle->next != NULL) {
+    handle->next->delta += handle->delta;
+  }
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Sets comparator for next timer.
+ ******************************************************************************/
+static void set_comparator_for_next_timer(void)
+{
+  sl_sleeptimer_tick_count_t compare_value;
+
+  compare_value = last_delta_update_count + timer_head->delta;
+
+  sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+  sleeptimer_hal_set_compare(compare_value);
+
+  update_next_timer_to_expire_is_power_manager();
+}
+
+/*******************************************************************************
+ * Updates delta of first timer.
+ ******************************************************************************/
+static void update_first_timer_delta(void)
+{
+  sl_sleeptimer_tick_count_t current_cnt = sleeptimer_hal_get_counter();
+  sl_sleeptimer_tick_count_t time_diff;
+
+  if (timer_head) {
+    time_diff = current_cnt - last_delta_update_count;
+    if (timer_head->delta >= time_diff) {
+      timer_head->delta -= time_diff;
+      last_delta_update_count = current_cnt;
+    } else {
+      last_delta_update_count = current_cnt - timer_head->delta;
+      timer_head->delta = 0;
+    }
+  } else {
+    last_delta_update_count = current_cnt;
+  }
+}
+
+/*******************************************************************************
+ * Creates and start a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_initial Initial timeout, in timer ticks.
+ * @param timeout_periodic Periodic timeout, in timer ticks. This timeout
+ *        applies once timeoutInitial expires. Can be set to 0 for a one
+ *        shot timer.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+static sl_status_t create_timer(sl_sleeptimer_timer_handle_t *handle,
+                                sl_sleeptimer_tick_count_t timeout_initial,
+                                sl_sleeptimer_tick_count_t timeout_periodic,
+                                sl_sleeptimer_timer_callback_t callback,
+                                void *callback_data,
+                                uint8_t priority,
+                                uint16_t option_flags)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  handle->priority = priority;
+  handle->callback_data = callback_data;
+  handle->next = NULL;
+  handle->timeout_periodic = timeout_periodic;
+  handle->callback = callback;
+  handle->option_flags = option_flags;
+
+  if (timeout_initial == 0) {
+    handle->delta = 0;
+    if (handle->callback != NULL) {
+      handle->callback(handle, handle->callback_data);
+    }
+    if (timeout_periodic != 0) {
+      timeout_initial = timeout_periodic;
+    } else {
+      return SL_STATUS_OK;
+    }
+  }
+
+  CORE_ENTER_ATOMIC();
+  update_first_timer_delta();
+  delta_list_insert_timer(handle, timeout_initial);
+
+  // If first timer, update timer comparator.
+  if (timer_head == handle) {
+    set_comparator_for_next_timer();
+  }
+
+  CORE_EXIT_ATOMIC();
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Updates internal flag that indicates if next timer to expire is the power
+ * manager's one.
+ ******************************************************************************/
+static void update_next_timer_to_expire_is_power_manager(void)
+{
+  sl_sleeptimer_timer_handle_t *current = timer_head;
+  uint32_t delta_diff_with_first = 0;
+
+  next_timer_to_expire_is_power_manager = false;
+
+  while (delta_diff_with_first <= 1) {
+    if (current->option_flags & SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG) {
+      next_timer_to_expire_is_power_manager = true;
+      break;
+    }
+
+    current = current->next;
+    if (current == NULL) {
+      break;
+    }
+
+    delta_diff_with_first += current->delta;
+  }
+}
+
+/**************************************************************************//**
+ * Determines if the power manager's early wakeup expired during the last ISR
+ * and it was the only timer to expire in that period.
+ *
+ * @return true if power manager sleep can return to sleep,
+ *         false otherwise.
+ *****************************************************************************/
+bool sl_sleeptimer_is_power_manager_early_restore_timer_latest_to_expire(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+  bool sleep;
+
+  CORE_ENTER_ATOMIC();
+  sleep = sleep_on_isr_exit;
+  sleep_on_isr_exit = false;
+  CORE_EXIT_ATOMIC();
+
+  return sleep;
+}
+
+/*******************************************************************************
+ * Convert dividend to logarithmic value. It only works for even
+ * numbers equal to 2^n.
+ *
+ * @param  div An unscaled dividend.
+ *
+ * @return Logarithm of 2.
+ ******************************************************************************/
+__STATIC_INLINE uint32_t div_to_log2(uint32_t div)
+{
+  return 31UL - __CLZ(div);  // Count leading zeroes and "reverse" result.
+}
+
+/*******************************************************************************
+ * Determines if a number is a power of two.
+ *
+ * @param  nbr Input value.
+ *
+ * @return True if the number is a power of two.
+ ******************************************************************************/
+__STATIC_INLINE bool is_power_of_2(uint32_t nbr)
+{
+  if ((((nbr) != 0u) && (((nbr) & ((nbr) - 1u)) == 0u))) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+/*******************************************************************************
+ * Compute the day of the week.
+ *
+ * @param day Days since January 1st of 1970.
+ *
+ * @return the day of the week.
+ ******************************************************************************/
+static sl_sleeptimer_weekDay_t compute_day_of_week(uint32_t day)
+{
+  return (sl_sleeptimer_weekDay_t)((day + 4) % 7);
+}
+
+/*******************************************************************************
+ * Compute the day of the year. This function assumes that the inputs are properly
+ * sanitized.
+ *
+ * @param month Number of months since January.
+ * @param day Day of the month
+ * @param is_leap_year Specifies if the year computed against is a leap year.
+ *
+ * @return the number of days since the beginning of the year
+ ******************************************************************************/
+static uint16_t compute_day_of_year(sl_sleeptimer_month_t month, uint8_t day, bool is_leap_year)
+{
+  uint8_t i;
+  uint16_t dayOfYear = 0;
+
+  for (i = 0; i < month; ++i) {
+    dayOfYear += days_in_month[is_leap_year][i];
+  }
+  dayOfYear += day;
+
+  return dayOfYear;
+}
+
+/*******************************************************************************
+ * Checks if the year is a leap year.
+ *
+ * @param year Year to check.
+ *
+ * @return true if the year is a leap year. False otherwise.
+ ******************************************************************************/
+static bool is_leap_year(uint16_t year)
+{
+  bool leap_year;
+
+  leap_year = (((year %   4u) == 0u)
+               && (((year % 100u) != 0u) || ((year % 400u) == 0u))) ? true : false;
+
+  return (leap_year);
+}
+
+/*******************************************************************************
+ * Checks if the time stamp, format and time zone are
+ *  within the supported range.
+ *
+ * @param time Time stamp to check.
+ * @param format Format of the time.
+ * @param time_zone Time zone offset in second.
+ *
+ * @return true if the time is valid. False otherwise.
+ ******************************************************************************/
+static bool is_valid_time(sl_sleeptimer_timestamp_t time,
+                          sl_sleeptimer_time_format_t format,
+                          sl_sleeptimer_time_zone_offset_t time_zone)
+{
+  bool valid_time = false;
+
+  // Check for overflow.
+  if ((time_zone < 0 && time > (uint32_t)abs(time_zone)) \
+      || (time_zone >= 0 && (time <= UINT32_MAX - time_zone))) {
+    valid_time = true;
+  }
+  if (format == TIME_FORMAT_UNIX) {
+    if (time > TIME_UNIX_TIMESTAMP_MAX) { // Check if Unix time stamp is an unsigned 31 bits.
+      valid_time = false;
+    }
+  } else {
+    if ((format == TIME_FORMAT_NTP) && (time >= TIME_NTP_EPOCH_OFFSET_SEC)) {
+      valid_time &= true;
+    } else if ((format == TIME_FORMAT_ZIGBEE_CLUSTER) && (time <= TIME_UNIX_TIMESTAMP_MAX - TIME_ZIGBEE_EPOCH_OFFSET_SEC)) {
+      valid_time &= true;
+    } else {
+      valid_time = false;
+    }
+  }
+  return valid_time;
+}
+
+/*******************************************************************************
+ * Checks if the date is valid.
+ *
+ * @param date Date to check.
+ *
+ * @return true if the date is valid. False otherwise.
+ ******************************************************************************/
+static bool is_valid_date(sl_sleeptimer_date_t *date)
+{
+  if ((date == NULL)
+      || (date->year > TIME_UNIX_YEAR_MAX)
+      || (date->month > MONTH_DECEMBER)
+      || (date->month_day == 0 || date->month_day > days_in_month[is_leap_year(date->year)][date->month])
+      || (date->hour > 23)
+      || (date->min > 59)
+      || (date->sec > 59)) {
+    return false;
+  }
+
+  // Unix is valid until the 19th of January 2038 at 03:14:07
+  if (date->year == TIME_UNIX_YEAR_MAX) {
+    if ((uint8_t)date->month > (uint8_t)MONTH_JANUARY) {
+      return false;
+    } else if (date->month_day > 19) {
+      return false;
+    } else if (date->hour > 3) {
+      return false;
+    } else if (date->min > 14) {
+      return false;
+    } else if (date->sec > 7) {
+      return false;
+    }
+  }
+
+  return true;
+}
+#endif

--- a/gecko/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c
+++ b/gecko/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c
@@ -1,0 +1,235 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER Hardware abstraction implementation for BURTC.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "em_burtc.h"
+#include "em_core.h"
+#include "em_cmu.h"
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_BURTC
+
+#if defined(_SILICON_LABS_32B_SERIES_0)
+#error BURTC implementation of the sleeptimer not available on Series 0 chips
+#endif
+
+// Minimum difference between current count value and what the comparator of the timer can be set to.
+#define SLEEPTIMER_COMPARE_MIN_DIFF  4
+
+#define SLEEPTIMER_TMR_WIDTH (_BURTC_CNT_MASK)
+
+static uint32_t get_time_diff(uint32_t a, uint32_t b);
+
+/******************************************************************************
+ * Convert HAL interrupt flag BURTC-interrupt-enable bitmask
+ *****************************************************************************/
+static uint32_t irqien_hal2burtc(uint8_t hal_flag)
+{
+  uint32_t burtc_if = 0u;
+
+  if (hal_flag & SLEEPTIMER_EVENT_OF) {
+    burtc_if |= BURTC_IEN_OF;
+  }
+
+  if (hal_flag & SLEEPTIMER_EVENT_COMP) {
+    burtc_if |= BURTC_IEN_COMP;
+  }
+
+  return burtc_if;
+}
+
+/******************************************************************************
+ * Convert BURTC interrupt flags to HAL events
+ *****************************************************************************/
+static uint8_t irqflags_burtc2hal(uint32_t burtc_flag)
+{
+  uint8_t hal_if = 0u;
+
+  if (burtc_flag & BURTC_IF_OF) {
+    hal_if |= SLEEPTIMER_EVENT_OF;
+  }
+
+  if (burtc_flag & BURTC_IF_COMP) {
+    hal_if |= SLEEPTIMER_EVENT_COMP;
+  }
+
+  return hal_if;
+}
+
+/******************************************************************************
+ * Initializes BURTC sleep timer.
+ *****************************************************************************/
+void sleeptimer_hal_init_timer()
+{
+  BURTC_Init_TypeDef burtc_init = BURTC_INIT_DEFAULT;
+
+  CMU_ClockEnable(cmuClock_BURTC, true);
+
+  burtc_init.start  = false;
+  burtc_init.clkDiv = SL_SLEEPTIMER_FREQ_DIVIDER;
+
+  BURTC_Init(&burtc_init);
+  BURTC_IntDisable(_BURTC_IEN_MASK);
+  BURTC_IntClear(_BURTC_IF_MASK);
+  BURTC_CounterReset();
+
+  BURTC_Start();
+  BURTC_SyncWait();
+
+  // Setup BURTC interrupt
+  NVIC_ClearPendingIRQ(BURTC_IRQn);
+  NVIC_EnableIRQ(BURTC_IRQn);
+}
+
+/******************************************************************************
+ * Gets BURTC counter.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void)
+{
+  return BURTC_CounterGet();
+}
+
+/******************************************************************************
+ * Gets BURTC compare value
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void)
+{
+  return BURTC_CompareGet(0U);
+}
+
+/******************************************************************************
+ * Sets BURTC compare value
+ *****************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value)
+{
+  uint32_t counter = sleeptimer_hal_get_counter();
+  uint32_t compare_current = sleeptimer_hal_get_compare();
+  uint32_t compare_new = value;
+
+  if (((BURTC_IntGet() & _BURTC_IF_COMP_MASK) != 0)
+      || get_time_diff(compare_current, counter) > SLEEPTIMER_COMPARE_MIN_DIFF
+      || compare_current == counter) {
+    // Add margin if necessary
+    if (get_time_diff(compare_new, counter) < SLEEPTIMER_COMPARE_MIN_DIFF) {
+      compare_new = counter + SLEEPTIMER_COMPARE_MIN_DIFF;
+    }
+
+    // wrap around if necessary
+    compare_new %= SLEEPTIMER_TMR_WIDTH;
+
+    BURTC_CompareSet(0U, compare_new);
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+  }
+}
+
+/******************************************************************************
+ * Enables BURTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag)
+{
+  BURTC_IntEnable(irqien_hal2burtc(local_flag));
+}
+
+/******************************************************************************
+ * Disables BURTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag)
+{
+  BURTC_IntDisable(irqien_hal2burtc(local_flag));
+}
+
+/******************************************************************************
+ * Gets status of specified interrupt.
+ *
+ * Note: This function must be called with interrupts disabled.
+ *****************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag)
+{
+  bool int_is_set = false;
+  uint32_t irq_flag = BURTC_IntGet();
+
+  switch (local_flag) {
+    case SLEEPTIMER_EVENT_COMP:
+      int_is_set = (irq_flag & BURTC_IF_COMP);
+      break;
+
+    case SLEEPTIMER_EVENT_OF:
+      int_is_set = (irq_flag & BURTC_IF_OF);
+      break;
+
+    default:
+      break;
+  }
+
+  return int_is_set;
+}
+
+/*******************************************************************************
+ * Gets BURTC timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void)
+{
+  return (CMU_ClockFreqGet(cmuClock_BURTC) >> (CMU_PrescToLog2(SL_SLEEPTIMER_FREQ_DIVIDER - 1)));
+}
+
+/*******************************************************************************
+ * BURTC interrupt handler.
+ ******************************************************************************/
+void BURTC_IRQHandler(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint8_t local_flag = 0;
+  uint32_t irq_flag;
+
+  CORE_ENTER_ATOMIC();
+  irq_flag = BURTC_IntGet();
+  local_flag = irqflags_burtc2hal(irq_flag);
+
+  BURTC_IntClear(irq_flag & (BURTC_IF_OF | BURTC_IF_COMP));
+
+  process_timer_irq(local_flag);
+
+  CORE_EXIT_ATOMIC();
+}
+
+/*******************************************************************************
+ * Computes difference between two times taking into account timer wrap-around.
+ *
+ * @param a Time.
+ * @param b Time to substract from a.
+ *
+ * @return Time difference.
+ ******************************************************************************/
+static uint32_t get_time_diff(uint32_t a, uint32_t b)
+{
+  return (a - b);
+}
+
+#endif

--- a/gecko/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c
+++ b/gecko/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c
@@ -1,0 +1,400 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER hardware abstraction implementation for PRORTC.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "em_core.h"
+#include "em_cmu.h"
+#include "em_bus.h"
+
+#if defined(SL_COMPONENT_CATALOG_PRESENT)
+#include  <sl_component_catalog.h>
+#endif
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT) && (_SILICON_LABS_32B_SERIES_2_CONFIG == 1)
+#include "sli_power_manager.h"
+#endif
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_PRORTC
+
+// Minimum difference between current count value and what the comparator of the timer can be set to.
+#define SLEEPTIMER_COMPARE_MIN_DIFF  2
+#define PRORTC_CNT_MASK              0xFFFFFFFFUL
+
+#define SLEEPTIMER_TMR_WIDTH (PRORTC_CNT_MASK)
+
+#define TIMER_COMP_REQ                   0U
+
+#define _PRORTC_IF_COMP_SHIFT              1                             /**< Shift value for RTC_COMP */
+#define PRORTC_IF_OF                      (0x1UL << 0)                   /**< Overflow Interrupt Flag */
+
+#if (TIMER_COMP_REQ == 0)
+#define PRORTC_IF_COMP_BIT RTCC_IF_CC0
+#elif  (TIMER_COMP_REQ == 1)
+#define PRORTC_IF_COMP_BIT RTCC_IF_CC1
+#endif
+
+#ifndef SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER
+#define SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER 0
+#endif
+
+#if SL_SLEEPTIMER_FREQ_DIVIDER != 1
+#warning A value other than 1 for SL_SLEEPTIMER_FREQ_DIVIDER is not supported on Radio Internal RTC (PRORTC)
+#endif
+
+static uint32_t get_time_diff(uint32_t a, uint32_t b);
+
+static bool cc_disabled = true;
+
+/******************************************************************************
+ * Initializes PRORTC sleep timer.
+ *****************************************************************************/
+void sleeptimer_hal_init_timer(void)
+{
+#if defined(_SILICON_LABS_32B_SERIES_1)
+  uint32_t cmu_status = CMU->STATUS;
+  uint32_t lfr_clk_sel = CMU_LFRCLKSEL_LFR_DEFAULT;
+
+  if ((cmu_status & _CMU_STATUS_LFXORDY_MASK) == CMU_STATUS_LFXORDY) {
+    lfr_clk_sel = CMU_LFRCLKSEL_LFR_LFXO;
+#ifdef PLFRCO_PRESENT
+  } else if ((cmu_status & _CMU_STATUS_PLFRCORDY_MASK) == CMU_STATUS_PLFRCORDY) {
+    lfr_clk_sel = CMU_LFRCLKSEL_LFR_PLFRCO;
+#endif
+  } else {
+    lfr_clk_sel = CMU_LFRCLKSEL_LFR_LFRCO;
+  }
+
+  // Set the Low Frequency R Clock Select Register
+  CMU->LFRCLKSEL = (CMU->LFRCLKSEL & ~_CMU_LFRCLKSEL_LFR_MASK)
+                   | (lfr_clk_sel << _CMU_LFRCLKSEL_LFR_SHIFT);
+
+  // Enable the PRORTC module
+  CMU->LFRCLKEN0 |= 1 << _CMU_LFRCLKEN0_PRORTC_SHIFT;
+
+  PRORTC->IFC = _PRORTC_IF_MASK;
+  PRORTC->CTRL = _PRORTC_CTRL_EN_MASK;
+#else
+  bool use_clk_lfxo  = true;
+#if _SILICON_LABS_32B_SERIES_2_CONFIG > 1
+  bool use_clk_lfrco = true;
+#endif
+
+  // Must enable radio clock branch to clock the radio bus as PRORTC is on this bus.
+  CMU->RADIOCLKCTRL = CMU_RADIOCLKCTRL_EN;
+
+#if defined(CMU_CLKEN1_PRORTC)
+  CMU->CLKEN1_SET = CMU_CLKEN1_PRORTC;
+#endif
+
+#if _SILICON_LABS_32B_SERIES_2_CONFIG > 1
+  uint32_t enabled_clocks = CMU->CLKEN0;
+  use_clk_lfxo = ((enabled_clocks & _CMU_CLKEN0_LFXO_MASK) == _CMU_CLKEN0_LFXO_MASK);
+  use_clk_lfrco = ((enabled_clocks & _CMU_CLKEN0_LFRCO_MASK) == _CMU_CLKEN0_LFRCO_MASK);
+#endif //_SILICON_LABS_32B_SERIES_2_CONFIG == 2
+
+  // On demand clocking for series 2 chips, make sure that the clock is
+  // not force disabled i.e. FORCEEN = 0, DISONDEMAND = 1
+  // Cannot rely on ENS bit of STATUS register since that is only set
+  // when a module uses the LF clock otherwise the ENS bit will be set to 0.
+  use_clk_lfxo = use_clk_lfxo
+                 && ((LFXO->CTRL
+                      & (_LFXO_CTRL_FORCEEN_MASK | _LFXO_CTRL_DISONDEMAND_MASK))
+                     != _LFXO_CTRL_DISONDEMAND_MASK);
+
+#if _SILICON_LABS_32B_SERIES_2_CONFIG > 1
+  if (!use_clk_lfxo) {
+    use_clk_lfrco = use_clk_lfrco
+                    && ((LFRCO->CTRL
+                         & (_LFRCO_CTRL_FORCEEN_MASK | _LFRCO_CTRL_DISONDEMAND_MASK))
+                        != _LFRCO_CTRL_DISONDEMAND_MASK);
+    // At this point, if LFRCO is force disabled, sleeptimer won't work.
+  }
+#endif
+
+  if (use_clk_lfxo) {
+    CMU->PRORTCCLKCTRL = CMU_PRORTCCLKCTRL_CLKSEL_LFXO;
+  } else {
+    CMU->PRORTCCLKCTRL = CMU_PRORTCCLKCTRL_CLKSEL_LFRCO;
+  }
+
+  PRORTC->EN_SET = RTCC_EN_EN;
+
+  PRORTC->CC[TIMER_COMP_REQ].CTRL = (_RTCC_CC_CTRL_MODE_OFF << _RTCC_CC_CTRL_MODE_SHIFT)
+                                    | (_RTCC_CC_CTRL_CMOA_PULSE << _RTCC_CC_CTRL_CMOA_SHIFT)
+                                    | (_RTCC_CC_CTRL_ICEDGE_NONE << _RTCC_CC_CTRL_ICEDGE_SHIFT)
+                                    | (_RTCC_CC_CTRL_COMPBASE_CNT << _RTCC_CC_CTRL_COMPBASE_SHIFT);
+
+  // Write the start bit until it syncs to the low frequency domain
+  do {
+    PRORTC->CMD = RTCC_CMD_START;
+    while ((PRORTC->SYNCBUSY & _RTCC_SYNCBUSY_MASK) != 0U) ;
+  } while ((PRORTC->STATUS & _RTCC_STATUS_RUNNING_MASK) != RTCC_STATUS_RUNNING);
+
+  // Disable ALL PRORTC interrupts
+  PRORTC->IEN &= ~_RTCC_IEN_MASK;
+
+  // Clear any pending interrupts
+#if defined (RTCC_HAS_SET_CLEAR)
+  PRORTC->IF_CLR = _RTCC_IF_MASK;
+#else
+  PRORTC->IFC = _RTCC_IF_MASK;
+#endif
+#endif
+
+  NVIC_ClearPendingIRQ(PRORTC_IRQn);
+  NVIC_EnableIRQ(PRORTC_IRQn);
+}
+
+/******************************************************************************
+ * Gets PRORTC counter value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void)
+{
+  return PRORTC->CNT;
+}
+
+/******************************************************************************
+ * Gets PRORTC compare value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void)
+{
+#if defined(_SILICON_LABS_32B_SERIES_1)
+  return PRORTC->COMP[TIMER_COMP_REQ].COMP;
+#else
+  return PRORTC->CC[TIMER_COMP_REQ].OCVALUE;
+#endif
+}
+
+/******************************************************************************
+ * Sets PRORTC compare value.
+ *****************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value)
+{
+  uint32_t counter = sleeptimer_hal_get_counter();
+  uint32_t compare = sleeptimer_hal_get_compare();
+  uint32_t compare_value = value;
+
+  if (((PRORTC->IF & PRORTC_IF_COMP_BIT) != 0)
+      || get_time_diff(compare, counter) > SLEEPTIMER_COMPARE_MIN_DIFF
+      || compare == counter) {
+    // Add margin if necessary
+    if (get_time_diff(compare_value, counter) < SLEEPTIMER_COMPARE_MIN_DIFF) {
+      compare_value = counter + SLEEPTIMER_COMPARE_MIN_DIFF;
+    }
+    compare_value %= SLEEPTIMER_TMR_WIDTH;
+
+#if defined(_SILICON_LABS_32B_SERIES_1)
+    PRORTC->COMP[TIMER_COMP_REQ].COMP = compare_value;
+#else
+    PRORTC->CC[TIMER_COMP_REQ].OCVALUE = compare_value;
+#endif
+
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+  }
+
+#if defined(_SILICON_LABS_32B_SERIES_2)
+  if (cc_disabled) {
+    PRORTC->CC[TIMER_COMP_REQ].CTRL |= RTCC_CC_CTRL_MODE_OUTPUTCOMPARE;
+    cc_disabled = false;
+  }
+#endif
+}
+
+/******************************************************************************
+ * Enables PRORTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag)
+{
+  uint32_t prortc_ien = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    prortc_ien |= PRORTC_IF_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+#if defined(_SILICON_LABS_32B_SERIES_1)
+    if (cc_disabled == true) {
+#if defined (RTCC_HAS_SET_CLEAR)
+      PRORTC->IF_CLR = PRORTC_IF_COMP_BIT;
+#else
+      PRORTC->IFC = PRORTC_IF_COMP_BIT;
+#endif
+
+      cc_disabled = false;
+    }
+#endif
+
+    prortc_ien |= PRORTC_IF_COMP_BIT;
+  }
+
+  BUS_RegMaskedSet(&PRORTC->IEN, prortc_ien);
+}
+
+/******************************************************************************
+ * Disables PRORTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag)
+{
+  uint32_t prortc_int_dis = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    prortc_int_dis |= PRORTC_IF_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    prortc_int_dis |= PRORTC_IF_COMP_BIT;
+    cc_disabled = true;
+
+#if defined(_SILICON_LABS_32B_SERIES_2)
+    PRORTC->CC[TIMER_COMP_REQ].CTRL &= ~_RTCC_CC_CTRL_MODE_MASK;
+#endif
+  }
+
+  BUS_RegMaskedClear(&PRORTC->IEN, prortc_int_dis);
+}
+
+/******************************************************************************
+ * Gets status of specified interrupt.
+ *
+ * Note: This function must be called with interrupts disabled.
+ *****************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag)
+{
+  bool int_is_set = false;
+  uint32_t irq_flag = PRORTC->IF;;
+
+  switch (local_flag) {
+    case SLEEPTIMER_EVENT_COMP:
+      int_is_set = ((irq_flag & PRORTC_IF_COMP_BIT) == PRORTC_IF_COMP_BIT);
+      break;
+
+    case SLEEPTIMER_EVENT_OF:
+      int_is_set = ((irq_flag & PRORTC_IF_OF) == PRORTC_IF_OF);
+      break;
+
+    default:
+      break;
+  }
+
+  return int_is_set;
+}
+
+/*******************************************************************************
+ * PRORTC interrupt handler.
+ ******************************************************************************/
+#if (SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER == 1)
+void PRORTC_IRQHandler(void)
+#else
+void PRORTC_IRQHandlerOverride(void)
+#endif
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint8_t local_flag = 0;
+  uint32_t irq_flag;
+
+  CORE_ENTER_ATOMIC();
+  irq_flag = PRORTC->IF;
+
+  if (irq_flag & PRORTC_IF_OF) {
+    local_flag |= SLEEPTIMER_EVENT_OF;
+  }
+  if (irq_flag & PRORTC_IF_COMP_BIT) {
+    local_flag |= SLEEPTIMER_EVENT_COMP;
+  }
+
+  /* Clear interrupt source. */
+#if defined (RTCC_HAS_SET_CLEAR)
+  PRORTC->IF_CLR = irq_flag;
+#else
+  PRORTC->IFC = irq_flag;
+#endif
+
+  process_timer_irq(local_flag);
+  CORE_EXIT_ATOMIC();
+}
+
+/*******************************************************************************
+ * Gets PRORTC timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void)
+{
+#if defined(_SILICON_LABS_32B_SERIES_1)
+  uint32_t lfr_clk_sel;
+#endif
+  uint32_t freq;
+
+#if defined(_SILICON_LABS_32B_SERIES_1)
+  lfr_clk_sel = (CMU->LFRCLKSEL & _CMU_LFRCLKSEL_LFR_MASK) << _CMU_LFRCLKSEL_LFR_SHIFT;
+
+  switch (lfr_clk_sel) {
+    case _CMU_LFRCLKSEL_LFR_LFXO:
+      freq = SystemLFXOClockGet();
+      break;
+
+#if defined(PLFRCO_PRESENT)
+    case _CMU_LFRCLKSEL_LFR_PLFRCO:
+      freq = SystemLFRCOClockGet();
+      break;
+#endif
+
+    case _CMU_LFRCLKSEL_LFR_LFRCO:
+    default:
+      freq = SystemLFRCOClockGet();
+      break;
+  }
+
+  freq >>= (CMU->LFRPRESC0 & _CMU_LFRPRESC0_PRORTC_MASK)
+           >> _CMU_LFRPRESC0_PRORTC_SHIFT;
+#elif defined(_SILICON_LABS_32B_SERIES_2)
+  if (CMU->PRORTCCLKCTRL == CMU_PRORTCCLKCTRL_CLKSEL_LFXO) {
+    freq = SystemLFXOClockGet();
+  } else {
+    freq = SystemLFRCOClockGet();
+  }
+#endif
+
+  return freq;
+}
+
+/*******************************************************************************
+ * Computes difference between two times taking into account timer wrap-around.
+ *
+ * @param a Time.
+ * @param b Time to substract from a.
+ *
+ * @return Time difference.
+ ******************************************************************************/
+static uint32_t get_time_diff(uint32_t a, uint32_t b)
+{
+  return (a - b);
+}
+
+#endif

--- a/gecko/service/sleeptimer/src/sl_sleeptimer_hal_rtc.c
+++ b/gecko/service/sleeptimer/src/sl_sleeptimer_hal_rtc.c
@@ -1,0 +1,266 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER Hardware abstraction implementation for RTC.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "em_rtc.h"
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "em_core.h"
+#include "em_cmu.h"
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_RTC
+
+// Use RTC compare channel B.
+#define SLEEPTIMER_RTC_COMP_SHIFT (2u)
+#define SLEEPTIMER_RTC_COMP       (1 << SLEEPTIMER_RTC_COMP_SHIFT)
+
+// Minimum difference between current count value and what the comparator of the timer can be set to.
+// Almost always current count + 1. However, the RTC on legacy gecko (EFM32G) requires the comparator to be set to at least current cnt + 4.
+#ifdef _EFM32_GECKO_FAMILY
+#define SLEEPTIMER_COMPARE_MIN_DIFF  5
+#else
+#define SLEEPTIMER_COMPARE_MIN_DIFF  2
+#endif
+
+#define SLEEPTIMER_TMR_WIDTH (_RTC_CNT_MASK)
+#define SLEEPTIMER_TMR_BIT_WIDTH 24u
+
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b);
+
+static volatile uint8_t rtc_overflow_count = 0;
+static volatile uint32_t compare_value_32 = 0;
+static bool comp_int_disabled = true;
+
+/******************************************************************************
+ * Initializes RTC sleep timer.
+ *****************************************************************************/
+void sleeptimer_hal_init_timer()
+{
+  RTC_Init_TypeDef rtc_init;
+
+  CMU_ClockDivSet(cmuClock_RTC, SL_SLEEPTIMER_FREQ_DIVIDER);
+  CMU_ClockEnable(cmuClock_RTC, true);
+
+  // Initialize RTC.
+  rtc_init.comp0Top = false;
+  rtc_init.debugRun = false;
+  rtc_init.enable = true;
+  RTC_Init(&rtc_init);
+  RTC_IntDisable(_RTC_IEN_MASK);
+  RTC_IntClear(_RTC_IFC_MASK);
+#if !defined(_EFM32_GECKO_FAMILY)
+  RTC_CounterSet(0u);
+#endif
+
+  // Setup RTC interrupt
+  NVIC_ClearPendingIRQ(RTC_IRQn);
+  NVIC_EnableIRQ(RTC_IRQn);
+}
+
+/******************************************************************************
+ * Gets RTC counter.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void)
+{
+  uint32_t tick_cnt;
+  uint16_t of_cnt;
+
+  tick_cnt = RTC_CounterGet();
+  of_cnt = rtc_overflow_count;
+
+  if (RTC_IntGet() & RTC_IF_OF) {
+    tick_cnt = RTC_CounterGet();
+    of_cnt++;
+  }
+
+  return tick_cnt | ((uint32_t)of_cnt << SLEEPTIMER_TMR_BIT_WIDTH);
+}
+
+/******************************************************************************
+ * Gets RTC compare value
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void)
+{
+  return compare_value_32;
+}
+
+/******************************************************************************
+ * Sets RTC compare value
+ *****************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value)
+{
+  uint32_t counter = sleeptimer_hal_get_counter();
+  uint32_t compare_value = value;
+  if (((RTC_IntGet() & SLEEPTIMER_RTC_COMP) != 0)
+      || get_time_diff(compare_value_32, counter) > SLEEPTIMER_COMPARE_MIN_DIFF
+      || compare_value_32 == counter) {
+    // Add margin if necessary
+    if (get_time_diff(compare_value, counter) < SLEEPTIMER_COMPARE_MIN_DIFF) {
+      compare_value = counter + SLEEPTIMER_COMPARE_MIN_DIFF;
+    }
+
+    compare_value_32 = compare_value;
+    if (compare_value_32 - counter <= SLEEPTIMER_TMR_WIDTH) {
+      RTC_CompareSet(1, compare_value_32 % (SLEEPTIMER_TMR_WIDTH + 1));
+      sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+    } else {
+      sleeptimer_hal_disable_int(SLEEPTIMER_EVENT_COMP);
+    }
+  }
+}
+
+/******************************************************************************
+ * Enables RTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag)
+{
+  uint32_t rtc_ien = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    rtc_ien |= RTC_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    if (comp_int_disabled == true) {
+      RTC_IntClear(SLEEPTIMER_RTC_COMP);
+      comp_int_disabled = false;
+    }
+
+    rtc_ien |= SLEEPTIMER_RTC_COMP;
+  }
+
+  RTC_IntEnable(rtc_ien);
+}
+
+/******************************************************************************
+ * Disables RTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag)
+{
+  uint32_t rtc_int_clr = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    rtc_int_clr |= RTC_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    rtc_int_clr |= SLEEPTIMER_RTC_COMP;
+    comp_int_disabled = true;
+  }
+
+  RTC_IntDisable(rtc_int_clr);
+}
+
+/******************************************************************************
+ * Gets status of specified interrupt.
+ *
+ * Note: This function must be called with interrupts disabled.
+ *****************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag)
+{
+  bool int_is_set = false;
+  uint32_t irq_flag = RTC_IntGet();
+
+  switch (local_flag) {
+    case SLEEPTIMER_EVENT_COMP:
+      int_is_set = ((irq_flag & SLEEPTIMER_RTC_COMP) == SLEEPTIMER_RTC_COMP);
+      break;
+
+    case SLEEPTIMER_EVENT_OF:
+      int_is_set = ((irq_flag & RTC_IF_OF) == RTC_IF_OF)
+                   && (((rtc_overflow_count << SLEEPTIMER_TMR_BIT_WIDTH) + SLEEPTIMER_TMR_WIDTH) == UINT32_MAX);
+      break;
+
+    default:
+      break;
+  }
+
+  return int_is_set;
+}
+
+/*******************************************************************************
+ * Gets RTC timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void)
+{
+  return CMU_ClockFreqGet(cmuClock_RTC);
+}
+
+/*******************************************************************************
+ * RTC interrupt handler.
+ ******************************************************************************/
+void RTC_IRQHandler(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint8_t local_flag = 0;
+  uint32_t irq_flag;
+  uint32_t compare_value_24 = 0;
+
+  CORE_ENTER_ATOMIC();
+  irq_flag = RTC_IntGet();
+
+  if (irq_flag & RTC_IF_OF) {
+    if (((rtc_overflow_count << SLEEPTIMER_TMR_BIT_WIDTH) + SLEEPTIMER_TMR_WIDTH) == UINT32_MAX) {
+      local_flag |= SLEEPTIMER_EVENT_OF;
+    }
+    rtc_overflow_count++;
+    compare_value_24 = compare_value_32;
+    compare_value_24 -= (rtc_overflow_count << SLEEPTIMER_TMR_BIT_WIDTH);
+    if (compare_value_24 <= SLEEPTIMER_TMR_WIDTH) {
+      RTC_CompareSet(1, compare_value_24);
+      sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+    }
+  }
+  if (irq_flag & SLEEPTIMER_RTC_COMP) {
+    local_flag |= SLEEPTIMER_EVENT_COMP;
+  }
+  RTC_IntClear(irq_flag & (RTC_IFC_OF | SLEEPTIMER_RTC_COMP));
+
+  if (local_flag != 0) {
+    process_timer_irq(local_flag);
+  }
+  CORE_EXIT_ATOMIC();
+}
+
+/*******************************************************************************
+ * Computes difference between two times taking into account timer wrap-around.
+ *
+ * @param a Time.
+ * @param b Time to substract from a.
+ *
+ * @return Time difference.
+ ******************************************************************************/
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b)
+{
+  return (a - b);
+}
+
+#endif

--- a/gecko/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c
+++ b/gecko/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c
@@ -1,0 +1,233 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER hardware abstraction implementation for RTCC.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "em_rtcc.h"
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "em_core.h"
+#include "em_cmu.h"
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_RTCC
+
+// Minimum difference between current count value and what the comparator of the timer can be set to.
+#define SLEEPTIMER_COMPARE_MIN_DIFF  2
+
+#define SLEEPTIMER_TMR_WIDTH (_RTCC_CNT_MASK)
+
+static bool cc_disabled = true;
+
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b);
+
+/******************************************************************************
+ * Initializes RTCC sleep timer.
+ *****************************************************************************/
+void sleeptimer_hal_init_timer(void)
+{
+  RTCC_Init_TypeDef rtcc_init   = RTCC_INIT_DEFAULT;
+  RTCC_CCChConf_TypeDef channel = RTCC_CH_INIT_COMPARE_DEFAULT;
+
+  CMU_ClockEnable(cmuClock_RTCC, true);
+
+  rtcc_init.enable = false;
+  rtcc_init.presc = (RTCC_CntPresc_TypeDef)(CMU_PrescToLog2(SL_SLEEPTIMER_FREQ_DIVIDER - 1));
+
+  RTCC_Init(&rtcc_init);
+
+  // Compare channel starts disabled and is enabled only when compare match interrupt is enabled.
+  channel.chMode = rtccCapComChModeOff;
+  RTCC_ChannelInit(1u, &channel);
+
+  RTCC_IntDisable(_RTCC_IEN_MASK);
+  RTCC_IntClear(_RTCC_IF_MASK);
+  RTCC_CounterSet(0u);
+
+  RTCC_Enable(true);
+
+  NVIC_ClearPendingIRQ(RTCC_IRQn);
+  NVIC_EnableIRQ(RTCC_IRQn);
+}
+
+/******************************************************************************
+ * Gets RTCC counter value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void)
+{
+  return RTCC_CounterGet();
+}
+
+/******************************************************************************
+ * Gets RTCC compare value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void)
+{
+  return RTCC_ChannelCCVGet(1u);
+}
+
+/******************************************************************************
+ * Sets RTCC compare value.
+ *****************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value)
+{
+  uint32_t counter = sleeptimer_hal_get_counter();
+  uint32_t compare = sleeptimer_hal_get_compare();
+  uint32_t compare_value = value;
+  if (((RTCC_IntGet() & RTCC_IEN_CC1) != 0)
+      || get_time_diff(compare, counter) > SLEEPTIMER_COMPARE_MIN_DIFF
+      || compare == counter) {
+    // Add margin if necessary
+    if (get_time_diff(compare_value, counter) < SLEEPTIMER_COMPARE_MIN_DIFF) {
+      compare_value = counter + SLEEPTIMER_COMPARE_MIN_DIFF;
+    }
+    compare_value %= SLEEPTIMER_TMR_WIDTH;
+
+    RTCC_ChannelCCVSet(1u, compare_value);
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+  }
+
+  if (cc_disabled) {
+    RTCC->CC[1].CTRL |= RTCC_CC_CTRL_MODE_OUTPUTCOMPARE;
+    cc_disabled = false;
+  }
+}
+
+/******************************************************************************
+ * Enables RTCC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag)
+{
+  uint32_t rtcc_ien = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    rtcc_ien |= RTCC_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    rtcc_ien |= RTCC_IEN_CC1;
+  }
+
+  RTCC_IntEnable(rtcc_ien);
+}
+
+/******************************************************************************
+ * Disables RTCC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag)
+{
+  uint32_t rtcc_int_dis = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    rtcc_int_dis |= RTCC_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    rtcc_int_dis |= RTCC_IEN_CC1;
+
+    cc_disabled = true;
+    RTCC->CC[1].CTRL &= ~_RTCC_CC_CTRL_MODE_MASK;
+  }
+
+  RTCC_IntDisable(rtcc_int_dis);
+}
+
+/******************************************************************************
+ * Gets status of specified interrupt.
+ *
+ * Note: This function must be called with interrupts disabled.
+ *****************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag)
+{
+  bool int_is_set = false;
+  uint32_t irq_flag = RTCC_IntGet();
+
+  switch (local_flag) {
+    case SLEEPTIMER_EVENT_COMP:
+      int_is_set = ((irq_flag & RTCC_IF_CC1) == RTCC_IF_CC1);
+      break;
+
+    case SLEEPTIMER_EVENT_OF:
+      int_is_set = ((irq_flag & RTCC_IF_OF) == RTCC_IF_OF);
+      break;
+
+    default:
+      break;
+  }
+
+  return int_is_set;
+}
+
+/*******************************************************************************
+ * RTCC interrupt handler.
+ ******************************************************************************/
+void RTCC_IRQHandler(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint8_t local_flag = 0;
+  uint32_t irq_flag;
+
+  CORE_ENTER_ATOMIC();
+  irq_flag = RTCC_IntGet();
+
+  if (irq_flag & RTCC_IF_OF) {
+    local_flag |= SLEEPTIMER_EVENT_OF;
+  }
+  if (irq_flag & RTCC_IF_CC1) {
+    local_flag |= SLEEPTIMER_EVENT_COMP;
+  }
+  RTCC_IntClear(irq_flag & (RTCC_IF_OF | RTCC_IF_CC1 | RTCC_IF_CC0));
+
+  process_timer_irq(local_flag);
+
+  CORE_EXIT_ATOMIC();
+}
+
+/*******************************************************************************
+ * Gets RTCC timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void)
+{
+  return (CMU_ClockFreqGet(cmuClock_RTCC) >> (CMU_PrescToLog2(SL_SLEEPTIMER_FREQ_DIVIDER - 1)));
+}
+
+/*******************************************************************************
+ * Computes difference between two times taking into account timer wrap-around.
+ *
+ * @param a Time.
+ * @param b Time to substract from a.
+ *
+ * @return Time difference.
+ ******************************************************************************/
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b)
+{
+  return (a - b);
+}
+
+#endif

--- a/gecko/service/sleeptimer/src/sli_sleeptimer_hal.h
+++ b/gecko/service/sleeptimer/src/sli_sleeptimer_hal.h
@@ -1,0 +1,114 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER hardware abstraction layer definition.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_SLEEPTIMER_HAL_H
+#define SL_SLEEPTIMER_HAL_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "em_device.h"
+#include "sli_sleeptimer.h"
+#include "sl_sleeptimer_config.h"
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_DEFAULT
+#if defined(RTCC_PRESENT) && RTCC_COUNT >= 1
+#undef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL SL_SLEEPTIMER_PERIPHERAL_RTCC
+#elif defined(RTC_PRESENT) && RTC_COUNT >= 1
+#undef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL SL_SLEEPTIMER_PERIPHERAL_RTC
+#elif defined(BURTC_PRESENT) && BURTC_COUNT >= 1
+#undef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL SL_SLEEPTIMER_PERIPHERAL_BURTC
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*******************************************************************************
+ * Hardware Abstraction Layer of the sleep timer init.
+ ******************************************************************************/
+void sleeptimer_hal_init_timer(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the current timer count.
+ *
+ * @return Value in ticks of the timer counter.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get a timer comparator value.
+ *
+ * @return Value in ticks of the timer comparator.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to set a timer comparator value.
+ *
+ * @param value Number of ticks to set.
+ ******************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to enable timer interrupts.
+ *
+ * @param local_flag Internal interrupt flag.
+ ******************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to disable timer interrupts.
+ *
+ * @param local_flag Internal interrupt flag.
+ ******************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag);
+
+/*******************************************************************************
+ * Process the timer interrupt.
+ *
+ * @param flags Internal interrupt flag.
+ ******************************************************************************/
+void process_timer_irq(uint8_t local_flag);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SL_SLEEPTIMER_HAL_H */


### PR DESCRIPTION
Allows using the RTC, RTCC or BURTC for low-energy system timers

Signed-off-by: Thorvald Natvig <thorvald@natvig.com>