### PR TITLE
zephyr: Add an explicit name for the module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,4 @@
+name: hal_silabs
 build:
   cmake: .
 blobs:


### PR DESCRIPTION
This is consistent with most other HALs and also makes the fetching of binary blobs consistent ("west blobs fetch hal_silabs").