### PR TITLE
CODEOWNERS: Add basic skeleton

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+*       @jhedberg @asmellby @jerome-pouiller @Martinhoff-maker
+/si32/  @rettichschnidi @M1cha @asmellby @jerome-pouiller @jhedberg


### PR DESCRIPTION
Add a CODEOWNERS file based on the Maintainers and Collaborators from the Zephyr main tree MAINTAINERS.yml file.