### PR TITLE
zephyr: define PRODUCT_NO for efr32bg22_brd4184b

### DIFF
--- a/gecko/CMakeLists.txt
+++ b/gecko/CMakeLists.txt
@@ -30,6 +30,11 @@ if (${CONFIG_BOARD} STREQUAL "efr32bg22_brd4184a")
   set(PRODUCT_NO "sdid205")
 endif()
 
+if (${CONFIG_BOARD} STREQUAL "efr32bg22_brd4184b")
+  set(SILABS_GECKO_BOARD "brd4184b")
+  set(PRODUCT_NO "sdid205")
+endif()
+
 if (${CONFIG_BOARD} STREQUAL "efr32bg27_brd2602a")
   set(SILABS_GECKO_BOARD "brd2602a")
   set(PRODUCT_NO "sdid205")


### PR DESCRIPTION
This will be needed for `efr32bg22_brd4184b` board support in Zephyr.