### PR TITLE
gecko/CMakeLists: don't error out on missing SOC_GECKO_SERIES1/2

### DIFF
--- a/gecko/CMakeLists.txt
+++ b/gecko/CMakeLists.txt
@@ -50,8 +50,6 @@ elseif(${CONFIG_SOC_GECKO_SERIES2})
     platform/radio/rail_lib/plugin/pa-conversions/efr32xg${GECKO_SERIES_NUMBER}/config
     platform/radio/rail_lib/chip/efr32/efr32xg2x
   )
-else()
-  message(FATAL_ERROR "Unknown gecko series type. Is CONFIG_SOC_GECKO_SERIES1/2 set?")
 endif()
 
 zephyr_include_directories(


### PR DESCRIPTION
Right now, CMake errors out if either `CONFIG_SOC_GECKO_SERIES1` or `CONFIG_SOC_GECKO_SERIES2` is undefined. This check is for adding the right RAIL headers for the chosen SoC series.

Using RAIL is not required for normal SoC operation in Zephyr, so erroring out here is not required.