### PR TITLE
wiseconnect: Use static allocation for threads

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_rsi_utility.h
+++ b/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_rsi_utility.h
@@ -61,6 +61,16 @@
 #ifndef SL_SI91X_EVENT_HANDLER_STACK_SIZE
 #define SL_SI91X_EVENT_HANDLER_STACK_SIZE 1536
 #endif
+
+/**
+ * Stack size of the bus thread.
+ * Override by defining SL_SI91X_BUS_THREAD_STACK_SIZE in your project
+ * or add -DSL_SI91X_BUS_THREAD_STACK_SIZE=<new value> to compiler options.
+ */
+#ifndef SL_SI91X_BUS_THREAD_STACK_SIZE
+#define SL_SI91X_BUS_THREAD_STACK_SIZE 1636
+#endif
+
 typedef bool (*sli_si91x_wifi_buffer_comparator)(const sl_wifi_buffer_t *buffer, const void *userdata);
 
 typedef struct {


### PR DESCRIPTION
Allocate stack memory and control blocks statically for `bus thread` and `event thread` instead of dynamically. This change addresses a known issue in Zephyr related to dynamic allocation of stack and control blocks.