### PR TITLE
wiseconnect: Fix compiler warning

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/mcu/drivers/unified_peripheral_drivers/src/sl_si91x_peripheral_gpio.c
+++ b/wiseconnect/components/device/silabs/si91x/mcu/drivers/unified_peripheral_drivers/src/sl_si91x_peripheral_gpio.c
@@ -859,7 +859,7 @@ uint32_t sl_si91x_gpio_get_group_interrupt_status(uint8_t port, sl_si91x_group_i
  ******************************************************************************/
 void sl_si91x_gpio_select_group_interrupt_wakeup(uint8_t port,
                                                  sl_si91x_group_interrupt_t group_interrupt,
-                                                 uint8_t flags)
+                                                 sl_si91x_gpio_wakeup_t flags)
 {
   SL_GPIO_ASSERT(SL_GPIO_VALIDATE_PORT(port));
   SL_GPIO_ASSERT(SL_GPIO_VALIDATE_PARAMETER(group_interrupt));


### PR DESCRIPTION
gcc 14.3 complains:

    error: conflicting types for
    'sl_si91x_gpio_select_group_interrupt_wakeup' due to enum/integer
    mismatch; have 'void(uint8_t, sl_si91x_group_interrupt_t, uint8_t)'
    {aka 'void(unsigned char, sl_si91x_group_interrupt_t, unsigned
    char)'} [-Werror=enum-int-mismatch]