### PR TITLE
wiseconnect: Fixed setting of si91x bus events in the driver path

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_rom.c
+++ b/wiseconnect/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_rom.c
@@ -277,7 +277,7 @@ sl_status_t sli_m4_interrupt_isr(void)
 
     mask_ta_interrupt(TA_RSI_BUFFER_FULL_CLEAR_EVENT);
 
-    sli_si91x_set_event(SL_SI91X_TA_BUFFER_FULL_CLEAR_EVENT);
+    sl_si91x_host_set_bus_event(SL_SI91X_TA_BUFFER_FULL_CLEAR_EVENT);
 
     // Clear the interrupt
     clear_ta_to_m4_interrupt(TA_RSI_BUFFER_FULL_CLEAR_EVENT);

--- a/wiseconnect/components/device/silabs/si91x/wireless/socket/src/sl_si91x_socket_utility.c
+++ b/wiseconnect/components/device/silabs/si91x/wireless/socket/src/sl_si91x_socket_utility.c
@@ -1042,7 +1042,7 @@ sl_status_t sli_si91x_send_socket_command(sli_si91x_socket_t *socket,
   node_buffer->id        = this_packet_id;
   sli_si91x_append_to_buffer_queue(&socket->command_queue.tx_queue, node_buffer);
   tx_socket_command_queues_status |= (1 << socket->index);
-  sli_si91x_set_event(SL_SI91X_SOCKET_COMMAND_TX_PENDING_EVENT);
+  sl_si91x_host_set_bus_event(SL_SI91X_SOCKET_COMMAND_TX_PENDING_EVENT);
   CORE_ExitAtomic(state);
 
   if (wait_period != 0) {
@@ -1130,7 +1130,7 @@ sl_status_t sli_si91x_send_socket_data(sli_si91x_socket_t *si91x_socket,
   CORE_irqState_t state = CORE_EnterAtomic();
   sli_si91x_append_to_buffer_queue(&si91x_socket->tx_data_queue, buffer);
   tx_socket_data_queues_status |= (1 << si91x_socket->index);
-  sli_si91x_set_event(SL_SI91X_SOCKET_DATA_TX_PENDING_EVENT);
+  sl_si91x_host_set_bus_event(SL_SI91X_SOCKET_DATA_TX_PENDING_EVENT);
   CORE_ExitAtomic(state);
 
   return SL_STATUS_OK;


### PR DESCRIPTION
Corrected the assignments of SL_SI91X_SOCKET_DATA_TX_PENDING_EVENT,
SL_SI91X_SOCKET_COMMAND_TX_PENDING_EVENT, and
SL_SI91X_TA_BUFFER_FULL_CLEAR_EVENT to si91x_bus_event instead of
si91x_event, ensuring proper setting for the bus events.