### PR TITLE
simplicity_sdk: Add missing SecureFault IRQ number

### DIFF
--- a/scripts/patch_simplicity_sdk.sh
+++ b/scripts/patch_simplicity_sdk.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Add missing SecureFault interrupt number to device headers
+sed -i '' "s/\(UsageFault_IRQn.*\)/\1\n#if defined(CONFIG_ARM_SECURE_FIRMWARE)\n  SecureFault_IRQn       = -9,\n#endif/" simplicity_sdk/platform/Device/SiliconLabs/*/Include/*.h

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c112f352gm32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c112f352gm32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c112f352gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c112f352gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c222f352gm32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c222f352gm32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c222f352gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c222f352gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c222f352gn32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c222f352gn32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512gm32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512gm32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512gn32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512gn32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22c224f512im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22e224f512im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22e224f512im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22e224f512im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG22/Include/efr32bg22e224f512im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c140f768im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c140f768im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c140f768im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c140f768im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c230f768im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c230f768im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c230f768im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c230f768im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c320f768gj39.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c320f768gj39.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c320f768ij39.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32BG27/Include/efr32bg27c320f768ij39.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f128gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f128gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f256gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f256gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f256gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f256gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f512gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f512gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f512gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a010f512gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a011f512gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a011f512gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f128gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f128gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f256gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f256gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f256gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f256gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f512gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f512gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f512gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a020f512gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a021f512gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23a021f512gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b010f128gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b010f128gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b010f512gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b010f512gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b010f512im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b010f512im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b010f512im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b010f512im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b020f128gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b020f128gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b020f512im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b020f512im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b020f512im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b020f512im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b021f512im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b021f512im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b021f512im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32FG23/Include/efr32fg23b021f512im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f1024im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f512im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f512im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f768im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a010f768im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a020f1024im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a020f1024im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a020f512im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a020f512im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a020f768im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21a020f768im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b010f1024im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b010f1024im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b010f512im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b010f512im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b010f768im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b010f768im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b020f1024im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b020f1024im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b020f512im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b020f512im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b020f768im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/efr32mg21b020f768im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/rm21z000f1024im32.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG21/Include/rm21z000f1024im32.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn         = -11,              /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn       = -10,              /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn           = -5,               /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn           = -2,               /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1024im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1024im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1024im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1024im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1536gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1536gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1536gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1536gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f768im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f768im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f768im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a010f768im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1024im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1024im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1024im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1024im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1536gm40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1536gm40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1536gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1536gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f768im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a020f768im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a021f1024im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a021f1024im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a110f1024im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a110f1024im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a110f1536gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a110f1536gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a111f1536gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a111f1536gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a120f1536gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a120f1536gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a121f1536gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a121f1536gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a410f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a410f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a410f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a410f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a420f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a420f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a420f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a420f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a610f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a610f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a620f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24a620f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b010f1024im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b010f1024im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b010f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b010f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b010f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b010f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b020f1024im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b020f1024im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b020f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b020f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b020f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b020f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b110f1536gm48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b110f1536gm48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b110f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b110f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b120f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b120f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b210f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b210f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b210f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b210f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b220f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b220f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b310f1536im48.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b310f1536im48.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */

--- a/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b610f1536im40.h
+++ b/simplicity_sdk/platform/Device/SiliconLabs/EFR32MG24/Include/efr32mg24b610f1536im40.h
@@ -53,6 +53,9 @@ typedef enum IRQn{
   MemoryManagement_IRQn  = -12,             /*!< -12 Cortex-M Memory Management Interrupt */
   BusFault_IRQn          = -11,             /*!< -11 Cortex-M Bus Fault Interrupt         */
   UsageFault_IRQn        = -10,             /*!< -10 Cortex-M Usage Fault Interrupt       */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+  SecureFault_IRQn       = -9,
+#endif
   SVCall_IRQn            = -5,              /*!< -5  Cortex-M SV Call Interrupt           */
   DebugMonitor_IRQn      = -4,              /*!< -4  Cortex-M Debug Monitor Interrupt     */
   PendSV_IRQn            = -2,              /*!< -2  Cortex-M Pend SV Interrupt           */


### PR DESCRIPTION
This enables the use of CONFIG_ARM_SECURE_FIRMWARE in the main tree, which avoids us needing to specify -mcmse in the HAL CMakeLists.txt.
