### PR TITLE
modules: hal_silabs: add BLE support for EFR32XG24

### DIFF
--- a/gecko/CMakeLists.txt
+++ b/gecko/CMakeLists.txt
@@ -11,6 +11,9 @@
 # respectively.
 string(TOUPPER ${CONFIG_SOC_SERIES} SILABS_GECKO_DEVICE)
 
+# Get SoC series number, i.e. translate e.g. efr32bg22 -> 22
+string(SUBSTRING ${CONFIG_SOC_SERIES} 7 2 GECKO_SERIES_NUMBER)
+
 set(SILABS_GECKO_PART_NUMBER ${CONFIG_SOC_PART_NUMBER})
 
 if (${CONFIG_BOARD} STREQUAL "efr32_radio_brd4187c")
@@ -41,7 +44,7 @@ zephyr_include_directories(
   platform/radio/rail_lib/chip/efr32/efr32xg2x
   platform/radio/rail_lib/common
   platform/radio/rail_lib/plugin/pa-conversions
-  platform/radio/rail_lib/plugin/pa-conversions/efr32xg22/config
+  platform/radio/rail_lib/plugin/pa-conversions/efr32xg${GECKO_SERIES_NUMBER}/config
   protocol/bluetooth//bgstack/ll/inc
   service/device_init/config/s2
   service/device_init/config/s2/${PRODUCT_NO}
@@ -131,6 +134,7 @@ endfunction()
 if(CONFIG_BT_SILABS_HCI)
   # rail
   zephyr_sources(platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c)
+  zephyr_sources(platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c)
 
   # sl_protocol_crypto
   zephyr_sources(util/third_party/crypto/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_crypto.c)
@@ -138,9 +142,9 @@ if(CONFIG_BT_SILABS_HCI)
   zephyr_sources(util/third_party/crypto/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_radioaes.c)
 
   # prebuilt libs
-  add_prebuilt_library(liblinklayer gecko/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_${CONFIG_SOC_SERIES}_gcc_release.a)
-  add_prebuilt_library(libbgcommon  gecko/protocol/bluetooth/bgcommon/lib/libbgcommon_${CONFIG_SOC_SERIES}_gcc_release.a)
-  add_prebuilt_library(librail      gecko/platform/radio/rail_lib//autogen/librail_release/librail_${CONFIG_SOC_SERIES}_gcc_release.a)
+  add_prebuilt_library(liblinklayer gecko/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg${GECKO_SERIES_NUMBER}_gcc_release.a)
+  add_prebuilt_library(libbgcommon  gecko/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32xg${GECKO_SERIES_NUMBER}_gcc_release.a)
+  add_prebuilt_library(librail      gecko/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg${GECKO_SERIES_NUMBER}_gcc_release.a)
 
   # link mbedTLS
   if(CONFIG_MBEDTLS)

--- a/gecko/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config/sl_rail_util_pa_config.h
+++ b/gecko/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config/sl_rail_util_pa_config.h
@@ -1,0 +1,81 @@
+/***************************************************************************//**
+ * @file
+ * @brief Power Amplifier configuration file.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_RAIL_UTIL_PA_CONFIG_H
+#define SL_RAIL_UTIL_PA_CONFIG_H
+
+#include "rail_types.h"
+
+// <<< Use Configuration Wizard in Context Menu >>>
+// <h>PA configuration
+
+// <o SL_RAIL_UTIL_PA_POWER_DECI_DBM> Initial PA Power (deci-dBm, 100 = 10.0 dBm)
+// <i> Default: 100
+#define SL_RAIL_UTIL_PA_POWER_DECI_DBM      100
+
+// <o SL_RAIL_UTIL_PA_RAMP_TIME_US> PA Ramp Time (microseconds)
+// <0-65535:1>
+// <i> Default: 10
+#define SL_RAIL_UTIL_PA_RAMP_TIME_US        10
+
+// <o SL_RAIL_UTIL_PA_VOLTAGE_MV> Milli-volts on PA supply pin (PA_VDD)
+// <0-65535:1>
+// <i> Default: 3300
+#define SL_RAIL_UTIL_PA_VOLTAGE_MV          3300
+
+// <o SL_RAIL_UTIL_PA_SELECTION_2P4GHZ> 2.4 GHz PA Selection
+// <RAIL_TX_POWER_MODE_2P4GIG_HIGHEST=> Highest Possible
+// <RAIL_TX_POWER_MODE_2P4GIG_HP=> High Power (chip-specific)
+// <RAIL_TX_POWER_MODE_2P4GIG_LP=> Low Power
+// <RAIL_TX_POWER_MODE_NONE=> Disable
+// <i> Default: RAIL_TX_POWER_MODE_2P4GIG_HIGHEST
+#define SL_RAIL_UTIL_PA_SELECTION_2P4GHZ    RAIL_TX_POWER_MODE_2P4GIG_HIGHEST
+
+// <o SL_RAIL_UTIL_PA_SELECTION_SUBGHZ> Sub-1 GHz PA Selection
+// <RAIL_TX_POWER_MODE_NONE=> Disable
+// <i> Default: RAIL_TX_POWER_MODE_NONE
+#define SL_RAIL_UTIL_PA_SELECTION_SUBGHZ    RAIL_TX_POWER_MODE_NONE
+
+// <s.50 SL_RAIL_UTIL_PA_CURVE_HEADER> Header file containing custom PA curves
+// <i> Default: "pa_curves_efr32.h"
+#define SL_RAIL_UTIL_PA_CURVE_HEADER        "pa_curves_efr32.h"
+
+// <s.50 SL_RAIL_UTIL_PA_CURVE_TYPES> Header file containing PA curve types
+// <i> Default: "pa_curve_types_efr32.h"
+#define SL_RAIL_UTIL_PA_CURVE_TYPES         "pa_curve_types_efr32.h"
+
+// <q SL_RAIL_UTIL_PA_CALIBRATION_ENABLE> Enable PA Calibration
+// <i> Default: 0
+#define SL_RAIL_UTIL_PA_CALIBRATION_ENABLE  0
+
+// </h>
+// <<< end of configuration section >>>
+
+#endif // SL_RAIL_UTIL_PA_CONFIG_H

--- a/gecko/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/sl_rail_util_pa_curves_10dbm.h
+++ b/gecko/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/sl_rail_util_pa_curves_10dbm.h
@@ -1,0 +1,115 @@
+/***************************************************************************//**
+ * @file
+ * @brief PA power conversion curves used by Silicon Labs PA power conversion
+ *   functions.
+ * @details This file contains the curves needed convert PA power levels to
+ *   dBm powers.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef __PA_CURVES_H_
+#define __PA_CURVES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RAIL_PA_CURVES_PIECEWISE_SEGMENTS (8U)
+#define RAIL_PA_CURVES_LP_VALUES (16U)
+
+#define RAIL_PA_CURVES_2P4_HP_VBAT_MAX_POWER      100
+#define RAIL_PA_CURVES_2P4_HP_VBAT_MIN_POWER      -260
+#define RAIL_PA_CURVES_2P4_HP_VBAT_CURVES \
+  { { 65535, 0, 0 },                      \
+    { 65535, 0, 0 },                      \
+    { 90, 1644, -90531 },                 \
+    { 38, 468, 1744 },                    \
+    { 21, 223, 11774 },                   \
+    { 11, 100, 11531 },                   \
+    { 7, 61, 9783 },                      \
+    { 3, 6, 3749 } }
+
+#define RAIL_PA_CURVES_2P4_LP_VBAT_MAX_POWER      0
+#define RAIL_PA_CURVES_2P4_LP_VBAT_MIN_POWER      -260
+#define RAIL_PA_CURVES_2P4_LP_VBAT_CURVES \
+  {                                       \
+    -250, /*! Power Level 0 */            \
+    -148, /*! Power Level 1 */            \
+    -95,  /*! Power Level 2 */            \
+    -68,  /*! Power Level 3 */            \
+    -51,  /*! Power Level 4 */            \
+    -40,  /*! Power Level 5 */            \
+    -32,  /*! Power Level 6 */            \
+    -26,  /*! Power Level 7 */            \
+    -22,  /*! Power Level 8 */            \
+    -18,  /*! Power Level 9 */            \
+    -16,  /*! Power Level 10 */           \
+    -13,  /*! Power Level 11 */           \
+    -12,  /*! Power Level 12 */           \
+    -10,  /*! Power Level 13 */           \
+    -9,   /*! Power Level 14 */           \
+    -9,   /*! Power Level 15 */           \
+  }
+// *INDENT-OFF*
+// Macro to declare the variables needed to initialize RAIL_TxPowerCurvesConfig_t for use in
+// RAIL_InitTxPowerCurves, assuming battery powered operation
+#define RAIL_DECLARE_TX_POWER_VBAT_CURVES_ALT                                  \
+  static const RAIL_TxPowerCurveAlt_t RAIL_piecewiseDataHp = {                 \
+    RAIL_PA_CURVES_2P4_HP_VBAT_MAX_POWER,                                      \
+    RAIL_PA_CURVES_2P4_HP_VBAT_MIN_POWER,                                      \
+    RAIL_PA_CURVES_2P4_HP_VBAT_CURVES,                                         \
+  };                                                                           \
+  static const int16_t RAIL_curves24Lp[RAIL_PA_CURVES_LP_VALUES] =             \
+    RAIL_PA_CURVES_2P4_LP_VBAT_CURVES;
+// *INDENT-OFF*
+
+#define RAIL_DECLARE_TX_POWER_CURVES_CONFIG_ALT                                \
+  {                                                                            \
+    .curves = {                                                                \
+      {                                                                        \
+        .algorithm = RAIL_PA_ALGORITHM_PIECEWISE_LINEAR,                       \
+        .segments = RAIL_PA_CURVES_PIECEWISE_SEGMENTS,                         \
+        .min = RAIL_TX_POWER_LEVEL_2P4_HP_MIN,                                 \
+        .max = RAIL_TX_POWER_LEVEL_2P4_HP_MAX,                                 \
+        .conversion = { .powerCurve = &RAIL_piecewiseDataHp },                 \
+      },                                                                       \
+      {                                                                        \
+        .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,                          \
+        .segments = 0U,                                                        \
+        .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,                                 \
+        .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,                                 \
+        .conversion = { .mappingTable = &RAIL_curves24Lp[0] },                 \
+      },                                                                        \
+    }                                                                          \
+  }
+// *INDENT-OFF*
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/gecko/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/sl_rail_util_pa_curves_20dbm.h
+++ b/gecko/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/sl_rail_util_pa_curves_20dbm.h
@@ -1,0 +1,116 @@
+/***************************************************************************//**
+ * @file
+ * @brief PA power conversion curves used by Silicon Labs PA power conversion
+ *   functions.
+ * @details This file contains the curves needed convert PA power levels to
+ *   dBm powers.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef __PA_CURVES_H_
+#define __PA_CURVES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RAIL_PA_CURVES_PIECEWISE_SEGMENTS (8U)
+#define RAIL_PA_CURVES_LP_VALUES (16U)
+
+#define RAIL_PA_CURVES_2P4_HP_VBAT_MAX_POWER      200
+#define RAIL_PA_CURVES_2P4_HP_VBAT_MIN_POWER      -260
+#define RAIL_PA_CURVES_2P4_HP_VBAT_CURVES \
+  { { 180, 2377, -314962 },               \
+    { 72, 710, -43395 },                  \
+    { 40, 397, -6404 },                   \
+    { 24, 227, 6629 },                    \
+    { 15, 153, 9469 },                    \
+    { 9, 92, 9349 },                      \
+    { 6, 55, 7867 },                      \
+    { 3, 26, 5495 } }
+
+#define RAIL_PA_CURVES_2P4_LP_VBAT_MAX_POWER      0
+#define RAIL_PA_CURVES_2P4_LP_VBAT_MIN_POWER      -260
+#define RAIL_PA_CURVES_2P4_LP_VBAT_CURVES \
+  {                                       \
+    -250, /*! Power Level 0 */            \
+    -148, /*! Power Level 1 */            \
+    -95,  /*! Power Level 2 */            \
+    -68,  /*! Power Level 3 */            \
+    -51,  /*! Power Level 4 */            \
+    -40,  /*! Power Level 5 */            \
+    -32,  /*! Power Level 6 */            \
+    -26,  /*! Power Level 7 */            \
+    -22,  /*! Power Level 8 */            \
+    -18,  /*! Power Level 9 */            \
+    -16,  /*! Power Level 10 */           \
+    -13,  /*! Power Level 11 */           \
+    -12,  /*! Power Level 12 */           \
+    -10,  /*! Power Level 13 */           \
+    -9,   /*! Power Level 14 */           \
+    -9,   /*! Power Level 15 */           \
+  }
+
+// *INDENT-OFF*
+// Macro to declare the variables needed to initialize RAIL_TxPowerCurvesConfig_t for use in
+// RAIL_InitTxPowerCurves, assuming battery powered operation
+#define RAIL_DECLARE_TX_POWER_VBAT_CURVES_ALT                                  \
+  static const RAIL_TxPowerCurveAlt_t RAIL_piecewiseDataHp = {                 \
+    RAIL_PA_CURVES_2P4_HP_VBAT_MAX_POWER,                                      \
+    RAIL_PA_CURVES_2P4_HP_VBAT_MIN_POWER,                                      \
+    RAIL_PA_CURVES_2P4_HP_VBAT_CURVES,                                         \
+  };                                                                           \
+  static const int16_t RAIL_curves24Lp[RAIL_PA_CURVES_LP_VALUES] =             \
+    RAIL_PA_CURVES_2P4_LP_VBAT_CURVES;
+// *INDENT-OFF*
+
+#define RAIL_DECLARE_TX_POWER_CURVES_CONFIG_ALT                                \
+  {                                                                            \
+    .curves = {                                                                \
+      {                                                                        \
+        .algorithm = RAIL_PA_ALGORITHM_PIECEWISE_LINEAR,                       \
+        .segments = RAIL_PA_CURVES_PIECEWISE_SEGMENTS,                         \
+        .min = RAIL_TX_POWER_LEVEL_2P4_HP_MIN,                                 \
+        .max = RAIL_TX_POWER_LEVEL_2P4_HP_MAX,                                 \
+        .conversion = { .powerCurve = &RAIL_piecewiseDataHp },                 \
+      },                                                                       \
+      {                                                                        \
+        .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,                          \
+        .segments = 0U,                                                        \
+        .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,                                 \
+        .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,                                 \
+        .conversion = { .mappingTable = &RAIL_curves24Lp[0] },                 \
+      },                                                                        \
+    }                                                                          \
+  }
+// *INDENT-OFF*
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,7 +1,8 @@
 build:
   cmake: .
 blobs:
-  - path: gecko/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32bg22_gcc_release.a
+  # libbluetooth
+  - path: gecko/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg22_gcc_release.a
     sha256: 99b3f9abc04c20da4ad8383993275691586aa872ea72a526a544984bb99dc27e
     type: lib
     version: '4.0.2'
@@ -9,7 +10,17 @@ blobs:
     url: https://github.com/SiliconLabs/gecko_sdk/raw/gsdk_4.0/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg22_gcc_release.a
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
-  - path: gecko/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32bg22_gcc_release.a
+  - path: gecko/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a
+    sha256: f7d70a643ce70de03259aab93a56ac25d5e2a24fc730f96e7357cb5713a5f76e
+    type: lib
+    version: '4.0.2'
+    license-path: zephyr/blobs/license/MSLA.txt
+    url: https://github.com/SiliconLabs/gecko_sdk/raw/gsdk_4.0/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a
+    description: "Binary libraries supporting EFR32 RF subsystems"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+
+  # libbgcommon
+  - path: gecko/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32xg22_gcc_release.a
     sha256: 324b6a724449f83c095db76df11b8ae393b6bd090b1d94c78f2db0af3333426a
     type: lib
     version: '4.0.2'
@@ -17,11 +28,29 @@ blobs:
     url: https://github.com/SiliconLabs/gecko_sdk/raw/gsdk_4.0/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32xg22_gcc_release.a
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
-  - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_efr32bg22_gcc_release.a
+  - path: gecko/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32xg24_gcc_release.a
+    sha256: 26f4ce34228f9f7578868ead2e2a4c01e2ba1f6d0053096b5d316fca34d20eac
+    type: lib
+    version: '4.0.2'
+    license-path: zephyr/blobs/license/MSLA.txt
+    url: https://github.com/SiliconLabs/gecko_sdk/raw/gsdk_4.0/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32xg24_gcc_release.a
+    description: "Binary libraries supporting EFR32 RF subsystems"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+
+  # librail
+  - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg22_gcc_release.a
     sha256: 8e31545401df4b4dbb2ae0a5814547407a24f431e2e72bb4699a158b83396f23
     type: lib
     version: '4.0.2'
     license-path: zephyr/blobs/license/Zlib.txt
-    url: https://github.com/SiliconLabs/gecko_sdk/raw/gsdk_4.0/platform/radio/rail_lib//autogen/librail_release/librail_efr32xg22_gcc_release.a
+    url: https://github.com/SiliconLabs/gecko_sdk/raw/gsdk_4.0/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg22_gcc_release.a
+    description: "Binary libraries supporting EFR32 RF subsystems"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+  - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg24_gcc_release.a
+    sha256: 4b5947c3f0b2a762ebca11fbf27632eef8c9c68291907c232b20fe841ecd69be
+    type: lib
+    version: '4.0.2'
+    license-path: zephyr/blobs/license/Zlib.txt
+    url: https://github.com/SiliconLabs/gecko_sdk/raw/gsdk_4.0/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg24_gcc_release.a
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk


### PR DESCRIPTION
This PR adds BLE support for EFR32XG24. It includes RAIL library with binary blobs for EFR32XG24 platform. Binary blobs are downloaded with the west blobs command.