### PR TITLE
gecko/cmake: replace 'SOC_GECKO_SERIESx' with 'SOC_FAMILY_SILABS_Sx'

### DIFF
--- a/gecko/CMakeLists.txt
+++ b/gecko/CMakeLists.txt
@@ -25,12 +25,12 @@ function(add_prebuilt_library lib_name prebuilt_path)
 endfunction()
 
 if(${CONFIG_SOC_GECKO_HAS_RADIO})
-  if(${CONFIG_SOC_GECKO_SERIES1})
+  if(${CONFIG_SOC_FAMILY_SILABS_S1})
     zephyr_include_directories(
       platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/config
       platform/radio/rail_lib/chip/efr32/efr32xg1x
     )
-  elseif(${CONFIG_SOC_GECKO_SERIES2})
+  elseif(${CONFIG_SOC_FAMILY_SILABS_S2})
     zephyr_include_directories(
       platform/radio/rail_lib/plugin/pa-conversions/efr32xg${GECKO_SERIES_NUMBER}/config
       platform/radio/rail_lib/chip/efr32/efr32xg2x


### PR DESCRIPTION
The `SOC_GECKO_SERIESx` Kconfig symbol no longer exists in Zephyr and was replaced with `SOC_FAMILY_SILABS_Sx` during migration to hwmv2.

References (this will fix related issue after updating west manifest): https://github.com/zephyrproject-rtos/zephyr/issues/69902