### PR TITLE
gecko: Update BG22, BG27 and MG24 Device files | Update to GSDK 4.4.0

### DIFF
--- a/gecko/Device/SiliconLabs/EFR32BG22/Include/efr32bg22_syscfg.h
+++ b/gecko/Device/SiliconLabs/EFR32BG22/Include/efr32bg22_syscfg.h
@@ -298,7 +298,15 @@ typedef struct {
 #define _SYSCFG_CHIPREV_FAMILY_SHIFT                       6                                     /**< Shift value for SYSCFG_FAMILY               */
 #define _SYSCFG_CHIPREV_FAMILY_MASK                        0xFC0UL                               /**< Bit mask for SYSCFG_FAMILY                  */
 #define _SYSCFG_CHIPREV_FAMILY_DEFAULT                     0x00000000UL                          /**< Mode DEFAULT for SYSCFG_CHIPREV             */
+#define _SYSCFG_CHIPREV_FAMILY_PG22                        0x00000018UL                          /**< Mode PG22 for SYSCFG_CHIPREV                */
+#define _SYSCFG_CHIPREV_FAMILY_MG22                        0x00000034UL                          /**< Mode MG22 for SYSCFG_CHIPREV                */
+#define _SYSCFG_CHIPREV_FAMILY_BG22                        0x00000035UL                          /**< Mode BG22 for SYSCFG_CHIPREV                */
+#define _SYSCFG_CHIPREV_FAMILY_FG22                        0x00000037UL                          /**< Mode FG22 for SYSCFG_CHIPREV                */
 #define SYSCFG_CHIPREV_FAMILY_DEFAULT                      (_SYSCFG_CHIPREV_FAMILY_DEFAULT << 6) /**< Shifted mode DEFAULT for SYSCFG_CHIPREV     */
+#define SYSCFG_CHIPREV_FAMILY_PG22                         (_SYSCFG_CHIPREV_FAMILY_PG22 << 6)    /**< Shifted mode PG22 for SYSCFG_CHIPREV        */
+#define SYSCFG_CHIPREV_FAMILY_MG22                         (_SYSCFG_CHIPREV_FAMILY_MG22 << 6)    /**< Shifted mode MG22 for SYSCFG_CHIPREV        */
+#define SYSCFG_CHIPREV_FAMILY_BG22                         (_SYSCFG_CHIPREV_FAMILY_BG22 << 6)    /**< Shifted mode BG22 for SYSCFG_CHIPREV        */
+#define SYSCFG_CHIPREV_FAMILY_FG22                         (_SYSCFG_CHIPREV_FAMILY_FG22 << 6)    /**< Shifted mode FG22 for SYSCFG_CHIPREV        */
 #define _SYSCFG_CHIPREV_MINOR_SHIFT                        12                                    /**< Shift value for SYSCFG_MINOR                */
 #define _SYSCFG_CHIPREV_MINOR_MASK                         0xFF000UL                             /**< Bit mask for SYSCFG_MINOR                   */
 #define _SYSCFG_CHIPREV_MINOR_DEFAULT                      0x00000000UL                          /**< Mode DEFAULT for SYSCFG_CHIPREV             */
@@ -588,4 +596,4 @@ typedef struct {
 /** @} End of group EFR32BG22_SYSCFG_CFGNS */
 /** @} End of group Parts */
 
-#endif /* EFR32BG22_SYSCFG_H */
+#endif // EFR32BG22_SYSCFG_H

--- a/gecko/Device/SiliconLabs/EFR32BG22/Include/system_efr32bg22.h
+++ b/gecko/Device/SiliconLabs/EFR32BG22/Include/system_efr32bg22.h
@@ -206,6 +206,11 @@ static __INLINE void SystemCoreClockUpdate(void)
 }
 
 void     SystemInit(void);
+#if !defined(SL_LEGACY_LINKER)
+void     FlashToRamCopy(uint32_t *from,
+                        uint32_t *to,
+                        uint32_t size);
+#endif
 uint32_t SystemHFRCODPLLClockGet(void);
 void     SystemHFRCODPLLClockSet(uint32_t freq);
 uint32_t SystemSYSCLKGet(void);

--- a/gecko/Device/SiliconLabs/EFR32BG22/Source/system_efr32bg22.c
+++ b/gecko/Device/SiliconLabs/EFR32BG22/Source/system_efr32bg22.c
@@ -189,6 +189,35 @@ void SystemInit(void)
 #endif /*SL_TRUSTZONE_SECURE */
 }
 
+#if !defined(SL_LEGACY_LINKER)
+/**************************************************************************//**
+ * @brief
+ *   Copy data.
+ *
+ * @details
+ *   Used to copy data from Flash to Ram at startup and runtime.
+ *
+ * @param[in] from
+ *   Pointer to the source address in Flash.
+ *
+ * @param[in] to
+ *   Pointer to the destination address in Ram.
+ *
+ * @param[in] size
+ *   Size of data to copy.
+ *****************************************************************************/
+void FlashToRamCopy(uint32_t *from,
+                    uint32_t *to,
+                    uint32_t size)
+{
+  if (size != 0) {
+    while (size--) {
+      *to++ = *from++;
+    }
+  }
+}
+#endif
+
 /**************************************************************************//**
  * @brief
  *   Get current HFRCODPLL frequency.

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_dcdc.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_dcdc.h
@@ -249,15 +249,9 @@ typedef struct {
 #define _DCDC_EM01CTRL0_DRVSPEED_SHIFT                8                                               /**< Shift value for DCDC_DRVSPEED               */
 #define _DCDC_EM01CTRL0_DRVSPEED_MASK                 0x300UL                                         /**< Bit mask for DCDC_DRVSPEED                  */
 #define _DCDC_EM01CTRL0_DRVSPEED_DEFAULT              0x00000001UL                                    /**< Mode DEFAULT for DCDC_EM01CTRL0             */
-#define _DCDC_EM01CTRL0_DRVSPEED_BEST_EMI             0x00000000UL                                    /**< Mode BEST_EMI for DCDC_EM01CTRL0            */
 #define _DCDC_EM01CTRL0_DRVSPEED_DEFAULT_SETTING      0x00000001UL                                    /**< Mode DEFAULT_SETTING for DCDC_EM01CTRL0     */
-#define _DCDC_EM01CTRL0_DRVSPEED_INTERMEDIATE         0x00000002UL                                    /**< Mode INTERMEDIATE for DCDC_EM01CTRL0        */
-#define _DCDC_EM01CTRL0_DRVSPEED_BEST_EFFICIENCY      0x00000003UL                                    /**< Mode BEST_EFFICIENCY for DCDC_EM01CTRL0     */
 #define DCDC_EM01CTRL0_DRVSPEED_DEFAULT               (_DCDC_EM01CTRL0_DRVSPEED_DEFAULT << 8)         /**< Shifted mode DEFAULT for DCDC_EM01CTRL0     */
-#define DCDC_EM01CTRL0_DRVSPEED_BEST_EMI              (_DCDC_EM01CTRL0_DRVSPEED_BEST_EMI << 8)        /**< Shifted mode BEST_EMI for DCDC_EM01CTRL0    */
 #define DCDC_EM01CTRL0_DRVSPEED_DEFAULT_SETTING       (_DCDC_EM01CTRL0_DRVSPEED_DEFAULT_SETTING << 8) /**< Shifted mode DEFAULT_SETTING for DCDC_EM01CTRL0*/
-#define DCDC_EM01CTRL0_DRVSPEED_INTERMEDIATE          (_DCDC_EM01CTRL0_DRVSPEED_INTERMEDIATE << 8)    /**< Shifted mode INTERMEDIATE for DCDC_EM01CTRL0*/
-#define DCDC_EM01CTRL0_DRVSPEED_BEST_EFFICIENCY       (_DCDC_EM01CTRL0_DRVSPEED_BEST_EFFICIENCY << 8) /**< Shifted mode BEST_EFFICIENCY for DCDC_EM01CTRL0*/
 
 /* Bit fields for DCDC EM23CTRL0 */
 #define _DCDC_EM23CTRL0_RESETVALUE                    0x00000103UL                                    /**< Default value for DCDC_EM23CTRL0            */
@@ -273,15 +267,9 @@ typedef struct {
 #define _DCDC_EM23CTRL0_DRVSPEED_SHIFT                8                                               /**< Shift value for DCDC_DRVSPEED               */
 #define _DCDC_EM23CTRL0_DRVSPEED_MASK                 0x300UL                                         /**< Bit mask for DCDC_DRVSPEED                  */
 #define _DCDC_EM23CTRL0_DRVSPEED_DEFAULT              0x00000001UL                                    /**< Mode DEFAULT for DCDC_EM23CTRL0             */
-#define _DCDC_EM23CTRL0_DRVSPEED_BEST_EMI             0x00000000UL                                    /**< Mode BEST_EMI for DCDC_EM23CTRL0            */
 #define _DCDC_EM23CTRL0_DRVSPEED_DEFAULT_SETTING      0x00000001UL                                    /**< Mode DEFAULT_SETTING for DCDC_EM23CTRL0     */
-#define _DCDC_EM23CTRL0_DRVSPEED_INTERMEDIATE         0x00000002UL                                    /**< Mode INTERMEDIATE for DCDC_EM23CTRL0        */
-#define _DCDC_EM23CTRL0_DRVSPEED_BEST_EFFICIENCY      0x00000003UL                                    /**< Mode BEST_EFFICIENCY for DCDC_EM23CTRL0     */
 #define DCDC_EM23CTRL0_DRVSPEED_DEFAULT               (_DCDC_EM23CTRL0_DRVSPEED_DEFAULT << 8)         /**< Shifted mode DEFAULT for DCDC_EM23CTRL0     */
-#define DCDC_EM23CTRL0_DRVSPEED_BEST_EMI              (_DCDC_EM23CTRL0_DRVSPEED_BEST_EMI << 8)        /**< Shifted mode BEST_EMI for DCDC_EM23CTRL0    */
 #define DCDC_EM23CTRL0_DRVSPEED_DEFAULT_SETTING       (_DCDC_EM23CTRL0_DRVSPEED_DEFAULT_SETTING << 8) /**< Shifted mode DEFAULT_SETTING for DCDC_EM23CTRL0*/
-#define DCDC_EM23CTRL0_DRVSPEED_INTERMEDIATE          (_DCDC_EM23CTRL0_DRVSPEED_INTERMEDIATE << 8)    /**< Shifted mode INTERMEDIATE for DCDC_EM23CTRL0*/
-#define DCDC_EM23CTRL0_DRVSPEED_BEST_EFFICIENCY       (_DCDC_EM23CTRL0_DRVSPEED_BEST_EFFICIENCY << 8) /**< Shifted mode BEST_EFFICIENCY for DCDC_EM23CTRL0*/
 
 /* Bit fields for DCDC BSTCTRL */
 #define _DCDC_BSTCTRL_RESETVALUE                      0x00000047UL                                 /**< Default value for DCDC_BSTCTRL              */
@@ -328,21 +316,22 @@ typedef struct {
 #define DCDC_BSTCTRL_IPKTMAXCTRL_TMAX_2P03us          (_DCDC_BSTCTRL_IPKTMAXCTRL_TMAX_2P03us << 4) /**< Shifted mode TMAX_2P03us for DCDC_BSTCTRL   */
 
 /* Bit fields for DCDC BSTEM01CTRL */
-#define _DCDC_BSTEM01CTRL_RESETVALUE                  0x0000010CUL                                      /**< Default value for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_RESETVALUE                  0x0000010DUL                                      /**< Default value for DCDC_BSTEM01CTRL          */
 #define _DCDC_BSTEM01CTRL_MASK                        0x0000030FUL                                      /**< Mask for DCDC_BSTEM01CTRL                   */
 #define _DCDC_BSTEM01CTRL_IPKVAL_SHIFT                0                                                 /**< Shift value for DCDC_IPKVAL                 */
 #define _DCDC_BSTEM01CTRL_IPKVAL_MASK                 0xFUL                                             /**< Bit mask for DCDC_IPKVAL                    */
-#define _DCDC_BSTEM01CTRL_IPKVAL_DEFAULT              0x0000000CUL                                      /**< Mode DEFAULT for DCDC_BSTEM01CTRL           */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load10mA             0x00000003UL                                      /**< Mode Load10mA for DCDC_BSTEM01CTRL          */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load11mA             0x00000004UL                                      /**< Mode Load11mA for DCDC_BSTEM01CTRL          */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load13mA             0x00000005UL                                      /**< Mode Load13mA for DCDC_BSTEM01CTRL          */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load15mA             0x00000006UL                                      /**< Mode Load15mA for DCDC_BSTEM01CTRL          */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load16mA             0x00000007UL                                      /**< Mode Load16mA for DCDC_BSTEM01CTRL          */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load18mA             0x00000008UL                                      /**< Mode Load18mA for DCDC_BSTEM01CTRL          */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load20mA             0x00000009UL                                      /**< Mode Load20mA for DCDC_BSTEM01CTRL          */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load21mA             0x0000000AUL                                      /**< Mode Load21mA for DCDC_BSTEM01CTRL          */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load23mA             0x0000000BUL                                      /**< Mode Load23mA for DCDC_BSTEM01CTRL          */
-#define _DCDC_BSTEM01CTRL_IPKVAL_Load25mA             0x0000000CUL                                      /**< Mode Load25mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_DEFAULT              0x0000000DUL                                      /**< Mode DEFAULT for DCDC_BSTEM01CTRL           */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load10mA             0x00000004UL                                      /**< Mode Load10mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load11mA             0x00000005UL                                      /**< Mode Load11mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load13mA             0x00000006UL                                      /**< Mode Load13mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load15mA             0x00000007UL                                      /**< Mode Load15mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load16mA             0x00000008UL                                      /**< Mode Load16mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load18mA             0x00000009UL                                      /**< Mode Load18mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load20mA             0x0000000AUL                                      /**< Mode Load20mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load21mA             0x0000000BUL                                      /**< Mode Load21mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load23mA             0x0000000CUL                                      /**< Mode Load23mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load25mA             0x0000000DUL                                      /**< Mode Load25mA for DCDC_BSTEM01CTRL          */
+#define _DCDC_BSTEM01CTRL_IPKVAL_Load26mA             0x0000000EUL                                      /**< Mode Load26mA for DCDC_BSTEM01CTRL          */
 #define DCDC_BSTEM01CTRL_IPKVAL_DEFAULT               (_DCDC_BSTEM01CTRL_IPKVAL_DEFAULT << 0)           /**< Shifted mode DEFAULT for DCDC_BSTEM01CTRL   */
 #define DCDC_BSTEM01CTRL_IPKVAL_Load10mA              (_DCDC_BSTEM01CTRL_IPKVAL_Load10mA << 0)          /**< Shifted mode Load10mA for DCDC_BSTEM01CTRL  */
 #define DCDC_BSTEM01CTRL_IPKVAL_Load11mA              (_DCDC_BSTEM01CTRL_IPKVAL_Load11mA << 0)          /**< Shifted mode Load11mA for DCDC_BSTEM01CTRL  */
@@ -354,40 +343,31 @@ typedef struct {
 #define DCDC_BSTEM01CTRL_IPKVAL_Load21mA              (_DCDC_BSTEM01CTRL_IPKVAL_Load21mA << 0)          /**< Shifted mode Load21mA for DCDC_BSTEM01CTRL  */
 #define DCDC_BSTEM01CTRL_IPKVAL_Load23mA              (_DCDC_BSTEM01CTRL_IPKVAL_Load23mA << 0)          /**< Shifted mode Load23mA for DCDC_BSTEM01CTRL  */
 #define DCDC_BSTEM01CTRL_IPKVAL_Load25mA              (_DCDC_BSTEM01CTRL_IPKVAL_Load25mA << 0)          /**< Shifted mode Load25mA for DCDC_BSTEM01CTRL  */
+#define DCDC_BSTEM01CTRL_IPKVAL_Load26mA              (_DCDC_BSTEM01CTRL_IPKVAL_Load26mA << 0)          /**< Shifted mode Load26mA for DCDC_BSTEM01CTRL  */
 #define _DCDC_BSTEM01CTRL_DRVSPEED_SHIFT              8                                                 /**< Shift value for DCDC_DRVSPEED               */
 #define _DCDC_BSTEM01CTRL_DRVSPEED_MASK               0x300UL                                           /**< Bit mask for DCDC_DRVSPEED                  */
 #define _DCDC_BSTEM01CTRL_DRVSPEED_DEFAULT            0x00000001UL                                      /**< Mode DEFAULT for DCDC_BSTEM01CTRL           */
-#define _DCDC_BSTEM01CTRL_DRVSPEED_BEST_EMI           0x00000000UL                                      /**< Mode BEST_EMI for DCDC_BSTEM01CTRL          */
 #define _DCDC_BSTEM01CTRL_DRVSPEED_DEFAULT_SETTING    0x00000001UL                                      /**< Mode DEFAULT_SETTING for DCDC_BSTEM01CTRL   */
-#define _DCDC_BSTEM01CTRL_DRVSPEED_INTERMEDIATE       0x00000002UL                                      /**< Mode INTERMEDIATE for DCDC_BSTEM01CTRL      */
-#define _DCDC_BSTEM01CTRL_DRVSPEED_BEST_EFFICIENCY    0x00000003UL                                      /**< Mode BEST_EFFICIENCY for DCDC_BSTEM01CTRL   */
 #define DCDC_BSTEM01CTRL_DRVSPEED_DEFAULT             (_DCDC_BSTEM01CTRL_DRVSPEED_DEFAULT << 8)         /**< Shifted mode DEFAULT for DCDC_BSTEM01CTRL   */
-#define DCDC_BSTEM01CTRL_DRVSPEED_BEST_EMI            (_DCDC_BSTEM01CTRL_DRVSPEED_BEST_EMI << 8)        /**< Shifted mode BEST_EMI for DCDC_BSTEM01CTRL  */
 #define DCDC_BSTEM01CTRL_DRVSPEED_DEFAULT_SETTING     (_DCDC_BSTEM01CTRL_DRVSPEED_DEFAULT_SETTING << 8) /**< Shifted mode DEFAULT_SETTING for DCDC_BSTEM01CTRL*/
-#define DCDC_BSTEM01CTRL_DRVSPEED_INTERMEDIATE        (_DCDC_BSTEM01CTRL_DRVSPEED_INTERMEDIATE << 8)    /**< Shifted mode INTERMEDIATE for DCDC_BSTEM01CTRL*/
-#define DCDC_BSTEM01CTRL_DRVSPEED_BEST_EFFICIENCY     (_DCDC_BSTEM01CTRL_DRVSPEED_BEST_EFFICIENCY << 8) /**< Shifted mode BEST_EFFICIENCY for DCDC_BSTEM01CTRL*/
 
 /* Bit fields for DCDC BSTEM23CTRL */
-#define _DCDC_BSTEM23CTRL_RESETVALUE                  0x00000109UL                                      /**< Default value for DCDC_BSTEM23CTRL          */
+#define _DCDC_BSTEM23CTRL_RESETVALUE                  0x0000010AUL                                      /**< Default value for DCDC_BSTEM23CTRL          */
 #define _DCDC_BSTEM23CTRL_MASK                        0x0000030FUL                                      /**< Mask for DCDC_BSTEM23CTRL                   */
 #define _DCDC_BSTEM23CTRL_IPKVAL_SHIFT                0                                                 /**< Shift value for DCDC_IPKVAL                 */
 #define _DCDC_BSTEM23CTRL_IPKVAL_MASK                 0xFUL                                             /**< Bit mask for DCDC_IPKVAL                    */
-#define _DCDC_BSTEM23CTRL_IPKVAL_DEFAULT              0x00000009UL                                      /**< Mode DEFAULT for DCDC_BSTEM23CTRL           */
-#define _DCDC_BSTEM23CTRL_IPKVAL_Load10mA             0x00000009UL                                      /**< Mode Load10mA for DCDC_BSTEM23CTRL          */
+#define _DCDC_BSTEM23CTRL_IPKVAL_DEFAULT              0x0000000AUL                                      /**< Mode DEFAULT for DCDC_BSTEM23CTRL           */
+#define _DCDC_BSTEM23CTRL_IPKVAL_Load5mA              0x00000004UL                                      /**< Mode Load5mA for DCDC_BSTEM23CTRL           */
+#define _DCDC_BSTEM23CTRL_IPKVAL_Load10mA             0x0000000AUL                                      /**< Mode Load10mA for DCDC_BSTEM23CTRL          */
 #define DCDC_BSTEM23CTRL_IPKVAL_DEFAULT               (_DCDC_BSTEM23CTRL_IPKVAL_DEFAULT << 0)           /**< Shifted mode DEFAULT for DCDC_BSTEM23CTRL   */
+#define DCDC_BSTEM23CTRL_IPKVAL_Load5mA               (_DCDC_BSTEM23CTRL_IPKVAL_Load5mA << 0)           /**< Shifted mode Load5mA for DCDC_BSTEM23CTRL   */
 #define DCDC_BSTEM23CTRL_IPKVAL_Load10mA              (_DCDC_BSTEM23CTRL_IPKVAL_Load10mA << 0)          /**< Shifted mode Load10mA for DCDC_BSTEM23CTRL  */
 #define _DCDC_BSTEM23CTRL_DRVSPEED_SHIFT              8                                                 /**< Shift value for DCDC_DRVSPEED               */
 #define _DCDC_BSTEM23CTRL_DRVSPEED_MASK               0x300UL                                           /**< Bit mask for DCDC_DRVSPEED                  */
 #define _DCDC_BSTEM23CTRL_DRVSPEED_DEFAULT            0x00000001UL                                      /**< Mode DEFAULT for DCDC_BSTEM23CTRL           */
-#define _DCDC_BSTEM23CTRL_DRVSPEED_BEST_EMI           0x00000000UL                                      /**< Mode BEST_EMI for DCDC_BSTEM23CTRL          */
 #define _DCDC_BSTEM23CTRL_DRVSPEED_DEFAULT_SETTING    0x00000001UL                                      /**< Mode DEFAULT_SETTING for DCDC_BSTEM23CTRL   */
-#define _DCDC_BSTEM23CTRL_DRVSPEED_INTERMEDIATE       0x00000002UL                                      /**< Mode INTERMEDIATE for DCDC_BSTEM23CTRL      */
-#define _DCDC_BSTEM23CTRL_DRVSPEED_BEST_EFFICIENCY    0x00000003UL                                      /**< Mode BEST_EFFICIENCY for DCDC_BSTEM23CTRL   */
 #define DCDC_BSTEM23CTRL_DRVSPEED_DEFAULT             (_DCDC_BSTEM23CTRL_DRVSPEED_DEFAULT << 8)         /**< Shifted mode DEFAULT for DCDC_BSTEM23CTRL   */
-#define DCDC_BSTEM23CTRL_DRVSPEED_BEST_EMI            (_DCDC_BSTEM23CTRL_DRVSPEED_BEST_EMI << 8)        /**< Shifted mode BEST_EMI for DCDC_BSTEM23CTRL  */
 #define DCDC_BSTEM23CTRL_DRVSPEED_DEFAULT_SETTING     (_DCDC_BSTEM23CTRL_DRVSPEED_DEFAULT_SETTING << 8) /**< Shifted mode DEFAULT_SETTING for DCDC_BSTEM23CTRL*/
-#define DCDC_BSTEM23CTRL_DRVSPEED_INTERMEDIATE        (_DCDC_BSTEM23CTRL_DRVSPEED_INTERMEDIATE << 8)    /**< Shifted mode INTERMEDIATE for DCDC_BSTEM23CTRL*/
-#define DCDC_BSTEM23CTRL_DRVSPEED_BEST_EFFICIENCY     (_DCDC_BSTEM23CTRL_DRVSPEED_BEST_EFFICIENCY << 8) /**< Shifted mode BEST_EFFICIENCY for DCDC_BSTEM23CTRL*/
 
 /* Bit fields for DCDC IF */
 #define _DCDC_IF_RESETVALUE                           0x00000000UL                       /**< Default value for DCDC_IF                   */
@@ -699,4 +679,4 @@ typedef struct {
 /** @} End of group EFR32BG27_DCDC */
 /** @} End of group Parts */
 
-#endif /* EFR32BG27_DCDC_H */
+#endif // EFR32BG27_DCDC_H

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_devinfo.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_devinfo.h
@@ -147,15 +147,11 @@ typedef struct {
 #define _DEVINFO_PART_FAMILY_SHIFT                               24                                      /**< Shift value for DEVINFO_FAMILY              */
 #define _DEVINFO_PART_FAMILY_MASK                                0x3F000000UL                            /**< Bit mask for DEVINFO_FAMILY                 */
 #define _DEVINFO_PART_FAMILY_DEFAULT                             0x00000000UL                            /**< Mode DEFAULT for DEVINFO_PART               */
-#define _DEVINFO_PART_FAMILY_FG                                  0x00000000UL                            /**< Mode FG for DEVINFO_PART                    */
 #define _DEVINFO_PART_FAMILY_MG                                  0x00000001UL                            /**< Mode MG for DEVINFO_PART                    */
 #define _DEVINFO_PART_FAMILY_BG                                  0x00000002UL                            /**< Mode BG for DEVINFO_PART                    */
-#define _DEVINFO_PART_FAMILY_PG                                  0x00000005UL                            /**< Mode PG for DEVINFO_PART                    */
 #define DEVINFO_PART_FAMILY_DEFAULT                              (_DEVINFO_PART_FAMILY_DEFAULT << 24)    /**< Shifted mode DEFAULT for DEVINFO_PART       */
-#define DEVINFO_PART_FAMILY_FG                                   (_DEVINFO_PART_FAMILY_FG << 24)         /**< Shifted mode FG for DEVINFO_PART            */
 #define DEVINFO_PART_FAMILY_MG                                   (_DEVINFO_PART_FAMILY_MG << 24)         /**< Shifted mode MG for DEVINFO_PART            */
 #define DEVINFO_PART_FAMILY_BG                                   (_DEVINFO_PART_FAMILY_BG << 24)         /**< Shifted mode BG for DEVINFO_PART            */
-#define DEVINFO_PART_FAMILY_PG                                   (_DEVINFO_PART_FAMILY_PG << 24)         /**< Shifted mode PG for DEVINFO_PART            */
 
 /* Bit fields for DEVINFO MEMINFO */
 #define _DEVINFO_MEMINFO_RESETVALUE                              0x00000000UL                                  /**< Default value for DEVINFO_MEMINFO           */

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_eusart.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_eusart.h
@@ -497,7 +497,10 @@ typedef struct {
 #define EUSART_CFG1_RXFIW_THIRTEENFRAMES            (_EUSART_CFG1_RXFIW_THIRTEENFRAMES << 27)   /**< Shifted mode THIRTEENFRAMES for EUSART_CFG1 */
 #define EUSART_CFG1_RXFIW_FOURTEENFRAMES            (_EUSART_CFG1_RXFIW_FOURTEENFRAMES << 27)   /**< Shifted mode FOURTEENFRAMES for EUSART_CFG1 */
 #define EUSART_CFG1_RXFIW_FIFTEENFRAMES             (_EUSART_CFG1_RXFIW_FIFTEENFRAMES << 27)    /**< Shifted mode FIFTEENFRAMES for EUSART_CFG1  */
-#define EUSART_CFG1_RXFIW_SIXTEENFRAMES             (_EUSART_CFG1_RXFIW_SIXTEENFRAMES << 27)    /**< Shifted mode SIXTEENFRAMES for EUSART_CFG1  */  * Bit fields for EUSART CFG2 */  define _EUSART_CFG2_RESETVALUE                     0x00000020UL                              /**< Default value for EUSART_CFG2               */
+#define EUSART_CFG1_RXFIW_SIXTEENFRAMES             (_EUSART_CFG1_RXFIW_SIXTEENFRAMES << 27)    /**< Shifted mode SIXTEENFRAMES for EUSART_CFG1  */
+
+/* Bit fields for EUSART CFG2 */
+#define _EUSART_CFG2_RESETVALUE                     0x00000020UL                              /**< Default value for EUSART_CFG2               */
 #define _EUSART_CFG2_MASK                           0xFF0000FFUL                              /**< Mask for EUSART_CFG2                        */
 #define EUSART_CFG2_MASTER                          (0x1UL << 0)                              /**< Master mode                                 */
 #define _EUSART_CFG2_MASTER_SHIFT                   0                                         /**< Shift value for EUSART_MASTER               */

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_gpio.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_gpio.h
@@ -791,7 +791,7 @@ typedef struct {
 #define _GPIO_EXTIPINSELH_EXTIPINSEL3_PIN9              0x00000001UL                                   /**< Mode PIN9 for GPIO_EXTIPINSELH              */
 #define _GPIO_EXTIPINSELH_EXTIPINSEL3_PIN10             0x00000002UL                                   /**< Mode PIN10 for GPIO_EXTIPINSELH             */
 #define _GPIO_EXTIPINSELH_EXTIPINSEL3_PIN11             0x00000003UL                                   /**< Mode PIN11 for GPIO_EXTIPINSELH             */
-#define GPIO_EXTIPINSELH_EXTIPINSEL3_DEFAULT            (_GPIO_EXTIPINSELH_EXTIPINSEL3_DEFAULT << 12   /**< Shifted mode DEFAULT for GPIO_EXTIPINSELH   */
+#define GPIO_EXTIPINSELH_EXTIPINSEL3_DEFAULT            (_GPIO_EXTIPINSELH_EXTIPINSEL3_DEFAULT << 12)   /**< Shifted mode DEFAULT for GPIO_EXTIPINSELH   */
 #define GPIO_EXTIPINSELH_EXTIPINSEL3_PIN8               (_GPIO_EXTIPINSELH_EXTIPINSEL3_PIN8 << 12)     /**< Shifted mode PIN8 for GPIO_EXTIPINSELH      */
 #define GPIO_EXTIPINSELH_EXTIPINSEL3_PIN9               (_GPIO_EXTIPINSELH_EXTIPINSEL3_PIN9 << 12)     /**< Shifted mode PIN9 for GPIO_EXTIPINSELH      */
 #define GPIO_EXTIPINSELH_EXTIPINSEL3_PIN10              (_GPIO_EXTIPINSELH_EXTIPINSEL3_PIN10 << 12)    /**< Shifted mode PIN10 for GPIO_EXTIPINSELH     */

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_ldma.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27_ldma.h
@@ -191,7 +191,7 @@ typedef struct {
 #define LDMA_CTRL_CORERST_DEFAULT               (_LDMA_CTRL_CORERST_DEFAULT << 31)      /**< Shifted mode DEFAULT for LDMA_CTRL          */
 
 /* Bit fields for LDMA STATUS */
-#define _LDMA_STATUS_RESETVALUE                 0x1F100000UL                            /**< Default value for LDMA_STATUS               */
+#define _LDMA_STATUS_RESETVALUE                 0x08100000UL                            /**< Default value for LDMA_STATUS               */
 #define _LDMA_STATUS_MASK                       0x1F1F1FFBUL                            /**< Mask for LDMA_STATUS                        */
 #define LDMA_STATUS_ANYBUSY                     (0x1UL << 0)                            /**< Any DMA Channel Busy                        */
 #define _LDMA_STATUS_ANYBUSY_SHIFT              0                                       /**< Shift value for LDMA_ANYBUSY                */
@@ -217,7 +217,7 @@ typedef struct {
 #define LDMA_STATUS_FIFOLEVEL_DEFAULT           (_LDMA_STATUS_FIFOLEVEL_DEFAULT << 16)  /**< Shifted mode DEFAULT for LDMA_STATUS        */
 #define _LDMA_STATUS_CHNUM_SHIFT                24                                      /**< Shift value for LDMA_CHNUM                  */
 #define _LDMA_STATUS_CHNUM_MASK                 0x1F000000UL                            /**< Bit mask for LDMA_CHNUM                     */
-#define _LDMA_STATUS_CHNUM_DEFAULT              0x0000001FUL                            /**< Mode DEFAULT for LDMA_STATUS                */
+#define _LDMA_STATUS_CHNUM_DEFAULT              0x00000008UL                            /**< Mode DEFAULT for LDMA_STATUS                */
 #define LDMA_STATUS_CHNUM_DEFAULT               (_LDMA_STATUS_CHNUM_DEFAULT << 24)      /**< Shifted mode DEFAULT for LDMA_STATUS        */
 
 /* Bit fields for LDMA SYNCSWSET */

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c140f768im32.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c140f768im32.h
@@ -1284,6 +1284,28 @@ typedef enum IRQn{
                                         : ((n) == 1) ? I2C1_DELAY_CHAIN_NUM \
                                         : 0x0UL)
 
+/* Instance macros for IADC */
+#define IADC(n)                        (((n) == 0) ? IADC0 \
+                                        : 0x0UL)
+#define IADC_NUM(ref)                  (((ref) == IADC0) ? 0 \
+                                        : -1)
+#define IADC_CONFIGNUM(n)              (((n) == 0) ? IADC0_CONFIGNUM \
+                                        : 0x0UL)
+#define IADC_FULLRANGEUNIPOLAR(n)      (((n) == 0) ? IADC0_FULLRANGEUNIPOLAR \
+                                        : 0x0UL)
+#define IADC_SCANBYTES(n)              (((n) == 0) ? IADC0_SCANBYTES \
+                                        : 0x0UL)
+#define IADC_ENTRIES(n)                (((n) == 0) ? IADC0_ENTRIES \
+                                        : 0x0UL)
+
+/* Instance macros for LETIMER */
+#define LETIMER(n)                     (((n) == 0) ? LETIMER0 \
+                                        : 0x0UL)
+#define LETIMER_NUM(ref)               (((ref) == LETIMER0) ? 0 \
+                                        : -1)
+#define LETIMER_CNT_WIDTH(n)           (((n) == 0) ? LETIMER0_CNT_WIDTH \
+                                        : 0x0UL)
+
 /* Instance macros for TIMER */
 #define TIMER(n)                       (((n) == 0) ? TIMER0   \
                                         : ((n) == 1) ? TIMER1 \

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c140f768im40.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c140f768im40.h
@@ -1300,6 +1300,28 @@ typedef enum IRQn{
                                         : ((n) == 1) ? I2C1_DELAY_CHAIN_NUM \
                                         : 0x0UL)
 
+/* Instance macros for IADC */
+#define IADC(n)                        (((n) == 0) ? IADC0 \
+                                        : 0x0UL)
+#define IADC_NUM(ref)                  (((ref) == IADC0) ? 0 \
+                                        : -1)
+#define IADC_CONFIGNUM(n)              (((n) == 0) ? IADC0_CONFIGNUM \
+                                        : 0x0UL)
+#define IADC_FULLRANGEUNIPOLAR(n)      (((n) == 0) ? IADC0_FULLRANGEUNIPOLAR \
+                                        : 0x0UL)
+#define IADC_SCANBYTES(n)              (((n) == 0) ? IADC0_SCANBYTES \
+                                        : 0x0UL)
+#define IADC_ENTRIES(n)                (((n) == 0) ? IADC0_ENTRIES \
+                                        : 0x0UL)
+
+/* Instance macros for LETIMER */
+#define LETIMER(n)                     (((n) == 0) ? LETIMER0 \
+                                        : 0x0UL)
+#define LETIMER_NUM(ref)               (((ref) == LETIMER0) ? 0 \
+                                        : -1)
+#define LETIMER_CNT_WIDTH(n)           (((n) == 0) ? LETIMER0_CNT_WIDTH \
+                                        : 0x0UL)
+
 /* Instance macros for TIMER */
 #define TIMER(n)                       (((n) == 0) ? TIMER0   \
                                         : ((n) == 1) ? TIMER1 \

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c230f768im32.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c230f768im32.h
@@ -1279,6 +1279,28 @@ typedef enum IRQn{
                                         : ((n) == 1) ? I2C1_DELAY_CHAIN_NUM \
                                         : 0x0UL)
 
+/* Instance macros for IADC */
+#define IADC(n)                        (((n) == 0) ? IADC0 \
+                                        : 0x0UL)
+#define IADC_NUM(ref)                  (((ref) == IADC0) ? 0 \
+                                        : -1)
+#define IADC_CONFIGNUM(n)              (((n) == 0) ? IADC0_CONFIGNUM \
+                                        : 0x0UL)
+#define IADC_FULLRANGEUNIPOLAR(n)      (((n) == 0) ? IADC0_FULLRANGEUNIPOLAR \
+                                        : 0x0UL)
+#define IADC_SCANBYTES(n)              (((n) == 0) ? IADC0_SCANBYTES \
+                                        : 0x0UL)
+#define IADC_ENTRIES(n)                (((n) == 0) ? IADC0_ENTRIES \
+                                        : 0x0UL)
+
+/* Instance macros for LETIMER */
+#define LETIMER(n)                     (((n) == 0) ? LETIMER0 \
+                                        : 0x0UL)
+#define LETIMER_NUM(ref)               (((ref) == LETIMER0) ? 0 \
+                                        : -1)
+#define LETIMER_CNT_WIDTH(n)           (((n) == 0) ? LETIMER0_CNT_WIDTH \
+                                        : 0x0UL)
+
 /* Instance macros for TIMER */
 #define TIMER(n)                       (((n) == 0) ? TIMER0   \
                                         : ((n) == 1) ? TIMER1 \

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c230f768im40.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c230f768im40.h
@@ -1299,6 +1299,28 @@ typedef enum IRQn{
                                         : ((n) == 1) ? I2C1_DELAY_CHAIN_NUM \
                                         : 0x0UL)
 
+/* Instance macros for IADC */
+#define IADC(n)                        (((n) == 0) ? IADC0 \
+                                        : 0x0UL)
+#define IADC_NUM(ref)                  (((ref) == IADC0) ? 0 \
+                                        : -1)
+#define IADC_CONFIGNUM(n)              (((n) == 0) ? IADC0_CONFIGNUM \
+                                        : 0x0UL)
+#define IADC_FULLRANGEUNIPOLAR(n)      (((n) == 0) ? IADC0_FULLRANGEUNIPOLAR \
+                                        : 0x0UL)
+#define IADC_SCANBYTES(n)              (((n) == 0) ? IADC0_SCANBYTES \
+                                        : 0x0UL)
+#define IADC_ENTRIES(n)                (((n) == 0) ? IADC0_ENTRIES \
+                                        : 0x0UL)
+
+/* Instance macros for LETIMER */
+#define LETIMER(n)                     (((n) == 0) ? LETIMER0 \
+                                        : 0x0UL)
+#define LETIMER_NUM(ref)               (((ref) == LETIMER0) ? 0 \
+                                        : -1)
+#define LETIMER_CNT_WIDTH(n)           (((n) == 0) ? LETIMER0_CNT_WIDTH \
+                                        : 0x0UL)
+
 /* Instance macros for TIMER */
 #define TIMER(n)                       (((n) == 0) ? TIMER0   \
                                         : ((n) == 1) ? TIMER1 \

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c320f768gj39.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c320f768gj39.h
@@ -1285,6 +1285,28 @@ typedef enum IRQn{
                                         : ((n) == 1) ? I2C1_DELAY_CHAIN_NUM \
                                         : 0x0UL)
 
+/* Instance macros for IADC */
+#define IADC(n)                        (((n) == 0) ? IADC0 \
+                                        : 0x0UL)
+#define IADC_NUM(ref)                  (((ref) == IADC0) ? 0 \
+                                        : -1)
+#define IADC_CONFIGNUM(n)              (((n) == 0) ? IADC0_CONFIGNUM \
+                                        : 0x0UL)
+#define IADC_FULLRANGEUNIPOLAR(n)      (((n) == 0) ? IADC0_FULLRANGEUNIPOLAR \
+                                        : 0x0UL)
+#define IADC_SCANBYTES(n)              (((n) == 0) ? IADC0_SCANBYTES \
+                                        : 0x0UL)
+#define IADC_ENTRIES(n)                (((n) == 0) ? IADC0_ENTRIES \
+                                        : 0x0UL)
+
+/* Instance macros for LETIMER */
+#define LETIMER(n)                     (((n) == 0) ? LETIMER0 \
+                                        : 0x0UL)
+#define LETIMER_NUM(ref)               (((ref) == LETIMER0) ? 0 \
+                                        : -1)
+#define LETIMER_CNT_WIDTH(n)           (((n) == 0) ? LETIMER0_CNT_WIDTH \
+                                        : 0x0UL)
+
 /* Instance macros for TIMER */
 #define TIMER(n)                       (((n) == 0) ? TIMER0   \
                                         : ((n) == 1) ? TIMER1 \

--- a/gecko/Device/SiliconLabs/EFR32BG27/Include/system_efr32bg27.h
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Include/system_efr32bg27.h
@@ -66,22 +66,18 @@ extern uint32_t SystemHfrcoFreq;     /**< System HFRCO frequency */
 #endif
 
 /*Re-direction of IRQn.*/
-#if (_SILICON_LABS_32B_SERIES_2_CONFIG >= 2)
 #if defined (SL_TRUSTZONE_SECURE)
 #define SMU_PRIVILEGED_IRQn    SMU_S_PRIVILEGED_IRQn
 #else
 #define SMU_PRIVILEGED_IRQn    SMU_NS_PRIVILEGED_IRQn
 #endif /* SL_TRUSTZONE_SECURE */
-#endif /* _SILICON_LABS_32B_SERIES_2_CONFIG */
 
 /*Re-direction of IRQHandler.*/
-#if (_SILICON_LABS_32B_SERIES_2_CONFIG >= 2)
 #if defined (SL_TRUSTZONE_SECURE)
 #define SMU_PRIVILEGED_IRQHandler    SMU_S_PRIVILEGED_IRQHandler
 #else
 #define SMU_PRIVILEGED_IRQHandler    SMU_NS_PRIVILEGED_IRQHandler
 #endif /* SL_TRUSTZONE_SECURE */
-#endif /* _SILICON_LABS_32B_SERIES_2_CONFIG */
 
 /*******************************************************************************
  *****************************   PROTOTYPES   **********************************
@@ -213,6 +209,11 @@ static __INLINE void SystemCoreClockUpdate(void)
 }
 
 void     SystemInit(void);
+#if !defined(SL_LEGACY_LINKER)
+void     FlashToRamCopy(uint32_t *from,
+                        uint32_t *to,
+                        uint32_t size);
+#endif
 uint32_t SystemHFRCODPLLClockGet(void);
 void     SystemHFRCODPLLClockSet(uint32_t freq);
 uint32_t SystemSYSCLKGet(void);

--- a/gecko/Device/SiliconLabs/EFR32BG27/Source/system_efr32bg27.c
+++ b/gecko/Device/SiliconLabs/EFR32BG27/Source/system_efr32bg27.c
@@ -164,10 +164,7 @@ void SystemInit(void)
  * as SMU is used to configure the trustzone state of the system. */
 #if !defined(SL_TRUSTZONE_SECURE) && !defined(SL_TRUSTZONE_NONSECURE) \
   && defined(__TZ_PRESENT)
-
-#if (_SILICON_LABS_32B_SERIES_2_CONFIG >= 2)
   CMU->CLKEN1_SET = CMU_CLKEN1_SMU;
-#endif
 
   /* config SMU to Secure and other peripherals to Non-Secure. */
   SMU->PPUSATD0_CLR = _SMU_PPUSATD0_MASK;
@@ -193,6 +190,35 @@ void SystemInit(void)
   SMU->IEN = SMU_IEN_PPUSEC | SMU_IEN_BMPUSEC;
 #endif /*SL_TRUSTZONE_SECURE */
 }
+
+#if !defined(SL_LEGACY_LINKER)
+/**************************************************************************//**
+ * @brief
+ *   Copy data.
+ *
+ * @details
+ *   Used to copy data from Flash to Ram at startup and runtime.
+ *
+ * @param[in] from
+ *   Pointer to the source address in Flash.
+ *
+ * @param[in] to
+ *   Pointer to the destination address in Ram.
+ *
+ * @param[in] size
+ *   Size of data to copy.
+ *****************************************************************************/
+void FlashToRamCopy(uint32_t *from,
+                    uint32_t *to,
+                    uint32_t size)
+{
+  if (size != 0) {
+    while (size--) {
+      *to++ = *from++;
+    }
+  }
+}
+#endif
 
 /**************************************************************************//**
  * @brief

--- a/gecko/Device/SiliconLabs/EFR32MG24/Include/efr32mg24_mpahbram.h
+++ b/gecko/Device/SiliconLabs/EFR32MG24/Include/efr32mg24_mpahbram.h
@@ -3,7 +3,7 @@
  * @brief EFR32MG24 MPAHBRAM register and bit field definitions
  ******************************************************************************
  * # License
- * <b>Copyright 2022 Silicon Laboratories, Inc. www.silabs.com</b>
+ * <b>Copyright 2023 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -53,15 +53,9 @@ typedef struct {
   __IM uint32_t  ECCMERRIND;                    /**< Multiple ECC error indication                      */
   __IOM uint32_t IF;                            /**< Interrupt Flags                                    */
   __IOM uint32_t IEN;                           /**< Interrupt Enable                                   */
-  __IOM uint32_t RAMBANKSVALID;                 /**< New Register                                       */
-  __IOM uint32_t CFGSRTOP;                      /**< Sequential Region on Top                           */
-  __IOM uint32_t CFGSRMAP;                      /**< Sequential Region Map                              */
-  __IOM uint32_t CFGIU0MAP;                     /**< Interleaving Unit 0 Map                            */
-  __IOM uint32_t CFGIU1MAP;                     /**< Interleaving Unit 1 Map                            */
-  __IOM uint32_t CFGIU2MAP;                     /**< Interleaving Unit 2 Map                            */
-  __IOM uint32_t CFGIU3MAP;                     /**< Interleaving Unit 3 Map                            */
-  uint32_t       RESERVED0[1U];                 /**< Reserved for future use                            */
-  uint32_t       RESERVED1[1006U];              /**< Reserved for future use                            */
+  uint32_t       RESERVED0[7U];                 /**< Reserved for future use                            */
+  uint32_t       RESERVED1[1U];                 /**< Reserved for future use                            */
+  uint32_t       RESERVED2[1006U];              /**< Reserved for future use                            */
   __IM uint32_t  IPVERSION_SET;                 /**< IP version ID                                      */
   __IOM uint32_t CMD_SET;                       /**< Command register                                   */
   __IOM uint32_t CTRL_SET;                      /**< Control register                                   */
@@ -72,15 +66,9 @@ typedef struct {
   __IM uint32_t  ECCMERRIND_SET;                /**< Multiple ECC error indication                      */
   __IOM uint32_t IF_SET;                        /**< Interrupt Flags                                    */
   __IOM uint32_t IEN_SET;                       /**< Interrupt Enable                                   */
-  __IOM uint32_t RAMBANKSVALID_SET;             /**< New Register                                       */
-  __IOM uint32_t CFGSRTOP_SET;                  /**< Sequential Region on Top                           */
-  __IOM uint32_t CFGSRMAP_SET;                  /**< Sequential Region Map                              */
-  __IOM uint32_t CFGIU0MAP_SET;                 /**< Interleaving Unit 0 Map                            */
-  __IOM uint32_t CFGIU1MAP_SET;                 /**< Interleaving Unit 1 Map                            */
-  __IOM uint32_t CFGIU2MAP_SET;                 /**< Interleaving Unit 2 Map                            */
-  __IOM uint32_t CFGIU3MAP_SET;                 /**< Interleaving Unit 3 Map                            */
-  uint32_t       RESERVED2[1U];                 /**< Reserved for future use                            */
-  uint32_t       RESERVED3[1006U];              /**< Reserved for future use                            */
+  uint32_t       RESERVED3[7U];                 /**< Reserved for future use                            */
+  uint32_t       RESERVED4[1U];                 /**< Reserved for future use                            */
+  uint32_t       RESERVED5[1006U];              /**< Reserved for future use                            */
   __IM uint32_t  IPVERSION_CLR;                 /**< IP version ID                                      */
   __IOM uint32_t CMD_CLR;                       /**< Command register                                   */
   __IOM uint32_t CTRL_CLR;                      /**< Control register                                   */
@@ -91,15 +79,9 @@ typedef struct {
   __IM uint32_t  ECCMERRIND_CLR;                /**< Multiple ECC error indication                      */
   __IOM uint32_t IF_CLR;                        /**< Interrupt Flags                                    */
   __IOM uint32_t IEN_CLR;                       /**< Interrupt Enable                                   */
-  __IOM uint32_t RAMBANKSVALID_CLR;             /**< New Register                                       */
-  __IOM uint32_t CFGSRTOP_CLR;                  /**< Sequential Region on Top                           */
-  __IOM uint32_t CFGSRMAP_CLR;                  /**< Sequential Region Map                              */
-  __IOM uint32_t CFGIU0MAP_CLR;                 /**< Interleaving Unit 0 Map                            */
-  __IOM uint32_t CFGIU1MAP_CLR;                 /**< Interleaving Unit 1 Map                            */
-  __IOM uint32_t CFGIU2MAP_CLR;                 /**< Interleaving Unit 2 Map                            */
-  __IOM uint32_t CFGIU3MAP_CLR;                 /**< Interleaving Unit 3 Map                            */
-  uint32_t       RESERVED4[1U];                 /**< Reserved for future use                            */
-  uint32_t       RESERVED5[1006U];              /**< Reserved for future use                            */
+  uint32_t       RESERVED6[7U];                 /**< Reserved for future use                            */
+  uint32_t       RESERVED7[1U];                 /**< Reserved for future use                            */
+  uint32_t       RESERVED8[1006U];              /**< Reserved for future use                            */
   __IM uint32_t  IPVERSION_TGL;                 /**< IP version ID                                      */
   __IOM uint32_t CMD_TGL;                       /**< Command register                                   */
   __IOM uint32_t CTRL_TGL;                      /**< Control register                                   */
@@ -110,14 +92,8 @@ typedef struct {
   __IM uint32_t  ECCMERRIND_TGL;                /**< Multiple ECC error indication                      */
   __IOM uint32_t IF_TGL;                        /**< Interrupt Flags                                    */
   __IOM uint32_t IEN_TGL;                       /**< Interrupt Enable                                   */
-  __IOM uint32_t RAMBANKSVALID_TGL;             /**< New Register                                       */
-  __IOM uint32_t CFGSRTOP_TGL;                  /**< Sequential Region on Top                           */
-  __IOM uint32_t CFGSRMAP_TGL;                  /**< Sequential Region Map                              */
-  __IOM uint32_t CFGIU0MAP_TGL;                 /**< Interleaving Unit 0 Map                            */
-  __IOM uint32_t CFGIU1MAP_TGL;                 /**< Interleaving Unit 1 Map                            */
-  __IOM uint32_t CFGIU2MAP_TGL;                 /**< Interleaving Unit 2 Map                            */
-  __IOM uint32_t CFGIU3MAP_TGL;                 /**< Interleaving Unit 3 Map                            */
-  uint32_t       RESERVED6[1U];                 /**< Reserved for future use                            */
+  uint32_t       RESERVED9[7U];                 /**< Reserved for future use                            */
+  uint32_t       RESERVED10[1U];                /**< Reserved for future use                            */
 } MPAHBRAM_TypeDef;
 /** @} End of group EFR32MG24_MPAHBRAM */
 
@@ -129,315 +105,226 @@ typedef struct {
  *****************************************************************************/
 
 /* Bit fields for MPAHBRAM IPVERSION */
-#define _MPAHBRAM_IPVERSION_RESETVALUE                    0x00000002UL                                 /**< Default value for MPAHBRAM_IPVERSION        */
-#define _MPAHBRAM_IPVERSION_MASK                          0x00000003UL                                 /**< Mask for MPAHBRAM_IPVERSION                 */
-#define _MPAHBRAM_IPVERSION_IPVERSION_SHIFT               0                                            /**< Shift value for MPAHBRAM_IPVERSION          */
-#define _MPAHBRAM_IPVERSION_IPVERSION_MASK                0x3UL                                        /**< Bit mask for MPAHBRAM_IPVERSION             */
-#define _MPAHBRAM_IPVERSION_IPVERSION_DEFAULT             0x00000002UL                                 /**< Mode DEFAULT for MPAHBRAM_IPVERSION         */
-#define MPAHBRAM_IPVERSION_IPVERSION_DEFAULT              (_MPAHBRAM_IPVERSION_IPVERSION_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_IPVERSION */
+#define _MPAHBRAM_IPVERSION_RESETVALUE            0x00000002UL                                 /**< Default value for MPAHBRAM_IPVERSION        */
+#define _MPAHBRAM_IPVERSION_MASK                  0x00000003UL                                 /**< Mask for MPAHBRAM_IPVERSION                 */
+#define _MPAHBRAM_IPVERSION_IPVERSION_SHIFT       0                                            /**< Shift value for MPAHBRAM_IPVERSION          */
+#define _MPAHBRAM_IPVERSION_IPVERSION_MASK        0x3UL                                        /**< Bit mask for MPAHBRAM_IPVERSION             */
+#define _MPAHBRAM_IPVERSION_IPVERSION_DEFAULT     0x00000002UL                                 /**< Mode DEFAULT for MPAHBRAM_IPVERSION         */
+#define MPAHBRAM_IPVERSION_IPVERSION_DEFAULT      (_MPAHBRAM_IPVERSION_IPVERSION_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_IPVERSION */
 
 /* Bit fields for MPAHBRAM CMD */
-#define _MPAHBRAM_CMD_RESETVALUE                          0x00000000UL                               /**< Default value for MPAHBRAM_CMD              */
-#define _MPAHBRAM_CMD_MASK                                0x0000000FUL                               /**< Mask for MPAHBRAM_CMD                       */
-#define MPAHBRAM_CMD_CLEARECCADDR0                        (0x1UL << 0)                               /**< Clear ECCERRADDR0                           */
-#define _MPAHBRAM_CMD_CLEARECCADDR0_SHIFT                 0                                          /**< Shift value for MPAHBRAM_CLEARECCADDR0      */
-#define _MPAHBRAM_CMD_CLEARECCADDR0_MASK                  0x1UL                                      /**< Bit mask for MPAHBRAM_CLEARECCADDR0         */
-#define _MPAHBRAM_CMD_CLEARECCADDR0_DEFAULT               0x00000000UL                               /**< Mode DEFAULT for MPAHBRAM_CMD               */
-#define MPAHBRAM_CMD_CLEARECCADDR0_DEFAULT                (_MPAHBRAM_CMD_CLEARECCADDR0_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_CMD       */
-#define MPAHBRAM_CMD_CLEARECCADDR1                        (0x1UL << 1)                               /**< Clear ECCERRADDR1                           */
-#define _MPAHBRAM_CMD_CLEARECCADDR1_SHIFT                 1                                          /**< Shift value for MPAHBRAM_CLEARECCADDR1      */
-#define _MPAHBRAM_CMD_CLEARECCADDR1_MASK                  0x2UL                                      /**< Bit mask for MPAHBRAM_CLEARECCADDR1         */
-#define _MPAHBRAM_CMD_CLEARECCADDR1_DEFAULT               0x00000000UL                               /**< Mode DEFAULT for MPAHBRAM_CMD               */
-#define MPAHBRAM_CMD_CLEARECCADDR1_DEFAULT                (_MPAHBRAM_CMD_CLEARECCADDR1_DEFAULT << 1) /**< Shifted mode DEFAULT for MPAHBRAM_CMD       */
-#define MPAHBRAM_CMD_CLEARECCADDR2                        (0x1UL << 2)                               /**< Clear ECCERRADDR2                           */
-#define _MPAHBRAM_CMD_CLEARECCADDR2_SHIFT                 2                                          /**< Shift value for MPAHBRAM_CLEARECCADDR2      */
-#define _MPAHBRAM_CMD_CLEARECCADDR2_MASK                  0x4UL                                      /**< Bit mask for MPAHBRAM_CLEARECCADDR2         */
-#define _MPAHBRAM_CMD_CLEARECCADDR2_DEFAULT               0x00000000UL                               /**< Mode DEFAULT for MPAHBRAM_CMD               */
-#define MPAHBRAM_CMD_CLEARECCADDR2_DEFAULT                (_MPAHBRAM_CMD_CLEARECCADDR2_DEFAULT << 2) /**< Shifted mode DEFAULT for MPAHBRAM_CMD       */
-#define MPAHBRAM_CMD_CLEARECCADDR3                        (0x1UL << 3)                               /**< Clear ECCERRADDR3                           */
-#define _MPAHBRAM_CMD_CLEARECCADDR3_SHIFT                 3                                          /**< Shift value for MPAHBRAM_CLEARECCADDR3      */
-#define _MPAHBRAM_CMD_CLEARECCADDR3_MASK                  0x8UL                                      /**< Bit mask for MPAHBRAM_CLEARECCADDR3         */
-#define _MPAHBRAM_CMD_CLEARECCADDR3_DEFAULT               0x00000000UL                               /**< Mode DEFAULT for MPAHBRAM_CMD               */
-#define MPAHBRAM_CMD_CLEARECCADDR3_DEFAULT                (_MPAHBRAM_CMD_CLEARECCADDR3_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_CMD       */
+#define _MPAHBRAM_CMD_RESETVALUE                  0x00000000UL                               /**< Default value for MPAHBRAM_CMD              */
+#define _MPAHBRAM_CMD_MASK                        0x0000000FUL                               /**< Mask for MPAHBRAM_CMD                       */
+#define MPAHBRAM_CMD_CLEARECCADDR0                (0x1UL << 0)                               /**< Clear ECCERRADDR0                           */
+#define _MPAHBRAM_CMD_CLEARECCADDR0_SHIFT         0                                          /**< Shift value for MPAHBRAM_CLEARECCADDR0      */
+#define _MPAHBRAM_CMD_CLEARECCADDR0_MASK          0x1UL                                      /**< Bit mask for MPAHBRAM_CLEARECCADDR0         */
+#define _MPAHBRAM_CMD_CLEARECCADDR0_DEFAULT       0x00000000UL                               /**< Mode DEFAULT for MPAHBRAM_CMD               */
+#define MPAHBRAM_CMD_CLEARECCADDR0_DEFAULT        (_MPAHBRAM_CMD_CLEARECCADDR0_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_CMD       */
+#define MPAHBRAM_CMD_CLEARECCADDR1                (0x1UL << 1)                               /**< Clear ECCERRADDR1                           */
+#define _MPAHBRAM_CMD_CLEARECCADDR1_SHIFT         1                                          /**< Shift value for MPAHBRAM_CLEARECCADDR1      */
+#define _MPAHBRAM_CMD_CLEARECCADDR1_MASK          0x2UL                                      /**< Bit mask for MPAHBRAM_CLEARECCADDR1         */
+#define _MPAHBRAM_CMD_CLEARECCADDR1_DEFAULT       0x00000000UL                               /**< Mode DEFAULT for MPAHBRAM_CMD               */
+#define MPAHBRAM_CMD_CLEARECCADDR1_DEFAULT        (_MPAHBRAM_CMD_CLEARECCADDR1_DEFAULT << 1) /**< Shifted mode DEFAULT for MPAHBRAM_CMD       */
+#define MPAHBRAM_CMD_CLEARECCADDR2                (0x1UL << 2)                               /**< Clear ECCERRADDR2                           */
+#define _MPAHBRAM_CMD_CLEARECCADDR2_SHIFT         2                                          /**< Shift value for MPAHBRAM_CLEARECCADDR2      */
+#define _MPAHBRAM_CMD_CLEARECCADDR2_MASK          0x4UL                                      /**< Bit mask for MPAHBRAM_CLEARECCADDR2         */
+#define _MPAHBRAM_CMD_CLEARECCADDR2_DEFAULT       0x00000000UL                               /**< Mode DEFAULT for MPAHBRAM_CMD               */
+#define MPAHBRAM_CMD_CLEARECCADDR2_DEFAULT        (_MPAHBRAM_CMD_CLEARECCADDR2_DEFAULT << 2) /**< Shifted mode DEFAULT for MPAHBRAM_CMD       */
+#define MPAHBRAM_CMD_CLEARECCADDR3                (0x1UL << 3)                               /**< Clear ECCERRADDR3                           */
+#define _MPAHBRAM_CMD_CLEARECCADDR3_SHIFT         3                                          /**< Shift value for MPAHBRAM_CLEARECCADDR3      */
+#define _MPAHBRAM_CMD_CLEARECCADDR3_MASK          0x8UL                                      /**< Bit mask for MPAHBRAM_CLEARECCADDR3         */
+#define _MPAHBRAM_CMD_CLEARECCADDR3_DEFAULT       0x00000000UL                               /**< Mode DEFAULT for MPAHBRAM_CMD               */
+#define MPAHBRAM_CMD_CLEARECCADDR3_DEFAULT        (_MPAHBRAM_CMD_CLEARECCADDR3_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_CMD       */
 
 /* Bit fields for MPAHBRAM CTRL */
-#define _MPAHBRAM_CTRL_RESETVALUE                         0x00000040UL                                  /**< Default value for MPAHBRAM_CTRL             */
-#define _MPAHBRAM_CTRL_MASK                               0x000000FFUL                                  /**< Mask for MPAHBRAM_CTRL                      */
-#define MPAHBRAM_CTRL_ECCEN                               (0x1UL << 0)                                  /**< Enable ECC functionality                    */
-#define _MPAHBRAM_CTRL_ECCEN_SHIFT                        0                                             /**< Shift value for MPAHBRAM_ECCEN              */
-#define _MPAHBRAM_CTRL_ECCEN_MASK                         0x1UL                                         /**< Bit mask for MPAHBRAM_ECCEN                 */
-#define _MPAHBRAM_CTRL_ECCEN_DEFAULT                      0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
-#define MPAHBRAM_CTRL_ECCEN_DEFAULT                       (_MPAHBRAM_CTRL_ECCEN_DEFAULT << 0)           /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
-#define MPAHBRAM_CTRL_ECCWEN                              (0x1UL << 1)                                  /**< Enable ECC syndrome writes                  */
-#define _MPAHBRAM_CTRL_ECCWEN_SHIFT                       1                                             /**< Shift value for MPAHBRAM_ECCWEN             */
-#define _MPAHBRAM_CTRL_ECCWEN_MASK                        0x2UL                                         /**< Bit mask for MPAHBRAM_ECCWEN                */
-#define _MPAHBRAM_CTRL_ECCWEN_DEFAULT                     0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
-#define MPAHBRAM_CTRL_ECCWEN_DEFAULT                      (_MPAHBRAM_CTRL_ECCWEN_DEFAULT << 1)          /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
-#define MPAHBRAM_CTRL_ECCERRFAULTEN                       (0x1UL << 2)                                  /**< ECC Error bus fault enable                  */
-#define _MPAHBRAM_CTRL_ECCERRFAULTEN_SHIFT                2                                             /**< Shift value for MPAHBRAM_ECCERRFAULTEN      */
-#define _MPAHBRAM_CTRL_ECCERRFAULTEN_MASK                 0x4UL                                         /**< Bit mask for MPAHBRAM_ECCERRFAULTEN         */
-#define _MPAHBRAM_CTRL_ECCERRFAULTEN_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
-#define MPAHBRAM_CTRL_ECCERRFAULTEN_DEFAULT               (_MPAHBRAM_CTRL_ECCERRFAULTEN_DEFAULT << 2)   /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
-#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_SHIFT              3                                             /**< Shift value for MPAHBRAM_AHBPORTPRIORITY    */
-#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_MASK               0x38UL                                        /**< Bit mask for MPAHBRAM_AHBPORTPRIORITY       */
-#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_DEFAULT            0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
-#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_NONE               0x00000000UL                                  /**< Mode NONE for MPAHBRAM_CTRL                 */
-#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT0              0x00000001UL                                  /**< Mode PORT0 for MPAHBRAM_CTRL                */
-#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT1              0x00000002UL                                  /**< Mode PORT1 for MPAHBRAM_CTRL                */
-#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT2              0x00000003UL                                  /**< Mode PORT2 for MPAHBRAM_CTRL                */
-#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT3              0x00000004UL                                  /**< Mode PORT3 for MPAHBRAM_CTRL                */
-#define MPAHBRAM_CTRL_AHBPORTPRIORITY_DEFAULT             (_MPAHBRAM_CTRL_AHBPORTPRIORITY_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
-#define MPAHBRAM_CTRL_AHBPORTPRIORITY_NONE                (_MPAHBRAM_CTRL_AHBPORTPRIORITY_NONE << 3)    /**< Shifted mode NONE for MPAHBRAM_CTRL         */
-#define MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT0               (_MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT0 << 3)   /**< Shifted mode PORT0 for MPAHBRAM_CTRL        */
-#define MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT1               (_MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT1 << 3)   /**< Shifted mode PORT1 for MPAHBRAM_CTRL        */
-#define MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT2               (_MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT2 << 3)   /**< Shifted mode PORT2 for MPAHBRAM_CTRL        */
-#define MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT3               (_MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT3 << 3)   /**< Shifted mode PORT3 for MPAHBRAM_CTRL        */
-#define MPAHBRAM_CTRL_ADDRFAULTEN                         (0x1UL << 6)                                  /**< Address fault bus fault enable              */
-#define _MPAHBRAM_CTRL_ADDRFAULTEN_SHIFT                  6                                             /**< Shift value for MPAHBRAM_ADDRFAULTEN        */
-#define _MPAHBRAM_CTRL_ADDRFAULTEN_MASK                   0x40UL                                        /**< Bit mask for MPAHBRAM_ADDRFAULTEN           */
-#define _MPAHBRAM_CTRL_ADDRFAULTEN_DEFAULT                0x00000001UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
-#define MPAHBRAM_CTRL_ADDRFAULTEN_DEFAULT                 (_MPAHBRAM_CTRL_ADDRFAULTEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
-#define MPAHBRAM_CTRL_WAITSTATES                          (0x1UL << 7)                                  /**< RAM read wait states                        */
-#define _MPAHBRAM_CTRL_WAITSTATES_SHIFT                   7                                             /**< Shift value for MPAHBRAM_WAITSTATES         */
-#define _MPAHBRAM_CTRL_WAITSTATES_MASK                    0x80UL                                        /**< Bit mask for MPAHBRAM_WAITSTATES            */
-#define _MPAHBRAM_CTRL_WAITSTATES_DEFAULT                 0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
-#define MPAHBRAM_CTRL_WAITSTATES_DEFAULT                  (_MPAHBRAM_CTRL_WAITSTATES_DEFAULT << 7)      /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
+#define _MPAHBRAM_CTRL_RESETVALUE                 0x00000040UL                                  /**< Default value for MPAHBRAM_CTRL             */
+#define _MPAHBRAM_CTRL_MASK                       0x000000FFUL                                  /**< Mask for MPAHBRAM_CTRL                      */
+#define MPAHBRAM_CTRL_ECCEN                       (0x1UL << 0)                                  /**< Enable ECC functionality                    */
+#define _MPAHBRAM_CTRL_ECCEN_SHIFT                0                                             /**< Shift value for MPAHBRAM_ECCEN              */
+#define _MPAHBRAM_CTRL_ECCEN_MASK                 0x1UL                                         /**< Bit mask for MPAHBRAM_ECCEN                 */
+#define _MPAHBRAM_CTRL_ECCEN_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
+#define MPAHBRAM_CTRL_ECCEN_DEFAULT               (_MPAHBRAM_CTRL_ECCEN_DEFAULT << 0)           /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
+#define MPAHBRAM_CTRL_ECCWEN                      (0x1UL << 1)                                  /**< Enable ECC syndrome writes                  */
+#define _MPAHBRAM_CTRL_ECCWEN_SHIFT               1                                             /**< Shift value for MPAHBRAM_ECCWEN             */
+#define _MPAHBRAM_CTRL_ECCWEN_MASK                0x2UL                                         /**< Bit mask for MPAHBRAM_ECCWEN                */
+#define _MPAHBRAM_CTRL_ECCWEN_DEFAULT             0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
+#define MPAHBRAM_CTRL_ECCWEN_DEFAULT              (_MPAHBRAM_CTRL_ECCWEN_DEFAULT << 1)          /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
+#define MPAHBRAM_CTRL_ECCERRFAULTEN               (0x1UL << 2)                                  /**< ECC Error bus fault enable                  */
+#define _MPAHBRAM_CTRL_ECCERRFAULTEN_SHIFT        2                                             /**< Shift value for MPAHBRAM_ECCERRFAULTEN      */
+#define _MPAHBRAM_CTRL_ECCERRFAULTEN_MASK         0x4UL                                         /**< Bit mask for MPAHBRAM_ECCERRFAULTEN         */
+#define _MPAHBRAM_CTRL_ECCERRFAULTEN_DEFAULT      0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
+#define MPAHBRAM_CTRL_ECCERRFAULTEN_DEFAULT       (_MPAHBRAM_CTRL_ECCERRFAULTEN_DEFAULT << 2)   /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
+#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_SHIFT      3                                             /**< Shift value for MPAHBRAM_AHBPORTPRIORITY    */
+#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_MASK       0x38UL                                        /**< Bit mask for MPAHBRAM_AHBPORTPRIORITY       */
+#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_DEFAULT    0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
+#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_NONE       0x00000000UL                                  /**< Mode NONE for MPAHBRAM_CTRL                 */
+#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT0      0x00000001UL                                  /**< Mode PORT0 for MPAHBRAM_CTRL                */
+#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT1      0x00000002UL                                  /**< Mode PORT1 for MPAHBRAM_CTRL                */
+#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT2      0x00000003UL                                  /**< Mode PORT2 for MPAHBRAM_CTRL                */
+#define _MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT3      0x00000004UL                                  /**< Mode PORT3 for MPAHBRAM_CTRL                */
+#define MPAHBRAM_CTRL_AHBPORTPRIORITY_DEFAULT     (_MPAHBRAM_CTRL_AHBPORTPRIORITY_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
+#define MPAHBRAM_CTRL_AHBPORTPRIORITY_NONE        (_MPAHBRAM_CTRL_AHBPORTPRIORITY_NONE << 3)    /**< Shifted mode NONE for MPAHBRAM_CTRL         */
+#define MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT0       (_MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT0 << 3)   /**< Shifted mode PORT0 for MPAHBRAM_CTRL        */
+#define MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT1       (_MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT1 << 3)   /**< Shifted mode PORT1 for MPAHBRAM_CTRL        */
+#define MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT2       (_MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT2 << 3)   /**< Shifted mode PORT2 for MPAHBRAM_CTRL        */
+#define MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT3       (_MPAHBRAM_CTRL_AHBPORTPRIORITY_PORT3 << 3)   /**< Shifted mode PORT3 for MPAHBRAM_CTRL        */
+#define MPAHBRAM_CTRL_ADDRFAULTEN                 (0x1UL << 6)                                  /**< Address fault bus fault enable              */
+#define _MPAHBRAM_CTRL_ADDRFAULTEN_SHIFT          6                                             /**< Shift value for MPAHBRAM_ADDRFAULTEN        */
+#define _MPAHBRAM_CTRL_ADDRFAULTEN_MASK           0x40UL                                        /**< Bit mask for MPAHBRAM_ADDRFAULTEN           */
+#define _MPAHBRAM_CTRL_ADDRFAULTEN_DEFAULT        0x00000001UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
+#define MPAHBRAM_CTRL_ADDRFAULTEN_DEFAULT         (_MPAHBRAM_CTRL_ADDRFAULTEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
+#define MPAHBRAM_CTRL_WAITSTATES                  (0x1UL << 7)                                  /**< RAM read wait states                        */
+#define _MPAHBRAM_CTRL_WAITSTATES_SHIFT           7                                             /**< Shift value for MPAHBRAM_WAITSTATES         */
+#define _MPAHBRAM_CTRL_WAITSTATES_MASK            0x80UL                                        /**< Bit mask for MPAHBRAM_WAITSTATES            */
+#define _MPAHBRAM_CTRL_WAITSTATES_DEFAULT         0x00000000UL                                  /**< Mode DEFAULT for MPAHBRAM_CTRL              */
+#define MPAHBRAM_CTRL_WAITSTATES_DEFAULT          (_MPAHBRAM_CTRL_WAITSTATES_DEFAULT << 7)      /**< Shifted mode DEFAULT for MPAHBRAM_CTRL      */
 
 /* Bit fields for MPAHBRAM ECCERRADDR0 */
-#define _MPAHBRAM_ECCERRADDR0_RESETVALUE                  0x00000000UL                              /**< Default value for MPAHBRAM_ECCERRADDR0      */
-#define _MPAHBRAM_ECCERRADDR0_MASK                        0xFFFFFFFFUL                              /**< Mask for MPAHBRAM_ECCERRADDR0               */
-#define _MPAHBRAM_ECCERRADDR0_ADDR_SHIFT                  0                                         /**< Shift value for MPAHBRAM_ADDR               */
-#define _MPAHBRAM_ECCERRADDR0_ADDR_MASK                   0xFFFFFFFFUL                              /**< Bit mask for MPAHBRAM_ADDR                  */
-#define _MPAHBRAM_ECCERRADDR0_ADDR_DEFAULT                0x00000000UL                              /**< Mode DEFAULT for MPAHBRAM_ECCERRADDR0       */
-#define MPAHBRAM_ECCERRADDR0_ADDR_DEFAULT                 (_MPAHBRAM_ECCERRADDR0_ADDR_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCERRADDR0*/
+#define _MPAHBRAM_ECCERRADDR0_RESETVALUE          0x00000000UL                              /**< Default value for MPAHBRAM_ECCERRADDR0      */
+#define _MPAHBRAM_ECCERRADDR0_MASK                0xFFFFFFFFUL                              /**< Mask for MPAHBRAM_ECCERRADDR0               */
+#define _MPAHBRAM_ECCERRADDR0_ADDR_SHIFT          0                                         /**< Shift value for MPAHBRAM_ADDR               */
+#define _MPAHBRAM_ECCERRADDR0_ADDR_MASK           0xFFFFFFFFUL                              /**< Bit mask for MPAHBRAM_ADDR                  */
+#define _MPAHBRAM_ECCERRADDR0_ADDR_DEFAULT        0x00000000UL                              /**< Mode DEFAULT for MPAHBRAM_ECCERRADDR0       */
+#define MPAHBRAM_ECCERRADDR0_ADDR_DEFAULT         (_MPAHBRAM_ECCERRADDR0_ADDR_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCERRADDR0*/
 
 /* Bit fields for MPAHBRAM ECCERRADDR1 */
-#define _MPAHBRAM_ECCERRADDR1_RESETVALUE                  0x00000000UL                              /**< Default value for MPAHBRAM_ECCERRADDR1      */
-#define _MPAHBRAM_ECCERRADDR1_MASK                        0xFFFFFFFFUL                              /**< Mask for MPAHBRAM_ECCERRADDR1               */
-#define _MPAHBRAM_ECCERRADDR1_ADDR_SHIFT                  0                                         /**< Shift value for MPAHBRAM_ADDR               */
-#define _MPAHBRAM_ECCERRADDR1_ADDR_MASK                   0xFFFFFFFFUL                              /**< Bit mask for MPAHBRAM_ADDR                  */
-#define _MPAHBRAM_ECCERRADDR1_ADDR_DEFAULT                0x00000000UL                              /**< Mode DEFAULT for MPAHBRAM_ECCERRADDR1       */
-#define MPAHBRAM_ECCERRADDR1_ADDR_DEFAULT                 (_MPAHBRAM_ECCERRADDR1_ADDR_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCERRADDR1*/
+#define _MPAHBRAM_ECCERRADDR1_RESETVALUE          0x00000000UL                              /**< Default value for MPAHBRAM_ECCERRADDR1      */
+#define _MPAHBRAM_ECCERRADDR1_MASK                0xFFFFFFFFUL                              /**< Mask for MPAHBRAM_ECCERRADDR1               */
+#define _MPAHBRAM_ECCERRADDR1_ADDR_SHIFT          0                                         /**< Shift value for MPAHBRAM_ADDR               */
+#define _MPAHBRAM_ECCERRADDR1_ADDR_MASK           0xFFFFFFFFUL                              /**< Bit mask for MPAHBRAM_ADDR                  */
+#define _MPAHBRAM_ECCERRADDR1_ADDR_DEFAULT        0x00000000UL                              /**< Mode DEFAULT for MPAHBRAM_ECCERRADDR1       */
+#define MPAHBRAM_ECCERRADDR1_ADDR_DEFAULT         (_MPAHBRAM_ECCERRADDR1_ADDR_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCERRADDR1*/
 
 /* Bit fields for MPAHBRAM ECCERRADDR2 */
-#define _MPAHBRAM_ECCERRADDR2_RESETVALUE                  0x00000000UL                              /**< Default value for MPAHBRAM_ECCERRADDR2      */
-#define _MPAHBRAM_ECCERRADDR2_MASK                        0xFFFFFFFFUL                              /**< Mask for MPAHBRAM_ECCERRADDR2               */
-#define _MPAHBRAM_ECCERRADDR2_ADDR_SHIFT                  0                                         /**< Shift value for MPAHBRAM_ADDR               */
-#define _MPAHBRAM_ECCERRADDR2_ADDR_MASK                   0xFFFFFFFFUL                              /**< Bit mask for MPAHBRAM_ADDR                  */
-#define _MPAHBRAM_ECCERRADDR2_ADDR_DEFAULT                0x00000000UL                              /**< Mode DEFAULT for MPAHBRAM_ECCERRADDR2       */
-#define MPAHBRAM_ECCERRADDR2_ADDR_DEFAULT                 (_MPAHBRAM_ECCERRADDR2_ADDR_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCERRADDR2*/
+#define _MPAHBRAM_ECCERRADDR2_RESETVALUE          0x00000000UL                              /**< Default value for MPAHBRAM_ECCERRADDR2      */
+#define _MPAHBRAM_ECCERRADDR2_MASK                0xFFFFFFFFUL                              /**< Mask for MPAHBRAM_ECCERRADDR2               */
+#define _MPAHBRAM_ECCERRADDR2_ADDR_SHIFT          0                                         /**< Shift value for MPAHBRAM_ADDR               */
+#define _MPAHBRAM_ECCERRADDR2_ADDR_MASK           0xFFFFFFFFUL                              /**< Bit mask for MPAHBRAM_ADDR                  */
+#define _MPAHBRAM_ECCERRADDR2_ADDR_DEFAULT        0x00000000UL                              /**< Mode DEFAULT for MPAHBRAM_ECCERRADDR2       */
+#define MPAHBRAM_ECCERRADDR2_ADDR_DEFAULT         (_MPAHBRAM_ECCERRADDR2_ADDR_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCERRADDR2*/
 
 /* Bit fields for MPAHBRAM ECCERRADDR3 */
-#define _MPAHBRAM_ECCERRADDR3_RESETVALUE                  0x00000000UL                              /**< Default value for MPAHBRAM_ECCERRADDR3      */
-#define _MPAHBRAM_ECCERRADDR3_MASK                        0xFFFFFFFFUL                              /**< Mask for MPAHBRAM_ECCERRADDR3               */
-#define _MPAHBRAM_ECCERRADDR3_ADDR_SHIFT                  0                                         /**< Shift value for MPAHBRAM_ADDR               */
-#define _MPAHBRAM_ECCERRADDR3_ADDR_MASK                   0xFFFFFFFFUL                              /**< Bit mask for MPAHBRAM_ADDR                  */
-#define _MPAHBRAM_ECCERRADDR3_ADDR_DEFAULT                0x00000000UL                              /**< Mode DEFAULT for MPAHBRAM_ECCERRADDR3       */
-#define MPAHBRAM_ECCERRADDR3_ADDR_DEFAULT                 (_MPAHBRAM_ECCERRADDR3_ADDR_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCERRADDR3*/
+#define _MPAHBRAM_ECCERRADDR3_RESETVALUE          0x00000000UL                              /**< Default value for MPAHBRAM_ECCERRADDR3      */
+#define _MPAHBRAM_ECCERRADDR3_MASK                0xFFFFFFFFUL                              /**< Mask for MPAHBRAM_ECCERRADDR3               */
+#define _MPAHBRAM_ECCERRADDR3_ADDR_SHIFT          0                                         /**< Shift value for MPAHBRAM_ADDR               */
+#define _MPAHBRAM_ECCERRADDR3_ADDR_MASK           0xFFFFFFFFUL                              /**< Bit mask for MPAHBRAM_ADDR                  */
+#define _MPAHBRAM_ECCERRADDR3_ADDR_DEFAULT        0x00000000UL                              /**< Mode DEFAULT for MPAHBRAM_ECCERRADDR3       */
+#define MPAHBRAM_ECCERRADDR3_ADDR_DEFAULT         (_MPAHBRAM_ECCERRADDR3_ADDR_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCERRADDR3*/
 
 /* Bit fields for MPAHBRAM ECCMERRIND */
-#define _MPAHBRAM_ECCMERRIND_RESETVALUE                   0x00000000UL                           /**< Default value for MPAHBRAM_ECCMERRIND       */
-#define _MPAHBRAM_ECCMERRIND_MASK                         0x0000000FUL                           /**< Mask for MPAHBRAM_ECCMERRIND                */
-#define MPAHBRAM_ECCMERRIND_P0                            (0x1UL << 0)                           /**< Multiple ECC errors on AHB port 0           */
-#define _MPAHBRAM_ECCMERRIND_P0_SHIFT                     0                                      /**< Shift value for MPAHBRAM_P0                 */
-#define _MPAHBRAM_ECCMERRIND_P0_MASK                      0x1UL                                  /**< Bit mask for MPAHBRAM_P0                    */
-#define _MPAHBRAM_ECCMERRIND_P0_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_ECCMERRIND        */
-#define MPAHBRAM_ECCMERRIND_P0_DEFAULT                    (_MPAHBRAM_ECCMERRIND_P0_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCMERRIND*/
-#define MPAHBRAM_ECCMERRIND_P1                            (0x1UL << 1)                           /**< Multiple ECC errors on AHB port 1           */
-#define _MPAHBRAM_ECCMERRIND_P1_SHIFT                     1                                      /**< Shift value for MPAHBRAM_P1                 */
-#define _MPAHBRAM_ECCMERRIND_P1_MASK                      0x2UL                                  /**< Bit mask for MPAHBRAM_P1                    */
-#define _MPAHBRAM_ECCMERRIND_P1_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_ECCMERRIND        */
-#define MPAHBRAM_ECCMERRIND_P1_DEFAULT                    (_MPAHBRAM_ECCMERRIND_P1_DEFAULT << 1) /**< Shifted mode DEFAULT for MPAHBRAM_ECCMERRIND*/
-#define MPAHBRAM_ECCMERRIND_P2                            (0x1UL << 2)                           /**< Multiple ECC errors on AHB port 2           */
-#define _MPAHBRAM_ECCMERRIND_P2_SHIFT                     2                                      /**< Shift value for MPAHBRAM_P2                 */
-#define _MPAHBRAM_ECCMERRIND_P2_MASK                      0x4UL                                  /**< Bit mask for MPAHBRAM_P2                    */
-#define _MPAHBRAM_ECCMERRIND_P2_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_ECCMERRIND        */
-#define MPAHBRAM_ECCMERRIND_P2_DEFAULT                    (_MPAHBRAM_ECCMERRIND_P2_DEFAULT << 2) /**< Shifted mode DEFAULT for MPAHBRAM_ECCMERRIND*/
-#define MPAHBRAM_ECCMERRIND_P3                            (0x1UL << 3)                           /**< Multiple ECC errors on AHB port 2           */
-#define _MPAHBRAM_ECCMERRIND_P3_SHIFT                     3                                      /**< Shift value for MPAHBRAM_P3                 */
-#define _MPAHBRAM_ECCMERRIND_P3_MASK                      0x8UL                                  /**< Bit mask for MPAHBRAM_P3                    */
-#define _MPAHBRAM_ECCMERRIND_P3_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_ECCMERRIND        */
-#define MPAHBRAM_ECCMERRIND_P3_DEFAULT                    (_MPAHBRAM_ECCMERRIND_P3_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_ECCMERRIND*/
+#define _MPAHBRAM_ECCMERRIND_RESETVALUE           0x00000000UL                           /**< Default value for MPAHBRAM_ECCMERRIND       */
+#define _MPAHBRAM_ECCMERRIND_MASK                 0x0000000FUL                           /**< Mask for MPAHBRAM_ECCMERRIND                */
+#define MPAHBRAM_ECCMERRIND_P0                    (0x1UL << 0)                           /**< Multiple ECC errors on AHB port 0           */
+#define _MPAHBRAM_ECCMERRIND_P0_SHIFT             0                                      /**< Shift value for MPAHBRAM_P0                 */
+#define _MPAHBRAM_ECCMERRIND_P0_MASK              0x1UL                                  /**< Bit mask for MPAHBRAM_P0                    */
+#define _MPAHBRAM_ECCMERRIND_P0_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_ECCMERRIND        */
+#define MPAHBRAM_ECCMERRIND_P0_DEFAULT            (_MPAHBRAM_ECCMERRIND_P0_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_ECCMERRIND*/
+#define MPAHBRAM_ECCMERRIND_P1                    (0x1UL << 1)                           /**< Multiple ECC errors on AHB port 1           */
+#define _MPAHBRAM_ECCMERRIND_P1_SHIFT             1                                      /**< Shift value for MPAHBRAM_P1                 */
+#define _MPAHBRAM_ECCMERRIND_P1_MASK              0x2UL                                  /**< Bit mask for MPAHBRAM_P1                    */
+#define _MPAHBRAM_ECCMERRIND_P1_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_ECCMERRIND        */
+#define MPAHBRAM_ECCMERRIND_P1_DEFAULT            (_MPAHBRAM_ECCMERRIND_P1_DEFAULT << 1) /**< Shifted mode DEFAULT for MPAHBRAM_ECCMERRIND*/
+#define MPAHBRAM_ECCMERRIND_P2                    (0x1UL << 2)                           /**< Multiple ECC errors on AHB port 2           */
+#define _MPAHBRAM_ECCMERRIND_P2_SHIFT             2                                      /**< Shift value for MPAHBRAM_P2                 */
+#define _MPAHBRAM_ECCMERRIND_P2_MASK              0x4UL                                  /**< Bit mask for MPAHBRAM_P2                    */
+#define _MPAHBRAM_ECCMERRIND_P2_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_ECCMERRIND        */
+#define MPAHBRAM_ECCMERRIND_P2_DEFAULT            (_MPAHBRAM_ECCMERRIND_P2_DEFAULT << 2) /**< Shifted mode DEFAULT for MPAHBRAM_ECCMERRIND*/
+#define MPAHBRAM_ECCMERRIND_P3                    (0x1UL << 3)                           /**< Multiple ECC errors on AHB port 2           */
+#define _MPAHBRAM_ECCMERRIND_P3_SHIFT             3                                      /**< Shift value for MPAHBRAM_P3                 */
+#define _MPAHBRAM_ECCMERRIND_P3_MASK              0x8UL                                  /**< Bit mask for MPAHBRAM_P3                    */
+#define _MPAHBRAM_ECCMERRIND_P3_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_ECCMERRIND        */
+#define MPAHBRAM_ECCMERRIND_P3_DEFAULT            (_MPAHBRAM_ECCMERRIND_P3_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_ECCMERRIND*/
 
 /* Bit fields for MPAHBRAM IF */
-#define _MPAHBRAM_IF_RESETVALUE                           0x00000000UL                          /**< Default value for MPAHBRAM_IF               */
-#define _MPAHBRAM_IF_MASK                                 0x000000FFUL                          /**< Mask for MPAHBRAM_IF                        */
-#define MPAHBRAM_IF_AHB0ERR1B                             (0x1UL << 0)                          /**< AHB0 1-bit ECC Error Interrupt Flag         */
-#define _MPAHBRAM_IF_AHB0ERR1B_SHIFT                      0                                     /**< Shift value for MPAHBRAM_AHB0ERR1B          */
-#define _MPAHBRAM_IF_AHB0ERR1B_MASK                       0x1UL                                 /**< Bit mask for MPAHBRAM_AHB0ERR1B             */
-#define _MPAHBRAM_IF_AHB0ERR1B_DEFAULT                    0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
-#define MPAHBRAM_IF_AHB0ERR1B_DEFAULT                     (_MPAHBRAM_IF_AHB0ERR1B_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
-#define MPAHBRAM_IF_AHB1ERR1B                             (0x1UL << 1)                          /**< AHB1 1-bit ECC Error Interrupt Flag         */
-#define _MPAHBRAM_IF_AHB1ERR1B_SHIFT                      1                                     /**< Shift value for MPAHBRAM_AHB1ERR1B          */
-#define _MPAHBRAM_IF_AHB1ERR1B_MASK                       0x2UL                                 /**< Bit mask for MPAHBRAM_AHB1ERR1B             */
-#define _MPAHBRAM_IF_AHB1ERR1B_DEFAULT                    0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
-#define MPAHBRAM_IF_AHB1ERR1B_DEFAULT                     (_MPAHBRAM_IF_AHB1ERR1B_DEFAULT << 1) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
-#define MPAHBRAM_IF_AHB2ERR1B                             (0x1UL << 2)                          /**< AHB2 1-bit ECC Error Interrupt Flag         */
-#define _MPAHBRAM_IF_AHB2ERR1B_SHIFT                      2                                     /**< Shift value for MPAHBRAM_AHB2ERR1B          */
-#define _MPAHBRAM_IF_AHB2ERR1B_MASK                       0x4UL                                 /**< Bit mask for MPAHBRAM_AHB2ERR1B             */
-#define _MPAHBRAM_IF_AHB2ERR1B_DEFAULT                    0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
-#define MPAHBRAM_IF_AHB2ERR1B_DEFAULT                     (_MPAHBRAM_IF_AHB2ERR1B_DEFAULT << 2) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
-#define MPAHBRAM_IF_AHB3ERR1B                             (0x1UL << 3)                          /**< AHB3 1-bit ECC Error Interrupt Flag         */
-#define _MPAHBRAM_IF_AHB3ERR1B_SHIFT                      3                                     /**< Shift value for MPAHBRAM_AHB3ERR1B          */
-#define _MPAHBRAM_IF_AHB3ERR1B_MASK                       0x8UL                                 /**< Bit mask for MPAHBRAM_AHB3ERR1B             */
-#define _MPAHBRAM_IF_AHB3ERR1B_DEFAULT                    0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
-#define MPAHBRAM_IF_AHB3ERR1B_DEFAULT                     (_MPAHBRAM_IF_AHB3ERR1B_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
-#define MPAHBRAM_IF_AHB0ERR2B                             (0x1UL << 4)                          /**< AHB0 2-bit ECC Error Interrupt Flag         */
-#define _MPAHBRAM_IF_AHB0ERR2B_SHIFT                      4                                     /**< Shift value for MPAHBRAM_AHB0ERR2B          */
-#define _MPAHBRAM_IF_AHB0ERR2B_MASK                       0x10UL                                /**< Bit mask for MPAHBRAM_AHB0ERR2B             */
-#define _MPAHBRAM_IF_AHB0ERR2B_DEFAULT                    0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
-#define MPAHBRAM_IF_AHB0ERR2B_DEFAULT                     (_MPAHBRAM_IF_AHB0ERR2B_DEFAULT << 4) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
-#define MPAHBRAM_IF_AHB1ERR2B                             (0x1UL << 5)                          /**< AHB1 2-bit ECC Error Interrupt Flag         */
-#define _MPAHBRAM_IF_AHB1ERR2B_SHIFT                      5                                     /**< Shift value for MPAHBRAM_AHB1ERR2B          */
-#define _MPAHBRAM_IF_AHB1ERR2B_MASK                       0x20UL                                /**< Bit mask for MPAHBRAM_AHB1ERR2B             */
-#define _MPAHBRAM_IF_AHB1ERR2B_DEFAULT                    0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
-#define MPAHBRAM_IF_AHB1ERR2B_DEFAULT                     (_MPAHBRAM_IF_AHB1ERR2B_DEFAULT << 5) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
-#define MPAHBRAM_IF_AHB2ERR2B                             (0x1UL << 6)                          /**< AHB2 2-bit ECC Error Interrupt Flag         */
-#define _MPAHBRAM_IF_AHB2ERR2B_SHIFT                      6                                     /**< Shift value for MPAHBRAM_AHB2ERR2B          */
-#define _MPAHBRAM_IF_AHB2ERR2B_MASK                       0x40UL                                /**< Bit mask for MPAHBRAM_AHB2ERR2B             */
-#define _MPAHBRAM_IF_AHB2ERR2B_DEFAULT                    0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
-#define MPAHBRAM_IF_AHB2ERR2B_DEFAULT                     (_MPAHBRAM_IF_AHB2ERR2B_DEFAULT << 6) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
-#define MPAHBRAM_IF_AHB3ERR2B                             (0x1UL << 7)                          /**< AHB3 2-bit ECC Error Interrupt Flag         */
-#define _MPAHBRAM_IF_AHB3ERR2B_SHIFT                      7                                     /**< Shift value for MPAHBRAM_AHB3ERR2B          */
-#define _MPAHBRAM_IF_AHB3ERR2B_MASK                       0x80UL                                /**< Bit mask for MPAHBRAM_AHB3ERR2B             */
-#define _MPAHBRAM_IF_AHB3ERR2B_DEFAULT                    0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
-#define MPAHBRAM_IF_AHB3ERR2B_DEFAULT                     (_MPAHBRAM_IF_AHB3ERR2B_DEFAULT << 7) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
+#define _MPAHBRAM_IF_RESETVALUE                   0x00000000UL                          /**< Default value for MPAHBRAM_IF               */
+#define _MPAHBRAM_IF_MASK                         0x000000FFUL                          /**< Mask for MPAHBRAM_IF                        */
+#define MPAHBRAM_IF_AHB0ERR1B                     (0x1UL << 0)                          /**< AHB0 1-bit ECC Error Interrupt Flag         */
+#define _MPAHBRAM_IF_AHB0ERR1B_SHIFT              0                                     /**< Shift value for MPAHBRAM_AHB0ERR1B          */
+#define _MPAHBRAM_IF_AHB0ERR1B_MASK               0x1UL                                 /**< Bit mask for MPAHBRAM_AHB0ERR1B             */
+#define _MPAHBRAM_IF_AHB0ERR1B_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
+#define MPAHBRAM_IF_AHB0ERR1B_DEFAULT             (_MPAHBRAM_IF_AHB0ERR1B_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
+#define MPAHBRAM_IF_AHB1ERR1B                     (0x1UL << 1)                          /**< AHB1 1-bit ECC Error Interrupt Flag         */
+#define _MPAHBRAM_IF_AHB1ERR1B_SHIFT              1                                     /**< Shift value for MPAHBRAM_AHB1ERR1B          */
+#define _MPAHBRAM_IF_AHB1ERR1B_MASK               0x2UL                                 /**< Bit mask for MPAHBRAM_AHB1ERR1B             */
+#define _MPAHBRAM_IF_AHB1ERR1B_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
+#define MPAHBRAM_IF_AHB1ERR1B_DEFAULT             (_MPAHBRAM_IF_AHB1ERR1B_DEFAULT << 1) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
+#define MPAHBRAM_IF_AHB2ERR1B                     (0x1UL << 2)                          /**< AHB2 1-bit ECC Error Interrupt Flag         */
+#define _MPAHBRAM_IF_AHB2ERR1B_SHIFT              2                                     /**< Shift value for MPAHBRAM_AHB2ERR1B          */
+#define _MPAHBRAM_IF_AHB2ERR1B_MASK               0x4UL                                 /**< Bit mask for MPAHBRAM_AHB2ERR1B             */
+#define _MPAHBRAM_IF_AHB2ERR1B_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
+#define MPAHBRAM_IF_AHB2ERR1B_DEFAULT             (_MPAHBRAM_IF_AHB2ERR1B_DEFAULT << 2) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
+#define MPAHBRAM_IF_AHB3ERR1B                     (0x1UL << 3)                          /**< AHB3 1-bit ECC Error Interrupt Flag         */
+#define _MPAHBRAM_IF_AHB3ERR1B_SHIFT              3                                     /**< Shift value for MPAHBRAM_AHB3ERR1B          */
+#define _MPAHBRAM_IF_AHB3ERR1B_MASK               0x8UL                                 /**< Bit mask for MPAHBRAM_AHB3ERR1B             */
+#define _MPAHBRAM_IF_AHB3ERR1B_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
+#define MPAHBRAM_IF_AHB3ERR1B_DEFAULT             (_MPAHBRAM_IF_AHB3ERR1B_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
+#define MPAHBRAM_IF_AHB0ERR2B                     (0x1UL << 4)                          /**< AHB0 2-bit ECC Error Interrupt Flag         */
+#define _MPAHBRAM_IF_AHB0ERR2B_SHIFT              4                                     /**< Shift value for MPAHBRAM_AHB0ERR2B          */
+#define _MPAHBRAM_IF_AHB0ERR2B_MASK               0x10UL                                /**< Bit mask for MPAHBRAM_AHB0ERR2B             */
+#define _MPAHBRAM_IF_AHB0ERR2B_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
+#define MPAHBRAM_IF_AHB0ERR2B_DEFAULT             (_MPAHBRAM_IF_AHB0ERR2B_DEFAULT << 4) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
+#define MPAHBRAM_IF_AHB1ERR2B                     (0x1UL << 5)                          /**< AHB1 2-bit ECC Error Interrupt Flag         */
+#define _MPAHBRAM_IF_AHB1ERR2B_SHIFT              5                                     /**< Shift value for MPAHBRAM_AHB1ERR2B          */
+#define _MPAHBRAM_IF_AHB1ERR2B_MASK               0x20UL                                /**< Bit mask for MPAHBRAM_AHB1ERR2B             */
+#define _MPAHBRAM_IF_AHB1ERR2B_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
+#define MPAHBRAM_IF_AHB1ERR2B_DEFAULT             (_MPAHBRAM_IF_AHB1ERR2B_DEFAULT << 5) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
+#define MPAHBRAM_IF_AHB2ERR2B                     (0x1UL << 6)                          /**< AHB2 2-bit ECC Error Interrupt Flag         */
+#define _MPAHBRAM_IF_AHB2ERR2B_SHIFT              6                                     /**< Shift value for MPAHBRAM_AHB2ERR2B          */
+#define _MPAHBRAM_IF_AHB2ERR2B_MASK               0x40UL                                /**< Bit mask for MPAHBRAM_AHB2ERR2B             */
+#define _MPAHBRAM_IF_AHB2ERR2B_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
+#define MPAHBRAM_IF_AHB2ERR2B_DEFAULT             (_MPAHBRAM_IF_AHB2ERR2B_DEFAULT << 6) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
+#define MPAHBRAM_IF_AHB3ERR2B                     (0x1UL << 7)                          /**< AHB3 2-bit ECC Error Interrupt Flag         */
+#define _MPAHBRAM_IF_AHB3ERR2B_SHIFT              7                                     /**< Shift value for MPAHBRAM_AHB3ERR2B          */
+#define _MPAHBRAM_IF_AHB3ERR2B_MASK               0x80UL                                /**< Bit mask for MPAHBRAM_AHB3ERR2B             */
+#define _MPAHBRAM_IF_AHB3ERR2B_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for MPAHBRAM_IF                */
+#define MPAHBRAM_IF_AHB3ERR2B_DEFAULT             (_MPAHBRAM_IF_AHB3ERR2B_DEFAULT << 7) /**< Shifted mode DEFAULT for MPAHBRAM_IF        */
 
 /* Bit fields for MPAHBRAM IEN */
-#define _MPAHBRAM_IEN_RESETVALUE                          0x00000000UL                           /**< Default value for MPAHBRAM_IEN              */
-#define _MPAHBRAM_IEN_MASK                                0x000000FFUL                           /**< Mask for MPAHBRAM_IEN                       */
-#define MPAHBRAM_IEN_AHB0ERR1B                            (0x1UL << 0)                           /**< AHB0 1-bit ECC Error Interrupt Enable       */
-#define _MPAHBRAM_IEN_AHB0ERR1B_SHIFT                     0                                      /**< Shift value for MPAHBRAM_AHB0ERR1B          */
-#define _MPAHBRAM_IEN_AHB0ERR1B_MASK                      0x1UL                                  /**< Bit mask for MPAHBRAM_AHB0ERR1B             */
-#define _MPAHBRAM_IEN_AHB0ERR1B_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
-#define MPAHBRAM_IEN_AHB0ERR1B_DEFAULT                    (_MPAHBRAM_IEN_AHB0ERR1B_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
-#define MPAHBRAM_IEN_AHB1ERR1B                            (0x1UL << 1)                           /**< AHB1 1-bit ECC Error Interrupt Enable       */
-#define _MPAHBRAM_IEN_AHB1ERR1B_SHIFT                     1                                      /**< Shift value for MPAHBRAM_AHB1ERR1B          */
-#define _MPAHBRAM_IEN_AHB1ERR1B_MASK                      0x2UL                                  /**< Bit mask for MPAHBRAM_AHB1ERR1B             */
-#define _MPAHBRAM_IEN_AHB1ERR1B_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
-#define MPAHBRAM_IEN_AHB1ERR1B_DEFAULT                    (_MPAHBRAM_IEN_AHB1ERR1B_DEFAULT << 1) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
-#define MPAHBRAM_IEN_AHB2ERR1B                            (0x1UL << 2)                           /**< AHB2 1-bit ECC Error Interrupt Enable       */
-#define _MPAHBRAM_IEN_AHB2ERR1B_SHIFT                     2                                      /**< Shift value for MPAHBRAM_AHB2ERR1B          */
-#define _MPAHBRAM_IEN_AHB2ERR1B_MASK                      0x4UL                                  /**< Bit mask for MPAHBRAM_AHB2ERR1B             */
-#define _MPAHBRAM_IEN_AHB2ERR1B_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
-#define MPAHBRAM_IEN_AHB2ERR1B_DEFAULT                    (_MPAHBRAM_IEN_AHB2ERR1B_DEFAULT << 2) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
-#define MPAHBRAM_IEN_AHB3ERR1B                            (0x1UL << 3)                           /**< AHB3 1-bit ECC Error Interrupt Enable       */
-#define _MPAHBRAM_IEN_AHB3ERR1B_SHIFT                     3                                      /**< Shift value for MPAHBRAM_AHB3ERR1B          */
-#define _MPAHBRAM_IEN_AHB3ERR1B_MASK                      0x8UL                                  /**< Bit mask for MPAHBRAM_AHB3ERR1B             */
-#define _MPAHBRAM_IEN_AHB3ERR1B_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
-#define MPAHBRAM_IEN_AHB3ERR1B_DEFAULT                    (_MPAHBRAM_IEN_AHB3ERR1B_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
-#define MPAHBRAM_IEN_AHB0ERR2B                            (0x1UL << 4)                           /**< AHB0 2-bit ECC Error Interrupt Enable       */
-#define _MPAHBRAM_IEN_AHB0ERR2B_SHIFT                     4                                      /**< Shift value for MPAHBRAM_AHB0ERR2B          */
-#define _MPAHBRAM_IEN_AHB0ERR2B_MASK                      0x10UL                                 /**< Bit mask for MPAHBRAM_AHB0ERR2B             */
-#define _MPAHBRAM_IEN_AHB0ERR2B_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
-#define MPAHBRAM_IEN_AHB0ERR2B_DEFAULT                    (_MPAHBRAM_IEN_AHB0ERR2B_DEFAULT << 4) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
-#define MPAHBRAM_IEN_AHB1ERR2B                            (0x1UL << 5)                           /**< AHB1 2-bit ECC Error Interrupt Enable       */
-#define _MPAHBRAM_IEN_AHB1ERR2B_SHIFT                     5                                      /**< Shift value for MPAHBRAM_AHB1ERR2B          */
-#define _MPAHBRAM_IEN_AHB1ERR2B_MASK                      0x20UL                                 /**< Bit mask for MPAHBRAM_AHB1ERR2B             */
-#define _MPAHBRAM_IEN_AHB1ERR2B_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
-#define MPAHBRAM_IEN_AHB1ERR2B_DEFAULT                    (_MPAHBRAM_IEN_AHB1ERR2B_DEFAULT << 5) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
-#define MPAHBRAM_IEN_AHB2ERR2B                            (0x1UL << 6)                           /**< AHB2 2-bit ECC Error Interrupt Enable       */
-#define _MPAHBRAM_IEN_AHB2ERR2B_SHIFT                     6                                      /**< Shift value for MPAHBRAM_AHB2ERR2B          */
-#define _MPAHBRAM_IEN_AHB2ERR2B_MASK                      0x40UL                                 /**< Bit mask for MPAHBRAM_AHB2ERR2B             */
-#define _MPAHBRAM_IEN_AHB2ERR2B_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
-#define MPAHBRAM_IEN_AHB2ERR2B_DEFAULT                    (_MPAHBRAM_IEN_AHB2ERR2B_DEFAULT << 6) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
-#define MPAHBRAM_IEN_AHB3ERR2B                            (0x1UL << 7)                           /**< AHB3 2-bit ECC Error Interrupt Enable       */
-#define _MPAHBRAM_IEN_AHB3ERR2B_SHIFT                     7                                      /**< Shift value for MPAHBRAM_AHB3ERR2B          */
-#define _MPAHBRAM_IEN_AHB3ERR2B_MASK                      0x80UL                                 /**< Bit mask for MPAHBRAM_AHB3ERR2B             */
-#define _MPAHBRAM_IEN_AHB3ERR2B_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
-#define MPAHBRAM_IEN_AHB3ERR2B_DEFAULT                    (_MPAHBRAM_IEN_AHB3ERR2B_DEFAULT << 7) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
-
-/* Bit fields for MPAHBRAM RAMBANKSVALID */
-#define _MPAHBRAM_RAMBANKSVALID_RESETVALUE                0xFFFFFFFFUL                                          /**< Default value for MPAHBRAM_RAMBANKSVALID    */
-#define _MPAHBRAM_RAMBANKSVALID_MASK                      0x0000FFFFUL                                          /**< Mask for MPAHBRAM_RAMBANKSVALID             */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_SHIFT       0                                                     /**< Shift value for MPAHBRAM_RAMBANKSVALID      */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_MASK        0xFFFFUL                                              /**< Bit mask for MPAHBRAM_RAMBANKSVALID         */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_DEFAULT     0xFFFFFFFFUL                                          /**< Mode DEFAULT for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0        0x00000001UL                                          /**< Mode BLK0 for MPAHBRAM_RAMBANKSVALID        */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO1     0x00000003UL                                          /**< Mode BLK0TO1 for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO2     0x00000007UL                                          /**< Mode BLK0TO2 for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO3     0x0000000FUL                                          /**< Mode BLK0TO3 for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO4     0x0000001FUL                                          /**< Mode BLK0TO4 for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO5     0x0000003FUL                                          /**< Mode BLK0TO5 for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO6     0x0000007FUL                                          /**< Mode BLK0TO6 for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO7     0x000000FFUL                                          /**< Mode BLK0TO7 for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO8     0x000001FFUL                                          /**< Mode BLK0TO8 for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO9     0x000003FFUL                                          /**< Mode BLK0TO9 for MPAHBRAM_RAMBANKSVALID     */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO10    0x000007FFUL                                          /**< Mode BLK0TO10 for MPAHBRAM_RAMBANKSVALID    */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO11    0x00000FFFUL                                          /**< Mode BLK0TO11 for MPAHBRAM_RAMBANKSVALID    */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO12    0x00001FFFUL                                          /**< Mode BLK0TO12 for MPAHBRAM_RAMBANKSVALID    */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO13    0x00003FFFUL                                          /**< Mode BLK0TO13 for MPAHBRAM_RAMBANKSVALID    */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO14    0x00007FFFUL                                          /**< Mode BLK0TO14 for MPAHBRAM_RAMBANKSVALID    */
-#define _MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO15    0x0000FFFFUL                                          /**< Mode BLK0TO15 for MPAHBRAM_RAMBANKSVALID    */
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_DEFAULT      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_DEFAULT << 0)  /**< Shifted mode DEFAULT for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0         (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0 << 0)     /**< Shifted mode BLK0 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO1      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO1 << 0)  /**< Shifted mode BLK0TO1 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO2      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO2 << 0)  /**< Shifted mode BLK0TO2 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO3      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO3 << 0)  /**< Shifted mode BLK0TO3 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO4      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO4 << 0)  /**< Shifted mode BLK0TO4 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO5      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO5 << 0)  /**< Shifted mode BLK0TO5 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO6      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO6 << 0)  /**< Shifted mode BLK0TO6 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO7      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO7 << 0)  /**< Shifted mode BLK0TO7 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO8      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO8 << 0)  /**< Shifted mode BLK0TO8 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO9      (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO9 << 0)  /**< Shifted mode BLK0TO9 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO10     (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO10 << 0) /**< Shifted mode BLK0TO10 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO11     (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO11 << 0) /**< Shifted mode BLK0TO11 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO12     (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO12 << 0) /**< Shifted mode BLK0TO12 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO13     (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO13 << 0) /**< Shifted mode BLK0TO13 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO14     (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO14 << 0) /**< Shifted mode BLK0TO14 for MPAHBRAM_RAMBANKSVALID*/
-#define MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO15     (_MPAHBRAM_RAMBANKSVALID_RAMBANKSVALID_BLK0TO15 << 0) /**< Shifted mode BLK0TO15 for MPAHBRAM_RAMBANKSVALID*/
-
-/* Bit fields for MPAHBRAM CFGSRTOP */
-#define _MPAHBRAM_CFGSRTOP_RESETVALUE                     0x00000000UL                            /**< Default value for MPAHBRAM_CFGSRTOP         */
-#define _MPAHBRAM_CFGSRTOP_MASK                           0x00000001UL                            /**< Mask for MPAHBRAM_CFGSRTOP                  */
-#define MPAHBRAM_CFGSRTOP_SRTOP                           (0x1UL << 0)                            /**< Sequential region on top                    */
-#define _MPAHBRAM_CFGSRTOP_SRTOP_SHIFT                    0                                       /**< Shift value for MPAHBRAM_SRTOP              */
-#define _MPAHBRAM_CFGSRTOP_SRTOP_MASK                     0x1UL                                   /**< Bit mask for MPAHBRAM_SRTOP                 */
-#define _MPAHBRAM_CFGSRTOP_SRTOP_DEFAULT                  0x00000000UL                            /**< Mode DEFAULT for MPAHBRAM_CFGSRTOP          */
-#define MPAHBRAM_CFGSRTOP_SRTOP_DEFAULT                   (_MPAHBRAM_CFGSRTOP_SRTOP_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_CFGSRTOP  */
-
-/* Bit fields for MPAHBRAM CFGSRMAP */
-#define _MPAHBRAM_CFGSRMAP_RESETVALUE                     0xFFFFFFFFUL                          /**< Default value for MPAHBRAM_CFGSRMAP         */
-#define _MPAHBRAM_CFGSRMAP_MASK                           0x0000FFFFUL                          /**< Mask for MPAHBRAM_CFGSRMAP                  */
-#define _MPAHBRAM_CFGSRMAP_MAP_SHIFT                      0                                     /**< Shift value for MPAHBRAM_MAP                */
-#define _MPAHBRAM_CFGSRMAP_MAP_MASK                       0xFFFFUL                              /**< Bit mask for MPAHBRAM_MAP                   */
-#define _MPAHBRAM_CFGSRMAP_MAP_DEFAULT                    0xFFFFFFFFUL                          /**< Mode DEFAULT for MPAHBRAM_CFGSRMAP          */
-#define MPAHBRAM_CFGSRMAP_MAP_DEFAULT                     (_MPAHBRAM_CFGSRMAP_MAP_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_CFGSRMAP  */
-
-/* Bit fields for MPAHBRAM CFGIU0MAP */
-#define _MPAHBRAM_CFGIU0MAP_RESETVALUE                    0x00000000UL                           /**< Default value for MPAHBRAM_CFGIU0MAP        */
-#define _MPAHBRAM_CFGIU0MAP_MASK                          0x0000FFFFUL                           /**< Mask for MPAHBRAM_CFGIU0MAP                 */
-#define _MPAHBRAM_CFGIU0MAP_MAP_SHIFT                     0                                      /**< Shift value for MPAHBRAM_MAP                */
-#define _MPAHBRAM_CFGIU0MAP_MAP_MASK                      0xFFFFUL                               /**< Bit mask for MPAHBRAM_MAP                   */
-#define _MPAHBRAM_CFGIU0MAP_MAP_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_CFGIU0MAP         */
-#define MPAHBRAM_CFGIU0MAP_MAP_DEFAULT                    (_MPAHBRAM_CFGIU0MAP_MAP_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_CFGIU0MAP */
-
-/* Bit fields for MPAHBRAM CFGIU1MAP */
-#define _MPAHBRAM_CFGIU1MAP_RESETVALUE                    0x00000000UL                           /**< Default value for MPAHBRAM_CFGIU1MAP        */
-#define _MPAHBRAM_CFGIU1MAP_MASK                          0x0000FFFFUL                           /**< Mask for MPAHBRAM_CFGIU1MAP                 */
-#define _MPAHBRAM_CFGIU1MAP_MAP_SHIFT                     0                                      /**< Shift value for MPAHBRAM_MAP                */
-#define _MPAHBRAM_CFGIU1MAP_MAP_MASK                      0xFFFFUL                               /**< Bit mask for MPAHBRAM_MAP                   */
-#define _MPAHBRAM_CFGIU1MAP_MAP_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_CFGIU1MAP         */
-#define MPAHBRAM_CFGIU1MAP_MAP_DEFAULT                    (_MPAHBRAM_CFGIU1MAP_MAP_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_CFGIU1MAP */
-
-/* Bit fields for MPAHBRAM CFGIU2MAP */
-#define _MPAHBRAM_CFGIU2MAP_RESETVALUE                    0x00000000UL                           /**< Default value for MPAHBRAM_CFGIU2MAP        */
-#define _MPAHBRAM_CFGIU2MAP_MASK                          0x0000FFFFUL                           /**< Mask for MPAHBRAM_CFGIU2MAP                 */
-#define _MPAHBRAM_CFGIU2MAP_MAP_SHIFT                     0                                      /**< Shift value for MPAHBRAM_MAP                */
-#define _MPAHBRAM_CFGIU2MAP_MAP_MASK                      0xFFFFUL                               /**< Bit mask for MPAHBRAM_MAP                   */
-#define _MPAHBRAM_CFGIU2MAP_MAP_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_CFGIU2MAP         */
-#define MPAHBRAM_CFGIU2MAP_MAP_DEFAULT                    (_MPAHBRAM_CFGIU2MAP_MAP_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_CFGIU2MAP */
-
-/* Bit fields for MPAHBRAM CFGIU3MAP */
-#define _MPAHBRAM_CFGIU3MAP_RESETVALUE                    0x00000000UL                           /**< Default value for MPAHBRAM_CFGIU3MAP        */
-#define _MPAHBRAM_CFGIU3MAP_MASK                          0x0000FFFFUL                           /**< Mask for MPAHBRAM_CFGIU3MAP                 */
-#define _MPAHBRAM_CFGIU3MAP_MAP_SHIFT                     0                                      /**< Shift value for MPAHBRAM_MAP                */
-#define _MPAHBRAM_CFGIU3MAP_MAP_MASK                      0xFFFFUL                               /**< Bit mask for MPAHBRAM_MAP                   */
-#define _MPAHBRAM_CFGIU3MAP_MAP_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_CFGIU3MAP         */
-#define MPAHBRAM_CFGIU3MAP_MAP_DEFAULT                    (_MPAHBRAM_CFGIU3MAP_MAP_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_CFGIU3MAP */
+#define _MPAHBRAM_IEN_RESETVALUE                  0x00000000UL                           /**< Default value for MPAHBRAM_IEN              */
+#define _MPAHBRAM_IEN_MASK                        0x000000FFUL                           /**< Mask for MPAHBRAM_IEN                       */
+#define MPAHBRAM_IEN_AHB0ERR1B                    (0x1UL << 0)                           /**< AHB0 1-bit ECC Error Interrupt Enable       */
+#define _MPAHBRAM_IEN_AHB0ERR1B_SHIFT             0                                      /**< Shift value for MPAHBRAM_AHB0ERR1B          */
+#define _MPAHBRAM_IEN_AHB0ERR1B_MASK              0x1UL                                  /**< Bit mask for MPAHBRAM_AHB0ERR1B             */
+#define _MPAHBRAM_IEN_AHB0ERR1B_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
+#define MPAHBRAM_IEN_AHB0ERR1B_DEFAULT            (_MPAHBRAM_IEN_AHB0ERR1B_DEFAULT << 0) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
+#define MPAHBRAM_IEN_AHB1ERR1B                    (0x1UL << 1)                           /**< AHB1 1-bit ECC Error Interrupt Enable       */
+#define _MPAHBRAM_IEN_AHB1ERR1B_SHIFT             1                                      /**< Shift value for MPAHBRAM_AHB1ERR1B          */
+#define _MPAHBRAM_IEN_AHB1ERR1B_MASK              0x2UL                                  /**< Bit mask for MPAHBRAM_AHB1ERR1B             */
+#define _MPAHBRAM_IEN_AHB1ERR1B_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
+#define MPAHBRAM_IEN_AHB1ERR1B_DEFAULT            (_MPAHBRAM_IEN_AHB1ERR1B_DEFAULT << 1) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
+#define MPAHBRAM_IEN_AHB2ERR1B                    (0x1UL << 2)                           /**< AHB2 1-bit ECC Error Interrupt Enable       */
+#define _MPAHBRAM_IEN_AHB2ERR1B_SHIFT             2                                      /**< Shift value for MPAHBRAM_AHB2ERR1B          */
+#define _MPAHBRAM_IEN_AHB2ERR1B_MASK              0x4UL                                  /**< Bit mask for MPAHBRAM_AHB2ERR1B             */
+#define _MPAHBRAM_IEN_AHB2ERR1B_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
+#define MPAHBRAM_IEN_AHB2ERR1B_DEFAULT            (_MPAHBRAM_IEN_AHB2ERR1B_DEFAULT << 2) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
+#define MPAHBRAM_IEN_AHB3ERR1B                    (0x1UL << 3)                           /**< AHB3 1-bit ECC Error Interrupt Enable       */
+#define _MPAHBRAM_IEN_AHB3ERR1B_SHIFT             3                                      /**< Shift value for MPAHBRAM_AHB3ERR1B          */
+#define _MPAHBRAM_IEN_AHB3ERR1B_MASK              0x8UL                                  /**< Bit mask for MPAHBRAM_AHB3ERR1B             */
+#define _MPAHBRAM_IEN_AHB3ERR1B_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
+#define MPAHBRAM_IEN_AHB3ERR1B_DEFAULT            (_MPAHBRAM_IEN_AHB3ERR1B_DEFAULT << 3) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
+#define MPAHBRAM_IEN_AHB0ERR2B                    (0x1UL << 4)                           /**< AHB0 2-bit ECC Error Interrupt Enable       */
+#define _MPAHBRAM_IEN_AHB0ERR2B_SHIFT             4                                      /**< Shift value for MPAHBRAM_AHB0ERR2B          */
+#define _MPAHBRAM_IEN_AHB0ERR2B_MASK              0x10UL                                 /**< Bit mask for MPAHBRAM_AHB0ERR2B             */
+#define _MPAHBRAM_IEN_AHB0ERR2B_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
+#define MPAHBRAM_IEN_AHB0ERR2B_DEFAULT            (_MPAHBRAM_IEN_AHB0ERR2B_DEFAULT << 4) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
+#define MPAHBRAM_IEN_AHB1ERR2B                    (0x1UL << 5)                           /**< AHB1 2-bit ECC Error Interrupt Enable       */
+#define _MPAHBRAM_IEN_AHB1ERR2B_SHIFT             5                                      /**< Shift value for MPAHBRAM_AHB1ERR2B          */
+#define _MPAHBRAM_IEN_AHB1ERR2B_MASK              0x20UL                                 /**< Bit mask for MPAHBRAM_AHB1ERR2B             */
+#define _MPAHBRAM_IEN_AHB1ERR2B_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
+#define MPAHBRAM_IEN_AHB1ERR2B_DEFAULT            (_MPAHBRAM_IEN_AHB1ERR2B_DEFAULT << 5) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
+#define MPAHBRAM_IEN_AHB2ERR2B                    (0x1UL << 6)                           /**< AHB2 2-bit ECC Error Interrupt Enable       */
+#define _MPAHBRAM_IEN_AHB2ERR2B_SHIFT             6                                      /**< Shift value for MPAHBRAM_AHB2ERR2B          */
+#define _MPAHBRAM_IEN_AHB2ERR2B_MASK              0x40UL                                 /**< Bit mask for MPAHBRAM_AHB2ERR2B             */
+#define _MPAHBRAM_IEN_AHB2ERR2B_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
+#define MPAHBRAM_IEN_AHB2ERR2B_DEFAULT            (_MPAHBRAM_IEN_AHB2ERR2B_DEFAULT << 6) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
+#define MPAHBRAM_IEN_AHB3ERR2B                    (0x1UL << 7)                           /**< AHB3 2-bit ECC Error Interrupt Enable       */
+#define _MPAHBRAM_IEN_AHB3ERR2B_SHIFT             7                                      /**< Shift value for MPAHBRAM_AHB3ERR2B          */
+#define _MPAHBRAM_IEN_AHB3ERR2B_MASK              0x80UL                                 /**< Bit mask for MPAHBRAM_AHB3ERR2B             */
+#define _MPAHBRAM_IEN_AHB3ERR2B_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for MPAHBRAM_IEN               */
+#define MPAHBRAM_IEN_AHB3ERR2B_DEFAULT            (_MPAHBRAM_IEN_AHB3ERR2B_DEFAULT << 7) /**< Shifted mode DEFAULT for MPAHBRAM_IEN       */
 
 /** @} End of group EFR32MG24_MPAHBRAM_BitFields */
 /** @} End of group EFR32MG24_MPAHBRAM */
 /** @} End of group Parts */
 
-#endif /* EFR32MG24_MPAHBRAM_H */
+#endif // EFR32MG24_MPAHBRAM_H

--- a/gecko/Device/SiliconLabs/EFR32MG24/Include/efr32mg24_syscfg.h
+++ b/gecko/Device/SiliconLabs/EFR32MG24/Include/efr32mg24_syscfg.h
@@ -3,7 +3,7 @@
  * @brief EFR32MG24 SYSCFG register and bit field definitions
  ******************************************************************************
  * # License
- * <b>Copyright 2022 Silicon Laboratories, Inc. www.silabs.com</b>
+ * <b>Copyright 2023 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * SPDX-License-Identifier: Zlib
@@ -361,7 +361,7 @@ typedef struct {
 #define SYSCFG_IEN_FRCRAMERR2B_DEFAULT                        (_SYSCFG_IEN_FRCRAMERR2B_DEFAULT << 29)    /**< Shifted mode DEFAULT for SYSCFG_IEN         */
 
 /* Bit fields for SYSCFG CHIPREVHW */
-#define _SYSCFG_CHIPREVHW_RESETVALUE                          0x00000C01UL                            /**< Default value for SYSCFG_CHIPREVHW          */
+#define _SYSCFG_CHIPREVHW_RESETVALUE                          0x00000F01UL                            /**< Default value for SYSCFG_CHIPREVHW          */
 #define _SYSCFG_CHIPREVHW_MASK                                0xFF0FFFFFUL                            /**< Mask for SYSCFG_CHIPREVHW                   */
 #define _SYSCFG_CHIPREVHW_MAJOR_SHIFT                         0                                       /**< Shift value for SYSCFG_MAJOR                */
 #define _SYSCFG_CHIPREVHW_MAJOR_MASK                          0x3FUL                                  /**< Bit mask for SYSCFG_MAJOR                   */
@@ -369,7 +369,7 @@ typedef struct {
 #define SYSCFG_CHIPREVHW_MAJOR_DEFAULT                        (_SYSCFG_CHIPREVHW_MAJOR_DEFAULT << 0)  /**< Shifted mode DEFAULT for SYSCFG_CHIPREVHW   */
 #define _SYSCFG_CHIPREVHW_FAMILY_SHIFT                        6                                       /**< Shift value for SYSCFG_FAMILY               */
 #define _SYSCFG_CHIPREVHW_FAMILY_MASK                         0xFC0UL                                 /**< Bit mask for SYSCFG_FAMILY                  */
-#define _SYSCFG_CHIPREVHW_FAMILY_DEFAULT                      0x00000030UL                            /**< Mode DEFAULT for SYSCFG_CHIPREVHW           */
+#define _SYSCFG_CHIPREVHW_FAMILY_DEFAULT                      0x0000003CUL                            /**< Mode DEFAULT for SYSCFG_CHIPREVHW           */
 #define SYSCFG_CHIPREVHW_FAMILY_DEFAULT                       (_SYSCFG_CHIPREVHW_FAMILY_DEFAULT << 6) /**< Shifted mode DEFAULT for SYSCFG_CHIPREVHW   */
 #define _SYSCFG_CHIPREVHW_MINOR_SHIFT                         12                                      /**< Shift value for SYSCFG_MINOR                */
 #define _SYSCFG_CHIPREVHW_MINOR_MASK                          0xFF000UL                               /**< Bit mask for SYSCFG_MINOR                   */
@@ -386,7 +386,11 @@ typedef struct {
 #define _SYSCFG_CHIPREV_FAMILY_SHIFT                          6                                     /**< Shift value for SYSCFG_FAMILY               */
 #define _SYSCFG_CHIPREV_FAMILY_MASK                           0xFC0UL                               /**< Bit mask for SYSCFG_FAMILY                  */
 #define _SYSCFG_CHIPREV_FAMILY_DEFAULT                        0x00000000UL                          /**< Mode DEFAULT for SYSCFG_CHIPREV             */
+#define _SYSCFG_CHIPREV_FAMILY_MG24                           0x0000003CUL                          /**< Mode MG24 for SYSCFG_CHIPREV                */
+#define _SYSCFG_CHIPREV_FAMILY_BG24                           0x0000003DUL                          /**< Mode BG24 for SYSCFG_CHIPREV                */
 #define SYSCFG_CHIPREV_FAMILY_DEFAULT                         (_SYSCFG_CHIPREV_FAMILY_DEFAULT << 6) /**< Shifted mode DEFAULT for SYSCFG_CHIPREV     */
+#define SYSCFG_CHIPREV_FAMILY_MG24                            (_SYSCFG_CHIPREV_FAMILY_MG24 << 6)    /**< Shifted mode MG24 for SYSCFG_CHIPREV        */
+#define SYSCFG_CHIPREV_FAMILY_BG24                            (_SYSCFG_CHIPREV_FAMILY_BG24 << 6)    /**< Shifted mode BG24 for SYSCFG_CHIPREV        */
 #define _SYSCFG_CHIPREV_MINOR_SHIFT                           12                                    /**< Shift value for SYSCFG_MINOR                */
 #define _SYSCFG_CHIPREV_MINOR_MASK                            0xFF000UL                             /**< Bit mask for SYSCFG_MINOR                   */
 #define _SYSCFG_CHIPREV_MINOR_DEFAULT                         0x00000000UL                          /**< Mode DEFAULT for SYSCFG_CHIPREV             */

--- a/gecko/Device/SiliconLabs/EFR32MG24/Include/system_efr32mg24.h
+++ b/gecko/Device/SiliconLabs/EFR32MG24/Include/system_efr32mg24.h
@@ -218,6 +218,11 @@ static __INLINE void SystemCoreClockUpdate(void)
 }
 
 void     SystemInit(void);
+#if !defined(SL_LEGACY_LINKER)
+void     FlashToRamCopy(uint32_t *from,
+                        uint32_t *to,
+                        uint32_t size);
+#endif
 uint32_t SystemHFRCODPLLClockGet(void);
 void     SystemHFRCODPLLClockSet(uint32_t freq);
 uint32_t SystemSYSCLKGet(void);

--- a/gecko/Device/SiliconLabs/EFR32MG24/Source/system_efr32mg24.c
+++ b/gecko/Device/SiliconLabs/EFR32MG24/Source/system_efr32mg24.c
@@ -191,6 +191,35 @@ void SystemInit(void)
 #endif /*SL_TRUSTZONE_SECURE */
 }
 
+#if !defined(SL_LEGACY_LINKER)
+/**************************************************************************//**
+ * @brief
+ *   Copy data.
+ *
+ * @details
+ *   Used to copy data from Flash to Ram at startup and runtime.
+ *
+ * @param[in] from
+ *   Pointer to the source address in Flash.
+ *
+ * @param[in] to
+ *   Pointer to the destination address in Ram.
+ *
+ * @param[in] size
+ *   Size of data to copy.
+ *****************************************************************************/
+void FlashToRamCopy(uint32_t *from,
+                    uint32_t *to,
+                    uint32_t size)
+{
+  if (size != 0) {
+    while (size--) {
+      *to++ = *from++;
+    }
+  }
+}
+#endif
+
 /**************************************************************************//**
  * @brief
  *   Get current HFRCODPLL frequency.


### PR DESCRIPTION
Origin: Silicon Labs Gecko SDK
URL: https://github.com/SiliconLabs/gecko_sdk
Version: 4.4.0
Purpose: Update hal_silabs to gecko_sdk v4.4.0.

Update the EFR32BG22, BG27 and MG24 device files inside gecko/Device/SiliconLabs/ from gecko_sdk to align the codebase of hal_silabs with gecko_sdk 4.4.0.