### PR TITLE
ext: gecko: Add Silabs Gecko SDK for EFM32TG SoCs

### DIFF
--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg108f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg108f16.h
@@ -1,0 +1,2743 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG108F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG108F16_H
+#define EFM32TG108F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16 EFM32TG108F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_Core EFM32TG108F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG108F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_Part EFM32TG108F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG108F16)
+#define EFM32TG108F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG108F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG108F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           1 /**< 1 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG108F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_Peripheral_TypeDefs EFM32TG108F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_dma_ch.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_DMA EFM32TG108F16 DMA
+ * @brief EFM32TG108F16_DMA Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IM uint32_t  STATUS;          /**< DMA Status Registers  */
+  __OM uint32_t  CONFIG;          /**< DMA Configuration Register  */
+  __IOM uint32_t CTRLBASE;        /**< Channel Control Data Base Pointer Register  */
+  __IM uint32_t  ALTCTRLBASE;     /**< Channel Alternate Control Data Base Pointer Register  */
+  __IM uint32_t  CHWAITSTATUS;    /**< Channel Wait on Request Status Register  */
+  __OM uint32_t  CHSWREQ;         /**< Channel Software Request Register  */
+  __IOM uint32_t CHUSEBURSTS;     /**< Channel Useburst Set Register  */
+  __OM uint32_t  CHUSEBURSTC;     /**< Channel Useburst Clear Register  */
+  __IOM uint32_t CHREQMASKS;      /**< Channel Request Mask Set Register  */
+  __OM uint32_t  CHREQMASKC;      /**< Channel Request Mask Clear Register  */
+  __IOM uint32_t CHENS;           /**< Channel Enable Set Register  */
+  __OM uint32_t  CHENC;           /**< Channel Enable Clear Register  */
+  __IOM uint32_t CHALTS;          /**< Channel Alternate Set Register  */
+  __OM uint32_t  CHALTC;          /**< Channel Alternate Clear Register  */
+  __IOM uint32_t CHPRIS;          /**< Channel Priority Set Register  */
+  __OM uint32_t  CHPRIC;          /**< Channel Priority Clear Register  */
+  uint32_t       RESERVED0[3U];   /**< Reserved for future use **/
+  __IOM uint32_t ERRORC;          /**< Bus Error Clear Register  */
+  uint32_t       RESERVED1[880U]; /**< Reserved for future use **/
+  __IM uint32_t  CHREQSTATUS;     /**< Channel Request Status  */
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
+  __IM uint32_t  CHSREQSTATUS;    /**< Channel Single Request Status  */
+
+  uint32_t       RESERVED3[121U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable register  */
+
+  uint32_t       RESERVED4[60U];  /**< Reserved registers */
+  DMA_CH_TypeDef CH[8U];          /**< Channel registers */
+} DMA_TypeDef;                    /**< DMA Register Declaration *//** @} */
+
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_CMU EFM32TG108F16 CMU
+ * @brief EFM32TG108F16_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_PRS EFM32TG108F16 PRS
+ * @brief EFM32TG108F16_PRS Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+
+  uint32_t       RESERVED0[1U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[8U];        /**< Channel registers */
+} PRS_TypeDef;                  /**< PRS Register Declaration *//** @} */
+
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG108F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_Peripheral_Base EFM32TG108F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG108F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_Peripheral_Declaration  EFM32TG108F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG108F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_BitFields EFM32TG108F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @addtogroup EFM32TG108F16_PRS_Signals
+ * @{
+ * @brief PRS Signal names
+ ******************************************************************************/
+
+#define PRS_VCMP_OUT             ((1 << 16) + 0)  /**< PRS Voltage comparator output */
+#define PRS_ACMP0_OUT            ((2 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_ACMP1_OUT            ((3 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_USART1_TXC           ((17 << 16) + 1) /**< PRS USART 1 TX complete */
+#define PRS_USART1_RXDATAV       ((17 << 16) + 2) /**< PRS USART 1 RX Data Valid */
+#define PRS_TIMER0_UF            ((28 << 16) + 0) /**< PRS Timer 0 Underflow */
+#define PRS_TIMER0_OF            ((28 << 16) + 1) /**< PRS Timer 0 Overflow */
+#define PRS_TIMER0_CC0           ((28 << 16) + 2) /**< PRS Timer 0 Compare/Capture 0 */
+#define PRS_TIMER0_CC1           ((28 << 16) + 3) /**< PRS Timer 0 Compare/Capture 1 */
+#define PRS_TIMER0_CC2           ((28 << 16) + 4) /**< PRS Timer 0 Compare/Capture 2 */
+#define PRS_TIMER1_UF            ((29 << 16) + 0) /**< PRS Timer 1 Underflow */
+#define PRS_TIMER1_OF            ((29 << 16) + 1) /**< PRS Timer 1 Overflow */
+#define PRS_TIMER1_CC0           ((29 << 16) + 2) /**< PRS Timer 1 Compare/Capture 0 */
+#define PRS_TIMER1_CC1           ((29 << 16) + 3) /**< PRS Timer 1 Compare/Capture 1 */
+#define PRS_TIMER1_CC2           ((29 << 16) + 4) /**< PRS Timer 1 Compare/Capture 2 */
+#define PRS_RTC_OF               ((40 << 16) + 0) /**< PRS RTC Overflow */
+#define PRS_RTC_COMP0            ((40 << 16) + 1) /**< PRS RTC Compare 0 */
+#define PRS_RTC_COMP1            ((40 << 16) + 2) /**< PRS RTC Compare 1 */
+#define PRS_GPIO_PIN0            ((48 << 16) + 0) /**< PRS GPIO pin 0 */
+#define PRS_GPIO_PIN1            ((48 << 16) + 1) /**< PRS GPIO pin 1 */
+#define PRS_GPIO_PIN2            ((48 << 16) + 2) /**< PRS GPIO pin 2 */
+#define PRS_GPIO_PIN3            ((48 << 16) + 3) /**< PRS GPIO pin 3 */
+#define PRS_GPIO_PIN4            ((48 << 16) + 4) /**< PRS GPIO pin 4 */
+#define PRS_GPIO_PIN5            ((48 << 16) + 5) /**< PRS GPIO pin 5 */
+#define PRS_GPIO_PIN6            ((48 << 16) + 6) /**< PRS GPIO pin 6 */
+#define PRS_GPIO_PIN7            ((48 << 16) + 7) /**< PRS GPIO pin 7 */
+#define PRS_GPIO_PIN8            ((49 << 16) + 0) /**< PRS GPIO pin 8 */
+#define PRS_GPIO_PIN9            ((49 << 16) + 1) /**< PRS GPIO pin 9 */
+#define PRS_GPIO_PIN10           ((49 << 16) + 2) /**< PRS GPIO pin 10 */
+#define PRS_GPIO_PIN11           ((49 << 16) + 3) /**< PRS GPIO pin 11 */
+#define PRS_GPIO_PIN12           ((49 << 16) + 4) /**< PRS GPIO pin 12 */
+#define PRS_GPIO_PIN13           ((49 << 16) + 5) /**< PRS GPIO pin 13 */
+#define PRS_GPIO_PIN14           ((49 << 16) + 6) /**< PRS GPIO pin 14 */
+#define PRS_GPIO_PIN15           ((49 << 16) + 7) /**< PRS GPIO pin 15 */
+#define PRS_LETIMER0_CH0         ((52 << 16) + 0) /**< PRS LETIMER CH0 Out */
+#define PRS_LETIMER0_CH1         ((52 << 16) + 1) /**< PRS LETIMER CH1 Out */
+#define PRS_LESENSE_SCANRES0     ((57 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 0 */
+#define PRS_LESENSE_SCANRES1     ((57 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 1 */
+#define PRS_LESENSE_SCANRES2     ((57 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 2 */
+#define PRS_LESENSE_SCANRES3     ((57 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 3 */
+#define PRS_LESENSE_SCANRES4     ((57 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 4 */
+#define PRS_LESENSE_SCANRES5     ((57 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 5 */
+#define PRS_LESENSE_SCANRES6     ((57 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 6 */
+#define PRS_LESENSE_SCANRES7     ((57 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 7 */
+#define PRS_LESENSE_SCANRES8     ((58 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 8 */
+#define PRS_LESENSE_SCANRES9     ((58 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 9 */
+#define PRS_LESENSE_SCANRES10    ((58 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 10 */
+#define PRS_LESENSE_SCANRES11    ((58 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 11 */
+#define PRS_LESENSE_SCANRES12    ((58 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 12 */
+#define PRS_LESENSE_SCANRES13    ((58 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 13 */
+#define PRS_LESENSE_SCANRES14    ((58 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 14 */
+#define PRS_LESENSE_SCANRES15    ((58 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 15 */
+#define PRS_LESENSE_DEC0         ((59 << 16) + 0) /**< PRS LESENSE Decoder PRS out 0 */
+#define PRS_LESENSE_DEC1         ((59 << 16) + 1) /**< PRS LESENSE Decoder PRS out 1 */
+#define PRS_LESENSE_DEC2         ((59 << 16) + 2) /**< PRS LESENSE Decoder PRS out 2 */
+
+/** @} End of group EFM32TG108F16_PRS */
+
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_DMA_BitFields  EFM32TG108F16_DMA Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for DMA STATUS */
+#define _DMA_STATUS_RESETVALUE                          0x10070000UL                          /**< Default value for DMA_STATUS */
+#define _DMA_STATUS_MASK                                0x001F00F1UL                          /**< Mask for DMA_STATUS */
+#define DMA_STATUS_EN                                   (0x1UL << 0)                          /**< DMA Enable Status */
+#define _DMA_STATUS_EN_SHIFT                            0                                     /**< Shift value for DMA_EN */
+#define _DMA_STATUS_EN_MASK                             0x1UL                                 /**< Bit mask for DMA_EN */
+#define _DMA_STATUS_EN_DEFAULT                          0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_EN_DEFAULT                           (_DMA_STATUS_EN_DEFAULT << 0)         /**< Shifted mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_SHIFT                         4                                     /**< Shift value for DMA_STATE */
+#define _DMA_STATUS_STATE_MASK                          0xF0UL                                /**< Bit mask for DMA_STATE */
+#define _DMA_STATUS_STATE_DEFAULT                       0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_IDLE                          0x00000000UL                          /**< Mode IDLE for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDCHCTRLDATA                  0x00000001UL                          /**< Mode RDCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCENDPTR                   0x00000002UL                          /**< Mode RDSRCENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDDSTENDPTR                   0x00000003UL                          /**< Mode RDDSTENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCDATA                     0x00000004UL                          /**< Mode RDSRCDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRDSTDATA                     0x00000005UL                          /**< Mode WRDSTDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WAITREQCLR                    0x00000006UL                          /**< Mode WAITREQCLR for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRCHCTRLDATA                  0x00000007UL                          /**< Mode WRCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_STALLED                       0x00000008UL                          /**< Mode STALLED for DMA_STATUS */
+#define _DMA_STATUS_STATE_DONE                          0x00000009UL                          /**< Mode DONE for DMA_STATUS */
+#define _DMA_STATUS_STATE_PERSCATTRANS                  0x0000000AUL                          /**< Mode PERSCATTRANS for DMA_STATUS */
+#define DMA_STATUS_STATE_DEFAULT                        (_DMA_STATUS_STATE_DEFAULT << 4)      /**< Shifted mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_STATE_IDLE                           (_DMA_STATUS_STATE_IDLE << 4)         /**< Shifted mode IDLE for DMA_STATUS */
+#define DMA_STATUS_STATE_RDCHCTRLDATA                   (_DMA_STATUS_STATE_RDCHCTRLDATA << 4) /**< Shifted mode RDCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCENDPTR                    (_DMA_STATUS_STATE_RDSRCENDPTR << 4)  /**< Shifted mode RDSRCENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDDSTENDPTR                    (_DMA_STATUS_STATE_RDDSTENDPTR << 4)  /**< Shifted mode RDDSTENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCDATA                      (_DMA_STATUS_STATE_RDSRCDATA << 4)    /**< Shifted mode RDSRCDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WRDSTDATA                      (_DMA_STATUS_STATE_WRDSTDATA << 4)    /**< Shifted mode WRDSTDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WAITREQCLR                     (_DMA_STATUS_STATE_WAITREQCLR << 4)   /**< Shifted mode WAITREQCLR for DMA_STATUS */
+#define DMA_STATUS_STATE_WRCHCTRLDATA                   (_DMA_STATUS_STATE_WRCHCTRLDATA << 4) /**< Shifted mode WRCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_STALLED                        (_DMA_STATUS_STATE_STALLED << 4)      /**< Shifted mode STALLED for DMA_STATUS */
+#define DMA_STATUS_STATE_DONE                           (_DMA_STATUS_STATE_DONE << 4)         /**< Shifted mode DONE for DMA_STATUS */
+#define DMA_STATUS_STATE_PERSCATTRANS                   (_DMA_STATUS_STATE_PERSCATTRANS << 4) /**< Shifted mode PERSCATTRANS for DMA_STATUS */
+#define _DMA_STATUS_CHNUM_SHIFT                         16                                    /**< Shift value for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_MASK                          0x1F0000UL                            /**< Bit mask for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_DEFAULT                       0x00000007UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_CHNUM_DEFAULT                        (_DMA_STATUS_CHNUM_DEFAULT << 16)     /**< Shifted mode DEFAULT for DMA_STATUS */
+
+/* Bit fields for DMA CONFIG */
+#define _DMA_CONFIG_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_CONFIG */
+#define _DMA_CONFIG_MASK                                0x00000021UL                      /**< Mask for DMA_CONFIG */
+#define DMA_CONFIG_EN                                   (0x1UL << 0)                      /**< Enable DMA */
+#define _DMA_CONFIG_EN_SHIFT                            0                                 /**< Shift value for DMA_EN */
+#define _DMA_CONFIG_EN_MASK                             0x1UL                             /**< Bit mask for DMA_EN */
+#define _DMA_CONFIG_EN_DEFAULT                          0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_EN_DEFAULT                           (_DMA_CONFIG_EN_DEFAULT << 0)     /**< Shifted mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT                               (0x1UL << 5)                      /**< Channel Protection Control */
+#define _DMA_CONFIG_CHPROT_SHIFT                        5                                 /**< Shift value for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_MASK                         0x20UL                            /**< Bit mask for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT_DEFAULT                       (_DMA_CONFIG_CHPROT_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CONFIG */
+
+/* Bit fields for DMA CTRLBASE */
+#define _DMA_CTRLBASE_RESETVALUE                        0x00000000UL                          /**< Default value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_MASK                              0xFFFFFFFFUL                          /**< Mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_SHIFT                    0                                     /**< Shift value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_MASK                     0xFFFFFFFFUL                          /**< Bit mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_DEFAULT                  0x00000000UL                          /**< Mode DEFAULT for DMA_CTRLBASE */
+#define DMA_CTRLBASE_CTRLBASE_DEFAULT                   (_DMA_CTRLBASE_CTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CTRLBASE */
+
+/* Bit fields for DMA ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_RESETVALUE                     0x00000080UL                                /**< Default value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_MASK                           0xFFFFFFFFUL                                /**< Mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_SHIFT              0                                           /**< Shift value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_MASK               0xFFFFFFFFUL                                /**< Bit mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT            0x00000080UL                                /**< Mode DEFAULT for DMA_ALTCTRLBASE */
+#define DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT             (_DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ALTCTRLBASE */
+
+/* Bit fields for DMA CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_RESETVALUE                    0x000000FFUL                                   /**< Default value for DMA_CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+
+/* Bit fields for DMA CHSWREQ */
+#define _DMA_CHSWREQ_RESETVALUE                         0x00000000UL                         /**< Default value for DMA_CHSWREQ */
+#define _DMA_CHSWREQ_MASK                               0x000000FFUL                         /**< Mask for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ                            (0x1UL << 0)                         /**< Channel 0 Software Request */
+#define _DMA_CHSWREQ_CH0SWREQ_SHIFT                     0                                    /**< Shift value for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_MASK                      0x1UL                                /**< Bit mask for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH0SWREQ_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ                            (0x1UL << 1)                         /**< Channel 1 Software Request */
+#define _DMA_CHSWREQ_CH1SWREQ_SHIFT                     1                                    /**< Shift value for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_MASK                      0x2UL                                /**< Bit mask for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH1SWREQ_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ                            (0x1UL << 2)                         /**< Channel 2 Software Request */
+#define _DMA_CHSWREQ_CH2SWREQ_SHIFT                     2                                    /**< Shift value for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_MASK                      0x4UL                                /**< Bit mask for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH2SWREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ                            (0x1UL << 3)                         /**< Channel 3 Software Request */
+#define _DMA_CHSWREQ_CH3SWREQ_SHIFT                     3                                    /**< Shift value for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_MASK                      0x8UL                                /**< Bit mask for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH3SWREQ_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ                            (0x1UL << 4)                         /**< Channel 4 Software Request */
+#define _DMA_CHSWREQ_CH4SWREQ_SHIFT                     4                                    /**< Shift value for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_MASK                      0x10UL                               /**< Bit mask for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH4SWREQ_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ                            (0x1UL << 5)                         /**< Channel 5 Software Request */
+#define _DMA_CHSWREQ_CH5SWREQ_SHIFT                     5                                    /**< Shift value for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_MASK                      0x20UL                               /**< Bit mask for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH5SWREQ_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ                            (0x1UL << 6)                         /**< Channel 6 Software Request */
+#define _DMA_CHSWREQ_CH6SWREQ_SHIFT                     6                                    /**< Shift value for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_MASK                      0x40UL                               /**< Bit mask for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH6SWREQ_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ                            (0x1UL << 7)                         /**< Channel 7 Software Request */
+#define _DMA_CHSWREQ_CH7SWREQ_SHIFT                     7                                    /**< Shift value for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_MASK                      0x80UL                               /**< Bit mask for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH7SWREQ_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+
+/* Bit fields for DMA CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_RESETVALUE                     0x00000000UL                                        /**< Default value for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_MASK                           0x000000FFUL                                        /**< Mask for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS                    (0x1UL << 0)                                        /**< Channel 0 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SHIFT             0                                                   /**< Shift value for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_MASK              0x1UL                                               /**< Bit mask for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST    0x00000000UL                                        /**< Mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY         0x00000001UL                                        /**< Mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT << 0)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST     (_DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST << 0) /**< Shifted mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY          (_DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY << 0)      /**< Shifted mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS                    (0x1UL << 1)                                        /**< Channel 1 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_SHIFT             1                                                   /**< Shift value for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_MASK              0x2UL                                               /**< Bit mask for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT << 1)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS                    (0x1UL << 2)                                        /**< Channel 2 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_SHIFT             2                                                   /**< Shift value for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_MASK              0x4UL                                               /**< Bit mask for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT << 2)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS                    (0x1UL << 3)                                        /**< Channel 3 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_SHIFT             3                                                   /**< Shift value for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_MASK              0x8UL                                               /**< Bit mask for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT << 3)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS                    (0x1UL << 4)                                        /**< Channel 4 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_SHIFT             4                                                   /**< Shift value for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_MASK              0x10UL                                              /**< Bit mask for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT << 4)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS                    (0x1UL << 5)                                        /**< Channel 5 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_SHIFT             5                                                   /**< Shift value for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_MASK              0x20UL                                              /**< Bit mask for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT << 5)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS                    (0x1UL << 6)                                        /**< Channel 6 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_SHIFT             6                                                   /**< Shift value for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_MASK              0x40UL                                              /**< Bit mask for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT << 6)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS                    (0x1UL << 7)                                        /**< Channel 7 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_SHIFT             7                                                   /**< Shift value for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_MASK              0x80UL                                              /**< Bit mask for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT << 7)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+
+/* Bit fields for DMA CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC                    (0x1UL << 0)                                 /**< Channel 0 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_SHIFT             0                                            /**< Shift value for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_MASK              0x1UL                                        /**< Bit mask for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC                    (0x1UL << 1)                                 /**< Channel 1 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_SHIFT             1                                            /**< Shift value for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_MASK              0x2UL                                        /**< Bit mask for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC                    (0x1UL << 2)                                 /**< Channel 2 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_SHIFT             2                                            /**< Shift value for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_MASK              0x4UL                                        /**< Bit mask for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC                    (0x1UL << 3)                                 /**< Channel 3 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_SHIFT             3                                            /**< Shift value for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_MASK              0x8UL                                        /**< Bit mask for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC                    (0x1UL << 4)                                 /**< Channel 4 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_SHIFT             4                                            /**< Shift value for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_MASK              0x10UL                                       /**< Bit mask for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC                    (0x1UL << 5)                                 /**< Channel 5 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_SHIFT             5                                            /**< Shift value for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_MASK              0x20UL                                       /**< Bit mask for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC                    (0x1UL << 6)                                 /**< Channel 6 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_SHIFT             6                                            /**< Shift value for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_MASK              0x40UL                                       /**< Bit mask for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC                    (0x1UL << 7)                                 /**< Channel 7 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_SHIFT             7                                            /**< Shift value for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_MASK              0x80UL                                       /**< Bit mask for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+
+/* Bit fields for DMA CHREQMASKS */
+#define _DMA_CHREQMASKS_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKS */
+#define _DMA_CHREQMASKS_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS                      (0x1UL << 0)                               /**< Channel 0 Request Mask Set */
+#define _DMA_CHREQMASKS_CH0REQMASKS_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH0REQMASKS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS                      (0x1UL << 1)                               /**< Channel 1 Request Mask Set */
+#define _DMA_CHREQMASKS_CH1REQMASKS_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH1REQMASKS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS                      (0x1UL << 2)                               /**< Channel 2 Request Mask Set */
+#define _DMA_CHREQMASKS_CH2REQMASKS_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH2REQMASKS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS                      (0x1UL << 3)                               /**< Channel 3 Request Mask Set */
+#define _DMA_CHREQMASKS_CH3REQMASKS_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH3REQMASKS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS                      (0x1UL << 4)                               /**< Channel 4 Request Mask Set */
+#define _DMA_CHREQMASKS_CH4REQMASKS_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH4REQMASKS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS                      (0x1UL << 5)                               /**< Channel 5 Request Mask Set */
+#define _DMA_CHREQMASKS_CH5REQMASKS_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH5REQMASKS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS                      (0x1UL << 6)                               /**< Channel 6 Request Mask Set */
+#define _DMA_CHREQMASKS_CH6REQMASKS_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH6REQMASKS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS                      (0x1UL << 7)                               /**< Channel 7 Request Mask Set */
+#define _DMA_CHREQMASKS_CH7REQMASKS_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH7REQMASKS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+
+/* Bit fields for DMA CHREQMASKC */
+#define _DMA_CHREQMASKC_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKC */
+#define _DMA_CHREQMASKC_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC                      (0x1UL << 0)                               /**< Channel 0 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH0REQMASKC_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH0REQMASKC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC                      (0x1UL << 1)                               /**< Channel 1 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH1REQMASKC_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH1REQMASKC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC                      (0x1UL << 2)                               /**< Channel 2 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH2REQMASKC_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH2REQMASKC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC                      (0x1UL << 3)                               /**< Channel 3 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH3REQMASKC_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH3REQMASKC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC                      (0x1UL << 4)                               /**< Channel 4 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH4REQMASKC_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH4REQMASKC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC                      (0x1UL << 5)                               /**< Channel 5 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH5REQMASKC_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH5REQMASKC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC                      (0x1UL << 6)                               /**< Channel 6 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH6REQMASKC_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH6REQMASKC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC                      (0x1UL << 7)                               /**< Channel 7 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH7REQMASKC_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH7REQMASKC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+
+/* Bit fields for DMA CHENS */
+#define _DMA_CHENS_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENS */
+#define _DMA_CHENS_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENS */
+#define DMA_CHENS_CH0ENS                                (0x1UL << 0)                     /**< Channel 0 Enable Set */
+#define _DMA_CHENS_CH0ENS_SHIFT                         0                                /**< Shift value for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH0ENS_DEFAULT                        (_DMA_CHENS_CH0ENS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS                                (0x1UL << 1)                     /**< Channel 1 Enable Set */
+#define _DMA_CHENS_CH1ENS_SHIFT                         1                                /**< Shift value for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS_DEFAULT                        (_DMA_CHENS_CH1ENS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS                                (0x1UL << 2)                     /**< Channel 2 Enable Set */
+#define _DMA_CHENS_CH2ENS_SHIFT                         2                                /**< Shift value for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS_DEFAULT                        (_DMA_CHENS_CH2ENS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS                                (0x1UL << 3)                     /**< Channel 3 Enable Set */
+#define _DMA_CHENS_CH3ENS_SHIFT                         3                                /**< Shift value for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS_DEFAULT                        (_DMA_CHENS_CH3ENS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS                                (0x1UL << 4)                     /**< Channel 4 Enable Set */
+#define _DMA_CHENS_CH4ENS_SHIFT                         4                                /**< Shift value for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS_DEFAULT                        (_DMA_CHENS_CH4ENS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS                                (0x1UL << 5)                     /**< Channel 5 Enable Set */
+#define _DMA_CHENS_CH5ENS_SHIFT                         5                                /**< Shift value for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS_DEFAULT                        (_DMA_CHENS_CH5ENS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS                                (0x1UL << 6)                     /**< Channel 6 Enable Set */
+#define _DMA_CHENS_CH6ENS_SHIFT                         6                                /**< Shift value for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS_DEFAULT                        (_DMA_CHENS_CH6ENS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS                                (0x1UL << 7)                     /**< Channel 7 Enable Set */
+#define _DMA_CHENS_CH7ENS_SHIFT                         7                                /**< Shift value for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS_DEFAULT                        (_DMA_CHENS_CH7ENS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENS */
+
+/* Bit fields for DMA CHENC */
+#define _DMA_CHENC_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENC */
+#define _DMA_CHENC_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENC */
+#define DMA_CHENC_CH0ENC                                (0x1UL << 0)                     /**< Channel 0 Enable Clear */
+#define _DMA_CHENC_CH0ENC_SHIFT                         0                                /**< Shift value for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH0ENC_DEFAULT                        (_DMA_CHENC_CH0ENC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC                                (0x1UL << 1)                     /**< Channel 1 Enable Clear */
+#define _DMA_CHENC_CH1ENC_SHIFT                         1                                /**< Shift value for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC_DEFAULT                        (_DMA_CHENC_CH1ENC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC                                (0x1UL << 2)                     /**< Channel 2 Enable Clear */
+#define _DMA_CHENC_CH2ENC_SHIFT                         2                                /**< Shift value for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC_DEFAULT                        (_DMA_CHENC_CH2ENC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC                                (0x1UL << 3)                     /**< Channel 3 Enable Clear */
+#define _DMA_CHENC_CH3ENC_SHIFT                         3                                /**< Shift value for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC_DEFAULT                        (_DMA_CHENC_CH3ENC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC                                (0x1UL << 4)                     /**< Channel 4 Enable Clear */
+#define _DMA_CHENC_CH4ENC_SHIFT                         4                                /**< Shift value for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC_DEFAULT                        (_DMA_CHENC_CH4ENC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC                                (0x1UL << 5)                     /**< Channel 5 Enable Clear */
+#define _DMA_CHENC_CH5ENC_SHIFT                         5                                /**< Shift value for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC_DEFAULT                        (_DMA_CHENC_CH5ENC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC                                (0x1UL << 6)                     /**< Channel 6 Enable Clear */
+#define _DMA_CHENC_CH6ENC_SHIFT                         6                                /**< Shift value for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC_DEFAULT                        (_DMA_CHENC_CH6ENC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC                                (0x1UL << 7)                     /**< Channel 7 Enable Clear */
+#define _DMA_CHENC_CH7ENC_SHIFT                         7                                /**< Shift value for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC_DEFAULT                        (_DMA_CHENC_CH7ENC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENC */
+
+/* Bit fields for DMA CHALTS */
+#define _DMA_CHALTS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTS */
+#define _DMA_CHALTS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS                              (0x1UL << 0)                       /**< Channel 0 Alternate Structure Set */
+#define _DMA_CHALTS_CH0ALTS_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS_DEFAULT                      (_DMA_CHALTS_CH0ALTS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS                              (0x1UL << 1)                       /**< Channel 1 Alternate Structure Set */
+#define _DMA_CHALTS_CH1ALTS_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS_DEFAULT                      (_DMA_CHALTS_CH1ALTS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS                              (0x1UL << 2)                       /**< Channel 2 Alternate Structure Set */
+#define _DMA_CHALTS_CH2ALTS_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS_DEFAULT                      (_DMA_CHALTS_CH2ALTS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS                              (0x1UL << 3)                       /**< Channel 3 Alternate Structure Set */
+#define _DMA_CHALTS_CH3ALTS_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS_DEFAULT                      (_DMA_CHALTS_CH3ALTS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS                              (0x1UL << 4)                       /**< Channel 4 Alternate Structure Set */
+#define _DMA_CHALTS_CH4ALTS_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS_DEFAULT                      (_DMA_CHALTS_CH4ALTS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS                              (0x1UL << 5)                       /**< Channel 5 Alternate Structure Set */
+#define _DMA_CHALTS_CH5ALTS_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS_DEFAULT                      (_DMA_CHALTS_CH5ALTS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS                              (0x1UL << 6)                       /**< Channel 6 Alternate Structure Set */
+#define _DMA_CHALTS_CH6ALTS_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS_DEFAULT                      (_DMA_CHALTS_CH6ALTS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS                              (0x1UL << 7)                       /**< Channel 7 Alternate Structure Set */
+#define _DMA_CHALTS_CH7ALTS_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS_DEFAULT                      (_DMA_CHALTS_CH7ALTS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTS */
+
+/* Bit fields for DMA CHALTC */
+#define _DMA_CHALTC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTC */
+#define _DMA_CHALTC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC                              (0x1UL << 0)                       /**< Channel 0 Alternate Clear */
+#define _DMA_CHALTC_CH0ALTC_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC_DEFAULT                      (_DMA_CHALTC_CH0ALTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC                              (0x1UL << 1)                       /**< Channel 1 Alternate Clear */
+#define _DMA_CHALTC_CH1ALTC_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC_DEFAULT                      (_DMA_CHALTC_CH1ALTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC                              (0x1UL << 2)                       /**< Channel 2 Alternate Clear */
+#define _DMA_CHALTC_CH2ALTC_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC_DEFAULT                      (_DMA_CHALTC_CH2ALTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC                              (0x1UL << 3)                       /**< Channel 3 Alternate Clear */
+#define _DMA_CHALTC_CH3ALTC_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC_DEFAULT                      (_DMA_CHALTC_CH3ALTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC                              (0x1UL << 4)                       /**< Channel 4 Alternate Clear */
+#define _DMA_CHALTC_CH4ALTC_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC_DEFAULT                      (_DMA_CHALTC_CH4ALTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC                              (0x1UL << 5)                       /**< Channel 5 Alternate Clear */
+#define _DMA_CHALTC_CH5ALTC_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC_DEFAULT                      (_DMA_CHALTC_CH5ALTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC                              (0x1UL << 6)                       /**< Channel 6 Alternate Clear */
+#define _DMA_CHALTC_CH6ALTC_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC_DEFAULT                      (_DMA_CHALTC_CH6ALTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC                              (0x1UL << 7)                       /**< Channel 7 Alternate Clear */
+#define _DMA_CHALTC_CH7ALTC_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC_DEFAULT                      (_DMA_CHALTC_CH7ALTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTC */
+
+/* Bit fields for DMA CHPRIS */
+#define _DMA_CHPRIS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIS */
+#define _DMA_CHPRIS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS                              (0x1UL << 0)                       /**< Channel 0 High Priority Set */
+#define _DMA_CHPRIS_CH0PRIS_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS_DEFAULT                      (_DMA_CHPRIS_CH0PRIS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS                              (0x1UL << 1)                       /**< Channel 1 High Priority Set */
+#define _DMA_CHPRIS_CH1PRIS_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS_DEFAULT                      (_DMA_CHPRIS_CH1PRIS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS                              (0x1UL << 2)                       /**< Channel 2 High Priority Set */
+#define _DMA_CHPRIS_CH2PRIS_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS_DEFAULT                      (_DMA_CHPRIS_CH2PRIS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS                              (0x1UL << 3)                       /**< Channel 3 High Priority Set */
+#define _DMA_CHPRIS_CH3PRIS_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS_DEFAULT                      (_DMA_CHPRIS_CH3PRIS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS                              (0x1UL << 4)                       /**< Channel 4 High Priority Set */
+#define _DMA_CHPRIS_CH4PRIS_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS_DEFAULT                      (_DMA_CHPRIS_CH4PRIS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS                              (0x1UL << 5)                       /**< Channel 5 High Priority Set */
+#define _DMA_CHPRIS_CH5PRIS_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS_DEFAULT                      (_DMA_CHPRIS_CH5PRIS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS                              (0x1UL << 6)                       /**< Channel 6 High Priority Set */
+#define _DMA_CHPRIS_CH6PRIS_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS_DEFAULT                      (_DMA_CHPRIS_CH6PRIS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS                              (0x1UL << 7)                       /**< Channel 7 High Priority Set */
+#define _DMA_CHPRIS_CH7PRIS_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS_DEFAULT                      (_DMA_CHPRIS_CH7PRIS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+
+/* Bit fields for DMA CHPRIC */
+#define _DMA_CHPRIC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIC */
+#define _DMA_CHPRIC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC                              (0x1UL << 0)                       /**< Channel 0 High Priority Clear */
+#define _DMA_CHPRIC_CH0PRIC_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC_DEFAULT                      (_DMA_CHPRIC_CH0PRIC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC                              (0x1UL << 1)                       /**< Channel 1 High Priority Clear */
+#define _DMA_CHPRIC_CH1PRIC_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC_DEFAULT                      (_DMA_CHPRIC_CH1PRIC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC                              (0x1UL << 2)                       /**< Channel 2 High Priority Clear */
+#define _DMA_CHPRIC_CH2PRIC_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC_DEFAULT                      (_DMA_CHPRIC_CH2PRIC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC                              (0x1UL << 3)                       /**< Channel 3 High Priority Clear */
+#define _DMA_CHPRIC_CH3PRIC_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC_DEFAULT                      (_DMA_CHPRIC_CH3PRIC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC                              (0x1UL << 4)                       /**< Channel 4 High Priority Clear */
+#define _DMA_CHPRIC_CH4PRIC_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC_DEFAULT                      (_DMA_CHPRIC_CH4PRIC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC                              (0x1UL << 5)                       /**< Channel 5 High Priority Clear */
+#define _DMA_CHPRIC_CH5PRIC_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC_DEFAULT                      (_DMA_CHPRIC_CH5PRIC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC                              (0x1UL << 6)                       /**< Channel 6 High Priority Clear */
+#define _DMA_CHPRIC_CH6PRIC_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC_DEFAULT                      (_DMA_CHPRIC_CH6PRIC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC                              (0x1UL << 7)                       /**< Channel 7 High Priority Clear */
+#define _DMA_CHPRIC_CH7PRIC_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC_DEFAULT                      (_DMA_CHPRIC_CH7PRIC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+
+/* Bit fields for DMA ERRORC */
+#define _DMA_ERRORC_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_ERRORC */
+#define _DMA_ERRORC_MASK                                0x00000001UL                      /**< Mask for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC                               (0x1UL << 0)                      /**< Bus Error Clear */
+#define _DMA_ERRORC_ERRORC_SHIFT                        0                                 /**< Shift value for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_MASK                         0x1UL                             /**< Bit mask for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC_DEFAULT                       (_DMA_ERRORC_ERRORC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ERRORC */
+
+/* Bit fields for DMA CHREQSTATUS */
+#define _DMA_CHREQSTATUS_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHREQSTATUS */
+#define _DMA_CHREQSTATUS_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS                    (0x1UL << 0)                                 /**< Channel 0 Request Status */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_SHIFT             0                                            /**< Shift value for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_MASK              0x1UL                                        /**< Bit mask for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS                    (0x1UL << 1)                                 /**< Channel 1 Request Status */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_SHIFT             1                                            /**< Shift value for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_MASK              0x2UL                                        /**< Bit mask for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS                    (0x1UL << 2)                                 /**< Channel 2 Request Status */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_SHIFT             2                                            /**< Shift value for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_MASK              0x4UL                                        /**< Bit mask for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS                    (0x1UL << 3)                                 /**< Channel 3 Request Status */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_SHIFT             3                                            /**< Shift value for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_MASK              0x8UL                                        /**< Bit mask for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS                    (0x1UL << 4)                                 /**< Channel 4 Request Status */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_SHIFT             4                                            /**< Shift value for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_MASK              0x10UL                                       /**< Bit mask for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS                    (0x1UL << 5)                                 /**< Channel 5 Request Status */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_SHIFT             5                                            /**< Shift value for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_MASK              0x20UL                                       /**< Bit mask for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS                    (0x1UL << 6)                                 /**< Channel 6 Request Status */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_SHIFT             6                                            /**< Shift value for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_MASK              0x40UL                                       /**< Bit mask for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS                    (0x1UL << 7)                                 /**< Channel 7 Request Status */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_SHIFT             7                                            /**< Shift value for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_MASK              0x80UL                                       /**< Bit mask for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+
+/* Bit fields for DMA CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_RESETVALUE                    0x00000000UL                                   /**< Default value for DMA_CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+
+/* Bit fields for DMA IF */
+#define _DMA_IF_RESETVALUE                              0x00000000UL                   /**< Default value for DMA_IF */
+#define _DMA_IF_MASK                                    0x800000FFUL                   /**< Mask for DMA_IF */
+#define DMA_IF_CH0DONE                                  (0x1UL << 0)                   /**< DMA Channel 0 Complete Interrupt Flag */
+#define _DMA_IF_CH0DONE_SHIFT                           0                              /**< Shift value for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_MASK                            0x1UL                          /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH0DONE_DEFAULT                          (_DMA_IF_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE                                  (0x1UL << 1)                   /**< DMA Channel 1 Complete Interrupt Flag */
+#define _DMA_IF_CH1DONE_SHIFT                           1                              /**< Shift value for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_MASK                            0x2UL                          /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE_DEFAULT                          (_DMA_IF_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE                                  (0x1UL << 2)                   /**< DMA Channel 2 Complete Interrupt Flag */
+#define _DMA_IF_CH2DONE_SHIFT                           2                              /**< Shift value for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_MASK                            0x4UL                          /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE_DEFAULT                          (_DMA_IF_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE                                  (0x1UL << 3)                   /**< DMA Channel 3 Complete Interrupt Flag */
+#define _DMA_IF_CH3DONE_SHIFT                           3                              /**< Shift value for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_MASK                            0x8UL                          /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE_DEFAULT                          (_DMA_IF_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE                                  (0x1UL << 4)                   /**< DMA Channel 4 Complete Interrupt Flag */
+#define _DMA_IF_CH4DONE_SHIFT                           4                              /**< Shift value for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_MASK                            0x10UL                         /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE_DEFAULT                          (_DMA_IF_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE                                  (0x1UL << 5)                   /**< DMA Channel 5 Complete Interrupt Flag */
+#define _DMA_IF_CH5DONE_SHIFT                           5                              /**< Shift value for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_MASK                            0x20UL                         /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE_DEFAULT                          (_DMA_IF_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE                                  (0x1UL << 6)                   /**< DMA Channel 6 Complete Interrupt Flag */
+#define _DMA_IF_CH6DONE_SHIFT                           6                              /**< Shift value for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_MASK                            0x40UL                         /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE_DEFAULT                          (_DMA_IF_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE                                  (0x1UL << 7)                   /**< DMA Channel 7 Complete Interrupt Flag */
+#define _DMA_IF_CH7DONE_SHIFT                           7                              /**< Shift value for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_MASK                            0x80UL                         /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE_DEFAULT                          (_DMA_IF_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR                                      (0x1UL << 31)                  /**< DMA Error Interrupt Flag */
+#define _DMA_IF_ERR_SHIFT                               31                             /**< Shift value for DMA_ERR */
+#define _DMA_IF_ERR_MASK                                0x80000000UL                   /**< Bit mask for DMA_ERR */
+#define _DMA_IF_ERR_DEFAULT                             0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR_DEFAULT                              (_DMA_IF_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IF */
+
+/* Bit fields for DMA IFS */
+#define _DMA_IFS_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFS */
+#define _DMA_IFS_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFS */
+#define DMA_IFS_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH0DONE_DEFAULT                         (_DMA_IFS_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE_DEFAULT                         (_DMA_IFS_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE_DEFAULT                         (_DMA_IFS_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE_DEFAULT                         (_DMA_IFS_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE_DEFAULT                         (_DMA_IFS_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE_DEFAULT                         (_DMA_IFS_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE_DEFAULT                         (_DMA_IFS_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE_DEFAULT                         (_DMA_IFS_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Set */
+#define _DMA_IFS_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFS_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFS_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR_DEFAULT                             (_DMA_IFS_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFS */
+
+/* Bit fields for DMA IFC */
+#define _DMA_IFC_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFC */
+#define _DMA_IFC_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFC */
+#define DMA_IFC_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH0DONE_DEFAULT                         (_DMA_IFC_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE_DEFAULT                         (_DMA_IFC_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE_DEFAULT                         (_DMA_IFC_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE_DEFAULT                         (_DMA_IFC_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE_DEFAULT                         (_DMA_IFC_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE_DEFAULT                         (_DMA_IFC_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE_DEFAULT                         (_DMA_IFC_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE_DEFAULT                         (_DMA_IFC_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Clear */
+#define _DMA_IFC_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFC_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFC_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR_DEFAULT                             (_DMA_IFC_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFC */
+
+/* Bit fields for DMA IEN */
+#define _DMA_IEN_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IEN */
+#define _DMA_IEN_MASK                                   0x800000FFUL                    /**< Mask for DMA_IEN */
+#define DMA_IEN_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Enable */
+#define _DMA_IEN_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH0DONE_DEFAULT                         (_DMA_IEN_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Enable */
+#define _DMA_IEN_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE_DEFAULT                         (_DMA_IEN_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Enable */
+#define _DMA_IEN_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE_DEFAULT                         (_DMA_IEN_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Enable */
+#define _DMA_IEN_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE_DEFAULT                         (_DMA_IEN_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Enable */
+#define _DMA_IEN_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE_DEFAULT                         (_DMA_IEN_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Enable */
+#define _DMA_IEN_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE_DEFAULT                         (_DMA_IEN_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Enable */
+#define _DMA_IEN_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE_DEFAULT                         (_DMA_IEN_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Enable */
+#define _DMA_IEN_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE_DEFAULT                         (_DMA_IEN_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Enable */
+#define _DMA_IEN_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IEN_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IEN_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR_DEFAULT                             (_DMA_IEN_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IEN */
+
+/* Bit fields for DMA CH_CTRL */
+#define _DMA_CH_CTRL_RESETVALUE                         0x00000000UL                                  /**< Default value for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_MASK                               0x003F000FUL                                  /**< Mask for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_SHIFT                       0                                             /**< Shift value for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_MASK                        0xFUL                                         /**< Bit mask for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAV               0x00000000UL                                  /**< Mode USART1RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV              0x00000000UL                                  /**< Mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                 0x00000000UL                                  /**< Mode I2C0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0UFOF                  0x00000000UL                                  /**< Mode TIMER0UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1UFOF                  0x00000000UL                                  /**< Mode TIMER1UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_MSCWDATA                    0x00000000UL                                  /**< Mode MSCWDATA for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV             0x00000000UL                                  /**< Mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBL                  0x00000001UL                                  /**< Mode USART1TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXBL                 0x00000001UL                                  /**< Mode LEUART0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0TXBL                    0x00000001UL                                  /**< Mode I2C0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC0                   0x00000001UL                                  /**< Mode TIMER0CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC0                   0x00000001UL                                  /**< Mode TIMER1CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXEMPTY               0x00000002UL                                  /**< Mode USART1TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY              0x00000002UL                                  /**< Mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC1                   0x00000002UL                                  /**< Mode TIMER0CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC1                   0x00000002UL                                  /**< Mode TIMER1CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT          0x00000003UL                                  /**< Mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC2                   0x00000003UL                                  /**< Mode TIMER0CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC2                   0x00000003UL                                  /**< Mode TIMER1CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT             0x00000004UL                                  /**< Mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAV                (_DMA_CH_CTRL_SIGSEL_USART1RXDATAV << 0)      /**< Shifted mode USART1RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV               (_DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV << 0)     /**< Shifted mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                  (_DMA_CH_CTRL_SIGSEL_I2C0RXDATAV << 0)        /**< Shifted mode I2C0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER0UFOF << 0)         /**< Shifted mode TIMER0UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER1UFOF << 0)         /**< Shifted mode TIMER1UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_MSCWDATA                     (_DMA_CH_CTRL_SIGSEL_MSCWDATA << 0)           /**< Shifted mode MSCWDATA for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV              (_DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV << 0)    /**< Shifted mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBL                   (_DMA_CH_CTRL_SIGSEL_USART1TXBL << 0)         /**< Shifted mode USART1TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXBL                  (_DMA_CH_CTRL_SIGSEL_LEUART0TXBL << 0)        /**< Shifted mode LEUART0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0TXBL                     (_DMA_CH_CTRL_SIGSEL_I2C0TXBL << 0)           /**< Shifted mode I2C0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC0 << 0)          /**< Shifted mode TIMER0CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC0 << 0)          /**< Shifted mode TIMER1CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXEMPTY                (_DMA_CH_CTRL_SIGSEL_USART1TXEMPTY << 0)      /**< Shifted mode USART1TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY               (_DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY << 0)     /**< Shifted mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC1 << 0)          /**< Shifted mode TIMER0CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC1 << 0)          /**< Shifted mode TIMER1CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT           (_DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT << 0) /**< Shifted mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC2 << 0)          /**< Shifted mode TIMER0CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC2 << 0)          /**< Shifted mode TIMER1CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT              (_DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT << 0)    /**< Shifted mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_SHIFT                    16                                            /**< Shift value for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_MASK                     0x3F0000UL                                    /**< Bit mask for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_NONE                     0x00000000UL                                  /**< Mode NONE for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_USART1                   0x0000000DUL                                  /**< Mode USART1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LEUART0                  0x00000010UL                                  /**< Mode LEUART0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_I2C0                     0x00000014UL                                  /**< Mode I2C0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER0                   0x00000018UL                                  /**< Mode TIMER0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER1                   0x00000019UL                                  /**< Mode TIMER1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_MSC                      0x00000030UL                                  /**< Mode MSC for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LESENSE                  0x00000032UL                                  /**< Mode LESENSE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_NONE                      (_DMA_CH_CTRL_SOURCESEL_NONE << 16)           /**< Shifted mode NONE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_USART1                    (_DMA_CH_CTRL_SOURCESEL_USART1 << 16)         /**< Shifted mode USART1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LEUART0                   (_DMA_CH_CTRL_SOURCESEL_LEUART0 << 16)        /**< Shifted mode LEUART0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_I2C0                      (_DMA_CH_CTRL_SOURCESEL_I2C0 << 16)           /**< Shifted mode I2C0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER0                    (_DMA_CH_CTRL_SOURCESEL_TIMER0 << 16)         /**< Shifted mode TIMER0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER1                    (_DMA_CH_CTRL_SOURCESEL_TIMER1 << 16)         /**< Shifted mode TIMER1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_MSC                       (_DMA_CH_CTRL_SOURCESEL_MSC << 16)            /**< Shifted mode MSC for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LESENSE                   (_DMA_CH_CTRL_SOURCESEL_LESENSE << 16)        /**< Shifted mode LESENSE for DMA_CH_CTRL */
+
+/** @} End of group EFM32TG108F16_DMA */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_CMU_BitFields  EFM32TG108F16_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000006UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x000009FBUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG108F16_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_PRS_BitFields  EFM32TG108F16_PRS Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for PRS SWPULSE */
+#define _PRS_SWPULSE_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWPULSE */
+#define _PRS_SWPULSE_MASK                       0x000000FFUL                         /**< Mask for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE                    (0x1UL << 0)                         /**< Channel 0 Pulse Generation */
+#define _PRS_SWPULSE_CH0PULSE_SHIFT             0                                    /**< Shift value for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_MASK              0x1UL                                /**< Bit mask for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE_DEFAULT            (_PRS_SWPULSE_CH0PULSE_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE                    (0x1UL << 1)                         /**< Channel 1 Pulse Generation */
+#define _PRS_SWPULSE_CH1PULSE_SHIFT             1                                    /**< Shift value for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_MASK              0x2UL                                /**< Bit mask for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE_DEFAULT            (_PRS_SWPULSE_CH1PULSE_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE                    (0x1UL << 2)                         /**< Channel 2 Pulse Generation */
+#define _PRS_SWPULSE_CH2PULSE_SHIFT             2                                    /**< Shift value for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_MASK              0x4UL                                /**< Bit mask for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE_DEFAULT            (_PRS_SWPULSE_CH2PULSE_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE                    (0x1UL << 3)                         /**< Channel 3 Pulse Generation */
+#define _PRS_SWPULSE_CH3PULSE_SHIFT             3                                    /**< Shift value for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_MASK              0x8UL                                /**< Bit mask for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE_DEFAULT            (_PRS_SWPULSE_CH3PULSE_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE                    (0x1UL << 4)                         /**< Channel 4 Pulse Generation */
+#define _PRS_SWPULSE_CH4PULSE_SHIFT             4                                    /**< Shift value for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_MASK              0x10UL                               /**< Bit mask for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE_DEFAULT            (_PRS_SWPULSE_CH4PULSE_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE                    (0x1UL << 5)                         /**< Channel 5 Pulse Generation */
+#define _PRS_SWPULSE_CH5PULSE_SHIFT             5                                    /**< Shift value for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_MASK              0x20UL                               /**< Bit mask for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE_DEFAULT            (_PRS_SWPULSE_CH5PULSE_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE                    (0x1UL << 6)                         /**< Channel 6 Pulse Generation */
+#define _PRS_SWPULSE_CH6PULSE_SHIFT             6                                    /**< Shift value for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_MASK              0x40UL                               /**< Bit mask for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE_DEFAULT            (_PRS_SWPULSE_CH6PULSE_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE                    (0x1UL << 7)                         /**< Channel 7 Pulse Generation */
+#define _PRS_SWPULSE_CH7PULSE_SHIFT             7                                    /**< Shift value for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_MASK              0x80UL                               /**< Bit mask for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE_DEFAULT            (_PRS_SWPULSE_CH7PULSE_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+
+/* Bit fields for PRS SWLEVEL */
+#define _PRS_SWLEVEL_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWLEVEL */
+#define _PRS_SWLEVEL_MASK                       0x000000FFUL                         /**< Mask for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL                    (0x1UL << 0)                         /**< Channel 0 Software Level */
+#define _PRS_SWLEVEL_CH0LEVEL_SHIFT             0                                    /**< Shift value for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_MASK              0x1UL                                /**< Bit mask for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL_DEFAULT            (_PRS_SWLEVEL_CH0LEVEL_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL                    (0x1UL << 1)                         /**< Channel 1 Software Level */
+#define _PRS_SWLEVEL_CH1LEVEL_SHIFT             1                                    /**< Shift value for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_MASK              0x2UL                                /**< Bit mask for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL_DEFAULT            (_PRS_SWLEVEL_CH1LEVEL_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL                    (0x1UL << 2)                         /**< Channel 2 Software Level */
+#define _PRS_SWLEVEL_CH2LEVEL_SHIFT             2                                    /**< Shift value for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_MASK              0x4UL                                /**< Bit mask for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL_DEFAULT            (_PRS_SWLEVEL_CH2LEVEL_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL                    (0x1UL << 3)                         /**< Channel 3 Software Level */
+#define _PRS_SWLEVEL_CH3LEVEL_SHIFT             3                                    /**< Shift value for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_MASK              0x8UL                                /**< Bit mask for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL_DEFAULT            (_PRS_SWLEVEL_CH3LEVEL_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL                    (0x1UL << 4)                         /**< Channel 4 Software Level */
+#define _PRS_SWLEVEL_CH4LEVEL_SHIFT             4                                    /**< Shift value for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_MASK              0x10UL                               /**< Bit mask for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL_DEFAULT            (_PRS_SWLEVEL_CH4LEVEL_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL                    (0x1UL << 5)                         /**< Channel 5 Software Level */
+#define _PRS_SWLEVEL_CH5LEVEL_SHIFT             5                                    /**< Shift value for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_MASK              0x20UL                               /**< Bit mask for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL_DEFAULT            (_PRS_SWLEVEL_CH5LEVEL_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL                    (0x1UL << 6)                         /**< Channel 6 Software Level */
+#define _PRS_SWLEVEL_CH6LEVEL_SHIFT             6                                    /**< Shift value for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_MASK              0x40UL                               /**< Bit mask for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL_DEFAULT            (_PRS_SWLEVEL_CH6LEVEL_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL                    (0x1UL << 7)                         /**< Channel 7 Software Level */
+#define _PRS_SWLEVEL_CH7LEVEL_SHIFT             7                                    /**< Shift value for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_MASK              0x80UL                               /**< Bit mask for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL_DEFAULT            (_PRS_SWLEVEL_CH7LEVEL_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+
+/* Bit fields for PRS ROUTE */
+#define _PRS_ROUTE_RESETVALUE                   0x00000000UL                       /**< Default value for PRS_ROUTE */
+#define _PRS_ROUTE_MASK                         0x0000070FUL                       /**< Mask for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN                        (0x1UL << 0)                       /**< CH0 Pin Enable */
+#define _PRS_ROUTE_CH0PEN_SHIFT                 0                                  /**< Shift value for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_MASK                  0x1UL                              /**< Bit mask for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN_DEFAULT                (_PRS_ROUTE_CH0PEN_DEFAULT << 0)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN                        (0x1UL << 1)                       /**< CH1 Pin Enable */
+#define _PRS_ROUTE_CH1PEN_SHIFT                 1                                  /**< Shift value for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_MASK                  0x2UL                              /**< Bit mask for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN_DEFAULT                (_PRS_ROUTE_CH1PEN_DEFAULT << 1)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN                        (0x1UL << 2)                       /**< CH2 Pin Enable */
+#define _PRS_ROUTE_CH2PEN_SHIFT                 2                                  /**< Shift value for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_MASK                  0x4UL                              /**< Bit mask for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN_DEFAULT                (_PRS_ROUTE_CH2PEN_DEFAULT << 2)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN                        (0x1UL << 3)                       /**< CH3 Pin Enable */
+#define _PRS_ROUTE_CH3PEN_SHIFT                 3                                  /**< Shift value for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_MASK                  0x8UL                              /**< Bit mask for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN_DEFAULT                (_PRS_ROUTE_CH3PEN_DEFAULT << 3)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_SHIFT               8                                  /**< Shift value for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_MASK                0x700UL                            /**< Bit mask for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_LOC0                0x00000000UL                       /**< Mode LOC0 for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_DEFAULT             0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_LOC1                0x00000001UL                       /**< Mode LOC1 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC0                 (_PRS_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_DEFAULT              (_PRS_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC1                 (_PRS_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for PRS_ROUTE */
+
+/* Bit fields for PRS CH_CTRL */
+#define _PRS_CH_CTRL_RESETVALUE                 0x00000000UL                                /**< Default value for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_MASK                       0x133F0007UL                                /**< Mask for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_SHIFT               0                                           /**< Shift value for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_MASK                0x7UL                                       /**< Bit mask for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_VCMPOUT             0x00000000UL                                /**< Mode VCMPOUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP0OUT            0x00000000UL                                /**< Mode ACMP0OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP1OUT            0x00000000UL                                /**< Mode ACMP1OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0UF            0x00000000UL                                /**< Mode TIMER0UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1UF            0x00000000UL                                /**< Mode TIMER1UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCOF               0x00000000UL                                /**< Mode RTCOF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN0            0x00000000UL                                /**< Mode GPIOPIN0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN8            0x00000000UL                                /**< Mode GPIOPIN8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH0         0x00000000UL                                /**< Mode LETIMER0CH0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES0     0x00000000UL                                /**< Mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES8     0x00000000UL                                /**< Mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC0         0x00000000UL                                /**< Mode LESENSEDEC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1TXC           0x00000001UL                                /**< Mode USART1TXC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0OF            0x00000001UL                                /**< Mode TIMER0OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1OF            0x00000001UL                                /**< Mode TIMER1OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP0            0x00000001UL                                /**< Mode RTCCOMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN1            0x00000001UL                                /**< Mode GPIOPIN1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN9            0x00000001UL                                /**< Mode GPIOPIN9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH1         0x00000001UL                                /**< Mode LETIMER0CH1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES1     0x00000001UL                                /**< Mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES9     0x00000001UL                                /**< Mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC1         0x00000001UL                                /**< Mode LESENSEDEC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1RXDATAV       0x00000002UL                                /**< Mode USART1RXDATAV for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC0           0x00000002UL                                /**< Mode TIMER0CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC0           0x00000002UL                                /**< Mode TIMER1CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP1            0x00000002UL                                /**< Mode RTCCOMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN2            0x00000002UL                                /**< Mode GPIOPIN2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN10           0x00000002UL                                /**< Mode GPIOPIN10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES2     0x00000002UL                                /**< Mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES10    0x00000002UL                                /**< Mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC2         0x00000002UL                                /**< Mode LESENSEDEC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC1           0x00000003UL                                /**< Mode TIMER0CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC1           0x00000003UL                                /**< Mode TIMER1CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN3            0x00000003UL                                /**< Mode GPIOPIN3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN11           0x00000003UL                                /**< Mode GPIOPIN11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES3     0x00000003UL                                /**< Mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES11    0x00000003UL                                /**< Mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC2           0x00000004UL                                /**< Mode TIMER0CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC2           0x00000004UL                                /**< Mode TIMER1CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN4            0x00000004UL                                /**< Mode GPIOPIN4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN12           0x00000004UL                                /**< Mode GPIOPIN12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES4     0x00000004UL                                /**< Mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES12    0x00000004UL                                /**< Mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN5            0x00000005UL                                /**< Mode GPIOPIN5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN13           0x00000005UL                                /**< Mode GPIOPIN13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES5     0x00000005UL                                /**< Mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES13    0x00000005UL                                /**< Mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN6            0x00000006UL                                /**< Mode GPIOPIN6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN14           0x00000006UL                                /**< Mode GPIOPIN14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES6     0x00000006UL                                /**< Mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES14    0x00000006UL                                /**< Mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN7            0x00000007UL                                /**< Mode GPIOPIN7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN15           0x00000007UL                                /**< Mode GPIOPIN15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES7     0x00000007UL                                /**< Mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES15    0x00000007UL                                /**< Mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_VCMPOUT              (_PRS_CH_CTRL_SIGSEL_VCMPOUT << 0)          /**< Shifted mode VCMPOUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP0OUT             (_PRS_CH_CTRL_SIGSEL_ACMP0OUT << 0)         /**< Shifted mode ACMP0OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP1OUT             (_PRS_CH_CTRL_SIGSEL_ACMP1OUT << 0)         /**< Shifted mode ACMP1OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0UF             (_PRS_CH_CTRL_SIGSEL_TIMER0UF << 0)         /**< Shifted mode TIMER0UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1UF             (_PRS_CH_CTRL_SIGSEL_TIMER1UF << 0)         /**< Shifted mode TIMER1UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCOF                (_PRS_CH_CTRL_SIGSEL_RTCOF << 0)            /**< Shifted mode RTCOF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN0             (_PRS_CH_CTRL_SIGSEL_GPIOPIN0 << 0)         /**< Shifted mode GPIOPIN0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN8             (_PRS_CH_CTRL_SIGSEL_GPIOPIN8 << 0)         /**< Shifted mode GPIOPIN8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH0          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH0 << 0)      /**< Shifted mode LETIMER0CH0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES0      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES0 << 0)  /**< Shifted mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES8      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES8 << 0)  /**< Shifted mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC0          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC0 << 0)      /**< Shifted mode LESENSEDEC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1TXC            (_PRS_CH_CTRL_SIGSEL_USART1TXC << 0)        /**< Shifted mode USART1TXC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0OF             (_PRS_CH_CTRL_SIGSEL_TIMER0OF << 0)         /**< Shifted mode TIMER0OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1OF             (_PRS_CH_CTRL_SIGSEL_TIMER1OF << 0)         /**< Shifted mode TIMER1OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP0             (_PRS_CH_CTRL_SIGSEL_RTCCOMP0 << 0)         /**< Shifted mode RTCCOMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN1             (_PRS_CH_CTRL_SIGSEL_GPIOPIN1 << 0)         /**< Shifted mode GPIOPIN1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN9             (_PRS_CH_CTRL_SIGSEL_GPIOPIN9 << 0)         /**< Shifted mode GPIOPIN9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH1          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH1 << 0)      /**< Shifted mode LETIMER0CH1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES1      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES1 << 0)  /**< Shifted mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES9      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES9 << 0)  /**< Shifted mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC1          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC1 << 0)      /**< Shifted mode LESENSEDEC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1RXDATAV        (_PRS_CH_CTRL_SIGSEL_USART1RXDATAV << 0)    /**< Shifted mode USART1RXDATAV for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC0            (_PRS_CH_CTRL_SIGSEL_TIMER0CC0 << 0)        /**< Shifted mode TIMER0CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC0            (_PRS_CH_CTRL_SIGSEL_TIMER1CC0 << 0)        /**< Shifted mode TIMER1CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP1             (_PRS_CH_CTRL_SIGSEL_RTCCOMP1 << 0)         /**< Shifted mode RTCCOMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN2             (_PRS_CH_CTRL_SIGSEL_GPIOPIN2 << 0)         /**< Shifted mode GPIOPIN2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN10            (_PRS_CH_CTRL_SIGSEL_GPIOPIN10 << 0)        /**< Shifted mode GPIOPIN10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES2      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES2 << 0)  /**< Shifted mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES10     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES10 << 0) /**< Shifted mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC2          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC2 << 0)      /**< Shifted mode LESENSEDEC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC1            (_PRS_CH_CTRL_SIGSEL_TIMER0CC1 << 0)        /**< Shifted mode TIMER0CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC1            (_PRS_CH_CTRL_SIGSEL_TIMER1CC1 << 0)        /**< Shifted mode TIMER1CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN3             (_PRS_CH_CTRL_SIGSEL_GPIOPIN3 << 0)         /**< Shifted mode GPIOPIN3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN11            (_PRS_CH_CTRL_SIGSEL_GPIOPIN11 << 0)        /**< Shifted mode GPIOPIN11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES3      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES3 << 0)  /**< Shifted mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES11     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES11 << 0) /**< Shifted mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC2            (_PRS_CH_CTRL_SIGSEL_TIMER0CC2 << 0)        /**< Shifted mode TIMER0CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC2            (_PRS_CH_CTRL_SIGSEL_TIMER1CC2 << 0)        /**< Shifted mode TIMER1CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN4             (_PRS_CH_CTRL_SIGSEL_GPIOPIN4 << 0)         /**< Shifted mode GPIOPIN4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN12            (_PRS_CH_CTRL_SIGSEL_GPIOPIN12 << 0)        /**< Shifted mode GPIOPIN12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES4      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES4 << 0)  /**< Shifted mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES12     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES12 << 0) /**< Shifted mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN5             (_PRS_CH_CTRL_SIGSEL_GPIOPIN5 << 0)         /**< Shifted mode GPIOPIN5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN13            (_PRS_CH_CTRL_SIGSEL_GPIOPIN13 << 0)        /**< Shifted mode GPIOPIN13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES5      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES5 << 0)  /**< Shifted mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES13     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES13 << 0) /**< Shifted mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN6             (_PRS_CH_CTRL_SIGSEL_GPIOPIN6 << 0)         /**< Shifted mode GPIOPIN6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN14            (_PRS_CH_CTRL_SIGSEL_GPIOPIN14 << 0)        /**< Shifted mode GPIOPIN14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES6      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES6 << 0)  /**< Shifted mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES14     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES14 << 0) /**< Shifted mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN7             (_PRS_CH_CTRL_SIGSEL_GPIOPIN7 << 0)         /**< Shifted mode GPIOPIN7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN15            (_PRS_CH_CTRL_SIGSEL_GPIOPIN15 << 0)        /**< Shifted mode GPIOPIN15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES7      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES7 << 0)  /**< Shifted mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES15     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES15 << 0) /**< Shifted mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_SHIFT            16                                          /**< Shift value for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_MASK             0x3F0000UL                                  /**< Bit mask for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_NONE             0x00000000UL                                /**< Mode NONE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_VCMP             0x00000001UL                                /**< Mode VCMP for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP0            0x00000002UL                                /**< Mode ACMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP1            0x00000003UL                                /**< Mode ACMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_USART1           0x00000011UL                                /**< Mode USART1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER0           0x0000001CUL                                /**< Mode TIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER1           0x0000001DUL                                /**< Mode TIMER1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_RTC              0x00000028UL                                /**< Mode RTC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOL            0x00000030UL                                /**< Mode GPIOL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOH            0x00000031UL                                /**< Mode GPIOH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LETIMER0         0x00000034UL                                /**< Mode LETIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEL         0x00000039UL                                /**< Mode LESENSEL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEH         0x0000003AUL                                /**< Mode LESENSEH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSED         0x0000003BUL                                /**< Mode LESENSED for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_NONE              (_PRS_CH_CTRL_SOURCESEL_NONE << 16)         /**< Shifted mode NONE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_VCMP              (_PRS_CH_CTRL_SOURCESEL_VCMP << 16)         /**< Shifted mode VCMP for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP0             (_PRS_CH_CTRL_SOURCESEL_ACMP0 << 16)        /**< Shifted mode ACMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP1             (_PRS_CH_CTRL_SOURCESEL_ACMP1 << 16)        /**< Shifted mode ACMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_USART1            (_PRS_CH_CTRL_SOURCESEL_USART1 << 16)       /**< Shifted mode USART1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER0            (_PRS_CH_CTRL_SOURCESEL_TIMER0 << 16)       /**< Shifted mode TIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER1            (_PRS_CH_CTRL_SOURCESEL_TIMER1 << 16)       /**< Shifted mode TIMER1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_RTC               (_PRS_CH_CTRL_SOURCESEL_RTC << 16)          /**< Shifted mode RTC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOL             (_PRS_CH_CTRL_SOURCESEL_GPIOL << 16)        /**< Shifted mode GPIOL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOH             (_PRS_CH_CTRL_SOURCESEL_GPIOH << 16)        /**< Shifted mode GPIOH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LETIMER0          (_PRS_CH_CTRL_SOURCESEL_LETIMER0 << 16)     /**< Shifted mode LETIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEL          (_PRS_CH_CTRL_SOURCESEL_LESENSEL << 16)     /**< Shifted mode LESENSEL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEH          (_PRS_CH_CTRL_SOURCESEL_LESENSEH << 16)     /**< Shifted mode LESENSEH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSED          (_PRS_CH_CTRL_SOURCESEL_LESENSED << 16)     /**< Shifted mode LESENSED for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_SHIFT                24                                          /**< Shift value for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_MASK                 0x3000000UL                                 /**< Bit mask for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_OFF                  0x00000000UL                                /**< Mode OFF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_POSEDGE              0x00000001UL                                /**< Mode POSEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_NEGEDGE              0x00000002UL                                /**< Mode NEGEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_BOTHEDGES            0x00000003UL                                /**< Mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_DEFAULT               (_PRS_CH_CTRL_EDSEL_DEFAULT << 24)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_OFF                   (_PRS_CH_CTRL_EDSEL_OFF << 24)              /**< Shifted mode OFF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_POSEDGE               (_PRS_CH_CTRL_EDSEL_POSEDGE << 24)          /**< Shifted mode POSEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_NEGEDGE               (_PRS_CH_CTRL_EDSEL_NEGEDGE << 24)          /**< Shifted mode NEGEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_BOTHEDGES             (_PRS_CH_CTRL_EDSEL_BOTHEDGES << 24)        /**< Shifted mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC                       (0x1UL << 28)                               /**< Asynchronous reflex */
+#define _PRS_CH_CTRL_ASYNC_SHIFT                28                                          /**< Shift value for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_MASK                 0x10000000UL                                /**< Bit mask for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC_DEFAULT               (_PRS_CH_CTRL_ASYNC_DEFAULT << 28)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+
+/** @} End of group EFM32TG108F16_PRS */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_UNLOCK EFM32TG108F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG108F16_UNLOCK */
+
+/** @} End of group EFM32TG108F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F16_Alternate_Function EFM32TG108F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG108F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG108F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG108F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg108f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg108f32.h
@@ -1,0 +1,2743 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG108F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG108F32_H
+#define EFM32TG108F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32 EFM32TG108F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_Core EFM32TG108F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG108F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_Part EFM32TG108F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG108F32)
+#define EFM32TG108F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG108F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG108F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           1 /**< 1 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG108F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_Peripheral_TypeDefs EFM32TG108F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_dma_ch.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_DMA EFM32TG108F32 DMA
+ * @brief EFM32TG108F32_DMA Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IM uint32_t  STATUS;          /**< DMA Status Registers  */
+  __OM uint32_t  CONFIG;          /**< DMA Configuration Register  */
+  __IOM uint32_t CTRLBASE;        /**< Channel Control Data Base Pointer Register  */
+  __IM uint32_t  ALTCTRLBASE;     /**< Channel Alternate Control Data Base Pointer Register  */
+  __IM uint32_t  CHWAITSTATUS;    /**< Channel Wait on Request Status Register  */
+  __OM uint32_t  CHSWREQ;         /**< Channel Software Request Register  */
+  __IOM uint32_t CHUSEBURSTS;     /**< Channel Useburst Set Register  */
+  __OM uint32_t  CHUSEBURSTC;     /**< Channel Useburst Clear Register  */
+  __IOM uint32_t CHREQMASKS;      /**< Channel Request Mask Set Register  */
+  __OM uint32_t  CHREQMASKC;      /**< Channel Request Mask Clear Register  */
+  __IOM uint32_t CHENS;           /**< Channel Enable Set Register  */
+  __OM uint32_t  CHENC;           /**< Channel Enable Clear Register  */
+  __IOM uint32_t CHALTS;          /**< Channel Alternate Set Register  */
+  __OM uint32_t  CHALTC;          /**< Channel Alternate Clear Register  */
+  __IOM uint32_t CHPRIS;          /**< Channel Priority Set Register  */
+  __OM uint32_t  CHPRIC;          /**< Channel Priority Clear Register  */
+  uint32_t       RESERVED0[3U];   /**< Reserved for future use **/
+  __IOM uint32_t ERRORC;          /**< Bus Error Clear Register  */
+  uint32_t       RESERVED1[880U]; /**< Reserved for future use **/
+  __IM uint32_t  CHREQSTATUS;     /**< Channel Request Status  */
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
+  __IM uint32_t  CHSREQSTATUS;    /**< Channel Single Request Status  */
+
+  uint32_t       RESERVED3[121U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable register  */
+
+  uint32_t       RESERVED4[60U];  /**< Reserved registers */
+  DMA_CH_TypeDef CH[8U];          /**< Channel registers */
+} DMA_TypeDef;                    /**< DMA Register Declaration *//** @} */
+
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_CMU EFM32TG108F32 CMU
+ * @brief EFM32TG108F32_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_PRS EFM32TG108F32 PRS
+ * @brief EFM32TG108F32_PRS Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+
+  uint32_t       RESERVED0[1U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[8U];        /**< Channel registers */
+} PRS_TypeDef;                  /**< PRS Register Declaration *//** @} */
+
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG108F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_Peripheral_Base EFM32TG108F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG108F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_Peripheral_Declaration  EFM32TG108F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG108F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_BitFields EFM32TG108F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @addtogroup EFM32TG108F32_PRS_Signals
+ * @{
+ * @brief PRS Signal names
+ ******************************************************************************/
+
+#define PRS_VCMP_OUT             ((1 << 16) + 0)  /**< PRS Voltage comparator output */
+#define PRS_ACMP0_OUT            ((2 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_ACMP1_OUT            ((3 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_USART1_TXC           ((17 << 16) + 1) /**< PRS USART 1 TX complete */
+#define PRS_USART1_RXDATAV       ((17 << 16) + 2) /**< PRS USART 1 RX Data Valid */
+#define PRS_TIMER0_UF            ((28 << 16) + 0) /**< PRS Timer 0 Underflow */
+#define PRS_TIMER0_OF            ((28 << 16) + 1) /**< PRS Timer 0 Overflow */
+#define PRS_TIMER0_CC0           ((28 << 16) + 2) /**< PRS Timer 0 Compare/Capture 0 */
+#define PRS_TIMER0_CC1           ((28 << 16) + 3) /**< PRS Timer 0 Compare/Capture 1 */
+#define PRS_TIMER0_CC2           ((28 << 16) + 4) /**< PRS Timer 0 Compare/Capture 2 */
+#define PRS_TIMER1_UF            ((29 << 16) + 0) /**< PRS Timer 1 Underflow */
+#define PRS_TIMER1_OF            ((29 << 16) + 1) /**< PRS Timer 1 Overflow */
+#define PRS_TIMER1_CC0           ((29 << 16) + 2) /**< PRS Timer 1 Compare/Capture 0 */
+#define PRS_TIMER1_CC1           ((29 << 16) + 3) /**< PRS Timer 1 Compare/Capture 1 */
+#define PRS_TIMER1_CC2           ((29 << 16) + 4) /**< PRS Timer 1 Compare/Capture 2 */
+#define PRS_RTC_OF               ((40 << 16) + 0) /**< PRS RTC Overflow */
+#define PRS_RTC_COMP0            ((40 << 16) + 1) /**< PRS RTC Compare 0 */
+#define PRS_RTC_COMP1            ((40 << 16) + 2) /**< PRS RTC Compare 1 */
+#define PRS_GPIO_PIN0            ((48 << 16) + 0) /**< PRS GPIO pin 0 */
+#define PRS_GPIO_PIN1            ((48 << 16) + 1) /**< PRS GPIO pin 1 */
+#define PRS_GPIO_PIN2            ((48 << 16) + 2) /**< PRS GPIO pin 2 */
+#define PRS_GPIO_PIN3            ((48 << 16) + 3) /**< PRS GPIO pin 3 */
+#define PRS_GPIO_PIN4            ((48 << 16) + 4) /**< PRS GPIO pin 4 */
+#define PRS_GPIO_PIN5            ((48 << 16) + 5) /**< PRS GPIO pin 5 */
+#define PRS_GPIO_PIN6            ((48 << 16) + 6) /**< PRS GPIO pin 6 */
+#define PRS_GPIO_PIN7            ((48 << 16) + 7) /**< PRS GPIO pin 7 */
+#define PRS_GPIO_PIN8            ((49 << 16) + 0) /**< PRS GPIO pin 8 */
+#define PRS_GPIO_PIN9            ((49 << 16) + 1) /**< PRS GPIO pin 9 */
+#define PRS_GPIO_PIN10           ((49 << 16) + 2) /**< PRS GPIO pin 10 */
+#define PRS_GPIO_PIN11           ((49 << 16) + 3) /**< PRS GPIO pin 11 */
+#define PRS_GPIO_PIN12           ((49 << 16) + 4) /**< PRS GPIO pin 12 */
+#define PRS_GPIO_PIN13           ((49 << 16) + 5) /**< PRS GPIO pin 13 */
+#define PRS_GPIO_PIN14           ((49 << 16) + 6) /**< PRS GPIO pin 14 */
+#define PRS_GPIO_PIN15           ((49 << 16) + 7) /**< PRS GPIO pin 15 */
+#define PRS_LETIMER0_CH0         ((52 << 16) + 0) /**< PRS LETIMER CH0 Out */
+#define PRS_LETIMER0_CH1         ((52 << 16) + 1) /**< PRS LETIMER CH1 Out */
+#define PRS_LESENSE_SCANRES0     ((57 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 0 */
+#define PRS_LESENSE_SCANRES1     ((57 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 1 */
+#define PRS_LESENSE_SCANRES2     ((57 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 2 */
+#define PRS_LESENSE_SCANRES3     ((57 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 3 */
+#define PRS_LESENSE_SCANRES4     ((57 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 4 */
+#define PRS_LESENSE_SCANRES5     ((57 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 5 */
+#define PRS_LESENSE_SCANRES6     ((57 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 6 */
+#define PRS_LESENSE_SCANRES7     ((57 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 7 */
+#define PRS_LESENSE_SCANRES8     ((58 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 8 */
+#define PRS_LESENSE_SCANRES9     ((58 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 9 */
+#define PRS_LESENSE_SCANRES10    ((58 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 10 */
+#define PRS_LESENSE_SCANRES11    ((58 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 11 */
+#define PRS_LESENSE_SCANRES12    ((58 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 12 */
+#define PRS_LESENSE_SCANRES13    ((58 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 13 */
+#define PRS_LESENSE_SCANRES14    ((58 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 14 */
+#define PRS_LESENSE_SCANRES15    ((58 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 15 */
+#define PRS_LESENSE_DEC0         ((59 << 16) + 0) /**< PRS LESENSE Decoder PRS out 0 */
+#define PRS_LESENSE_DEC1         ((59 << 16) + 1) /**< PRS LESENSE Decoder PRS out 1 */
+#define PRS_LESENSE_DEC2         ((59 << 16) + 2) /**< PRS LESENSE Decoder PRS out 2 */
+
+/** @} End of group EFM32TG108F32_PRS */
+
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_DMA_BitFields  EFM32TG108F32_DMA Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for DMA STATUS */
+#define _DMA_STATUS_RESETVALUE                          0x10070000UL                          /**< Default value for DMA_STATUS */
+#define _DMA_STATUS_MASK                                0x001F00F1UL                          /**< Mask for DMA_STATUS */
+#define DMA_STATUS_EN                                   (0x1UL << 0)                          /**< DMA Enable Status */
+#define _DMA_STATUS_EN_SHIFT                            0                                     /**< Shift value for DMA_EN */
+#define _DMA_STATUS_EN_MASK                             0x1UL                                 /**< Bit mask for DMA_EN */
+#define _DMA_STATUS_EN_DEFAULT                          0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_EN_DEFAULT                           (_DMA_STATUS_EN_DEFAULT << 0)         /**< Shifted mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_SHIFT                         4                                     /**< Shift value for DMA_STATE */
+#define _DMA_STATUS_STATE_MASK                          0xF0UL                                /**< Bit mask for DMA_STATE */
+#define _DMA_STATUS_STATE_DEFAULT                       0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_IDLE                          0x00000000UL                          /**< Mode IDLE for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDCHCTRLDATA                  0x00000001UL                          /**< Mode RDCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCENDPTR                   0x00000002UL                          /**< Mode RDSRCENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDDSTENDPTR                   0x00000003UL                          /**< Mode RDDSTENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCDATA                     0x00000004UL                          /**< Mode RDSRCDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRDSTDATA                     0x00000005UL                          /**< Mode WRDSTDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WAITREQCLR                    0x00000006UL                          /**< Mode WAITREQCLR for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRCHCTRLDATA                  0x00000007UL                          /**< Mode WRCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_STALLED                       0x00000008UL                          /**< Mode STALLED for DMA_STATUS */
+#define _DMA_STATUS_STATE_DONE                          0x00000009UL                          /**< Mode DONE for DMA_STATUS */
+#define _DMA_STATUS_STATE_PERSCATTRANS                  0x0000000AUL                          /**< Mode PERSCATTRANS for DMA_STATUS */
+#define DMA_STATUS_STATE_DEFAULT                        (_DMA_STATUS_STATE_DEFAULT << 4)      /**< Shifted mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_STATE_IDLE                           (_DMA_STATUS_STATE_IDLE << 4)         /**< Shifted mode IDLE for DMA_STATUS */
+#define DMA_STATUS_STATE_RDCHCTRLDATA                   (_DMA_STATUS_STATE_RDCHCTRLDATA << 4) /**< Shifted mode RDCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCENDPTR                    (_DMA_STATUS_STATE_RDSRCENDPTR << 4)  /**< Shifted mode RDSRCENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDDSTENDPTR                    (_DMA_STATUS_STATE_RDDSTENDPTR << 4)  /**< Shifted mode RDDSTENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCDATA                      (_DMA_STATUS_STATE_RDSRCDATA << 4)    /**< Shifted mode RDSRCDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WRDSTDATA                      (_DMA_STATUS_STATE_WRDSTDATA << 4)    /**< Shifted mode WRDSTDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WAITREQCLR                     (_DMA_STATUS_STATE_WAITREQCLR << 4)   /**< Shifted mode WAITREQCLR for DMA_STATUS */
+#define DMA_STATUS_STATE_WRCHCTRLDATA                   (_DMA_STATUS_STATE_WRCHCTRLDATA << 4) /**< Shifted mode WRCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_STALLED                        (_DMA_STATUS_STATE_STALLED << 4)      /**< Shifted mode STALLED for DMA_STATUS */
+#define DMA_STATUS_STATE_DONE                           (_DMA_STATUS_STATE_DONE << 4)         /**< Shifted mode DONE for DMA_STATUS */
+#define DMA_STATUS_STATE_PERSCATTRANS                   (_DMA_STATUS_STATE_PERSCATTRANS << 4) /**< Shifted mode PERSCATTRANS for DMA_STATUS */
+#define _DMA_STATUS_CHNUM_SHIFT                         16                                    /**< Shift value for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_MASK                          0x1F0000UL                            /**< Bit mask for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_DEFAULT                       0x00000007UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_CHNUM_DEFAULT                        (_DMA_STATUS_CHNUM_DEFAULT << 16)     /**< Shifted mode DEFAULT for DMA_STATUS */
+
+/* Bit fields for DMA CONFIG */
+#define _DMA_CONFIG_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_CONFIG */
+#define _DMA_CONFIG_MASK                                0x00000021UL                      /**< Mask for DMA_CONFIG */
+#define DMA_CONFIG_EN                                   (0x1UL << 0)                      /**< Enable DMA */
+#define _DMA_CONFIG_EN_SHIFT                            0                                 /**< Shift value for DMA_EN */
+#define _DMA_CONFIG_EN_MASK                             0x1UL                             /**< Bit mask for DMA_EN */
+#define _DMA_CONFIG_EN_DEFAULT                          0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_EN_DEFAULT                           (_DMA_CONFIG_EN_DEFAULT << 0)     /**< Shifted mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT                               (0x1UL << 5)                      /**< Channel Protection Control */
+#define _DMA_CONFIG_CHPROT_SHIFT                        5                                 /**< Shift value for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_MASK                         0x20UL                            /**< Bit mask for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT_DEFAULT                       (_DMA_CONFIG_CHPROT_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CONFIG */
+
+/* Bit fields for DMA CTRLBASE */
+#define _DMA_CTRLBASE_RESETVALUE                        0x00000000UL                          /**< Default value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_MASK                              0xFFFFFFFFUL                          /**< Mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_SHIFT                    0                                     /**< Shift value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_MASK                     0xFFFFFFFFUL                          /**< Bit mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_DEFAULT                  0x00000000UL                          /**< Mode DEFAULT for DMA_CTRLBASE */
+#define DMA_CTRLBASE_CTRLBASE_DEFAULT                   (_DMA_CTRLBASE_CTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CTRLBASE */
+
+/* Bit fields for DMA ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_RESETVALUE                     0x00000080UL                                /**< Default value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_MASK                           0xFFFFFFFFUL                                /**< Mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_SHIFT              0                                           /**< Shift value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_MASK               0xFFFFFFFFUL                                /**< Bit mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT            0x00000080UL                                /**< Mode DEFAULT for DMA_ALTCTRLBASE */
+#define DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT             (_DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ALTCTRLBASE */
+
+/* Bit fields for DMA CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_RESETVALUE                    0x000000FFUL                                   /**< Default value for DMA_CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+
+/* Bit fields for DMA CHSWREQ */
+#define _DMA_CHSWREQ_RESETVALUE                         0x00000000UL                         /**< Default value for DMA_CHSWREQ */
+#define _DMA_CHSWREQ_MASK                               0x000000FFUL                         /**< Mask for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ                            (0x1UL << 0)                         /**< Channel 0 Software Request */
+#define _DMA_CHSWREQ_CH0SWREQ_SHIFT                     0                                    /**< Shift value for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_MASK                      0x1UL                                /**< Bit mask for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH0SWREQ_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ                            (0x1UL << 1)                         /**< Channel 1 Software Request */
+#define _DMA_CHSWREQ_CH1SWREQ_SHIFT                     1                                    /**< Shift value for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_MASK                      0x2UL                                /**< Bit mask for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH1SWREQ_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ                            (0x1UL << 2)                         /**< Channel 2 Software Request */
+#define _DMA_CHSWREQ_CH2SWREQ_SHIFT                     2                                    /**< Shift value for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_MASK                      0x4UL                                /**< Bit mask for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH2SWREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ                            (0x1UL << 3)                         /**< Channel 3 Software Request */
+#define _DMA_CHSWREQ_CH3SWREQ_SHIFT                     3                                    /**< Shift value for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_MASK                      0x8UL                                /**< Bit mask for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH3SWREQ_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ                            (0x1UL << 4)                         /**< Channel 4 Software Request */
+#define _DMA_CHSWREQ_CH4SWREQ_SHIFT                     4                                    /**< Shift value for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_MASK                      0x10UL                               /**< Bit mask for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH4SWREQ_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ                            (0x1UL << 5)                         /**< Channel 5 Software Request */
+#define _DMA_CHSWREQ_CH5SWREQ_SHIFT                     5                                    /**< Shift value for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_MASK                      0x20UL                               /**< Bit mask for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH5SWREQ_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ                            (0x1UL << 6)                         /**< Channel 6 Software Request */
+#define _DMA_CHSWREQ_CH6SWREQ_SHIFT                     6                                    /**< Shift value for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_MASK                      0x40UL                               /**< Bit mask for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH6SWREQ_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ                            (0x1UL << 7)                         /**< Channel 7 Software Request */
+#define _DMA_CHSWREQ_CH7SWREQ_SHIFT                     7                                    /**< Shift value for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_MASK                      0x80UL                               /**< Bit mask for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH7SWREQ_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+
+/* Bit fields for DMA CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_RESETVALUE                     0x00000000UL                                        /**< Default value for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_MASK                           0x000000FFUL                                        /**< Mask for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS                    (0x1UL << 0)                                        /**< Channel 0 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SHIFT             0                                                   /**< Shift value for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_MASK              0x1UL                                               /**< Bit mask for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST    0x00000000UL                                        /**< Mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY         0x00000001UL                                        /**< Mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT << 0)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST     (_DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST << 0) /**< Shifted mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY          (_DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY << 0)      /**< Shifted mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS                    (0x1UL << 1)                                        /**< Channel 1 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_SHIFT             1                                                   /**< Shift value for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_MASK              0x2UL                                               /**< Bit mask for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT << 1)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS                    (0x1UL << 2)                                        /**< Channel 2 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_SHIFT             2                                                   /**< Shift value for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_MASK              0x4UL                                               /**< Bit mask for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT << 2)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS                    (0x1UL << 3)                                        /**< Channel 3 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_SHIFT             3                                                   /**< Shift value for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_MASK              0x8UL                                               /**< Bit mask for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT << 3)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS                    (0x1UL << 4)                                        /**< Channel 4 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_SHIFT             4                                                   /**< Shift value for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_MASK              0x10UL                                              /**< Bit mask for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT << 4)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS                    (0x1UL << 5)                                        /**< Channel 5 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_SHIFT             5                                                   /**< Shift value for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_MASK              0x20UL                                              /**< Bit mask for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT << 5)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS                    (0x1UL << 6)                                        /**< Channel 6 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_SHIFT             6                                                   /**< Shift value for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_MASK              0x40UL                                              /**< Bit mask for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT << 6)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS                    (0x1UL << 7)                                        /**< Channel 7 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_SHIFT             7                                                   /**< Shift value for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_MASK              0x80UL                                              /**< Bit mask for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT << 7)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+
+/* Bit fields for DMA CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC                    (0x1UL << 0)                                 /**< Channel 0 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_SHIFT             0                                            /**< Shift value for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_MASK              0x1UL                                        /**< Bit mask for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC                    (0x1UL << 1)                                 /**< Channel 1 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_SHIFT             1                                            /**< Shift value for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_MASK              0x2UL                                        /**< Bit mask for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC                    (0x1UL << 2)                                 /**< Channel 2 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_SHIFT             2                                            /**< Shift value for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_MASK              0x4UL                                        /**< Bit mask for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC                    (0x1UL << 3)                                 /**< Channel 3 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_SHIFT             3                                            /**< Shift value for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_MASK              0x8UL                                        /**< Bit mask for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC                    (0x1UL << 4)                                 /**< Channel 4 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_SHIFT             4                                            /**< Shift value for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_MASK              0x10UL                                       /**< Bit mask for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC                    (0x1UL << 5)                                 /**< Channel 5 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_SHIFT             5                                            /**< Shift value for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_MASK              0x20UL                                       /**< Bit mask for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC                    (0x1UL << 6)                                 /**< Channel 6 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_SHIFT             6                                            /**< Shift value for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_MASK              0x40UL                                       /**< Bit mask for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC                    (0x1UL << 7)                                 /**< Channel 7 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_SHIFT             7                                            /**< Shift value for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_MASK              0x80UL                                       /**< Bit mask for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+
+/* Bit fields for DMA CHREQMASKS */
+#define _DMA_CHREQMASKS_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKS */
+#define _DMA_CHREQMASKS_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS                      (0x1UL << 0)                               /**< Channel 0 Request Mask Set */
+#define _DMA_CHREQMASKS_CH0REQMASKS_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH0REQMASKS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS                      (0x1UL << 1)                               /**< Channel 1 Request Mask Set */
+#define _DMA_CHREQMASKS_CH1REQMASKS_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH1REQMASKS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS                      (0x1UL << 2)                               /**< Channel 2 Request Mask Set */
+#define _DMA_CHREQMASKS_CH2REQMASKS_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH2REQMASKS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS                      (0x1UL << 3)                               /**< Channel 3 Request Mask Set */
+#define _DMA_CHREQMASKS_CH3REQMASKS_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH3REQMASKS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS                      (0x1UL << 4)                               /**< Channel 4 Request Mask Set */
+#define _DMA_CHREQMASKS_CH4REQMASKS_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH4REQMASKS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS                      (0x1UL << 5)                               /**< Channel 5 Request Mask Set */
+#define _DMA_CHREQMASKS_CH5REQMASKS_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH5REQMASKS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS                      (0x1UL << 6)                               /**< Channel 6 Request Mask Set */
+#define _DMA_CHREQMASKS_CH6REQMASKS_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH6REQMASKS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS                      (0x1UL << 7)                               /**< Channel 7 Request Mask Set */
+#define _DMA_CHREQMASKS_CH7REQMASKS_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH7REQMASKS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+
+/* Bit fields for DMA CHREQMASKC */
+#define _DMA_CHREQMASKC_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKC */
+#define _DMA_CHREQMASKC_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC                      (0x1UL << 0)                               /**< Channel 0 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH0REQMASKC_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH0REQMASKC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC                      (0x1UL << 1)                               /**< Channel 1 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH1REQMASKC_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH1REQMASKC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC                      (0x1UL << 2)                               /**< Channel 2 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH2REQMASKC_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH2REQMASKC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC                      (0x1UL << 3)                               /**< Channel 3 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH3REQMASKC_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH3REQMASKC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC                      (0x1UL << 4)                               /**< Channel 4 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH4REQMASKC_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH4REQMASKC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC                      (0x1UL << 5)                               /**< Channel 5 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH5REQMASKC_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH5REQMASKC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC                      (0x1UL << 6)                               /**< Channel 6 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH6REQMASKC_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH6REQMASKC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC                      (0x1UL << 7)                               /**< Channel 7 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH7REQMASKC_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH7REQMASKC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+
+/* Bit fields for DMA CHENS */
+#define _DMA_CHENS_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENS */
+#define _DMA_CHENS_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENS */
+#define DMA_CHENS_CH0ENS                                (0x1UL << 0)                     /**< Channel 0 Enable Set */
+#define _DMA_CHENS_CH0ENS_SHIFT                         0                                /**< Shift value for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH0ENS_DEFAULT                        (_DMA_CHENS_CH0ENS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS                                (0x1UL << 1)                     /**< Channel 1 Enable Set */
+#define _DMA_CHENS_CH1ENS_SHIFT                         1                                /**< Shift value for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS_DEFAULT                        (_DMA_CHENS_CH1ENS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS                                (0x1UL << 2)                     /**< Channel 2 Enable Set */
+#define _DMA_CHENS_CH2ENS_SHIFT                         2                                /**< Shift value for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS_DEFAULT                        (_DMA_CHENS_CH2ENS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS                                (0x1UL << 3)                     /**< Channel 3 Enable Set */
+#define _DMA_CHENS_CH3ENS_SHIFT                         3                                /**< Shift value for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS_DEFAULT                        (_DMA_CHENS_CH3ENS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS                                (0x1UL << 4)                     /**< Channel 4 Enable Set */
+#define _DMA_CHENS_CH4ENS_SHIFT                         4                                /**< Shift value for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS_DEFAULT                        (_DMA_CHENS_CH4ENS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS                                (0x1UL << 5)                     /**< Channel 5 Enable Set */
+#define _DMA_CHENS_CH5ENS_SHIFT                         5                                /**< Shift value for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS_DEFAULT                        (_DMA_CHENS_CH5ENS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS                                (0x1UL << 6)                     /**< Channel 6 Enable Set */
+#define _DMA_CHENS_CH6ENS_SHIFT                         6                                /**< Shift value for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS_DEFAULT                        (_DMA_CHENS_CH6ENS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS                                (0x1UL << 7)                     /**< Channel 7 Enable Set */
+#define _DMA_CHENS_CH7ENS_SHIFT                         7                                /**< Shift value for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS_DEFAULT                        (_DMA_CHENS_CH7ENS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENS */
+
+/* Bit fields for DMA CHENC */
+#define _DMA_CHENC_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENC */
+#define _DMA_CHENC_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENC */
+#define DMA_CHENC_CH0ENC                                (0x1UL << 0)                     /**< Channel 0 Enable Clear */
+#define _DMA_CHENC_CH0ENC_SHIFT                         0                                /**< Shift value for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH0ENC_DEFAULT                        (_DMA_CHENC_CH0ENC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC                                (0x1UL << 1)                     /**< Channel 1 Enable Clear */
+#define _DMA_CHENC_CH1ENC_SHIFT                         1                                /**< Shift value for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC_DEFAULT                        (_DMA_CHENC_CH1ENC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC                                (0x1UL << 2)                     /**< Channel 2 Enable Clear */
+#define _DMA_CHENC_CH2ENC_SHIFT                         2                                /**< Shift value for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC_DEFAULT                        (_DMA_CHENC_CH2ENC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC                                (0x1UL << 3)                     /**< Channel 3 Enable Clear */
+#define _DMA_CHENC_CH3ENC_SHIFT                         3                                /**< Shift value for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC_DEFAULT                        (_DMA_CHENC_CH3ENC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC                                (0x1UL << 4)                     /**< Channel 4 Enable Clear */
+#define _DMA_CHENC_CH4ENC_SHIFT                         4                                /**< Shift value for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC_DEFAULT                        (_DMA_CHENC_CH4ENC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC                                (0x1UL << 5)                     /**< Channel 5 Enable Clear */
+#define _DMA_CHENC_CH5ENC_SHIFT                         5                                /**< Shift value for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC_DEFAULT                        (_DMA_CHENC_CH5ENC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC                                (0x1UL << 6)                     /**< Channel 6 Enable Clear */
+#define _DMA_CHENC_CH6ENC_SHIFT                         6                                /**< Shift value for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC_DEFAULT                        (_DMA_CHENC_CH6ENC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC                                (0x1UL << 7)                     /**< Channel 7 Enable Clear */
+#define _DMA_CHENC_CH7ENC_SHIFT                         7                                /**< Shift value for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC_DEFAULT                        (_DMA_CHENC_CH7ENC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENC */
+
+/* Bit fields for DMA CHALTS */
+#define _DMA_CHALTS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTS */
+#define _DMA_CHALTS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS                              (0x1UL << 0)                       /**< Channel 0 Alternate Structure Set */
+#define _DMA_CHALTS_CH0ALTS_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS_DEFAULT                      (_DMA_CHALTS_CH0ALTS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS                              (0x1UL << 1)                       /**< Channel 1 Alternate Structure Set */
+#define _DMA_CHALTS_CH1ALTS_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS_DEFAULT                      (_DMA_CHALTS_CH1ALTS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS                              (0x1UL << 2)                       /**< Channel 2 Alternate Structure Set */
+#define _DMA_CHALTS_CH2ALTS_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS_DEFAULT                      (_DMA_CHALTS_CH2ALTS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS                              (0x1UL << 3)                       /**< Channel 3 Alternate Structure Set */
+#define _DMA_CHALTS_CH3ALTS_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS_DEFAULT                      (_DMA_CHALTS_CH3ALTS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS                              (0x1UL << 4)                       /**< Channel 4 Alternate Structure Set */
+#define _DMA_CHALTS_CH4ALTS_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS_DEFAULT                      (_DMA_CHALTS_CH4ALTS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS                              (0x1UL << 5)                       /**< Channel 5 Alternate Structure Set */
+#define _DMA_CHALTS_CH5ALTS_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS_DEFAULT                      (_DMA_CHALTS_CH5ALTS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS                              (0x1UL << 6)                       /**< Channel 6 Alternate Structure Set */
+#define _DMA_CHALTS_CH6ALTS_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS_DEFAULT                      (_DMA_CHALTS_CH6ALTS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS                              (0x1UL << 7)                       /**< Channel 7 Alternate Structure Set */
+#define _DMA_CHALTS_CH7ALTS_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS_DEFAULT                      (_DMA_CHALTS_CH7ALTS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTS */
+
+/* Bit fields for DMA CHALTC */
+#define _DMA_CHALTC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTC */
+#define _DMA_CHALTC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC                              (0x1UL << 0)                       /**< Channel 0 Alternate Clear */
+#define _DMA_CHALTC_CH0ALTC_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC_DEFAULT                      (_DMA_CHALTC_CH0ALTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC                              (0x1UL << 1)                       /**< Channel 1 Alternate Clear */
+#define _DMA_CHALTC_CH1ALTC_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC_DEFAULT                      (_DMA_CHALTC_CH1ALTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC                              (0x1UL << 2)                       /**< Channel 2 Alternate Clear */
+#define _DMA_CHALTC_CH2ALTC_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC_DEFAULT                      (_DMA_CHALTC_CH2ALTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC                              (0x1UL << 3)                       /**< Channel 3 Alternate Clear */
+#define _DMA_CHALTC_CH3ALTC_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC_DEFAULT                      (_DMA_CHALTC_CH3ALTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC                              (0x1UL << 4)                       /**< Channel 4 Alternate Clear */
+#define _DMA_CHALTC_CH4ALTC_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC_DEFAULT                      (_DMA_CHALTC_CH4ALTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC                              (0x1UL << 5)                       /**< Channel 5 Alternate Clear */
+#define _DMA_CHALTC_CH5ALTC_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC_DEFAULT                      (_DMA_CHALTC_CH5ALTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC                              (0x1UL << 6)                       /**< Channel 6 Alternate Clear */
+#define _DMA_CHALTC_CH6ALTC_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC_DEFAULT                      (_DMA_CHALTC_CH6ALTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC                              (0x1UL << 7)                       /**< Channel 7 Alternate Clear */
+#define _DMA_CHALTC_CH7ALTC_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC_DEFAULT                      (_DMA_CHALTC_CH7ALTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTC */
+
+/* Bit fields for DMA CHPRIS */
+#define _DMA_CHPRIS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIS */
+#define _DMA_CHPRIS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS                              (0x1UL << 0)                       /**< Channel 0 High Priority Set */
+#define _DMA_CHPRIS_CH0PRIS_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS_DEFAULT                      (_DMA_CHPRIS_CH0PRIS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS                              (0x1UL << 1)                       /**< Channel 1 High Priority Set */
+#define _DMA_CHPRIS_CH1PRIS_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS_DEFAULT                      (_DMA_CHPRIS_CH1PRIS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS                              (0x1UL << 2)                       /**< Channel 2 High Priority Set */
+#define _DMA_CHPRIS_CH2PRIS_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS_DEFAULT                      (_DMA_CHPRIS_CH2PRIS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS                              (0x1UL << 3)                       /**< Channel 3 High Priority Set */
+#define _DMA_CHPRIS_CH3PRIS_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS_DEFAULT                      (_DMA_CHPRIS_CH3PRIS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS                              (0x1UL << 4)                       /**< Channel 4 High Priority Set */
+#define _DMA_CHPRIS_CH4PRIS_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS_DEFAULT                      (_DMA_CHPRIS_CH4PRIS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS                              (0x1UL << 5)                       /**< Channel 5 High Priority Set */
+#define _DMA_CHPRIS_CH5PRIS_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS_DEFAULT                      (_DMA_CHPRIS_CH5PRIS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS                              (0x1UL << 6)                       /**< Channel 6 High Priority Set */
+#define _DMA_CHPRIS_CH6PRIS_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS_DEFAULT                      (_DMA_CHPRIS_CH6PRIS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS                              (0x1UL << 7)                       /**< Channel 7 High Priority Set */
+#define _DMA_CHPRIS_CH7PRIS_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS_DEFAULT                      (_DMA_CHPRIS_CH7PRIS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+
+/* Bit fields for DMA CHPRIC */
+#define _DMA_CHPRIC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIC */
+#define _DMA_CHPRIC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC                              (0x1UL << 0)                       /**< Channel 0 High Priority Clear */
+#define _DMA_CHPRIC_CH0PRIC_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC_DEFAULT                      (_DMA_CHPRIC_CH0PRIC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC                              (0x1UL << 1)                       /**< Channel 1 High Priority Clear */
+#define _DMA_CHPRIC_CH1PRIC_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC_DEFAULT                      (_DMA_CHPRIC_CH1PRIC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC                              (0x1UL << 2)                       /**< Channel 2 High Priority Clear */
+#define _DMA_CHPRIC_CH2PRIC_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC_DEFAULT                      (_DMA_CHPRIC_CH2PRIC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC                              (0x1UL << 3)                       /**< Channel 3 High Priority Clear */
+#define _DMA_CHPRIC_CH3PRIC_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC_DEFAULT                      (_DMA_CHPRIC_CH3PRIC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC                              (0x1UL << 4)                       /**< Channel 4 High Priority Clear */
+#define _DMA_CHPRIC_CH4PRIC_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC_DEFAULT                      (_DMA_CHPRIC_CH4PRIC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC                              (0x1UL << 5)                       /**< Channel 5 High Priority Clear */
+#define _DMA_CHPRIC_CH5PRIC_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC_DEFAULT                      (_DMA_CHPRIC_CH5PRIC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC                              (0x1UL << 6)                       /**< Channel 6 High Priority Clear */
+#define _DMA_CHPRIC_CH6PRIC_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC_DEFAULT                      (_DMA_CHPRIC_CH6PRIC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC                              (0x1UL << 7)                       /**< Channel 7 High Priority Clear */
+#define _DMA_CHPRIC_CH7PRIC_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC_DEFAULT                      (_DMA_CHPRIC_CH7PRIC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+
+/* Bit fields for DMA ERRORC */
+#define _DMA_ERRORC_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_ERRORC */
+#define _DMA_ERRORC_MASK                                0x00000001UL                      /**< Mask for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC                               (0x1UL << 0)                      /**< Bus Error Clear */
+#define _DMA_ERRORC_ERRORC_SHIFT                        0                                 /**< Shift value for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_MASK                         0x1UL                             /**< Bit mask for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC_DEFAULT                       (_DMA_ERRORC_ERRORC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ERRORC */
+
+/* Bit fields for DMA CHREQSTATUS */
+#define _DMA_CHREQSTATUS_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHREQSTATUS */
+#define _DMA_CHREQSTATUS_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS                    (0x1UL << 0)                                 /**< Channel 0 Request Status */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_SHIFT             0                                            /**< Shift value for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_MASK              0x1UL                                        /**< Bit mask for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS                    (0x1UL << 1)                                 /**< Channel 1 Request Status */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_SHIFT             1                                            /**< Shift value for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_MASK              0x2UL                                        /**< Bit mask for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS                    (0x1UL << 2)                                 /**< Channel 2 Request Status */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_SHIFT             2                                            /**< Shift value for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_MASK              0x4UL                                        /**< Bit mask for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS                    (0x1UL << 3)                                 /**< Channel 3 Request Status */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_SHIFT             3                                            /**< Shift value for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_MASK              0x8UL                                        /**< Bit mask for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS                    (0x1UL << 4)                                 /**< Channel 4 Request Status */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_SHIFT             4                                            /**< Shift value for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_MASK              0x10UL                                       /**< Bit mask for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS                    (0x1UL << 5)                                 /**< Channel 5 Request Status */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_SHIFT             5                                            /**< Shift value for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_MASK              0x20UL                                       /**< Bit mask for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS                    (0x1UL << 6)                                 /**< Channel 6 Request Status */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_SHIFT             6                                            /**< Shift value for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_MASK              0x40UL                                       /**< Bit mask for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS                    (0x1UL << 7)                                 /**< Channel 7 Request Status */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_SHIFT             7                                            /**< Shift value for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_MASK              0x80UL                                       /**< Bit mask for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+
+/* Bit fields for DMA CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_RESETVALUE                    0x00000000UL                                   /**< Default value for DMA_CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+
+/* Bit fields for DMA IF */
+#define _DMA_IF_RESETVALUE                              0x00000000UL                   /**< Default value for DMA_IF */
+#define _DMA_IF_MASK                                    0x800000FFUL                   /**< Mask for DMA_IF */
+#define DMA_IF_CH0DONE                                  (0x1UL << 0)                   /**< DMA Channel 0 Complete Interrupt Flag */
+#define _DMA_IF_CH0DONE_SHIFT                           0                              /**< Shift value for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_MASK                            0x1UL                          /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH0DONE_DEFAULT                          (_DMA_IF_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE                                  (0x1UL << 1)                   /**< DMA Channel 1 Complete Interrupt Flag */
+#define _DMA_IF_CH1DONE_SHIFT                           1                              /**< Shift value for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_MASK                            0x2UL                          /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE_DEFAULT                          (_DMA_IF_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE                                  (0x1UL << 2)                   /**< DMA Channel 2 Complete Interrupt Flag */
+#define _DMA_IF_CH2DONE_SHIFT                           2                              /**< Shift value for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_MASK                            0x4UL                          /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE_DEFAULT                          (_DMA_IF_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE                                  (0x1UL << 3)                   /**< DMA Channel 3 Complete Interrupt Flag */
+#define _DMA_IF_CH3DONE_SHIFT                           3                              /**< Shift value for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_MASK                            0x8UL                          /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE_DEFAULT                          (_DMA_IF_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE                                  (0x1UL << 4)                   /**< DMA Channel 4 Complete Interrupt Flag */
+#define _DMA_IF_CH4DONE_SHIFT                           4                              /**< Shift value for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_MASK                            0x10UL                         /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE_DEFAULT                          (_DMA_IF_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE                                  (0x1UL << 5)                   /**< DMA Channel 5 Complete Interrupt Flag */
+#define _DMA_IF_CH5DONE_SHIFT                           5                              /**< Shift value for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_MASK                            0x20UL                         /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE_DEFAULT                          (_DMA_IF_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE                                  (0x1UL << 6)                   /**< DMA Channel 6 Complete Interrupt Flag */
+#define _DMA_IF_CH6DONE_SHIFT                           6                              /**< Shift value for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_MASK                            0x40UL                         /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE_DEFAULT                          (_DMA_IF_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE                                  (0x1UL << 7)                   /**< DMA Channel 7 Complete Interrupt Flag */
+#define _DMA_IF_CH7DONE_SHIFT                           7                              /**< Shift value for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_MASK                            0x80UL                         /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE_DEFAULT                          (_DMA_IF_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR                                      (0x1UL << 31)                  /**< DMA Error Interrupt Flag */
+#define _DMA_IF_ERR_SHIFT                               31                             /**< Shift value for DMA_ERR */
+#define _DMA_IF_ERR_MASK                                0x80000000UL                   /**< Bit mask for DMA_ERR */
+#define _DMA_IF_ERR_DEFAULT                             0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR_DEFAULT                              (_DMA_IF_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IF */
+
+/* Bit fields for DMA IFS */
+#define _DMA_IFS_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFS */
+#define _DMA_IFS_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFS */
+#define DMA_IFS_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH0DONE_DEFAULT                         (_DMA_IFS_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE_DEFAULT                         (_DMA_IFS_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE_DEFAULT                         (_DMA_IFS_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE_DEFAULT                         (_DMA_IFS_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE_DEFAULT                         (_DMA_IFS_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE_DEFAULT                         (_DMA_IFS_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE_DEFAULT                         (_DMA_IFS_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE_DEFAULT                         (_DMA_IFS_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Set */
+#define _DMA_IFS_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFS_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFS_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR_DEFAULT                             (_DMA_IFS_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFS */
+
+/* Bit fields for DMA IFC */
+#define _DMA_IFC_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFC */
+#define _DMA_IFC_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFC */
+#define DMA_IFC_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH0DONE_DEFAULT                         (_DMA_IFC_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE_DEFAULT                         (_DMA_IFC_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE_DEFAULT                         (_DMA_IFC_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE_DEFAULT                         (_DMA_IFC_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE_DEFAULT                         (_DMA_IFC_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE_DEFAULT                         (_DMA_IFC_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE_DEFAULT                         (_DMA_IFC_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE_DEFAULT                         (_DMA_IFC_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Clear */
+#define _DMA_IFC_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFC_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFC_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR_DEFAULT                             (_DMA_IFC_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFC */
+
+/* Bit fields for DMA IEN */
+#define _DMA_IEN_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IEN */
+#define _DMA_IEN_MASK                                   0x800000FFUL                    /**< Mask for DMA_IEN */
+#define DMA_IEN_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Enable */
+#define _DMA_IEN_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH0DONE_DEFAULT                         (_DMA_IEN_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Enable */
+#define _DMA_IEN_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE_DEFAULT                         (_DMA_IEN_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Enable */
+#define _DMA_IEN_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE_DEFAULT                         (_DMA_IEN_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Enable */
+#define _DMA_IEN_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE_DEFAULT                         (_DMA_IEN_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Enable */
+#define _DMA_IEN_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE_DEFAULT                         (_DMA_IEN_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Enable */
+#define _DMA_IEN_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE_DEFAULT                         (_DMA_IEN_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Enable */
+#define _DMA_IEN_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE_DEFAULT                         (_DMA_IEN_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Enable */
+#define _DMA_IEN_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE_DEFAULT                         (_DMA_IEN_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Enable */
+#define _DMA_IEN_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IEN_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IEN_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR_DEFAULT                             (_DMA_IEN_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IEN */
+
+/* Bit fields for DMA CH_CTRL */
+#define _DMA_CH_CTRL_RESETVALUE                         0x00000000UL                                  /**< Default value for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_MASK                               0x003F000FUL                                  /**< Mask for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_SHIFT                       0                                             /**< Shift value for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_MASK                        0xFUL                                         /**< Bit mask for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAV               0x00000000UL                                  /**< Mode USART1RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV              0x00000000UL                                  /**< Mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                 0x00000000UL                                  /**< Mode I2C0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0UFOF                  0x00000000UL                                  /**< Mode TIMER0UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1UFOF                  0x00000000UL                                  /**< Mode TIMER1UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_MSCWDATA                    0x00000000UL                                  /**< Mode MSCWDATA for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV             0x00000000UL                                  /**< Mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBL                  0x00000001UL                                  /**< Mode USART1TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXBL                 0x00000001UL                                  /**< Mode LEUART0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0TXBL                    0x00000001UL                                  /**< Mode I2C0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC0                   0x00000001UL                                  /**< Mode TIMER0CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC0                   0x00000001UL                                  /**< Mode TIMER1CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXEMPTY               0x00000002UL                                  /**< Mode USART1TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY              0x00000002UL                                  /**< Mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC1                   0x00000002UL                                  /**< Mode TIMER0CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC1                   0x00000002UL                                  /**< Mode TIMER1CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT          0x00000003UL                                  /**< Mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC2                   0x00000003UL                                  /**< Mode TIMER0CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC2                   0x00000003UL                                  /**< Mode TIMER1CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT             0x00000004UL                                  /**< Mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAV                (_DMA_CH_CTRL_SIGSEL_USART1RXDATAV << 0)      /**< Shifted mode USART1RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV               (_DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV << 0)     /**< Shifted mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                  (_DMA_CH_CTRL_SIGSEL_I2C0RXDATAV << 0)        /**< Shifted mode I2C0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER0UFOF << 0)         /**< Shifted mode TIMER0UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER1UFOF << 0)         /**< Shifted mode TIMER1UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_MSCWDATA                     (_DMA_CH_CTRL_SIGSEL_MSCWDATA << 0)           /**< Shifted mode MSCWDATA for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV              (_DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV << 0)    /**< Shifted mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBL                   (_DMA_CH_CTRL_SIGSEL_USART1TXBL << 0)         /**< Shifted mode USART1TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXBL                  (_DMA_CH_CTRL_SIGSEL_LEUART0TXBL << 0)        /**< Shifted mode LEUART0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0TXBL                     (_DMA_CH_CTRL_SIGSEL_I2C0TXBL << 0)           /**< Shifted mode I2C0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC0 << 0)          /**< Shifted mode TIMER0CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC0 << 0)          /**< Shifted mode TIMER1CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXEMPTY                (_DMA_CH_CTRL_SIGSEL_USART1TXEMPTY << 0)      /**< Shifted mode USART1TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY               (_DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY << 0)     /**< Shifted mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC1 << 0)          /**< Shifted mode TIMER0CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC1 << 0)          /**< Shifted mode TIMER1CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT           (_DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT << 0) /**< Shifted mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC2 << 0)          /**< Shifted mode TIMER0CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC2 << 0)          /**< Shifted mode TIMER1CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT              (_DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT << 0)    /**< Shifted mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_SHIFT                    16                                            /**< Shift value for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_MASK                     0x3F0000UL                                    /**< Bit mask for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_NONE                     0x00000000UL                                  /**< Mode NONE for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_USART1                   0x0000000DUL                                  /**< Mode USART1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LEUART0                  0x00000010UL                                  /**< Mode LEUART0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_I2C0                     0x00000014UL                                  /**< Mode I2C0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER0                   0x00000018UL                                  /**< Mode TIMER0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER1                   0x00000019UL                                  /**< Mode TIMER1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_MSC                      0x00000030UL                                  /**< Mode MSC for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LESENSE                  0x00000032UL                                  /**< Mode LESENSE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_NONE                      (_DMA_CH_CTRL_SOURCESEL_NONE << 16)           /**< Shifted mode NONE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_USART1                    (_DMA_CH_CTRL_SOURCESEL_USART1 << 16)         /**< Shifted mode USART1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LEUART0                   (_DMA_CH_CTRL_SOURCESEL_LEUART0 << 16)        /**< Shifted mode LEUART0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_I2C0                      (_DMA_CH_CTRL_SOURCESEL_I2C0 << 16)           /**< Shifted mode I2C0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER0                    (_DMA_CH_CTRL_SOURCESEL_TIMER0 << 16)         /**< Shifted mode TIMER0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER1                    (_DMA_CH_CTRL_SOURCESEL_TIMER1 << 16)         /**< Shifted mode TIMER1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_MSC                       (_DMA_CH_CTRL_SOURCESEL_MSC << 16)            /**< Shifted mode MSC for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LESENSE                   (_DMA_CH_CTRL_SOURCESEL_LESENSE << 16)        /**< Shifted mode LESENSE for DMA_CH_CTRL */
+
+/** @} End of group EFM32TG108F32_DMA */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_CMU_BitFields  EFM32TG108F32_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000006UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x000009FBUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG108F32_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_PRS_BitFields  EFM32TG108F32_PRS Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for PRS SWPULSE */
+#define _PRS_SWPULSE_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWPULSE */
+#define _PRS_SWPULSE_MASK                       0x000000FFUL                         /**< Mask for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE                    (0x1UL << 0)                         /**< Channel 0 Pulse Generation */
+#define _PRS_SWPULSE_CH0PULSE_SHIFT             0                                    /**< Shift value for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_MASK              0x1UL                                /**< Bit mask for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE_DEFAULT            (_PRS_SWPULSE_CH0PULSE_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE                    (0x1UL << 1)                         /**< Channel 1 Pulse Generation */
+#define _PRS_SWPULSE_CH1PULSE_SHIFT             1                                    /**< Shift value for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_MASK              0x2UL                                /**< Bit mask for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE_DEFAULT            (_PRS_SWPULSE_CH1PULSE_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE                    (0x1UL << 2)                         /**< Channel 2 Pulse Generation */
+#define _PRS_SWPULSE_CH2PULSE_SHIFT             2                                    /**< Shift value for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_MASK              0x4UL                                /**< Bit mask for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE_DEFAULT            (_PRS_SWPULSE_CH2PULSE_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE                    (0x1UL << 3)                         /**< Channel 3 Pulse Generation */
+#define _PRS_SWPULSE_CH3PULSE_SHIFT             3                                    /**< Shift value for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_MASK              0x8UL                                /**< Bit mask for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE_DEFAULT            (_PRS_SWPULSE_CH3PULSE_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE                    (0x1UL << 4)                         /**< Channel 4 Pulse Generation */
+#define _PRS_SWPULSE_CH4PULSE_SHIFT             4                                    /**< Shift value for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_MASK              0x10UL                               /**< Bit mask for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE_DEFAULT            (_PRS_SWPULSE_CH4PULSE_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE                    (0x1UL << 5)                         /**< Channel 5 Pulse Generation */
+#define _PRS_SWPULSE_CH5PULSE_SHIFT             5                                    /**< Shift value for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_MASK              0x20UL                               /**< Bit mask for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE_DEFAULT            (_PRS_SWPULSE_CH5PULSE_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE                    (0x1UL << 6)                         /**< Channel 6 Pulse Generation */
+#define _PRS_SWPULSE_CH6PULSE_SHIFT             6                                    /**< Shift value for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_MASK              0x40UL                               /**< Bit mask for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE_DEFAULT            (_PRS_SWPULSE_CH6PULSE_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE                    (0x1UL << 7)                         /**< Channel 7 Pulse Generation */
+#define _PRS_SWPULSE_CH7PULSE_SHIFT             7                                    /**< Shift value for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_MASK              0x80UL                               /**< Bit mask for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE_DEFAULT            (_PRS_SWPULSE_CH7PULSE_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+
+/* Bit fields for PRS SWLEVEL */
+#define _PRS_SWLEVEL_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWLEVEL */
+#define _PRS_SWLEVEL_MASK                       0x000000FFUL                         /**< Mask for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL                    (0x1UL << 0)                         /**< Channel 0 Software Level */
+#define _PRS_SWLEVEL_CH0LEVEL_SHIFT             0                                    /**< Shift value for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_MASK              0x1UL                                /**< Bit mask for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL_DEFAULT            (_PRS_SWLEVEL_CH0LEVEL_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL                    (0x1UL << 1)                         /**< Channel 1 Software Level */
+#define _PRS_SWLEVEL_CH1LEVEL_SHIFT             1                                    /**< Shift value for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_MASK              0x2UL                                /**< Bit mask for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL_DEFAULT            (_PRS_SWLEVEL_CH1LEVEL_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL                    (0x1UL << 2)                         /**< Channel 2 Software Level */
+#define _PRS_SWLEVEL_CH2LEVEL_SHIFT             2                                    /**< Shift value for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_MASK              0x4UL                                /**< Bit mask for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL_DEFAULT            (_PRS_SWLEVEL_CH2LEVEL_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL                    (0x1UL << 3)                         /**< Channel 3 Software Level */
+#define _PRS_SWLEVEL_CH3LEVEL_SHIFT             3                                    /**< Shift value for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_MASK              0x8UL                                /**< Bit mask for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL_DEFAULT            (_PRS_SWLEVEL_CH3LEVEL_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL                    (0x1UL << 4)                         /**< Channel 4 Software Level */
+#define _PRS_SWLEVEL_CH4LEVEL_SHIFT             4                                    /**< Shift value for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_MASK              0x10UL                               /**< Bit mask for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL_DEFAULT            (_PRS_SWLEVEL_CH4LEVEL_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL                    (0x1UL << 5)                         /**< Channel 5 Software Level */
+#define _PRS_SWLEVEL_CH5LEVEL_SHIFT             5                                    /**< Shift value for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_MASK              0x20UL                               /**< Bit mask for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL_DEFAULT            (_PRS_SWLEVEL_CH5LEVEL_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL                    (0x1UL << 6)                         /**< Channel 6 Software Level */
+#define _PRS_SWLEVEL_CH6LEVEL_SHIFT             6                                    /**< Shift value for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_MASK              0x40UL                               /**< Bit mask for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL_DEFAULT            (_PRS_SWLEVEL_CH6LEVEL_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL                    (0x1UL << 7)                         /**< Channel 7 Software Level */
+#define _PRS_SWLEVEL_CH7LEVEL_SHIFT             7                                    /**< Shift value for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_MASK              0x80UL                               /**< Bit mask for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL_DEFAULT            (_PRS_SWLEVEL_CH7LEVEL_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+
+/* Bit fields for PRS ROUTE */
+#define _PRS_ROUTE_RESETVALUE                   0x00000000UL                       /**< Default value for PRS_ROUTE */
+#define _PRS_ROUTE_MASK                         0x0000070FUL                       /**< Mask for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN                        (0x1UL << 0)                       /**< CH0 Pin Enable */
+#define _PRS_ROUTE_CH0PEN_SHIFT                 0                                  /**< Shift value for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_MASK                  0x1UL                              /**< Bit mask for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN_DEFAULT                (_PRS_ROUTE_CH0PEN_DEFAULT << 0)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN                        (0x1UL << 1)                       /**< CH1 Pin Enable */
+#define _PRS_ROUTE_CH1PEN_SHIFT                 1                                  /**< Shift value for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_MASK                  0x2UL                              /**< Bit mask for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN_DEFAULT                (_PRS_ROUTE_CH1PEN_DEFAULT << 1)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN                        (0x1UL << 2)                       /**< CH2 Pin Enable */
+#define _PRS_ROUTE_CH2PEN_SHIFT                 2                                  /**< Shift value for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_MASK                  0x4UL                              /**< Bit mask for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN_DEFAULT                (_PRS_ROUTE_CH2PEN_DEFAULT << 2)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN                        (0x1UL << 3)                       /**< CH3 Pin Enable */
+#define _PRS_ROUTE_CH3PEN_SHIFT                 3                                  /**< Shift value for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_MASK                  0x8UL                              /**< Bit mask for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN_DEFAULT                (_PRS_ROUTE_CH3PEN_DEFAULT << 3)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_SHIFT               8                                  /**< Shift value for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_MASK                0x700UL                            /**< Bit mask for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_LOC0                0x00000000UL                       /**< Mode LOC0 for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_DEFAULT             0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_LOC1                0x00000001UL                       /**< Mode LOC1 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC0                 (_PRS_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_DEFAULT              (_PRS_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC1                 (_PRS_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for PRS_ROUTE */
+
+/* Bit fields for PRS CH_CTRL */
+#define _PRS_CH_CTRL_RESETVALUE                 0x00000000UL                                /**< Default value for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_MASK                       0x133F0007UL                                /**< Mask for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_SHIFT               0                                           /**< Shift value for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_MASK                0x7UL                                       /**< Bit mask for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_VCMPOUT             0x00000000UL                                /**< Mode VCMPOUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP0OUT            0x00000000UL                                /**< Mode ACMP0OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP1OUT            0x00000000UL                                /**< Mode ACMP1OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0UF            0x00000000UL                                /**< Mode TIMER0UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1UF            0x00000000UL                                /**< Mode TIMER1UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCOF               0x00000000UL                                /**< Mode RTCOF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN0            0x00000000UL                                /**< Mode GPIOPIN0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN8            0x00000000UL                                /**< Mode GPIOPIN8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH0         0x00000000UL                                /**< Mode LETIMER0CH0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES0     0x00000000UL                                /**< Mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES8     0x00000000UL                                /**< Mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC0         0x00000000UL                                /**< Mode LESENSEDEC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1TXC           0x00000001UL                                /**< Mode USART1TXC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0OF            0x00000001UL                                /**< Mode TIMER0OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1OF            0x00000001UL                                /**< Mode TIMER1OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP0            0x00000001UL                                /**< Mode RTCCOMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN1            0x00000001UL                                /**< Mode GPIOPIN1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN9            0x00000001UL                                /**< Mode GPIOPIN9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH1         0x00000001UL                                /**< Mode LETIMER0CH1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES1     0x00000001UL                                /**< Mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES9     0x00000001UL                                /**< Mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC1         0x00000001UL                                /**< Mode LESENSEDEC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1RXDATAV       0x00000002UL                                /**< Mode USART1RXDATAV for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC0           0x00000002UL                                /**< Mode TIMER0CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC0           0x00000002UL                                /**< Mode TIMER1CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP1            0x00000002UL                                /**< Mode RTCCOMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN2            0x00000002UL                                /**< Mode GPIOPIN2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN10           0x00000002UL                                /**< Mode GPIOPIN10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES2     0x00000002UL                                /**< Mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES10    0x00000002UL                                /**< Mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC2         0x00000002UL                                /**< Mode LESENSEDEC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC1           0x00000003UL                                /**< Mode TIMER0CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC1           0x00000003UL                                /**< Mode TIMER1CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN3            0x00000003UL                                /**< Mode GPIOPIN3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN11           0x00000003UL                                /**< Mode GPIOPIN11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES3     0x00000003UL                                /**< Mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES11    0x00000003UL                                /**< Mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC2           0x00000004UL                                /**< Mode TIMER0CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC2           0x00000004UL                                /**< Mode TIMER1CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN4            0x00000004UL                                /**< Mode GPIOPIN4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN12           0x00000004UL                                /**< Mode GPIOPIN12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES4     0x00000004UL                                /**< Mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES12    0x00000004UL                                /**< Mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN5            0x00000005UL                                /**< Mode GPIOPIN5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN13           0x00000005UL                                /**< Mode GPIOPIN13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES5     0x00000005UL                                /**< Mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES13    0x00000005UL                                /**< Mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN6            0x00000006UL                                /**< Mode GPIOPIN6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN14           0x00000006UL                                /**< Mode GPIOPIN14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES6     0x00000006UL                                /**< Mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES14    0x00000006UL                                /**< Mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN7            0x00000007UL                                /**< Mode GPIOPIN7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN15           0x00000007UL                                /**< Mode GPIOPIN15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES7     0x00000007UL                                /**< Mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES15    0x00000007UL                                /**< Mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_VCMPOUT              (_PRS_CH_CTRL_SIGSEL_VCMPOUT << 0)          /**< Shifted mode VCMPOUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP0OUT             (_PRS_CH_CTRL_SIGSEL_ACMP0OUT << 0)         /**< Shifted mode ACMP0OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP1OUT             (_PRS_CH_CTRL_SIGSEL_ACMP1OUT << 0)         /**< Shifted mode ACMP1OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0UF             (_PRS_CH_CTRL_SIGSEL_TIMER0UF << 0)         /**< Shifted mode TIMER0UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1UF             (_PRS_CH_CTRL_SIGSEL_TIMER1UF << 0)         /**< Shifted mode TIMER1UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCOF                (_PRS_CH_CTRL_SIGSEL_RTCOF << 0)            /**< Shifted mode RTCOF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN0             (_PRS_CH_CTRL_SIGSEL_GPIOPIN0 << 0)         /**< Shifted mode GPIOPIN0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN8             (_PRS_CH_CTRL_SIGSEL_GPIOPIN8 << 0)         /**< Shifted mode GPIOPIN8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH0          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH0 << 0)      /**< Shifted mode LETIMER0CH0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES0      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES0 << 0)  /**< Shifted mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES8      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES8 << 0)  /**< Shifted mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC0          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC0 << 0)      /**< Shifted mode LESENSEDEC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1TXC            (_PRS_CH_CTRL_SIGSEL_USART1TXC << 0)        /**< Shifted mode USART1TXC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0OF             (_PRS_CH_CTRL_SIGSEL_TIMER0OF << 0)         /**< Shifted mode TIMER0OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1OF             (_PRS_CH_CTRL_SIGSEL_TIMER1OF << 0)         /**< Shifted mode TIMER1OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP0             (_PRS_CH_CTRL_SIGSEL_RTCCOMP0 << 0)         /**< Shifted mode RTCCOMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN1             (_PRS_CH_CTRL_SIGSEL_GPIOPIN1 << 0)         /**< Shifted mode GPIOPIN1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN9             (_PRS_CH_CTRL_SIGSEL_GPIOPIN9 << 0)         /**< Shifted mode GPIOPIN9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH1          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH1 << 0)      /**< Shifted mode LETIMER0CH1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES1      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES1 << 0)  /**< Shifted mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES9      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES9 << 0)  /**< Shifted mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC1          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC1 << 0)      /**< Shifted mode LESENSEDEC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1RXDATAV        (_PRS_CH_CTRL_SIGSEL_USART1RXDATAV << 0)    /**< Shifted mode USART1RXDATAV for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC0            (_PRS_CH_CTRL_SIGSEL_TIMER0CC0 << 0)        /**< Shifted mode TIMER0CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC0            (_PRS_CH_CTRL_SIGSEL_TIMER1CC0 << 0)        /**< Shifted mode TIMER1CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP1             (_PRS_CH_CTRL_SIGSEL_RTCCOMP1 << 0)         /**< Shifted mode RTCCOMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN2             (_PRS_CH_CTRL_SIGSEL_GPIOPIN2 << 0)         /**< Shifted mode GPIOPIN2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN10            (_PRS_CH_CTRL_SIGSEL_GPIOPIN10 << 0)        /**< Shifted mode GPIOPIN10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES2      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES2 << 0)  /**< Shifted mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES10     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES10 << 0) /**< Shifted mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC2          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC2 << 0)      /**< Shifted mode LESENSEDEC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC1            (_PRS_CH_CTRL_SIGSEL_TIMER0CC1 << 0)        /**< Shifted mode TIMER0CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC1            (_PRS_CH_CTRL_SIGSEL_TIMER1CC1 << 0)        /**< Shifted mode TIMER1CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN3             (_PRS_CH_CTRL_SIGSEL_GPIOPIN3 << 0)         /**< Shifted mode GPIOPIN3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN11            (_PRS_CH_CTRL_SIGSEL_GPIOPIN11 << 0)        /**< Shifted mode GPIOPIN11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES3      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES3 << 0)  /**< Shifted mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES11     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES11 << 0) /**< Shifted mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC2            (_PRS_CH_CTRL_SIGSEL_TIMER0CC2 << 0)        /**< Shifted mode TIMER0CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC2            (_PRS_CH_CTRL_SIGSEL_TIMER1CC2 << 0)        /**< Shifted mode TIMER1CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN4             (_PRS_CH_CTRL_SIGSEL_GPIOPIN4 << 0)         /**< Shifted mode GPIOPIN4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN12            (_PRS_CH_CTRL_SIGSEL_GPIOPIN12 << 0)        /**< Shifted mode GPIOPIN12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES4      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES4 << 0)  /**< Shifted mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES12     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES12 << 0) /**< Shifted mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN5             (_PRS_CH_CTRL_SIGSEL_GPIOPIN5 << 0)         /**< Shifted mode GPIOPIN5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN13            (_PRS_CH_CTRL_SIGSEL_GPIOPIN13 << 0)        /**< Shifted mode GPIOPIN13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES5      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES5 << 0)  /**< Shifted mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES13     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES13 << 0) /**< Shifted mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN6             (_PRS_CH_CTRL_SIGSEL_GPIOPIN6 << 0)         /**< Shifted mode GPIOPIN6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN14            (_PRS_CH_CTRL_SIGSEL_GPIOPIN14 << 0)        /**< Shifted mode GPIOPIN14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES6      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES6 << 0)  /**< Shifted mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES14     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES14 << 0) /**< Shifted mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN7             (_PRS_CH_CTRL_SIGSEL_GPIOPIN7 << 0)         /**< Shifted mode GPIOPIN7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN15            (_PRS_CH_CTRL_SIGSEL_GPIOPIN15 << 0)        /**< Shifted mode GPIOPIN15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES7      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES7 << 0)  /**< Shifted mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES15     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES15 << 0) /**< Shifted mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_SHIFT            16                                          /**< Shift value for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_MASK             0x3F0000UL                                  /**< Bit mask for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_NONE             0x00000000UL                                /**< Mode NONE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_VCMP             0x00000001UL                                /**< Mode VCMP for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP0            0x00000002UL                                /**< Mode ACMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP1            0x00000003UL                                /**< Mode ACMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_USART1           0x00000011UL                                /**< Mode USART1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER0           0x0000001CUL                                /**< Mode TIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER1           0x0000001DUL                                /**< Mode TIMER1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_RTC              0x00000028UL                                /**< Mode RTC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOL            0x00000030UL                                /**< Mode GPIOL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOH            0x00000031UL                                /**< Mode GPIOH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LETIMER0         0x00000034UL                                /**< Mode LETIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEL         0x00000039UL                                /**< Mode LESENSEL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEH         0x0000003AUL                                /**< Mode LESENSEH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSED         0x0000003BUL                                /**< Mode LESENSED for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_NONE              (_PRS_CH_CTRL_SOURCESEL_NONE << 16)         /**< Shifted mode NONE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_VCMP              (_PRS_CH_CTRL_SOURCESEL_VCMP << 16)         /**< Shifted mode VCMP for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP0             (_PRS_CH_CTRL_SOURCESEL_ACMP0 << 16)        /**< Shifted mode ACMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP1             (_PRS_CH_CTRL_SOURCESEL_ACMP1 << 16)        /**< Shifted mode ACMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_USART1            (_PRS_CH_CTRL_SOURCESEL_USART1 << 16)       /**< Shifted mode USART1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER0            (_PRS_CH_CTRL_SOURCESEL_TIMER0 << 16)       /**< Shifted mode TIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER1            (_PRS_CH_CTRL_SOURCESEL_TIMER1 << 16)       /**< Shifted mode TIMER1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_RTC               (_PRS_CH_CTRL_SOURCESEL_RTC << 16)          /**< Shifted mode RTC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOL             (_PRS_CH_CTRL_SOURCESEL_GPIOL << 16)        /**< Shifted mode GPIOL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOH             (_PRS_CH_CTRL_SOURCESEL_GPIOH << 16)        /**< Shifted mode GPIOH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LETIMER0          (_PRS_CH_CTRL_SOURCESEL_LETIMER0 << 16)     /**< Shifted mode LETIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEL          (_PRS_CH_CTRL_SOURCESEL_LESENSEL << 16)     /**< Shifted mode LESENSEL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEH          (_PRS_CH_CTRL_SOURCESEL_LESENSEH << 16)     /**< Shifted mode LESENSEH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSED          (_PRS_CH_CTRL_SOURCESEL_LESENSED << 16)     /**< Shifted mode LESENSED for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_SHIFT                24                                          /**< Shift value for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_MASK                 0x3000000UL                                 /**< Bit mask for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_OFF                  0x00000000UL                                /**< Mode OFF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_POSEDGE              0x00000001UL                                /**< Mode POSEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_NEGEDGE              0x00000002UL                                /**< Mode NEGEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_BOTHEDGES            0x00000003UL                                /**< Mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_DEFAULT               (_PRS_CH_CTRL_EDSEL_DEFAULT << 24)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_OFF                   (_PRS_CH_CTRL_EDSEL_OFF << 24)              /**< Shifted mode OFF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_POSEDGE               (_PRS_CH_CTRL_EDSEL_POSEDGE << 24)          /**< Shifted mode POSEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_NEGEDGE               (_PRS_CH_CTRL_EDSEL_NEGEDGE << 24)          /**< Shifted mode NEGEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_BOTHEDGES             (_PRS_CH_CTRL_EDSEL_BOTHEDGES << 24)        /**< Shifted mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC                       (0x1UL << 28)                               /**< Asynchronous reflex */
+#define _PRS_CH_CTRL_ASYNC_SHIFT                28                                          /**< Shift value for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_MASK                 0x10000000UL                                /**< Bit mask for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC_DEFAULT               (_PRS_CH_CTRL_ASYNC_DEFAULT << 28)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+
+/** @} End of group EFM32TG108F32_PRS */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_UNLOCK EFM32TG108F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG108F32_UNLOCK */
+
+/** @} End of group EFM32TG108F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F32_Alternate_Function EFM32TG108F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG108F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG108F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG108F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg108f4.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg108f4.h
@@ -1,0 +1,2743 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG108F4
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG108F4_H
+#define EFM32TG108F4_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4 EFM32TG108F4
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_Core EFM32TG108F4 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG108F4_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_Part EFM32TG108F4 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG108F4)
+#define EFM32TG108F4    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG108F4" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG108F4 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00001000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           1 /**< 1 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG108F4_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_Peripheral_TypeDefs EFM32TG108F4 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_dma_ch.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_DMA EFM32TG108F4 DMA
+ * @brief EFM32TG108F4_DMA Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IM uint32_t  STATUS;          /**< DMA Status Registers  */
+  __OM uint32_t  CONFIG;          /**< DMA Configuration Register  */
+  __IOM uint32_t CTRLBASE;        /**< Channel Control Data Base Pointer Register  */
+  __IM uint32_t  ALTCTRLBASE;     /**< Channel Alternate Control Data Base Pointer Register  */
+  __IM uint32_t  CHWAITSTATUS;    /**< Channel Wait on Request Status Register  */
+  __OM uint32_t  CHSWREQ;         /**< Channel Software Request Register  */
+  __IOM uint32_t CHUSEBURSTS;     /**< Channel Useburst Set Register  */
+  __OM uint32_t  CHUSEBURSTC;     /**< Channel Useburst Clear Register  */
+  __IOM uint32_t CHREQMASKS;      /**< Channel Request Mask Set Register  */
+  __OM uint32_t  CHREQMASKC;      /**< Channel Request Mask Clear Register  */
+  __IOM uint32_t CHENS;           /**< Channel Enable Set Register  */
+  __OM uint32_t  CHENC;           /**< Channel Enable Clear Register  */
+  __IOM uint32_t CHALTS;          /**< Channel Alternate Set Register  */
+  __OM uint32_t  CHALTC;          /**< Channel Alternate Clear Register  */
+  __IOM uint32_t CHPRIS;          /**< Channel Priority Set Register  */
+  __OM uint32_t  CHPRIC;          /**< Channel Priority Clear Register  */
+  uint32_t       RESERVED0[3U];   /**< Reserved for future use **/
+  __IOM uint32_t ERRORC;          /**< Bus Error Clear Register  */
+  uint32_t       RESERVED1[880U]; /**< Reserved for future use **/
+  __IM uint32_t  CHREQSTATUS;     /**< Channel Request Status  */
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
+  __IM uint32_t  CHSREQSTATUS;    /**< Channel Single Request Status  */
+
+  uint32_t       RESERVED3[121U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable register  */
+
+  uint32_t       RESERVED4[60U];  /**< Reserved registers */
+  DMA_CH_TypeDef CH[8U];          /**< Channel registers */
+} DMA_TypeDef;                    /**< DMA Register Declaration *//** @} */
+
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_CMU EFM32TG108F4 CMU
+ * @brief EFM32TG108F4_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_PRS EFM32TG108F4 PRS
+ * @brief EFM32TG108F4_PRS Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+
+  uint32_t       RESERVED0[1U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[8U];        /**< Channel registers */
+} PRS_TypeDef;                  /**< PRS Register Declaration *//** @} */
+
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG108F4_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_Peripheral_Base EFM32TG108F4 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG108F4_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_Peripheral_Declaration  EFM32TG108F4 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG108F4_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_BitFields EFM32TG108F4 Bit Fields
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @addtogroup EFM32TG108F4_PRS_Signals
+ * @{
+ * @brief PRS Signal names
+ ******************************************************************************/
+
+#define PRS_VCMP_OUT             ((1 << 16) + 0)  /**< PRS Voltage comparator output */
+#define PRS_ACMP0_OUT            ((2 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_ACMP1_OUT            ((3 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_USART1_TXC           ((17 << 16) + 1) /**< PRS USART 1 TX complete */
+#define PRS_USART1_RXDATAV       ((17 << 16) + 2) /**< PRS USART 1 RX Data Valid */
+#define PRS_TIMER0_UF            ((28 << 16) + 0) /**< PRS Timer 0 Underflow */
+#define PRS_TIMER0_OF            ((28 << 16) + 1) /**< PRS Timer 0 Overflow */
+#define PRS_TIMER0_CC0           ((28 << 16) + 2) /**< PRS Timer 0 Compare/Capture 0 */
+#define PRS_TIMER0_CC1           ((28 << 16) + 3) /**< PRS Timer 0 Compare/Capture 1 */
+#define PRS_TIMER0_CC2           ((28 << 16) + 4) /**< PRS Timer 0 Compare/Capture 2 */
+#define PRS_TIMER1_UF            ((29 << 16) + 0) /**< PRS Timer 1 Underflow */
+#define PRS_TIMER1_OF            ((29 << 16) + 1) /**< PRS Timer 1 Overflow */
+#define PRS_TIMER1_CC0           ((29 << 16) + 2) /**< PRS Timer 1 Compare/Capture 0 */
+#define PRS_TIMER1_CC1           ((29 << 16) + 3) /**< PRS Timer 1 Compare/Capture 1 */
+#define PRS_TIMER1_CC2           ((29 << 16) + 4) /**< PRS Timer 1 Compare/Capture 2 */
+#define PRS_RTC_OF               ((40 << 16) + 0) /**< PRS RTC Overflow */
+#define PRS_RTC_COMP0            ((40 << 16) + 1) /**< PRS RTC Compare 0 */
+#define PRS_RTC_COMP1            ((40 << 16) + 2) /**< PRS RTC Compare 1 */
+#define PRS_GPIO_PIN0            ((48 << 16) + 0) /**< PRS GPIO pin 0 */
+#define PRS_GPIO_PIN1            ((48 << 16) + 1) /**< PRS GPIO pin 1 */
+#define PRS_GPIO_PIN2            ((48 << 16) + 2) /**< PRS GPIO pin 2 */
+#define PRS_GPIO_PIN3            ((48 << 16) + 3) /**< PRS GPIO pin 3 */
+#define PRS_GPIO_PIN4            ((48 << 16) + 4) /**< PRS GPIO pin 4 */
+#define PRS_GPIO_PIN5            ((48 << 16) + 5) /**< PRS GPIO pin 5 */
+#define PRS_GPIO_PIN6            ((48 << 16) + 6) /**< PRS GPIO pin 6 */
+#define PRS_GPIO_PIN7            ((48 << 16) + 7) /**< PRS GPIO pin 7 */
+#define PRS_GPIO_PIN8            ((49 << 16) + 0) /**< PRS GPIO pin 8 */
+#define PRS_GPIO_PIN9            ((49 << 16) + 1) /**< PRS GPIO pin 9 */
+#define PRS_GPIO_PIN10           ((49 << 16) + 2) /**< PRS GPIO pin 10 */
+#define PRS_GPIO_PIN11           ((49 << 16) + 3) /**< PRS GPIO pin 11 */
+#define PRS_GPIO_PIN12           ((49 << 16) + 4) /**< PRS GPIO pin 12 */
+#define PRS_GPIO_PIN13           ((49 << 16) + 5) /**< PRS GPIO pin 13 */
+#define PRS_GPIO_PIN14           ((49 << 16) + 6) /**< PRS GPIO pin 14 */
+#define PRS_GPIO_PIN15           ((49 << 16) + 7) /**< PRS GPIO pin 15 */
+#define PRS_LETIMER0_CH0         ((52 << 16) + 0) /**< PRS LETIMER CH0 Out */
+#define PRS_LETIMER0_CH1         ((52 << 16) + 1) /**< PRS LETIMER CH1 Out */
+#define PRS_LESENSE_SCANRES0     ((57 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 0 */
+#define PRS_LESENSE_SCANRES1     ((57 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 1 */
+#define PRS_LESENSE_SCANRES2     ((57 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 2 */
+#define PRS_LESENSE_SCANRES3     ((57 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 3 */
+#define PRS_LESENSE_SCANRES4     ((57 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 4 */
+#define PRS_LESENSE_SCANRES5     ((57 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 5 */
+#define PRS_LESENSE_SCANRES6     ((57 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 6 */
+#define PRS_LESENSE_SCANRES7     ((57 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 7 */
+#define PRS_LESENSE_SCANRES8     ((58 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 8 */
+#define PRS_LESENSE_SCANRES9     ((58 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 9 */
+#define PRS_LESENSE_SCANRES10    ((58 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 10 */
+#define PRS_LESENSE_SCANRES11    ((58 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 11 */
+#define PRS_LESENSE_SCANRES12    ((58 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 12 */
+#define PRS_LESENSE_SCANRES13    ((58 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 13 */
+#define PRS_LESENSE_SCANRES14    ((58 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 14 */
+#define PRS_LESENSE_SCANRES15    ((58 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 15 */
+#define PRS_LESENSE_DEC0         ((59 << 16) + 0) /**< PRS LESENSE Decoder PRS out 0 */
+#define PRS_LESENSE_DEC1         ((59 << 16) + 1) /**< PRS LESENSE Decoder PRS out 1 */
+#define PRS_LESENSE_DEC2         ((59 << 16) + 2) /**< PRS LESENSE Decoder PRS out 2 */
+
+/** @} End of group EFM32TG108F4_PRS */
+
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_DMA_BitFields  EFM32TG108F4_DMA Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for DMA STATUS */
+#define _DMA_STATUS_RESETVALUE                          0x10070000UL                          /**< Default value for DMA_STATUS */
+#define _DMA_STATUS_MASK                                0x001F00F1UL                          /**< Mask for DMA_STATUS */
+#define DMA_STATUS_EN                                   (0x1UL << 0)                          /**< DMA Enable Status */
+#define _DMA_STATUS_EN_SHIFT                            0                                     /**< Shift value for DMA_EN */
+#define _DMA_STATUS_EN_MASK                             0x1UL                                 /**< Bit mask for DMA_EN */
+#define _DMA_STATUS_EN_DEFAULT                          0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_EN_DEFAULT                           (_DMA_STATUS_EN_DEFAULT << 0)         /**< Shifted mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_SHIFT                         4                                     /**< Shift value for DMA_STATE */
+#define _DMA_STATUS_STATE_MASK                          0xF0UL                                /**< Bit mask for DMA_STATE */
+#define _DMA_STATUS_STATE_DEFAULT                       0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_IDLE                          0x00000000UL                          /**< Mode IDLE for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDCHCTRLDATA                  0x00000001UL                          /**< Mode RDCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCENDPTR                   0x00000002UL                          /**< Mode RDSRCENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDDSTENDPTR                   0x00000003UL                          /**< Mode RDDSTENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCDATA                     0x00000004UL                          /**< Mode RDSRCDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRDSTDATA                     0x00000005UL                          /**< Mode WRDSTDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WAITREQCLR                    0x00000006UL                          /**< Mode WAITREQCLR for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRCHCTRLDATA                  0x00000007UL                          /**< Mode WRCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_STALLED                       0x00000008UL                          /**< Mode STALLED for DMA_STATUS */
+#define _DMA_STATUS_STATE_DONE                          0x00000009UL                          /**< Mode DONE for DMA_STATUS */
+#define _DMA_STATUS_STATE_PERSCATTRANS                  0x0000000AUL                          /**< Mode PERSCATTRANS for DMA_STATUS */
+#define DMA_STATUS_STATE_DEFAULT                        (_DMA_STATUS_STATE_DEFAULT << 4)      /**< Shifted mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_STATE_IDLE                           (_DMA_STATUS_STATE_IDLE << 4)         /**< Shifted mode IDLE for DMA_STATUS */
+#define DMA_STATUS_STATE_RDCHCTRLDATA                   (_DMA_STATUS_STATE_RDCHCTRLDATA << 4) /**< Shifted mode RDCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCENDPTR                    (_DMA_STATUS_STATE_RDSRCENDPTR << 4)  /**< Shifted mode RDSRCENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDDSTENDPTR                    (_DMA_STATUS_STATE_RDDSTENDPTR << 4)  /**< Shifted mode RDDSTENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCDATA                      (_DMA_STATUS_STATE_RDSRCDATA << 4)    /**< Shifted mode RDSRCDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WRDSTDATA                      (_DMA_STATUS_STATE_WRDSTDATA << 4)    /**< Shifted mode WRDSTDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WAITREQCLR                     (_DMA_STATUS_STATE_WAITREQCLR << 4)   /**< Shifted mode WAITREQCLR for DMA_STATUS */
+#define DMA_STATUS_STATE_WRCHCTRLDATA                   (_DMA_STATUS_STATE_WRCHCTRLDATA << 4) /**< Shifted mode WRCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_STALLED                        (_DMA_STATUS_STATE_STALLED << 4)      /**< Shifted mode STALLED for DMA_STATUS */
+#define DMA_STATUS_STATE_DONE                           (_DMA_STATUS_STATE_DONE << 4)         /**< Shifted mode DONE for DMA_STATUS */
+#define DMA_STATUS_STATE_PERSCATTRANS                   (_DMA_STATUS_STATE_PERSCATTRANS << 4) /**< Shifted mode PERSCATTRANS for DMA_STATUS */
+#define _DMA_STATUS_CHNUM_SHIFT                         16                                    /**< Shift value for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_MASK                          0x1F0000UL                            /**< Bit mask for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_DEFAULT                       0x00000007UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_CHNUM_DEFAULT                        (_DMA_STATUS_CHNUM_DEFAULT << 16)     /**< Shifted mode DEFAULT for DMA_STATUS */
+
+/* Bit fields for DMA CONFIG */
+#define _DMA_CONFIG_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_CONFIG */
+#define _DMA_CONFIG_MASK                                0x00000021UL                      /**< Mask for DMA_CONFIG */
+#define DMA_CONFIG_EN                                   (0x1UL << 0)                      /**< Enable DMA */
+#define _DMA_CONFIG_EN_SHIFT                            0                                 /**< Shift value for DMA_EN */
+#define _DMA_CONFIG_EN_MASK                             0x1UL                             /**< Bit mask for DMA_EN */
+#define _DMA_CONFIG_EN_DEFAULT                          0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_EN_DEFAULT                           (_DMA_CONFIG_EN_DEFAULT << 0)     /**< Shifted mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT                               (0x1UL << 5)                      /**< Channel Protection Control */
+#define _DMA_CONFIG_CHPROT_SHIFT                        5                                 /**< Shift value for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_MASK                         0x20UL                            /**< Bit mask for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT_DEFAULT                       (_DMA_CONFIG_CHPROT_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CONFIG */
+
+/* Bit fields for DMA CTRLBASE */
+#define _DMA_CTRLBASE_RESETVALUE                        0x00000000UL                          /**< Default value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_MASK                              0xFFFFFFFFUL                          /**< Mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_SHIFT                    0                                     /**< Shift value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_MASK                     0xFFFFFFFFUL                          /**< Bit mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_DEFAULT                  0x00000000UL                          /**< Mode DEFAULT for DMA_CTRLBASE */
+#define DMA_CTRLBASE_CTRLBASE_DEFAULT                   (_DMA_CTRLBASE_CTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CTRLBASE */
+
+/* Bit fields for DMA ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_RESETVALUE                     0x00000080UL                                /**< Default value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_MASK                           0xFFFFFFFFUL                                /**< Mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_SHIFT              0                                           /**< Shift value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_MASK               0xFFFFFFFFUL                                /**< Bit mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT            0x00000080UL                                /**< Mode DEFAULT for DMA_ALTCTRLBASE */
+#define DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT             (_DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ALTCTRLBASE */
+
+/* Bit fields for DMA CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_RESETVALUE                    0x000000FFUL                                   /**< Default value for DMA_CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+
+/* Bit fields for DMA CHSWREQ */
+#define _DMA_CHSWREQ_RESETVALUE                         0x00000000UL                         /**< Default value for DMA_CHSWREQ */
+#define _DMA_CHSWREQ_MASK                               0x000000FFUL                         /**< Mask for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ                            (0x1UL << 0)                         /**< Channel 0 Software Request */
+#define _DMA_CHSWREQ_CH0SWREQ_SHIFT                     0                                    /**< Shift value for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_MASK                      0x1UL                                /**< Bit mask for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH0SWREQ_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ                            (0x1UL << 1)                         /**< Channel 1 Software Request */
+#define _DMA_CHSWREQ_CH1SWREQ_SHIFT                     1                                    /**< Shift value for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_MASK                      0x2UL                                /**< Bit mask for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH1SWREQ_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ                            (0x1UL << 2)                         /**< Channel 2 Software Request */
+#define _DMA_CHSWREQ_CH2SWREQ_SHIFT                     2                                    /**< Shift value for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_MASK                      0x4UL                                /**< Bit mask for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH2SWREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ                            (0x1UL << 3)                         /**< Channel 3 Software Request */
+#define _DMA_CHSWREQ_CH3SWREQ_SHIFT                     3                                    /**< Shift value for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_MASK                      0x8UL                                /**< Bit mask for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH3SWREQ_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ                            (0x1UL << 4)                         /**< Channel 4 Software Request */
+#define _DMA_CHSWREQ_CH4SWREQ_SHIFT                     4                                    /**< Shift value for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_MASK                      0x10UL                               /**< Bit mask for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH4SWREQ_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ                            (0x1UL << 5)                         /**< Channel 5 Software Request */
+#define _DMA_CHSWREQ_CH5SWREQ_SHIFT                     5                                    /**< Shift value for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_MASK                      0x20UL                               /**< Bit mask for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH5SWREQ_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ                            (0x1UL << 6)                         /**< Channel 6 Software Request */
+#define _DMA_CHSWREQ_CH6SWREQ_SHIFT                     6                                    /**< Shift value for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_MASK                      0x40UL                               /**< Bit mask for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH6SWREQ_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ                            (0x1UL << 7)                         /**< Channel 7 Software Request */
+#define _DMA_CHSWREQ_CH7SWREQ_SHIFT                     7                                    /**< Shift value for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_MASK                      0x80UL                               /**< Bit mask for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH7SWREQ_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+
+/* Bit fields for DMA CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_RESETVALUE                     0x00000000UL                                        /**< Default value for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_MASK                           0x000000FFUL                                        /**< Mask for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS                    (0x1UL << 0)                                        /**< Channel 0 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SHIFT             0                                                   /**< Shift value for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_MASK              0x1UL                                               /**< Bit mask for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST    0x00000000UL                                        /**< Mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY         0x00000001UL                                        /**< Mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT << 0)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST     (_DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST << 0) /**< Shifted mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY          (_DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY << 0)      /**< Shifted mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS                    (0x1UL << 1)                                        /**< Channel 1 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_SHIFT             1                                                   /**< Shift value for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_MASK              0x2UL                                               /**< Bit mask for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT << 1)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS                    (0x1UL << 2)                                        /**< Channel 2 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_SHIFT             2                                                   /**< Shift value for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_MASK              0x4UL                                               /**< Bit mask for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT << 2)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS                    (0x1UL << 3)                                        /**< Channel 3 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_SHIFT             3                                                   /**< Shift value for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_MASK              0x8UL                                               /**< Bit mask for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT << 3)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS                    (0x1UL << 4)                                        /**< Channel 4 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_SHIFT             4                                                   /**< Shift value for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_MASK              0x10UL                                              /**< Bit mask for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT << 4)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS                    (0x1UL << 5)                                        /**< Channel 5 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_SHIFT             5                                                   /**< Shift value for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_MASK              0x20UL                                              /**< Bit mask for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT << 5)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS                    (0x1UL << 6)                                        /**< Channel 6 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_SHIFT             6                                                   /**< Shift value for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_MASK              0x40UL                                              /**< Bit mask for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT << 6)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS                    (0x1UL << 7)                                        /**< Channel 7 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_SHIFT             7                                                   /**< Shift value for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_MASK              0x80UL                                              /**< Bit mask for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT << 7)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+
+/* Bit fields for DMA CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC                    (0x1UL << 0)                                 /**< Channel 0 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_SHIFT             0                                            /**< Shift value for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_MASK              0x1UL                                        /**< Bit mask for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC                    (0x1UL << 1)                                 /**< Channel 1 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_SHIFT             1                                            /**< Shift value for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_MASK              0x2UL                                        /**< Bit mask for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC                    (0x1UL << 2)                                 /**< Channel 2 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_SHIFT             2                                            /**< Shift value for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_MASK              0x4UL                                        /**< Bit mask for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC                    (0x1UL << 3)                                 /**< Channel 3 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_SHIFT             3                                            /**< Shift value for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_MASK              0x8UL                                        /**< Bit mask for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC                    (0x1UL << 4)                                 /**< Channel 4 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_SHIFT             4                                            /**< Shift value for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_MASK              0x10UL                                       /**< Bit mask for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC                    (0x1UL << 5)                                 /**< Channel 5 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_SHIFT             5                                            /**< Shift value for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_MASK              0x20UL                                       /**< Bit mask for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC                    (0x1UL << 6)                                 /**< Channel 6 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_SHIFT             6                                            /**< Shift value for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_MASK              0x40UL                                       /**< Bit mask for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC                    (0x1UL << 7)                                 /**< Channel 7 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_SHIFT             7                                            /**< Shift value for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_MASK              0x80UL                                       /**< Bit mask for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+
+/* Bit fields for DMA CHREQMASKS */
+#define _DMA_CHREQMASKS_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKS */
+#define _DMA_CHREQMASKS_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS                      (0x1UL << 0)                               /**< Channel 0 Request Mask Set */
+#define _DMA_CHREQMASKS_CH0REQMASKS_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH0REQMASKS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS                      (0x1UL << 1)                               /**< Channel 1 Request Mask Set */
+#define _DMA_CHREQMASKS_CH1REQMASKS_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH1REQMASKS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS                      (0x1UL << 2)                               /**< Channel 2 Request Mask Set */
+#define _DMA_CHREQMASKS_CH2REQMASKS_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH2REQMASKS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS                      (0x1UL << 3)                               /**< Channel 3 Request Mask Set */
+#define _DMA_CHREQMASKS_CH3REQMASKS_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH3REQMASKS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS                      (0x1UL << 4)                               /**< Channel 4 Request Mask Set */
+#define _DMA_CHREQMASKS_CH4REQMASKS_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH4REQMASKS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS                      (0x1UL << 5)                               /**< Channel 5 Request Mask Set */
+#define _DMA_CHREQMASKS_CH5REQMASKS_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH5REQMASKS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS                      (0x1UL << 6)                               /**< Channel 6 Request Mask Set */
+#define _DMA_CHREQMASKS_CH6REQMASKS_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH6REQMASKS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS                      (0x1UL << 7)                               /**< Channel 7 Request Mask Set */
+#define _DMA_CHREQMASKS_CH7REQMASKS_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH7REQMASKS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+
+/* Bit fields for DMA CHREQMASKC */
+#define _DMA_CHREQMASKC_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKC */
+#define _DMA_CHREQMASKC_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC                      (0x1UL << 0)                               /**< Channel 0 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH0REQMASKC_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH0REQMASKC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC                      (0x1UL << 1)                               /**< Channel 1 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH1REQMASKC_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH1REQMASKC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC                      (0x1UL << 2)                               /**< Channel 2 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH2REQMASKC_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH2REQMASKC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC                      (0x1UL << 3)                               /**< Channel 3 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH3REQMASKC_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH3REQMASKC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC                      (0x1UL << 4)                               /**< Channel 4 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH4REQMASKC_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH4REQMASKC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC                      (0x1UL << 5)                               /**< Channel 5 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH5REQMASKC_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH5REQMASKC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC                      (0x1UL << 6)                               /**< Channel 6 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH6REQMASKC_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH6REQMASKC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC                      (0x1UL << 7)                               /**< Channel 7 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH7REQMASKC_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH7REQMASKC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+
+/* Bit fields for DMA CHENS */
+#define _DMA_CHENS_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENS */
+#define _DMA_CHENS_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENS */
+#define DMA_CHENS_CH0ENS                                (0x1UL << 0)                     /**< Channel 0 Enable Set */
+#define _DMA_CHENS_CH0ENS_SHIFT                         0                                /**< Shift value for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH0ENS_DEFAULT                        (_DMA_CHENS_CH0ENS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS                                (0x1UL << 1)                     /**< Channel 1 Enable Set */
+#define _DMA_CHENS_CH1ENS_SHIFT                         1                                /**< Shift value for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS_DEFAULT                        (_DMA_CHENS_CH1ENS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS                                (0x1UL << 2)                     /**< Channel 2 Enable Set */
+#define _DMA_CHENS_CH2ENS_SHIFT                         2                                /**< Shift value for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS_DEFAULT                        (_DMA_CHENS_CH2ENS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS                                (0x1UL << 3)                     /**< Channel 3 Enable Set */
+#define _DMA_CHENS_CH3ENS_SHIFT                         3                                /**< Shift value for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS_DEFAULT                        (_DMA_CHENS_CH3ENS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS                                (0x1UL << 4)                     /**< Channel 4 Enable Set */
+#define _DMA_CHENS_CH4ENS_SHIFT                         4                                /**< Shift value for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS_DEFAULT                        (_DMA_CHENS_CH4ENS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS                                (0x1UL << 5)                     /**< Channel 5 Enable Set */
+#define _DMA_CHENS_CH5ENS_SHIFT                         5                                /**< Shift value for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS_DEFAULT                        (_DMA_CHENS_CH5ENS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS                                (0x1UL << 6)                     /**< Channel 6 Enable Set */
+#define _DMA_CHENS_CH6ENS_SHIFT                         6                                /**< Shift value for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS_DEFAULT                        (_DMA_CHENS_CH6ENS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS                                (0x1UL << 7)                     /**< Channel 7 Enable Set */
+#define _DMA_CHENS_CH7ENS_SHIFT                         7                                /**< Shift value for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS_DEFAULT                        (_DMA_CHENS_CH7ENS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENS */
+
+/* Bit fields for DMA CHENC */
+#define _DMA_CHENC_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENC */
+#define _DMA_CHENC_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENC */
+#define DMA_CHENC_CH0ENC                                (0x1UL << 0)                     /**< Channel 0 Enable Clear */
+#define _DMA_CHENC_CH0ENC_SHIFT                         0                                /**< Shift value for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH0ENC_DEFAULT                        (_DMA_CHENC_CH0ENC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC                                (0x1UL << 1)                     /**< Channel 1 Enable Clear */
+#define _DMA_CHENC_CH1ENC_SHIFT                         1                                /**< Shift value for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC_DEFAULT                        (_DMA_CHENC_CH1ENC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC                                (0x1UL << 2)                     /**< Channel 2 Enable Clear */
+#define _DMA_CHENC_CH2ENC_SHIFT                         2                                /**< Shift value for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC_DEFAULT                        (_DMA_CHENC_CH2ENC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC                                (0x1UL << 3)                     /**< Channel 3 Enable Clear */
+#define _DMA_CHENC_CH3ENC_SHIFT                         3                                /**< Shift value for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC_DEFAULT                        (_DMA_CHENC_CH3ENC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC                                (0x1UL << 4)                     /**< Channel 4 Enable Clear */
+#define _DMA_CHENC_CH4ENC_SHIFT                         4                                /**< Shift value for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC_DEFAULT                        (_DMA_CHENC_CH4ENC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC                                (0x1UL << 5)                     /**< Channel 5 Enable Clear */
+#define _DMA_CHENC_CH5ENC_SHIFT                         5                                /**< Shift value for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC_DEFAULT                        (_DMA_CHENC_CH5ENC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC                                (0x1UL << 6)                     /**< Channel 6 Enable Clear */
+#define _DMA_CHENC_CH6ENC_SHIFT                         6                                /**< Shift value for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC_DEFAULT                        (_DMA_CHENC_CH6ENC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC                                (0x1UL << 7)                     /**< Channel 7 Enable Clear */
+#define _DMA_CHENC_CH7ENC_SHIFT                         7                                /**< Shift value for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC_DEFAULT                        (_DMA_CHENC_CH7ENC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENC */
+
+/* Bit fields for DMA CHALTS */
+#define _DMA_CHALTS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTS */
+#define _DMA_CHALTS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS                              (0x1UL << 0)                       /**< Channel 0 Alternate Structure Set */
+#define _DMA_CHALTS_CH0ALTS_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS_DEFAULT                      (_DMA_CHALTS_CH0ALTS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS                              (0x1UL << 1)                       /**< Channel 1 Alternate Structure Set */
+#define _DMA_CHALTS_CH1ALTS_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS_DEFAULT                      (_DMA_CHALTS_CH1ALTS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS                              (0x1UL << 2)                       /**< Channel 2 Alternate Structure Set */
+#define _DMA_CHALTS_CH2ALTS_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS_DEFAULT                      (_DMA_CHALTS_CH2ALTS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS                              (0x1UL << 3)                       /**< Channel 3 Alternate Structure Set */
+#define _DMA_CHALTS_CH3ALTS_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS_DEFAULT                      (_DMA_CHALTS_CH3ALTS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS                              (0x1UL << 4)                       /**< Channel 4 Alternate Structure Set */
+#define _DMA_CHALTS_CH4ALTS_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS_DEFAULT                      (_DMA_CHALTS_CH4ALTS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS                              (0x1UL << 5)                       /**< Channel 5 Alternate Structure Set */
+#define _DMA_CHALTS_CH5ALTS_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS_DEFAULT                      (_DMA_CHALTS_CH5ALTS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS                              (0x1UL << 6)                       /**< Channel 6 Alternate Structure Set */
+#define _DMA_CHALTS_CH6ALTS_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS_DEFAULT                      (_DMA_CHALTS_CH6ALTS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS                              (0x1UL << 7)                       /**< Channel 7 Alternate Structure Set */
+#define _DMA_CHALTS_CH7ALTS_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS_DEFAULT                      (_DMA_CHALTS_CH7ALTS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTS */
+
+/* Bit fields for DMA CHALTC */
+#define _DMA_CHALTC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTC */
+#define _DMA_CHALTC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC                              (0x1UL << 0)                       /**< Channel 0 Alternate Clear */
+#define _DMA_CHALTC_CH0ALTC_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC_DEFAULT                      (_DMA_CHALTC_CH0ALTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC                              (0x1UL << 1)                       /**< Channel 1 Alternate Clear */
+#define _DMA_CHALTC_CH1ALTC_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC_DEFAULT                      (_DMA_CHALTC_CH1ALTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC                              (0x1UL << 2)                       /**< Channel 2 Alternate Clear */
+#define _DMA_CHALTC_CH2ALTC_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC_DEFAULT                      (_DMA_CHALTC_CH2ALTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC                              (0x1UL << 3)                       /**< Channel 3 Alternate Clear */
+#define _DMA_CHALTC_CH3ALTC_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC_DEFAULT                      (_DMA_CHALTC_CH3ALTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC                              (0x1UL << 4)                       /**< Channel 4 Alternate Clear */
+#define _DMA_CHALTC_CH4ALTC_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC_DEFAULT                      (_DMA_CHALTC_CH4ALTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC                              (0x1UL << 5)                       /**< Channel 5 Alternate Clear */
+#define _DMA_CHALTC_CH5ALTC_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC_DEFAULT                      (_DMA_CHALTC_CH5ALTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC                              (0x1UL << 6)                       /**< Channel 6 Alternate Clear */
+#define _DMA_CHALTC_CH6ALTC_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC_DEFAULT                      (_DMA_CHALTC_CH6ALTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC                              (0x1UL << 7)                       /**< Channel 7 Alternate Clear */
+#define _DMA_CHALTC_CH7ALTC_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC_DEFAULT                      (_DMA_CHALTC_CH7ALTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTC */
+
+/* Bit fields for DMA CHPRIS */
+#define _DMA_CHPRIS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIS */
+#define _DMA_CHPRIS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS                              (0x1UL << 0)                       /**< Channel 0 High Priority Set */
+#define _DMA_CHPRIS_CH0PRIS_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS_DEFAULT                      (_DMA_CHPRIS_CH0PRIS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS                              (0x1UL << 1)                       /**< Channel 1 High Priority Set */
+#define _DMA_CHPRIS_CH1PRIS_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS_DEFAULT                      (_DMA_CHPRIS_CH1PRIS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS                              (0x1UL << 2)                       /**< Channel 2 High Priority Set */
+#define _DMA_CHPRIS_CH2PRIS_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS_DEFAULT                      (_DMA_CHPRIS_CH2PRIS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS                              (0x1UL << 3)                       /**< Channel 3 High Priority Set */
+#define _DMA_CHPRIS_CH3PRIS_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS_DEFAULT                      (_DMA_CHPRIS_CH3PRIS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS                              (0x1UL << 4)                       /**< Channel 4 High Priority Set */
+#define _DMA_CHPRIS_CH4PRIS_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS_DEFAULT                      (_DMA_CHPRIS_CH4PRIS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS                              (0x1UL << 5)                       /**< Channel 5 High Priority Set */
+#define _DMA_CHPRIS_CH5PRIS_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS_DEFAULT                      (_DMA_CHPRIS_CH5PRIS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS                              (0x1UL << 6)                       /**< Channel 6 High Priority Set */
+#define _DMA_CHPRIS_CH6PRIS_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS_DEFAULT                      (_DMA_CHPRIS_CH6PRIS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS                              (0x1UL << 7)                       /**< Channel 7 High Priority Set */
+#define _DMA_CHPRIS_CH7PRIS_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS_DEFAULT                      (_DMA_CHPRIS_CH7PRIS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+
+/* Bit fields for DMA CHPRIC */
+#define _DMA_CHPRIC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIC */
+#define _DMA_CHPRIC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC                              (0x1UL << 0)                       /**< Channel 0 High Priority Clear */
+#define _DMA_CHPRIC_CH0PRIC_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC_DEFAULT                      (_DMA_CHPRIC_CH0PRIC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC                              (0x1UL << 1)                       /**< Channel 1 High Priority Clear */
+#define _DMA_CHPRIC_CH1PRIC_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC_DEFAULT                      (_DMA_CHPRIC_CH1PRIC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC                              (0x1UL << 2)                       /**< Channel 2 High Priority Clear */
+#define _DMA_CHPRIC_CH2PRIC_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC_DEFAULT                      (_DMA_CHPRIC_CH2PRIC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC                              (0x1UL << 3)                       /**< Channel 3 High Priority Clear */
+#define _DMA_CHPRIC_CH3PRIC_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC_DEFAULT                      (_DMA_CHPRIC_CH3PRIC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC                              (0x1UL << 4)                       /**< Channel 4 High Priority Clear */
+#define _DMA_CHPRIC_CH4PRIC_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC_DEFAULT                      (_DMA_CHPRIC_CH4PRIC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC                              (0x1UL << 5)                       /**< Channel 5 High Priority Clear */
+#define _DMA_CHPRIC_CH5PRIC_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC_DEFAULT                      (_DMA_CHPRIC_CH5PRIC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC                              (0x1UL << 6)                       /**< Channel 6 High Priority Clear */
+#define _DMA_CHPRIC_CH6PRIC_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC_DEFAULT                      (_DMA_CHPRIC_CH6PRIC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC                              (0x1UL << 7)                       /**< Channel 7 High Priority Clear */
+#define _DMA_CHPRIC_CH7PRIC_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC_DEFAULT                      (_DMA_CHPRIC_CH7PRIC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+
+/* Bit fields for DMA ERRORC */
+#define _DMA_ERRORC_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_ERRORC */
+#define _DMA_ERRORC_MASK                                0x00000001UL                      /**< Mask for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC                               (0x1UL << 0)                      /**< Bus Error Clear */
+#define _DMA_ERRORC_ERRORC_SHIFT                        0                                 /**< Shift value for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_MASK                         0x1UL                             /**< Bit mask for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC_DEFAULT                       (_DMA_ERRORC_ERRORC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ERRORC */
+
+/* Bit fields for DMA CHREQSTATUS */
+#define _DMA_CHREQSTATUS_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHREQSTATUS */
+#define _DMA_CHREQSTATUS_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS                    (0x1UL << 0)                                 /**< Channel 0 Request Status */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_SHIFT             0                                            /**< Shift value for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_MASK              0x1UL                                        /**< Bit mask for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS                    (0x1UL << 1)                                 /**< Channel 1 Request Status */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_SHIFT             1                                            /**< Shift value for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_MASK              0x2UL                                        /**< Bit mask for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS                    (0x1UL << 2)                                 /**< Channel 2 Request Status */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_SHIFT             2                                            /**< Shift value for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_MASK              0x4UL                                        /**< Bit mask for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS                    (0x1UL << 3)                                 /**< Channel 3 Request Status */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_SHIFT             3                                            /**< Shift value for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_MASK              0x8UL                                        /**< Bit mask for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS                    (0x1UL << 4)                                 /**< Channel 4 Request Status */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_SHIFT             4                                            /**< Shift value for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_MASK              0x10UL                                       /**< Bit mask for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS                    (0x1UL << 5)                                 /**< Channel 5 Request Status */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_SHIFT             5                                            /**< Shift value for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_MASK              0x20UL                                       /**< Bit mask for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS                    (0x1UL << 6)                                 /**< Channel 6 Request Status */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_SHIFT             6                                            /**< Shift value for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_MASK              0x40UL                                       /**< Bit mask for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS                    (0x1UL << 7)                                 /**< Channel 7 Request Status */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_SHIFT             7                                            /**< Shift value for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_MASK              0x80UL                                       /**< Bit mask for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+
+/* Bit fields for DMA CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_RESETVALUE                    0x00000000UL                                   /**< Default value for DMA_CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+
+/* Bit fields for DMA IF */
+#define _DMA_IF_RESETVALUE                              0x00000000UL                   /**< Default value for DMA_IF */
+#define _DMA_IF_MASK                                    0x800000FFUL                   /**< Mask for DMA_IF */
+#define DMA_IF_CH0DONE                                  (0x1UL << 0)                   /**< DMA Channel 0 Complete Interrupt Flag */
+#define _DMA_IF_CH0DONE_SHIFT                           0                              /**< Shift value for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_MASK                            0x1UL                          /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH0DONE_DEFAULT                          (_DMA_IF_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE                                  (0x1UL << 1)                   /**< DMA Channel 1 Complete Interrupt Flag */
+#define _DMA_IF_CH1DONE_SHIFT                           1                              /**< Shift value for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_MASK                            0x2UL                          /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE_DEFAULT                          (_DMA_IF_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE                                  (0x1UL << 2)                   /**< DMA Channel 2 Complete Interrupt Flag */
+#define _DMA_IF_CH2DONE_SHIFT                           2                              /**< Shift value for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_MASK                            0x4UL                          /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE_DEFAULT                          (_DMA_IF_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE                                  (0x1UL << 3)                   /**< DMA Channel 3 Complete Interrupt Flag */
+#define _DMA_IF_CH3DONE_SHIFT                           3                              /**< Shift value for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_MASK                            0x8UL                          /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE_DEFAULT                          (_DMA_IF_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE                                  (0x1UL << 4)                   /**< DMA Channel 4 Complete Interrupt Flag */
+#define _DMA_IF_CH4DONE_SHIFT                           4                              /**< Shift value for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_MASK                            0x10UL                         /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE_DEFAULT                          (_DMA_IF_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE                                  (0x1UL << 5)                   /**< DMA Channel 5 Complete Interrupt Flag */
+#define _DMA_IF_CH5DONE_SHIFT                           5                              /**< Shift value for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_MASK                            0x20UL                         /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE_DEFAULT                          (_DMA_IF_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE                                  (0x1UL << 6)                   /**< DMA Channel 6 Complete Interrupt Flag */
+#define _DMA_IF_CH6DONE_SHIFT                           6                              /**< Shift value for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_MASK                            0x40UL                         /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE_DEFAULT                          (_DMA_IF_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE                                  (0x1UL << 7)                   /**< DMA Channel 7 Complete Interrupt Flag */
+#define _DMA_IF_CH7DONE_SHIFT                           7                              /**< Shift value for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_MASK                            0x80UL                         /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE_DEFAULT                          (_DMA_IF_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR                                      (0x1UL << 31)                  /**< DMA Error Interrupt Flag */
+#define _DMA_IF_ERR_SHIFT                               31                             /**< Shift value for DMA_ERR */
+#define _DMA_IF_ERR_MASK                                0x80000000UL                   /**< Bit mask for DMA_ERR */
+#define _DMA_IF_ERR_DEFAULT                             0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR_DEFAULT                              (_DMA_IF_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IF */
+
+/* Bit fields for DMA IFS */
+#define _DMA_IFS_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFS */
+#define _DMA_IFS_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFS */
+#define DMA_IFS_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH0DONE_DEFAULT                         (_DMA_IFS_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE_DEFAULT                         (_DMA_IFS_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE_DEFAULT                         (_DMA_IFS_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE_DEFAULT                         (_DMA_IFS_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE_DEFAULT                         (_DMA_IFS_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE_DEFAULT                         (_DMA_IFS_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE_DEFAULT                         (_DMA_IFS_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE_DEFAULT                         (_DMA_IFS_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Set */
+#define _DMA_IFS_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFS_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFS_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR_DEFAULT                             (_DMA_IFS_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFS */
+
+/* Bit fields for DMA IFC */
+#define _DMA_IFC_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFC */
+#define _DMA_IFC_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFC */
+#define DMA_IFC_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH0DONE_DEFAULT                         (_DMA_IFC_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE_DEFAULT                         (_DMA_IFC_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE_DEFAULT                         (_DMA_IFC_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE_DEFAULT                         (_DMA_IFC_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE_DEFAULT                         (_DMA_IFC_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE_DEFAULT                         (_DMA_IFC_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE_DEFAULT                         (_DMA_IFC_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE_DEFAULT                         (_DMA_IFC_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Clear */
+#define _DMA_IFC_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFC_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFC_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR_DEFAULT                             (_DMA_IFC_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFC */
+
+/* Bit fields for DMA IEN */
+#define _DMA_IEN_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IEN */
+#define _DMA_IEN_MASK                                   0x800000FFUL                    /**< Mask for DMA_IEN */
+#define DMA_IEN_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Enable */
+#define _DMA_IEN_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH0DONE_DEFAULT                         (_DMA_IEN_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Enable */
+#define _DMA_IEN_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE_DEFAULT                         (_DMA_IEN_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Enable */
+#define _DMA_IEN_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE_DEFAULT                         (_DMA_IEN_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Enable */
+#define _DMA_IEN_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE_DEFAULT                         (_DMA_IEN_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Enable */
+#define _DMA_IEN_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE_DEFAULT                         (_DMA_IEN_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Enable */
+#define _DMA_IEN_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE_DEFAULT                         (_DMA_IEN_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Enable */
+#define _DMA_IEN_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE_DEFAULT                         (_DMA_IEN_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Enable */
+#define _DMA_IEN_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE_DEFAULT                         (_DMA_IEN_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Enable */
+#define _DMA_IEN_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IEN_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IEN_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR_DEFAULT                             (_DMA_IEN_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IEN */
+
+/* Bit fields for DMA CH_CTRL */
+#define _DMA_CH_CTRL_RESETVALUE                         0x00000000UL                                  /**< Default value for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_MASK                               0x003F000FUL                                  /**< Mask for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_SHIFT                       0                                             /**< Shift value for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_MASK                        0xFUL                                         /**< Bit mask for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAV               0x00000000UL                                  /**< Mode USART1RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV              0x00000000UL                                  /**< Mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                 0x00000000UL                                  /**< Mode I2C0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0UFOF                  0x00000000UL                                  /**< Mode TIMER0UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1UFOF                  0x00000000UL                                  /**< Mode TIMER1UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_MSCWDATA                    0x00000000UL                                  /**< Mode MSCWDATA for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV             0x00000000UL                                  /**< Mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBL                  0x00000001UL                                  /**< Mode USART1TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXBL                 0x00000001UL                                  /**< Mode LEUART0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0TXBL                    0x00000001UL                                  /**< Mode I2C0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC0                   0x00000001UL                                  /**< Mode TIMER0CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC0                   0x00000001UL                                  /**< Mode TIMER1CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXEMPTY               0x00000002UL                                  /**< Mode USART1TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY              0x00000002UL                                  /**< Mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC1                   0x00000002UL                                  /**< Mode TIMER0CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC1                   0x00000002UL                                  /**< Mode TIMER1CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT          0x00000003UL                                  /**< Mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC2                   0x00000003UL                                  /**< Mode TIMER0CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC2                   0x00000003UL                                  /**< Mode TIMER1CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT             0x00000004UL                                  /**< Mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAV                (_DMA_CH_CTRL_SIGSEL_USART1RXDATAV << 0)      /**< Shifted mode USART1RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV               (_DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV << 0)     /**< Shifted mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                  (_DMA_CH_CTRL_SIGSEL_I2C0RXDATAV << 0)        /**< Shifted mode I2C0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER0UFOF << 0)         /**< Shifted mode TIMER0UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER1UFOF << 0)         /**< Shifted mode TIMER1UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_MSCWDATA                     (_DMA_CH_CTRL_SIGSEL_MSCWDATA << 0)           /**< Shifted mode MSCWDATA for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV              (_DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV << 0)    /**< Shifted mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBL                   (_DMA_CH_CTRL_SIGSEL_USART1TXBL << 0)         /**< Shifted mode USART1TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXBL                  (_DMA_CH_CTRL_SIGSEL_LEUART0TXBL << 0)        /**< Shifted mode LEUART0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0TXBL                     (_DMA_CH_CTRL_SIGSEL_I2C0TXBL << 0)           /**< Shifted mode I2C0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC0 << 0)          /**< Shifted mode TIMER0CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC0 << 0)          /**< Shifted mode TIMER1CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXEMPTY                (_DMA_CH_CTRL_SIGSEL_USART1TXEMPTY << 0)      /**< Shifted mode USART1TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY               (_DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY << 0)     /**< Shifted mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC1 << 0)          /**< Shifted mode TIMER0CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC1 << 0)          /**< Shifted mode TIMER1CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT           (_DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT << 0) /**< Shifted mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC2 << 0)          /**< Shifted mode TIMER0CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC2 << 0)          /**< Shifted mode TIMER1CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT              (_DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT << 0)    /**< Shifted mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_SHIFT                    16                                            /**< Shift value for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_MASK                     0x3F0000UL                                    /**< Bit mask for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_NONE                     0x00000000UL                                  /**< Mode NONE for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_USART1                   0x0000000DUL                                  /**< Mode USART1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LEUART0                  0x00000010UL                                  /**< Mode LEUART0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_I2C0                     0x00000014UL                                  /**< Mode I2C0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER0                   0x00000018UL                                  /**< Mode TIMER0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER1                   0x00000019UL                                  /**< Mode TIMER1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_MSC                      0x00000030UL                                  /**< Mode MSC for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LESENSE                  0x00000032UL                                  /**< Mode LESENSE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_NONE                      (_DMA_CH_CTRL_SOURCESEL_NONE << 16)           /**< Shifted mode NONE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_USART1                    (_DMA_CH_CTRL_SOURCESEL_USART1 << 16)         /**< Shifted mode USART1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LEUART0                   (_DMA_CH_CTRL_SOURCESEL_LEUART0 << 16)        /**< Shifted mode LEUART0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_I2C0                      (_DMA_CH_CTRL_SOURCESEL_I2C0 << 16)           /**< Shifted mode I2C0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER0                    (_DMA_CH_CTRL_SOURCESEL_TIMER0 << 16)         /**< Shifted mode TIMER0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER1                    (_DMA_CH_CTRL_SOURCESEL_TIMER1 << 16)         /**< Shifted mode TIMER1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_MSC                       (_DMA_CH_CTRL_SOURCESEL_MSC << 16)            /**< Shifted mode MSC for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LESENSE                   (_DMA_CH_CTRL_SOURCESEL_LESENSE << 16)        /**< Shifted mode LESENSE for DMA_CH_CTRL */
+
+/** @} End of group EFM32TG108F4_DMA */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_CMU_BitFields  EFM32TG108F4_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000006UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x000009FBUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG108F4_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_PRS_BitFields  EFM32TG108F4_PRS Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for PRS SWPULSE */
+#define _PRS_SWPULSE_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWPULSE */
+#define _PRS_SWPULSE_MASK                       0x000000FFUL                         /**< Mask for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE                    (0x1UL << 0)                         /**< Channel 0 Pulse Generation */
+#define _PRS_SWPULSE_CH0PULSE_SHIFT             0                                    /**< Shift value for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_MASK              0x1UL                                /**< Bit mask for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE_DEFAULT            (_PRS_SWPULSE_CH0PULSE_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE                    (0x1UL << 1)                         /**< Channel 1 Pulse Generation */
+#define _PRS_SWPULSE_CH1PULSE_SHIFT             1                                    /**< Shift value for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_MASK              0x2UL                                /**< Bit mask for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE_DEFAULT            (_PRS_SWPULSE_CH1PULSE_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE                    (0x1UL << 2)                         /**< Channel 2 Pulse Generation */
+#define _PRS_SWPULSE_CH2PULSE_SHIFT             2                                    /**< Shift value for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_MASK              0x4UL                                /**< Bit mask for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE_DEFAULT            (_PRS_SWPULSE_CH2PULSE_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE                    (0x1UL << 3)                         /**< Channel 3 Pulse Generation */
+#define _PRS_SWPULSE_CH3PULSE_SHIFT             3                                    /**< Shift value for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_MASK              0x8UL                                /**< Bit mask for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE_DEFAULT            (_PRS_SWPULSE_CH3PULSE_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE                    (0x1UL << 4)                         /**< Channel 4 Pulse Generation */
+#define _PRS_SWPULSE_CH4PULSE_SHIFT             4                                    /**< Shift value for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_MASK              0x10UL                               /**< Bit mask for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE_DEFAULT            (_PRS_SWPULSE_CH4PULSE_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE                    (0x1UL << 5)                         /**< Channel 5 Pulse Generation */
+#define _PRS_SWPULSE_CH5PULSE_SHIFT             5                                    /**< Shift value for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_MASK              0x20UL                               /**< Bit mask for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE_DEFAULT            (_PRS_SWPULSE_CH5PULSE_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE                    (0x1UL << 6)                         /**< Channel 6 Pulse Generation */
+#define _PRS_SWPULSE_CH6PULSE_SHIFT             6                                    /**< Shift value for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_MASK              0x40UL                               /**< Bit mask for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE_DEFAULT            (_PRS_SWPULSE_CH6PULSE_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE                    (0x1UL << 7)                         /**< Channel 7 Pulse Generation */
+#define _PRS_SWPULSE_CH7PULSE_SHIFT             7                                    /**< Shift value for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_MASK              0x80UL                               /**< Bit mask for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE_DEFAULT            (_PRS_SWPULSE_CH7PULSE_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+
+/* Bit fields for PRS SWLEVEL */
+#define _PRS_SWLEVEL_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWLEVEL */
+#define _PRS_SWLEVEL_MASK                       0x000000FFUL                         /**< Mask for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL                    (0x1UL << 0)                         /**< Channel 0 Software Level */
+#define _PRS_SWLEVEL_CH0LEVEL_SHIFT             0                                    /**< Shift value for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_MASK              0x1UL                                /**< Bit mask for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL_DEFAULT            (_PRS_SWLEVEL_CH0LEVEL_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL                    (0x1UL << 1)                         /**< Channel 1 Software Level */
+#define _PRS_SWLEVEL_CH1LEVEL_SHIFT             1                                    /**< Shift value for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_MASK              0x2UL                                /**< Bit mask for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL_DEFAULT            (_PRS_SWLEVEL_CH1LEVEL_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL                    (0x1UL << 2)                         /**< Channel 2 Software Level */
+#define _PRS_SWLEVEL_CH2LEVEL_SHIFT             2                                    /**< Shift value for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_MASK              0x4UL                                /**< Bit mask for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL_DEFAULT            (_PRS_SWLEVEL_CH2LEVEL_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL                    (0x1UL << 3)                         /**< Channel 3 Software Level */
+#define _PRS_SWLEVEL_CH3LEVEL_SHIFT             3                                    /**< Shift value for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_MASK              0x8UL                                /**< Bit mask for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL_DEFAULT            (_PRS_SWLEVEL_CH3LEVEL_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL                    (0x1UL << 4)                         /**< Channel 4 Software Level */
+#define _PRS_SWLEVEL_CH4LEVEL_SHIFT             4                                    /**< Shift value for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_MASK              0x10UL                               /**< Bit mask for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL_DEFAULT            (_PRS_SWLEVEL_CH4LEVEL_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL                    (0x1UL << 5)                         /**< Channel 5 Software Level */
+#define _PRS_SWLEVEL_CH5LEVEL_SHIFT             5                                    /**< Shift value for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_MASK              0x20UL                               /**< Bit mask for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL_DEFAULT            (_PRS_SWLEVEL_CH5LEVEL_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL                    (0x1UL << 6)                         /**< Channel 6 Software Level */
+#define _PRS_SWLEVEL_CH6LEVEL_SHIFT             6                                    /**< Shift value for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_MASK              0x40UL                               /**< Bit mask for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL_DEFAULT            (_PRS_SWLEVEL_CH6LEVEL_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL                    (0x1UL << 7)                         /**< Channel 7 Software Level */
+#define _PRS_SWLEVEL_CH7LEVEL_SHIFT             7                                    /**< Shift value for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_MASK              0x80UL                               /**< Bit mask for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL_DEFAULT            (_PRS_SWLEVEL_CH7LEVEL_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+
+/* Bit fields for PRS ROUTE */
+#define _PRS_ROUTE_RESETVALUE                   0x00000000UL                       /**< Default value for PRS_ROUTE */
+#define _PRS_ROUTE_MASK                         0x0000070FUL                       /**< Mask for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN                        (0x1UL << 0)                       /**< CH0 Pin Enable */
+#define _PRS_ROUTE_CH0PEN_SHIFT                 0                                  /**< Shift value for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_MASK                  0x1UL                              /**< Bit mask for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN_DEFAULT                (_PRS_ROUTE_CH0PEN_DEFAULT << 0)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN                        (0x1UL << 1)                       /**< CH1 Pin Enable */
+#define _PRS_ROUTE_CH1PEN_SHIFT                 1                                  /**< Shift value for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_MASK                  0x2UL                              /**< Bit mask for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN_DEFAULT                (_PRS_ROUTE_CH1PEN_DEFAULT << 1)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN                        (0x1UL << 2)                       /**< CH2 Pin Enable */
+#define _PRS_ROUTE_CH2PEN_SHIFT                 2                                  /**< Shift value for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_MASK                  0x4UL                              /**< Bit mask for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN_DEFAULT                (_PRS_ROUTE_CH2PEN_DEFAULT << 2)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN                        (0x1UL << 3)                       /**< CH3 Pin Enable */
+#define _PRS_ROUTE_CH3PEN_SHIFT                 3                                  /**< Shift value for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_MASK                  0x8UL                              /**< Bit mask for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN_DEFAULT                (_PRS_ROUTE_CH3PEN_DEFAULT << 3)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_SHIFT               8                                  /**< Shift value for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_MASK                0x700UL                            /**< Bit mask for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_LOC0                0x00000000UL                       /**< Mode LOC0 for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_DEFAULT             0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_LOC1                0x00000001UL                       /**< Mode LOC1 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC0                 (_PRS_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_DEFAULT              (_PRS_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC1                 (_PRS_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for PRS_ROUTE */
+
+/* Bit fields for PRS CH_CTRL */
+#define _PRS_CH_CTRL_RESETVALUE                 0x00000000UL                                /**< Default value for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_MASK                       0x133F0007UL                                /**< Mask for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_SHIFT               0                                           /**< Shift value for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_MASK                0x7UL                                       /**< Bit mask for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_VCMPOUT             0x00000000UL                                /**< Mode VCMPOUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP0OUT            0x00000000UL                                /**< Mode ACMP0OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP1OUT            0x00000000UL                                /**< Mode ACMP1OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0UF            0x00000000UL                                /**< Mode TIMER0UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1UF            0x00000000UL                                /**< Mode TIMER1UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCOF               0x00000000UL                                /**< Mode RTCOF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN0            0x00000000UL                                /**< Mode GPIOPIN0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN8            0x00000000UL                                /**< Mode GPIOPIN8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH0         0x00000000UL                                /**< Mode LETIMER0CH0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES0     0x00000000UL                                /**< Mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES8     0x00000000UL                                /**< Mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC0         0x00000000UL                                /**< Mode LESENSEDEC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1TXC           0x00000001UL                                /**< Mode USART1TXC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0OF            0x00000001UL                                /**< Mode TIMER0OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1OF            0x00000001UL                                /**< Mode TIMER1OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP0            0x00000001UL                                /**< Mode RTCCOMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN1            0x00000001UL                                /**< Mode GPIOPIN1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN9            0x00000001UL                                /**< Mode GPIOPIN9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH1         0x00000001UL                                /**< Mode LETIMER0CH1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES1     0x00000001UL                                /**< Mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES9     0x00000001UL                                /**< Mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC1         0x00000001UL                                /**< Mode LESENSEDEC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1RXDATAV       0x00000002UL                                /**< Mode USART1RXDATAV for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC0           0x00000002UL                                /**< Mode TIMER0CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC0           0x00000002UL                                /**< Mode TIMER1CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP1            0x00000002UL                                /**< Mode RTCCOMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN2            0x00000002UL                                /**< Mode GPIOPIN2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN10           0x00000002UL                                /**< Mode GPIOPIN10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES2     0x00000002UL                                /**< Mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES10    0x00000002UL                                /**< Mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC2         0x00000002UL                                /**< Mode LESENSEDEC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC1           0x00000003UL                                /**< Mode TIMER0CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC1           0x00000003UL                                /**< Mode TIMER1CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN3            0x00000003UL                                /**< Mode GPIOPIN3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN11           0x00000003UL                                /**< Mode GPIOPIN11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES3     0x00000003UL                                /**< Mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES11    0x00000003UL                                /**< Mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC2           0x00000004UL                                /**< Mode TIMER0CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC2           0x00000004UL                                /**< Mode TIMER1CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN4            0x00000004UL                                /**< Mode GPIOPIN4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN12           0x00000004UL                                /**< Mode GPIOPIN12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES4     0x00000004UL                                /**< Mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES12    0x00000004UL                                /**< Mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN5            0x00000005UL                                /**< Mode GPIOPIN5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN13           0x00000005UL                                /**< Mode GPIOPIN13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES5     0x00000005UL                                /**< Mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES13    0x00000005UL                                /**< Mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN6            0x00000006UL                                /**< Mode GPIOPIN6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN14           0x00000006UL                                /**< Mode GPIOPIN14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES6     0x00000006UL                                /**< Mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES14    0x00000006UL                                /**< Mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN7            0x00000007UL                                /**< Mode GPIOPIN7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN15           0x00000007UL                                /**< Mode GPIOPIN15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES7     0x00000007UL                                /**< Mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES15    0x00000007UL                                /**< Mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_VCMPOUT              (_PRS_CH_CTRL_SIGSEL_VCMPOUT << 0)          /**< Shifted mode VCMPOUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP0OUT             (_PRS_CH_CTRL_SIGSEL_ACMP0OUT << 0)         /**< Shifted mode ACMP0OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP1OUT             (_PRS_CH_CTRL_SIGSEL_ACMP1OUT << 0)         /**< Shifted mode ACMP1OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0UF             (_PRS_CH_CTRL_SIGSEL_TIMER0UF << 0)         /**< Shifted mode TIMER0UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1UF             (_PRS_CH_CTRL_SIGSEL_TIMER1UF << 0)         /**< Shifted mode TIMER1UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCOF                (_PRS_CH_CTRL_SIGSEL_RTCOF << 0)            /**< Shifted mode RTCOF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN0             (_PRS_CH_CTRL_SIGSEL_GPIOPIN0 << 0)         /**< Shifted mode GPIOPIN0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN8             (_PRS_CH_CTRL_SIGSEL_GPIOPIN8 << 0)         /**< Shifted mode GPIOPIN8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH0          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH0 << 0)      /**< Shifted mode LETIMER0CH0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES0      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES0 << 0)  /**< Shifted mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES8      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES8 << 0)  /**< Shifted mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC0          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC0 << 0)      /**< Shifted mode LESENSEDEC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1TXC            (_PRS_CH_CTRL_SIGSEL_USART1TXC << 0)        /**< Shifted mode USART1TXC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0OF             (_PRS_CH_CTRL_SIGSEL_TIMER0OF << 0)         /**< Shifted mode TIMER0OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1OF             (_PRS_CH_CTRL_SIGSEL_TIMER1OF << 0)         /**< Shifted mode TIMER1OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP0             (_PRS_CH_CTRL_SIGSEL_RTCCOMP0 << 0)         /**< Shifted mode RTCCOMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN1             (_PRS_CH_CTRL_SIGSEL_GPIOPIN1 << 0)         /**< Shifted mode GPIOPIN1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN9             (_PRS_CH_CTRL_SIGSEL_GPIOPIN9 << 0)         /**< Shifted mode GPIOPIN9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH1          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH1 << 0)      /**< Shifted mode LETIMER0CH1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES1      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES1 << 0)  /**< Shifted mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES9      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES9 << 0)  /**< Shifted mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC1          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC1 << 0)      /**< Shifted mode LESENSEDEC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1RXDATAV        (_PRS_CH_CTRL_SIGSEL_USART1RXDATAV << 0)    /**< Shifted mode USART1RXDATAV for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC0            (_PRS_CH_CTRL_SIGSEL_TIMER0CC0 << 0)        /**< Shifted mode TIMER0CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC0            (_PRS_CH_CTRL_SIGSEL_TIMER1CC0 << 0)        /**< Shifted mode TIMER1CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP1             (_PRS_CH_CTRL_SIGSEL_RTCCOMP1 << 0)         /**< Shifted mode RTCCOMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN2             (_PRS_CH_CTRL_SIGSEL_GPIOPIN2 << 0)         /**< Shifted mode GPIOPIN2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN10            (_PRS_CH_CTRL_SIGSEL_GPIOPIN10 << 0)        /**< Shifted mode GPIOPIN10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES2      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES2 << 0)  /**< Shifted mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES10     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES10 << 0) /**< Shifted mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC2          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC2 << 0)      /**< Shifted mode LESENSEDEC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC1            (_PRS_CH_CTRL_SIGSEL_TIMER0CC1 << 0)        /**< Shifted mode TIMER0CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC1            (_PRS_CH_CTRL_SIGSEL_TIMER1CC1 << 0)        /**< Shifted mode TIMER1CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN3             (_PRS_CH_CTRL_SIGSEL_GPIOPIN3 << 0)         /**< Shifted mode GPIOPIN3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN11            (_PRS_CH_CTRL_SIGSEL_GPIOPIN11 << 0)        /**< Shifted mode GPIOPIN11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES3      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES3 << 0)  /**< Shifted mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES11     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES11 << 0) /**< Shifted mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC2            (_PRS_CH_CTRL_SIGSEL_TIMER0CC2 << 0)        /**< Shifted mode TIMER0CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC2            (_PRS_CH_CTRL_SIGSEL_TIMER1CC2 << 0)        /**< Shifted mode TIMER1CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN4             (_PRS_CH_CTRL_SIGSEL_GPIOPIN4 << 0)         /**< Shifted mode GPIOPIN4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN12            (_PRS_CH_CTRL_SIGSEL_GPIOPIN12 << 0)        /**< Shifted mode GPIOPIN12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES4      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES4 << 0)  /**< Shifted mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES12     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES12 << 0) /**< Shifted mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN5             (_PRS_CH_CTRL_SIGSEL_GPIOPIN5 << 0)         /**< Shifted mode GPIOPIN5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN13            (_PRS_CH_CTRL_SIGSEL_GPIOPIN13 << 0)        /**< Shifted mode GPIOPIN13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES5      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES5 << 0)  /**< Shifted mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES13     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES13 << 0) /**< Shifted mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN6             (_PRS_CH_CTRL_SIGSEL_GPIOPIN6 << 0)         /**< Shifted mode GPIOPIN6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN14            (_PRS_CH_CTRL_SIGSEL_GPIOPIN14 << 0)        /**< Shifted mode GPIOPIN14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES6      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES6 << 0)  /**< Shifted mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES14     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES14 << 0) /**< Shifted mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN7             (_PRS_CH_CTRL_SIGSEL_GPIOPIN7 << 0)         /**< Shifted mode GPIOPIN7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN15            (_PRS_CH_CTRL_SIGSEL_GPIOPIN15 << 0)        /**< Shifted mode GPIOPIN15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES7      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES7 << 0)  /**< Shifted mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES15     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES15 << 0) /**< Shifted mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_SHIFT            16                                          /**< Shift value for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_MASK             0x3F0000UL                                  /**< Bit mask for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_NONE             0x00000000UL                                /**< Mode NONE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_VCMP             0x00000001UL                                /**< Mode VCMP for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP0            0x00000002UL                                /**< Mode ACMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP1            0x00000003UL                                /**< Mode ACMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_USART1           0x00000011UL                                /**< Mode USART1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER0           0x0000001CUL                                /**< Mode TIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER1           0x0000001DUL                                /**< Mode TIMER1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_RTC              0x00000028UL                                /**< Mode RTC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOL            0x00000030UL                                /**< Mode GPIOL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOH            0x00000031UL                                /**< Mode GPIOH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LETIMER0         0x00000034UL                                /**< Mode LETIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEL         0x00000039UL                                /**< Mode LESENSEL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEH         0x0000003AUL                                /**< Mode LESENSEH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSED         0x0000003BUL                                /**< Mode LESENSED for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_NONE              (_PRS_CH_CTRL_SOURCESEL_NONE << 16)         /**< Shifted mode NONE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_VCMP              (_PRS_CH_CTRL_SOURCESEL_VCMP << 16)         /**< Shifted mode VCMP for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP0             (_PRS_CH_CTRL_SOURCESEL_ACMP0 << 16)        /**< Shifted mode ACMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP1             (_PRS_CH_CTRL_SOURCESEL_ACMP1 << 16)        /**< Shifted mode ACMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_USART1            (_PRS_CH_CTRL_SOURCESEL_USART1 << 16)       /**< Shifted mode USART1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER0            (_PRS_CH_CTRL_SOURCESEL_TIMER0 << 16)       /**< Shifted mode TIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER1            (_PRS_CH_CTRL_SOURCESEL_TIMER1 << 16)       /**< Shifted mode TIMER1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_RTC               (_PRS_CH_CTRL_SOURCESEL_RTC << 16)          /**< Shifted mode RTC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOL             (_PRS_CH_CTRL_SOURCESEL_GPIOL << 16)        /**< Shifted mode GPIOL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOH             (_PRS_CH_CTRL_SOURCESEL_GPIOH << 16)        /**< Shifted mode GPIOH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LETIMER0          (_PRS_CH_CTRL_SOURCESEL_LETIMER0 << 16)     /**< Shifted mode LETIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEL          (_PRS_CH_CTRL_SOURCESEL_LESENSEL << 16)     /**< Shifted mode LESENSEL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEH          (_PRS_CH_CTRL_SOURCESEL_LESENSEH << 16)     /**< Shifted mode LESENSEH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSED          (_PRS_CH_CTRL_SOURCESEL_LESENSED << 16)     /**< Shifted mode LESENSED for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_SHIFT                24                                          /**< Shift value for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_MASK                 0x3000000UL                                 /**< Bit mask for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_OFF                  0x00000000UL                                /**< Mode OFF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_POSEDGE              0x00000001UL                                /**< Mode POSEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_NEGEDGE              0x00000002UL                                /**< Mode NEGEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_BOTHEDGES            0x00000003UL                                /**< Mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_DEFAULT               (_PRS_CH_CTRL_EDSEL_DEFAULT << 24)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_OFF                   (_PRS_CH_CTRL_EDSEL_OFF << 24)              /**< Shifted mode OFF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_POSEDGE               (_PRS_CH_CTRL_EDSEL_POSEDGE << 24)          /**< Shifted mode POSEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_NEGEDGE               (_PRS_CH_CTRL_EDSEL_NEGEDGE << 24)          /**< Shifted mode NEGEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_BOTHEDGES             (_PRS_CH_CTRL_EDSEL_BOTHEDGES << 24)        /**< Shifted mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC                       (0x1UL << 28)                               /**< Asynchronous reflex */
+#define _PRS_CH_CTRL_ASYNC_SHIFT                28                                          /**< Shift value for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_MASK                 0x10000000UL                                /**< Bit mask for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC_DEFAULT               (_PRS_CH_CTRL_ASYNC_DEFAULT << 28)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+
+/** @} End of group EFM32TG108F4_PRS */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_UNLOCK EFM32TG108F4 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG108F4_UNLOCK */
+
+/** @} End of group EFM32TG108F4_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F4_Alternate_Function EFM32TG108F4 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG108F4_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG108F4  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG108F4_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg108f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg108f8.h
@@ -1,0 +1,2743 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG108F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG108F8_H
+#define EFM32TG108F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8 EFM32TG108F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_Core EFM32TG108F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG108F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_Part EFM32TG108F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG108F8)
+#define EFM32TG108F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG108F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG108F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           1 /**< 1 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG108F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_Peripheral_TypeDefs EFM32TG108F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_dma_ch.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_DMA EFM32TG108F8 DMA
+ * @brief EFM32TG108F8_DMA Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IM uint32_t  STATUS;          /**< DMA Status Registers  */
+  __OM uint32_t  CONFIG;          /**< DMA Configuration Register  */
+  __IOM uint32_t CTRLBASE;        /**< Channel Control Data Base Pointer Register  */
+  __IM uint32_t  ALTCTRLBASE;     /**< Channel Alternate Control Data Base Pointer Register  */
+  __IM uint32_t  CHWAITSTATUS;    /**< Channel Wait on Request Status Register  */
+  __OM uint32_t  CHSWREQ;         /**< Channel Software Request Register  */
+  __IOM uint32_t CHUSEBURSTS;     /**< Channel Useburst Set Register  */
+  __OM uint32_t  CHUSEBURSTC;     /**< Channel Useburst Clear Register  */
+  __IOM uint32_t CHREQMASKS;      /**< Channel Request Mask Set Register  */
+  __OM uint32_t  CHREQMASKC;      /**< Channel Request Mask Clear Register  */
+  __IOM uint32_t CHENS;           /**< Channel Enable Set Register  */
+  __OM uint32_t  CHENC;           /**< Channel Enable Clear Register  */
+  __IOM uint32_t CHALTS;          /**< Channel Alternate Set Register  */
+  __OM uint32_t  CHALTC;          /**< Channel Alternate Clear Register  */
+  __IOM uint32_t CHPRIS;          /**< Channel Priority Set Register  */
+  __OM uint32_t  CHPRIC;          /**< Channel Priority Clear Register  */
+  uint32_t       RESERVED0[3U];   /**< Reserved for future use **/
+  __IOM uint32_t ERRORC;          /**< Bus Error Clear Register  */
+  uint32_t       RESERVED1[880U]; /**< Reserved for future use **/
+  __IM uint32_t  CHREQSTATUS;     /**< Channel Request Status  */
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
+  __IM uint32_t  CHSREQSTATUS;    /**< Channel Single Request Status  */
+
+  uint32_t       RESERVED3[121U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable register  */
+
+  uint32_t       RESERVED4[60U];  /**< Reserved registers */
+  DMA_CH_TypeDef CH[8U];          /**< Channel registers */
+} DMA_TypeDef;                    /**< DMA Register Declaration *//** @} */
+
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_CMU EFM32TG108F8 CMU
+ * @brief EFM32TG108F8_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_PRS EFM32TG108F8 PRS
+ * @brief EFM32TG108F8_PRS Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+
+  uint32_t       RESERVED0[1U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[8U];        /**< Channel registers */
+} PRS_TypeDef;                  /**< PRS Register Declaration *//** @} */
+
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG108F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_Peripheral_Base EFM32TG108F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG108F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_Peripheral_Declaration  EFM32TG108F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG108F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_BitFields EFM32TG108F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @addtogroup EFM32TG108F8_PRS_Signals
+ * @{
+ * @brief PRS Signal names
+ ******************************************************************************/
+
+#define PRS_VCMP_OUT             ((1 << 16) + 0)  /**< PRS Voltage comparator output */
+#define PRS_ACMP0_OUT            ((2 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_ACMP1_OUT            ((3 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_USART1_TXC           ((17 << 16) + 1) /**< PRS USART 1 TX complete */
+#define PRS_USART1_RXDATAV       ((17 << 16) + 2) /**< PRS USART 1 RX Data Valid */
+#define PRS_TIMER0_UF            ((28 << 16) + 0) /**< PRS Timer 0 Underflow */
+#define PRS_TIMER0_OF            ((28 << 16) + 1) /**< PRS Timer 0 Overflow */
+#define PRS_TIMER0_CC0           ((28 << 16) + 2) /**< PRS Timer 0 Compare/Capture 0 */
+#define PRS_TIMER0_CC1           ((28 << 16) + 3) /**< PRS Timer 0 Compare/Capture 1 */
+#define PRS_TIMER0_CC2           ((28 << 16) + 4) /**< PRS Timer 0 Compare/Capture 2 */
+#define PRS_TIMER1_UF            ((29 << 16) + 0) /**< PRS Timer 1 Underflow */
+#define PRS_TIMER1_OF            ((29 << 16) + 1) /**< PRS Timer 1 Overflow */
+#define PRS_TIMER1_CC0           ((29 << 16) + 2) /**< PRS Timer 1 Compare/Capture 0 */
+#define PRS_TIMER1_CC1           ((29 << 16) + 3) /**< PRS Timer 1 Compare/Capture 1 */
+#define PRS_TIMER1_CC2           ((29 << 16) + 4) /**< PRS Timer 1 Compare/Capture 2 */
+#define PRS_RTC_OF               ((40 << 16) + 0) /**< PRS RTC Overflow */
+#define PRS_RTC_COMP0            ((40 << 16) + 1) /**< PRS RTC Compare 0 */
+#define PRS_RTC_COMP1            ((40 << 16) + 2) /**< PRS RTC Compare 1 */
+#define PRS_GPIO_PIN0            ((48 << 16) + 0) /**< PRS GPIO pin 0 */
+#define PRS_GPIO_PIN1            ((48 << 16) + 1) /**< PRS GPIO pin 1 */
+#define PRS_GPIO_PIN2            ((48 << 16) + 2) /**< PRS GPIO pin 2 */
+#define PRS_GPIO_PIN3            ((48 << 16) + 3) /**< PRS GPIO pin 3 */
+#define PRS_GPIO_PIN4            ((48 << 16) + 4) /**< PRS GPIO pin 4 */
+#define PRS_GPIO_PIN5            ((48 << 16) + 5) /**< PRS GPIO pin 5 */
+#define PRS_GPIO_PIN6            ((48 << 16) + 6) /**< PRS GPIO pin 6 */
+#define PRS_GPIO_PIN7            ((48 << 16) + 7) /**< PRS GPIO pin 7 */
+#define PRS_GPIO_PIN8            ((49 << 16) + 0) /**< PRS GPIO pin 8 */
+#define PRS_GPIO_PIN9            ((49 << 16) + 1) /**< PRS GPIO pin 9 */
+#define PRS_GPIO_PIN10           ((49 << 16) + 2) /**< PRS GPIO pin 10 */
+#define PRS_GPIO_PIN11           ((49 << 16) + 3) /**< PRS GPIO pin 11 */
+#define PRS_GPIO_PIN12           ((49 << 16) + 4) /**< PRS GPIO pin 12 */
+#define PRS_GPIO_PIN13           ((49 << 16) + 5) /**< PRS GPIO pin 13 */
+#define PRS_GPIO_PIN14           ((49 << 16) + 6) /**< PRS GPIO pin 14 */
+#define PRS_GPIO_PIN15           ((49 << 16) + 7) /**< PRS GPIO pin 15 */
+#define PRS_LETIMER0_CH0         ((52 << 16) + 0) /**< PRS LETIMER CH0 Out */
+#define PRS_LETIMER0_CH1         ((52 << 16) + 1) /**< PRS LETIMER CH1 Out */
+#define PRS_LESENSE_SCANRES0     ((57 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 0 */
+#define PRS_LESENSE_SCANRES1     ((57 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 1 */
+#define PRS_LESENSE_SCANRES2     ((57 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 2 */
+#define PRS_LESENSE_SCANRES3     ((57 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 3 */
+#define PRS_LESENSE_SCANRES4     ((57 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 4 */
+#define PRS_LESENSE_SCANRES5     ((57 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 5 */
+#define PRS_LESENSE_SCANRES6     ((57 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 6 */
+#define PRS_LESENSE_SCANRES7     ((57 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 7 */
+#define PRS_LESENSE_SCANRES8     ((58 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 8 */
+#define PRS_LESENSE_SCANRES9     ((58 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 9 */
+#define PRS_LESENSE_SCANRES10    ((58 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 10 */
+#define PRS_LESENSE_SCANRES11    ((58 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 11 */
+#define PRS_LESENSE_SCANRES12    ((58 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 12 */
+#define PRS_LESENSE_SCANRES13    ((58 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 13 */
+#define PRS_LESENSE_SCANRES14    ((58 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 14 */
+#define PRS_LESENSE_SCANRES15    ((58 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 15 */
+#define PRS_LESENSE_DEC0         ((59 << 16) + 0) /**< PRS LESENSE Decoder PRS out 0 */
+#define PRS_LESENSE_DEC1         ((59 << 16) + 1) /**< PRS LESENSE Decoder PRS out 1 */
+#define PRS_LESENSE_DEC2         ((59 << 16) + 2) /**< PRS LESENSE Decoder PRS out 2 */
+
+/** @} End of group EFM32TG108F8_PRS */
+
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_DMA_BitFields  EFM32TG108F8_DMA Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for DMA STATUS */
+#define _DMA_STATUS_RESETVALUE                          0x10070000UL                          /**< Default value for DMA_STATUS */
+#define _DMA_STATUS_MASK                                0x001F00F1UL                          /**< Mask for DMA_STATUS */
+#define DMA_STATUS_EN                                   (0x1UL << 0)                          /**< DMA Enable Status */
+#define _DMA_STATUS_EN_SHIFT                            0                                     /**< Shift value for DMA_EN */
+#define _DMA_STATUS_EN_MASK                             0x1UL                                 /**< Bit mask for DMA_EN */
+#define _DMA_STATUS_EN_DEFAULT                          0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_EN_DEFAULT                           (_DMA_STATUS_EN_DEFAULT << 0)         /**< Shifted mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_SHIFT                         4                                     /**< Shift value for DMA_STATE */
+#define _DMA_STATUS_STATE_MASK                          0xF0UL                                /**< Bit mask for DMA_STATE */
+#define _DMA_STATUS_STATE_DEFAULT                       0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_IDLE                          0x00000000UL                          /**< Mode IDLE for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDCHCTRLDATA                  0x00000001UL                          /**< Mode RDCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCENDPTR                   0x00000002UL                          /**< Mode RDSRCENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDDSTENDPTR                   0x00000003UL                          /**< Mode RDDSTENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCDATA                     0x00000004UL                          /**< Mode RDSRCDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRDSTDATA                     0x00000005UL                          /**< Mode WRDSTDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WAITREQCLR                    0x00000006UL                          /**< Mode WAITREQCLR for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRCHCTRLDATA                  0x00000007UL                          /**< Mode WRCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_STALLED                       0x00000008UL                          /**< Mode STALLED for DMA_STATUS */
+#define _DMA_STATUS_STATE_DONE                          0x00000009UL                          /**< Mode DONE for DMA_STATUS */
+#define _DMA_STATUS_STATE_PERSCATTRANS                  0x0000000AUL                          /**< Mode PERSCATTRANS for DMA_STATUS */
+#define DMA_STATUS_STATE_DEFAULT                        (_DMA_STATUS_STATE_DEFAULT << 4)      /**< Shifted mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_STATE_IDLE                           (_DMA_STATUS_STATE_IDLE << 4)         /**< Shifted mode IDLE for DMA_STATUS */
+#define DMA_STATUS_STATE_RDCHCTRLDATA                   (_DMA_STATUS_STATE_RDCHCTRLDATA << 4) /**< Shifted mode RDCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCENDPTR                    (_DMA_STATUS_STATE_RDSRCENDPTR << 4)  /**< Shifted mode RDSRCENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDDSTENDPTR                    (_DMA_STATUS_STATE_RDDSTENDPTR << 4)  /**< Shifted mode RDDSTENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCDATA                      (_DMA_STATUS_STATE_RDSRCDATA << 4)    /**< Shifted mode RDSRCDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WRDSTDATA                      (_DMA_STATUS_STATE_WRDSTDATA << 4)    /**< Shifted mode WRDSTDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WAITREQCLR                     (_DMA_STATUS_STATE_WAITREQCLR << 4)   /**< Shifted mode WAITREQCLR for DMA_STATUS */
+#define DMA_STATUS_STATE_WRCHCTRLDATA                   (_DMA_STATUS_STATE_WRCHCTRLDATA << 4) /**< Shifted mode WRCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_STALLED                        (_DMA_STATUS_STATE_STALLED << 4)      /**< Shifted mode STALLED for DMA_STATUS */
+#define DMA_STATUS_STATE_DONE                           (_DMA_STATUS_STATE_DONE << 4)         /**< Shifted mode DONE for DMA_STATUS */
+#define DMA_STATUS_STATE_PERSCATTRANS                   (_DMA_STATUS_STATE_PERSCATTRANS << 4) /**< Shifted mode PERSCATTRANS for DMA_STATUS */
+#define _DMA_STATUS_CHNUM_SHIFT                         16                                    /**< Shift value for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_MASK                          0x1F0000UL                            /**< Bit mask for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_DEFAULT                       0x00000007UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_CHNUM_DEFAULT                        (_DMA_STATUS_CHNUM_DEFAULT << 16)     /**< Shifted mode DEFAULT for DMA_STATUS */
+
+/* Bit fields for DMA CONFIG */
+#define _DMA_CONFIG_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_CONFIG */
+#define _DMA_CONFIG_MASK                                0x00000021UL                      /**< Mask for DMA_CONFIG */
+#define DMA_CONFIG_EN                                   (0x1UL << 0)                      /**< Enable DMA */
+#define _DMA_CONFIG_EN_SHIFT                            0                                 /**< Shift value for DMA_EN */
+#define _DMA_CONFIG_EN_MASK                             0x1UL                             /**< Bit mask for DMA_EN */
+#define _DMA_CONFIG_EN_DEFAULT                          0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_EN_DEFAULT                           (_DMA_CONFIG_EN_DEFAULT << 0)     /**< Shifted mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT                               (0x1UL << 5)                      /**< Channel Protection Control */
+#define _DMA_CONFIG_CHPROT_SHIFT                        5                                 /**< Shift value for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_MASK                         0x20UL                            /**< Bit mask for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT_DEFAULT                       (_DMA_CONFIG_CHPROT_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CONFIG */
+
+/* Bit fields for DMA CTRLBASE */
+#define _DMA_CTRLBASE_RESETVALUE                        0x00000000UL                          /**< Default value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_MASK                              0xFFFFFFFFUL                          /**< Mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_SHIFT                    0                                     /**< Shift value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_MASK                     0xFFFFFFFFUL                          /**< Bit mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_DEFAULT                  0x00000000UL                          /**< Mode DEFAULT for DMA_CTRLBASE */
+#define DMA_CTRLBASE_CTRLBASE_DEFAULT                   (_DMA_CTRLBASE_CTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CTRLBASE */
+
+/* Bit fields for DMA ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_RESETVALUE                     0x00000080UL                                /**< Default value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_MASK                           0xFFFFFFFFUL                                /**< Mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_SHIFT              0                                           /**< Shift value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_MASK               0xFFFFFFFFUL                                /**< Bit mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT            0x00000080UL                                /**< Mode DEFAULT for DMA_ALTCTRLBASE */
+#define DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT             (_DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ALTCTRLBASE */
+
+/* Bit fields for DMA CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_RESETVALUE                    0x000000FFUL                                   /**< Default value for DMA_CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+
+/* Bit fields for DMA CHSWREQ */
+#define _DMA_CHSWREQ_RESETVALUE                         0x00000000UL                         /**< Default value for DMA_CHSWREQ */
+#define _DMA_CHSWREQ_MASK                               0x000000FFUL                         /**< Mask for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ                            (0x1UL << 0)                         /**< Channel 0 Software Request */
+#define _DMA_CHSWREQ_CH0SWREQ_SHIFT                     0                                    /**< Shift value for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_MASK                      0x1UL                                /**< Bit mask for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH0SWREQ_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ                            (0x1UL << 1)                         /**< Channel 1 Software Request */
+#define _DMA_CHSWREQ_CH1SWREQ_SHIFT                     1                                    /**< Shift value for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_MASK                      0x2UL                                /**< Bit mask for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH1SWREQ_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ                            (0x1UL << 2)                         /**< Channel 2 Software Request */
+#define _DMA_CHSWREQ_CH2SWREQ_SHIFT                     2                                    /**< Shift value for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_MASK                      0x4UL                                /**< Bit mask for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH2SWREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ                            (0x1UL << 3)                         /**< Channel 3 Software Request */
+#define _DMA_CHSWREQ_CH3SWREQ_SHIFT                     3                                    /**< Shift value for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_MASK                      0x8UL                                /**< Bit mask for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH3SWREQ_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ                            (0x1UL << 4)                         /**< Channel 4 Software Request */
+#define _DMA_CHSWREQ_CH4SWREQ_SHIFT                     4                                    /**< Shift value for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_MASK                      0x10UL                               /**< Bit mask for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH4SWREQ_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ                            (0x1UL << 5)                         /**< Channel 5 Software Request */
+#define _DMA_CHSWREQ_CH5SWREQ_SHIFT                     5                                    /**< Shift value for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_MASK                      0x20UL                               /**< Bit mask for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH5SWREQ_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ                            (0x1UL << 6)                         /**< Channel 6 Software Request */
+#define _DMA_CHSWREQ_CH6SWREQ_SHIFT                     6                                    /**< Shift value for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_MASK                      0x40UL                               /**< Bit mask for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH6SWREQ_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ                            (0x1UL << 7)                         /**< Channel 7 Software Request */
+#define _DMA_CHSWREQ_CH7SWREQ_SHIFT                     7                                    /**< Shift value for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_MASK                      0x80UL                               /**< Bit mask for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH7SWREQ_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+
+/* Bit fields for DMA CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_RESETVALUE                     0x00000000UL                                        /**< Default value for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_MASK                           0x000000FFUL                                        /**< Mask for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS                    (0x1UL << 0)                                        /**< Channel 0 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SHIFT             0                                                   /**< Shift value for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_MASK              0x1UL                                               /**< Bit mask for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST    0x00000000UL                                        /**< Mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY         0x00000001UL                                        /**< Mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT << 0)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST     (_DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST << 0) /**< Shifted mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY          (_DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY << 0)      /**< Shifted mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS                    (0x1UL << 1)                                        /**< Channel 1 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_SHIFT             1                                                   /**< Shift value for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_MASK              0x2UL                                               /**< Bit mask for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT << 1)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS                    (0x1UL << 2)                                        /**< Channel 2 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_SHIFT             2                                                   /**< Shift value for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_MASK              0x4UL                                               /**< Bit mask for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT << 2)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS                    (0x1UL << 3)                                        /**< Channel 3 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_SHIFT             3                                                   /**< Shift value for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_MASK              0x8UL                                               /**< Bit mask for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT << 3)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS                    (0x1UL << 4)                                        /**< Channel 4 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_SHIFT             4                                                   /**< Shift value for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_MASK              0x10UL                                              /**< Bit mask for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT << 4)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS                    (0x1UL << 5)                                        /**< Channel 5 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_SHIFT             5                                                   /**< Shift value for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_MASK              0x20UL                                              /**< Bit mask for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT << 5)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS                    (0x1UL << 6)                                        /**< Channel 6 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_SHIFT             6                                                   /**< Shift value for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_MASK              0x40UL                                              /**< Bit mask for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT << 6)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS                    (0x1UL << 7)                                        /**< Channel 7 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_SHIFT             7                                                   /**< Shift value for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_MASK              0x80UL                                              /**< Bit mask for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT << 7)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+
+/* Bit fields for DMA CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC                    (0x1UL << 0)                                 /**< Channel 0 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_SHIFT             0                                            /**< Shift value for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_MASK              0x1UL                                        /**< Bit mask for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC                    (0x1UL << 1)                                 /**< Channel 1 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_SHIFT             1                                            /**< Shift value for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_MASK              0x2UL                                        /**< Bit mask for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC                    (0x1UL << 2)                                 /**< Channel 2 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_SHIFT             2                                            /**< Shift value for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_MASK              0x4UL                                        /**< Bit mask for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC                    (0x1UL << 3)                                 /**< Channel 3 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_SHIFT             3                                            /**< Shift value for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_MASK              0x8UL                                        /**< Bit mask for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC                    (0x1UL << 4)                                 /**< Channel 4 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_SHIFT             4                                            /**< Shift value for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_MASK              0x10UL                                       /**< Bit mask for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC                    (0x1UL << 5)                                 /**< Channel 5 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_SHIFT             5                                            /**< Shift value for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_MASK              0x20UL                                       /**< Bit mask for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC                    (0x1UL << 6)                                 /**< Channel 6 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_SHIFT             6                                            /**< Shift value for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_MASK              0x40UL                                       /**< Bit mask for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC                    (0x1UL << 7)                                 /**< Channel 7 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_SHIFT             7                                            /**< Shift value for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_MASK              0x80UL                                       /**< Bit mask for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+
+/* Bit fields for DMA CHREQMASKS */
+#define _DMA_CHREQMASKS_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKS */
+#define _DMA_CHREQMASKS_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS                      (0x1UL << 0)                               /**< Channel 0 Request Mask Set */
+#define _DMA_CHREQMASKS_CH0REQMASKS_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH0REQMASKS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS                      (0x1UL << 1)                               /**< Channel 1 Request Mask Set */
+#define _DMA_CHREQMASKS_CH1REQMASKS_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH1REQMASKS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS                      (0x1UL << 2)                               /**< Channel 2 Request Mask Set */
+#define _DMA_CHREQMASKS_CH2REQMASKS_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH2REQMASKS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS                      (0x1UL << 3)                               /**< Channel 3 Request Mask Set */
+#define _DMA_CHREQMASKS_CH3REQMASKS_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH3REQMASKS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS                      (0x1UL << 4)                               /**< Channel 4 Request Mask Set */
+#define _DMA_CHREQMASKS_CH4REQMASKS_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH4REQMASKS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS                      (0x1UL << 5)                               /**< Channel 5 Request Mask Set */
+#define _DMA_CHREQMASKS_CH5REQMASKS_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH5REQMASKS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS                      (0x1UL << 6)                               /**< Channel 6 Request Mask Set */
+#define _DMA_CHREQMASKS_CH6REQMASKS_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH6REQMASKS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS                      (0x1UL << 7)                               /**< Channel 7 Request Mask Set */
+#define _DMA_CHREQMASKS_CH7REQMASKS_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH7REQMASKS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+
+/* Bit fields for DMA CHREQMASKC */
+#define _DMA_CHREQMASKC_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKC */
+#define _DMA_CHREQMASKC_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC                      (0x1UL << 0)                               /**< Channel 0 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH0REQMASKC_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH0REQMASKC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC                      (0x1UL << 1)                               /**< Channel 1 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH1REQMASKC_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH1REQMASKC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC                      (0x1UL << 2)                               /**< Channel 2 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH2REQMASKC_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH2REQMASKC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC                      (0x1UL << 3)                               /**< Channel 3 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH3REQMASKC_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH3REQMASKC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC                      (0x1UL << 4)                               /**< Channel 4 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH4REQMASKC_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH4REQMASKC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC                      (0x1UL << 5)                               /**< Channel 5 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH5REQMASKC_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH5REQMASKC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC                      (0x1UL << 6)                               /**< Channel 6 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH6REQMASKC_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH6REQMASKC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC                      (0x1UL << 7)                               /**< Channel 7 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH7REQMASKC_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH7REQMASKC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+
+/* Bit fields for DMA CHENS */
+#define _DMA_CHENS_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENS */
+#define _DMA_CHENS_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENS */
+#define DMA_CHENS_CH0ENS                                (0x1UL << 0)                     /**< Channel 0 Enable Set */
+#define _DMA_CHENS_CH0ENS_SHIFT                         0                                /**< Shift value for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH0ENS_DEFAULT                        (_DMA_CHENS_CH0ENS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS                                (0x1UL << 1)                     /**< Channel 1 Enable Set */
+#define _DMA_CHENS_CH1ENS_SHIFT                         1                                /**< Shift value for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS_DEFAULT                        (_DMA_CHENS_CH1ENS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS                                (0x1UL << 2)                     /**< Channel 2 Enable Set */
+#define _DMA_CHENS_CH2ENS_SHIFT                         2                                /**< Shift value for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS_DEFAULT                        (_DMA_CHENS_CH2ENS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS                                (0x1UL << 3)                     /**< Channel 3 Enable Set */
+#define _DMA_CHENS_CH3ENS_SHIFT                         3                                /**< Shift value for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS_DEFAULT                        (_DMA_CHENS_CH3ENS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS                                (0x1UL << 4)                     /**< Channel 4 Enable Set */
+#define _DMA_CHENS_CH4ENS_SHIFT                         4                                /**< Shift value for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS_DEFAULT                        (_DMA_CHENS_CH4ENS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS                                (0x1UL << 5)                     /**< Channel 5 Enable Set */
+#define _DMA_CHENS_CH5ENS_SHIFT                         5                                /**< Shift value for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS_DEFAULT                        (_DMA_CHENS_CH5ENS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS                                (0x1UL << 6)                     /**< Channel 6 Enable Set */
+#define _DMA_CHENS_CH6ENS_SHIFT                         6                                /**< Shift value for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS_DEFAULT                        (_DMA_CHENS_CH6ENS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS                                (0x1UL << 7)                     /**< Channel 7 Enable Set */
+#define _DMA_CHENS_CH7ENS_SHIFT                         7                                /**< Shift value for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS_DEFAULT                        (_DMA_CHENS_CH7ENS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENS */
+
+/* Bit fields for DMA CHENC */
+#define _DMA_CHENC_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENC */
+#define _DMA_CHENC_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENC */
+#define DMA_CHENC_CH0ENC                                (0x1UL << 0)                     /**< Channel 0 Enable Clear */
+#define _DMA_CHENC_CH0ENC_SHIFT                         0                                /**< Shift value for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH0ENC_DEFAULT                        (_DMA_CHENC_CH0ENC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC                                (0x1UL << 1)                     /**< Channel 1 Enable Clear */
+#define _DMA_CHENC_CH1ENC_SHIFT                         1                                /**< Shift value for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC_DEFAULT                        (_DMA_CHENC_CH1ENC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC                                (0x1UL << 2)                     /**< Channel 2 Enable Clear */
+#define _DMA_CHENC_CH2ENC_SHIFT                         2                                /**< Shift value for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC_DEFAULT                        (_DMA_CHENC_CH2ENC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC                                (0x1UL << 3)                     /**< Channel 3 Enable Clear */
+#define _DMA_CHENC_CH3ENC_SHIFT                         3                                /**< Shift value for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC_DEFAULT                        (_DMA_CHENC_CH3ENC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC                                (0x1UL << 4)                     /**< Channel 4 Enable Clear */
+#define _DMA_CHENC_CH4ENC_SHIFT                         4                                /**< Shift value for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC_DEFAULT                        (_DMA_CHENC_CH4ENC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC                                (0x1UL << 5)                     /**< Channel 5 Enable Clear */
+#define _DMA_CHENC_CH5ENC_SHIFT                         5                                /**< Shift value for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC_DEFAULT                        (_DMA_CHENC_CH5ENC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC                                (0x1UL << 6)                     /**< Channel 6 Enable Clear */
+#define _DMA_CHENC_CH6ENC_SHIFT                         6                                /**< Shift value for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC_DEFAULT                        (_DMA_CHENC_CH6ENC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC                                (0x1UL << 7)                     /**< Channel 7 Enable Clear */
+#define _DMA_CHENC_CH7ENC_SHIFT                         7                                /**< Shift value for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC_DEFAULT                        (_DMA_CHENC_CH7ENC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENC */
+
+/* Bit fields for DMA CHALTS */
+#define _DMA_CHALTS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTS */
+#define _DMA_CHALTS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS                              (0x1UL << 0)                       /**< Channel 0 Alternate Structure Set */
+#define _DMA_CHALTS_CH0ALTS_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS_DEFAULT                      (_DMA_CHALTS_CH0ALTS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS                              (0x1UL << 1)                       /**< Channel 1 Alternate Structure Set */
+#define _DMA_CHALTS_CH1ALTS_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS_DEFAULT                      (_DMA_CHALTS_CH1ALTS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS                              (0x1UL << 2)                       /**< Channel 2 Alternate Structure Set */
+#define _DMA_CHALTS_CH2ALTS_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS_DEFAULT                      (_DMA_CHALTS_CH2ALTS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS                              (0x1UL << 3)                       /**< Channel 3 Alternate Structure Set */
+#define _DMA_CHALTS_CH3ALTS_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS_DEFAULT                      (_DMA_CHALTS_CH3ALTS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS                              (0x1UL << 4)                       /**< Channel 4 Alternate Structure Set */
+#define _DMA_CHALTS_CH4ALTS_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS_DEFAULT                      (_DMA_CHALTS_CH4ALTS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS                              (0x1UL << 5)                       /**< Channel 5 Alternate Structure Set */
+#define _DMA_CHALTS_CH5ALTS_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS_DEFAULT                      (_DMA_CHALTS_CH5ALTS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS                              (0x1UL << 6)                       /**< Channel 6 Alternate Structure Set */
+#define _DMA_CHALTS_CH6ALTS_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS_DEFAULT                      (_DMA_CHALTS_CH6ALTS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS                              (0x1UL << 7)                       /**< Channel 7 Alternate Structure Set */
+#define _DMA_CHALTS_CH7ALTS_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS_DEFAULT                      (_DMA_CHALTS_CH7ALTS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTS */
+
+/* Bit fields for DMA CHALTC */
+#define _DMA_CHALTC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTC */
+#define _DMA_CHALTC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC                              (0x1UL << 0)                       /**< Channel 0 Alternate Clear */
+#define _DMA_CHALTC_CH0ALTC_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC_DEFAULT                      (_DMA_CHALTC_CH0ALTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC                              (0x1UL << 1)                       /**< Channel 1 Alternate Clear */
+#define _DMA_CHALTC_CH1ALTC_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC_DEFAULT                      (_DMA_CHALTC_CH1ALTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC                              (0x1UL << 2)                       /**< Channel 2 Alternate Clear */
+#define _DMA_CHALTC_CH2ALTC_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC_DEFAULT                      (_DMA_CHALTC_CH2ALTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC                              (0x1UL << 3)                       /**< Channel 3 Alternate Clear */
+#define _DMA_CHALTC_CH3ALTC_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC_DEFAULT                      (_DMA_CHALTC_CH3ALTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC                              (0x1UL << 4)                       /**< Channel 4 Alternate Clear */
+#define _DMA_CHALTC_CH4ALTC_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC_DEFAULT                      (_DMA_CHALTC_CH4ALTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC                              (0x1UL << 5)                       /**< Channel 5 Alternate Clear */
+#define _DMA_CHALTC_CH5ALTC_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC_DEFAULT                      (_DMA_CHALTC_CH5ALTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC                              (0x1UL << 6)                       /**< Channel 6 Alternate Clear */
+#define _DMA_CHALTC_CH6ALTC_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC_DEFAULT                      (_DMA_CHALTC_CH6ALTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC                              (0x1UL << 7)                       /**< Channel 7 Alternate Clear */
+#define _DMA_CHALTC_CH7ALTC_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC_DEFAULT                      (_DMA_CHALTC_CH7ALTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTC */
+
+/* Bit fields for DMA CHPRIS */
+#define _DMA_CHPRIS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIS */
+#define _DMA_CHPRIS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS                              (0x1UL << 0)                       /**< Channel 0 High Priority Set */
+#define _DMA_CHPRIS_CH0PRIS_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS_DEFAULT                      (_DMA_CHPRIS_CH0PRIS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS                              (0x1UL << 1)                       /**< Channel 1 High Priority Set */
+#define _DMA_CHPRIS_CH1PRIS_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS_DEFAULT                      (_DMA_CHPRIS_CH1PRIS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS                              (0x1UL << 2)                       /**< Channel 2 High Priority Set */
+#define _DMA_CHPRIS_CH2PRIS_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS_DEFAULT                      (_DMA_CHPRIS_CH2PRIS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS                              (0x1UL << 3)                       /**< Channel 3 High Priority Set */
+#define _DMA_CHPRIS_CH3PRIS_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS_DEFAULT                      (_DMA_CHPRIS_CH3PRIS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS                              (0x1UL << 4)                       /**< Channel 4 High Priority Set */
+#define _DMA_CHPRIS_CH4PRIS_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS_DEFAULT                      (_DMA_CHPRIS_CH4PRIS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS                              (0x1UL << 5)                       /**< Channel 5 High Priority Set */
+#define _DMA_CHPRIS_CH5PRIS_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS_DEFAULT                      (_DMA_CHPRIS_CH5PRIS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS                              (0x1UL << 6)                       /**< Channel 6 High Priority Set */
+#define _DMA_CHPRIS_CH6PRIS_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS_DEFAULT                      (_DMA_CHPRIS_CH6PRIS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS                              (0x1UL << 7)                       /**< Channel 7 High Priority Set */
+#define _DMA_CHPRIS_CH7PRIS_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS_DEFAULT                      (_DMA_CHPRIS_CH7PRIS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+
+/* Bit fields for DMA CHPRIC */
+#define _DMA_CHPRIC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIC */
+#define _DMA_CHPRIC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC                              (0x1UL << 0)                       /**< Channel 0 High Priority Clear */
+#define _DMA_CHPRIC_CH0PRIC_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC_DEFAULT                      (_DMA_CHPRIC_CH0PRIC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC                              (0x1UL << 1)                       /**< Channel 1 High Priority Clear */
+#define _DMA_CHPRIC_CH1PRIC_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC_DEFAULT                      (_DMA_CHPRIC_CH1PRIC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC                              (0x1UL << 2)                       /**< Channel 2 High Priority Clear */
+#define _DMA_CHPRIC_CH2PRIC_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC_DEFAULT                      (_DMA_CHPRIC_CH2PRIC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC                              (0x1UL << 3)                       /**< Channel 3 High Priority Clear */
+#define _DMA_CHPRIC_CH3PRIC_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC_DEFAULT                      (_DMA_CHPRIC_CH3PRIC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC                              (0x1UL << 4)                       /**< Channel 4 High Priority Clear */
+#define _DMA_CHPRIC_CH4PRIC_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC_DEFAULT                      (_DMA_CHPRIC_CH4PRIC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC                              (0x1UL << 5)                       /**< Channel 5 High Priority Clear */
+#define _DMA_CHPRIC_CH5PRIC_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC_DEFAULT                      (_DMA_CHPRIC_CH5PRIC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC                              (0x1UL << 6)                       /**< Channel 6 High Priority Clear */
+#define _DMA_CHPRIC_CH6PRIC_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC_DEFAULT                      (_DMA_CHPRIC_CH6PRIC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC                              (0x1UL << 7)                       /**< Channel 7 High Priority Clear */
+#define _DMA_CHPRIC_CH7PRIC_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC_DEFAULT                      (_DMA_CHPRIC_CH7PRIC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+
+/* Bit fields for DMA ERRORC */
+#define _DMA_ERRORC_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_ERRORC */
+#define _DMA_ERRORC_MASK                                0x00000001UL                      /**< Mask for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC                               (0x1UL << 0)                      /**< Bus Error Clear */
+#define _DMA_ERRORC_ERRORC_SHIFT                        0                                 /**< Shift value for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_MASK                         0x1UL                             /**< Bit mask for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC_DEFAULT                       (_DMA_ERRORC_ERRORC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ERRORC */
+
+/* Bit fields for DMA CHREQSTATUS */
+#define _DMA_CHREQSTATUS_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHREQSTATUS */
+#define _DMA_CHREQSTATUS_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS                    (0x1UL << 0)                                 /**< Channel 0 Request Status */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_SHIFT             0                                            /**< Shift value for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_MASK              0x1UL                                        /**< Bit mask for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS                    (0x1UL << 1)                                 /**< Channel 1 Request Status */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_SHIFT             1                                            /**< Shift value for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_MASK              0x2UL                                        /**< Bit mask for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS                    (0x1UL << 2)                                 /**< Channel 2 Request Status */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_SHIFT             2                                            /**< Shift value for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_MASK              0x4UL                                        /**< Bit mask for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS                    (0x1UL << 3)                                 /**< Channel 3 Request Status */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_SHIFT             3                                            /**< Shift value for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_MASK              0x8UL                                        /**< Bit mask for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS                    (0x1UL << 4)                                 /**< Channel 4 Request Status */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_SHIFT             4                                            /**< Shift value for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_MASK              0x10UL                                       /**< Bit mask for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS                    (0x1UL << 5)                                 /**< Channel 5 Request Status */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_SHIFT             5                                            /**< Shift value for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_MASK              0x20UL                                       /**< Bit mask for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS                    (0x1UL << 6)                                 /**< Channel 6 Request Status */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_SHIFT             6                                            /**< Shift value for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_MASK              0x40UL                                       /**< Bit mask for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS                    (0x1UL << 7)                                 /**< Channel 7 Request Status */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_SHIFT             7                                            /**< Shift value for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_MASK              0x80UL                                       /**< Bit mask for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+
+/* Bit fields for DMA CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_RESETVALUE                    0x00000000UL                                   /**< Default value for DMA_CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+
+/* Bit fields for DMA IF */
+#define _DMA_IF_RESETVALUE                              0x00000000UL                   /**< Default value for DMA_IF */
+#define _DMA_IF_MASK                                    0x800000FFUL                   /**< Mask for DMA_IF */
+#define DMA_IF_CH0DONE                                  (0x1UL << 0)                   /**< DMA Channel 0 Complete Interrupt Flag */
+#define _DMA_IF_CH0DONE_SHIFT                           0                              /**< Shift value for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_MASK                            0x1UL                          /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH0DONE_DEFAULT                          (_DMA_IF_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE                                  (0x1UL << 1)                   /**< DMA Channel 1 Complete Interrupt Flag */
+#define _DMA_IF_CH1DONE_SHIFT                           1                              /**< Shift value for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_MASK                            0x2UL                          /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE_DEFAULT                          (_DMA_IF_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE                                  (0x1UL << 2)                   /**< DMA Channel 2 Complete Interrupt Flag */
+#define _DMA_IF_CH2DONE_SHIFT                           2                              /**< Shift value for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_MASK                            0x4UL                          /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE_DEFAULT                          (_DMA_IF_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE                                  (0x1UL << 3)                   /**< DMA Channel 3 Complete Interrupt Flag */
+#define _DMA_IF_CH3DONE_SHIFT                           3                              /**< Shift value for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_MASK                            0x8UL                          /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE_DEFAULT                          (_DMA_IF_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE                                  (0x1UL << 4)                   /**< DMA Channel 4 Complete Interrupt Flag */
+#define _DMA_IF_CH4DONE_SHIFT                           4                              /**< Shift value for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_MASK                            0x10UL                         /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE_DEFAULT                          (_DMA_IF_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE                                  (0x1UL << 5)                   /**< DMA Channel 5 Complete Interrupt Flag */
+#define _DMA_IF_CH5DONE_SHIFT                           5                              /**< Shift value for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_MASK                            0x20UL                         /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE_DEFAULT                          (_DMA_IF_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE                                  (0x1UL << 6)                   /**< DMA Channel 6 Complete Interrupt Flag */
+#define _DMA_IF_CH6DONE_SHIFT                           6                              /**< Shift value for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_MASK                            0x40UL                         /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE_DEFAULT                          (_DMA_IF_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE                                  (0x1UL << 7)                   /**< DMA Channel 7 Complete Interrupt Flag */
+#define _DMA_IF_CH7DONE_SHIFT                           7                              /**< Shift value for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_MASK                            0x80UL                         /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE_DEFAULT                          (_DMA_IF_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR                                      (0x1UL << 31)                  /**< DMA Error Interrupt Flag */
+#define _DMA_IF_ERR_SHIFT                               31                             /**< Shift value for DMA_ERR */
+#define _DMA_IF_ERR_MASK                                0x80000000UL                   /**< Bit mask for DMA_ERR */
+#define _DMA_IF_ERR_DEFAULT                             0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR_DEFAULT                              (_DMA_IF_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IF */
+
+/* Bit fields for DMA IFS */
+#define _DMA_IFS_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFS */
+#define _DMA_IFS_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFS */
+#define DMA_IFS_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH0DONE_DEFAULT                         (_DMA_IFS_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE_DEFAULT                         (_DMA_IFS_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE_DEFAULT                         (_DMA_IFS_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE_DEFAULT                         (_DMA_IFS_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE_DEFAULT                         (_DMA_IFS_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE_DEFAULT                         (_DMA_IFS_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE_DEFAULT                         (_DMA_IFS_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE_DEFAULT                         (_DMA_IFS_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Set */
+#define _DMA_IFS_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFS_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFS_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR_DEFAULT                             (_DMA_IFS_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFS */
+
+/* Bit fields for DMA IFC */
+#define _DMA_IFC_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFC */
+#define _DMA_IFC_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFC */
+#define DMA_IFC_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH0DONE_DEFAULT                         (_DMA_IFC_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE_DEFAULT                         (_DMA_IFC_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE_DEFAULT                         (_DMA_IFC_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE_DEFAULT                         (_DMA_IFC_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE_DEFAULT                         (_DMA_IFC_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE_DEFAULT                         (_DMA_IFC_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE_DEFAULT                         (_DMA_IFC_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE_DEFAULT                         (_DMA_IFC_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Clear */
+#define _DMA_IFC_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFC_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFC_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR_DEFAULT                             (_DMA_IFC_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFC */
+
+/* Bit fields for DMA IEN */
+#define _DMA_IEN_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IEN */
+#define _DMA_IEN_MASK                                   0x800000FFUL                    /**< Mask for DMA_IEN */
+#define DMA_IEN_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Enable */
+#define _DMA_IEN_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH0DONE_DEFAULT                         (_DMA_IEN_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Enable */
+#define _DMA_IEN_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE_DEFAULT                         (_DMA_IEN_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Enable */
+#define _DMA_IEN_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE_DEFAULT                         (_DMA_IEN_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Enable */
+#define _DMA_IEN_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE_DEFAULT                         (_DMA_IEN_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Enable */
+#define _DMA_IEN_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE_DEFAULT                         (_DMA_IEN_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Enable */
+#define _DMA_IEN_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE_DEFAULT                         (_DMA_IEN_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Enable */
+#define _DMA_IEN_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE_DEFAULT                         (_DMA_IEN_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Enable */
+#define _DMA_IEN_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE_DEFAULT                         (_DMA_IEN_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Enable */
+#define _DMA_IEN_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IEN_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IEN_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR_DEFAULT                             (_DMA_IEN_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IEN */
+
+/* Bit fields for DMA CH_CTRL */
+#define _DMA_CH_CTRL_RESETVALUE                         0x00000000UL                                  /**< Default value for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_MASK                               0x003F000FUL                                  /**< Mask for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_SHIFT                       0                                             /**< Shift value for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_MASK                        0xFUL                                         /**< Bit mask for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAV               0x00000000UL                                  /**< Mode USART1RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV              0x00000000UL                                  /**< Mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                 0x00000000UL                                  /**< Mode I2C0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0UFOF                  0x00000000UL                                  /**< Mode TIMER0UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1UFOF                  0x00000000UL                                  /**< Mode TIMER1UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_MSCWDATA                    0x00000000UL                                  /**< Mode MSCWDATA for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV             0x00000000UL                                  /**< Mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBL                  0x00000001UL                                  /**< Mode USART1TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXBL                 0x00000001UL                                  /**< Mode LEUART0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0TXBL                    0x00000001UL                                  /**< Mode I2C0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC0                   0x00000001UL                                  /**< Mode TIMER0CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC0                   0x00000001UL                                  /**< Mode TIMER1CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXEMPTY               0x00000002UL                                  /**< Mode USART1TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY              0x00000002UL                                  /**< Mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC1                   0x00000002UL                                  /**< Mode TIMER0CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC1                   0x00000002UL                                  /**< Mode TIMER1CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT          0x00000003UL                                  /**< Mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC2                   0x00000003UL                                  /**< Mode TIMER0CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC2                   0x00000003UL                                  /**< Mode TIMER1CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT             0x00000004UL                                  /**< Mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAV                (_DMA_CH_CTRL_SIGSEL_USART1RXDATAV << 0)      /**< Shifted mode USART1RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV               (_DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV << 0)     /**< Shifted mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                  (_DMA_CH_CTRL_SIGSEL_I2C0RXDATAV << 0)        /**< Shifted mode I2C0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER0UFOF << 0)         /**< Shifted mode TIMER0UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER1UFOF << 0)         /**< Shifted mode TIMER1UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_MSCWDATA                     (_DMA_CH_CTRL_SIGSEL_MSCWDATA << 0)           /**< Shifted mode MSCWDATA for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV              (_DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV << 0)    /**< Shifted mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBL                   (_DMA_CH_CTRL_SIGSEL_USART1TXBL << 0)         /**< Shifted mode USART1TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXBL                  (_DMA_CH_CTRL_SIGSEL_LEUART0TXBL << 0)        /**< Shifted mode LEUART0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0TXBL                     (_DMA_CH_CTRL_SIGSEL_I2C0TXBL << 0)           /**< Shifted mode I2C0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC0 << 0)          /**< Shifted mode TIMER0CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC0 << 0)          /**< Shifted mode TIMER1CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXEMPTY                (_DMA_CH_CTRL_SIGSEL_USART1TXEMPTY << 0)      /**< Shifted mode USART1TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY               (_DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY << 0)     /**< Shifted mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC1 << 0)          /**< Shifted mode TIMER0CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC1 << 0)          /**< Shifted mode TIMER1CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT           (_DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT << 0) /**< Shifted mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC2 << 0)          /**< Shifted mode TIMER0CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC2 << 0)          /**< Shifted mode TIMER1CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT              (_DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT << 0)    /**< Shifted mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_SHIFT                    16                                            /**< Shift value for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_MASK                     0x3F0000UL                                    /**< Bit mask for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_NONE                     0x00000000UL                                  /**< Mode NONE for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_USART1                   0x0000000DUL                                  /**< Mode USART1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LEUART0                  0x00000010UL                                  /**< Mode LEUART0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_I2C0                     0x00000014UL                                  /**< Mode I2C0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER0                   0x00000018UL                                  /**< Mode TIMER0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER1                   0x00000019UL                                  /**< Mode TIMER1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_MSC                      0x00000030UL                                  /**< Mode MSC for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LESENSE                  0x00000032UL                                  /**< Mode LESENSE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_NONE                      (_DMA_CH_CTRL_SOURCESEL_NONE << 16)           /**< Shifted mode NONE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_USART1                    (_DMA_CH_CTRL_SOURCESEL_USART1 << 16)         /**< Shifted mode USART1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LEUART0                   (_DMA_CH_CTRL_SOURCESEL_LEUART0 << 16)        /**< Shifted mode LEUART0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_I2C0                      (_DMA_CH_CTRL_SOURCESEL_I2C0 << 16)           /**< Shifted mode I2C0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER0                    (_DMA_CH_CTRL_SOURCESEL_TIMER0 << 16)         /**< Shifted mode TIMER0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER1                    (_DMA_CH_CTRL_SOURCESEL_TIMER1 << 16)         /**< Shifted mode TIMER1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_MSC                       (_DMA_CH_CTRL_SOURCESEL_MSC << 16)            /**< Shifted mode MSC for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LESENSE                   (_DMA_CH_CTRL_SOURCESEL_LESENSE << 16)        /**< Shifted mode LESENSE for DMA_CH_CTRL */
+
+/** @} End of group EFM32TG108F8_DMA */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_CMU_BitFields  EFM32TG108F8_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000006UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x000009FBUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG108F8_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_PRS_BitFields  EFM32TG108F8_PRS Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for PRS SWPULSE */
+#define _PRS_SWPULSE_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWPULSE */
+#define _PRS_SWPULSE_MASK                       0x000000FFUL                         /**< Mask for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE                    (0x1UL << 0)                         /**< Channel 0 Pulse Generation */
+#define _PRS_SWPULSE_CH0PULSE_SHIFT             0                                    /**< Shift value for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_MASK              0x1UL                                /**< Bit mask for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE_DEFAULT            (_PRS_SWPULSE_CH0PULSE_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE                    (0x1UL << 1)                         /**< Channel 1 Pulse Generation */
+#define _PRS_SWPULSE_CH1PULSE_SHIFT             1                                    /**< Shift value for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_MASK              0x2UL                                /**< Bit mask for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE_DEFAULT            (_PRS_SWPULSE_CH1PULSE_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE                    (0x1UL << 2)                         /**< Channel 2 Pulse Generation */
+#define _PRS_SWPULSE_CH2PULSE_SHIFT             2                                    /**< Shift value for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_MASK              0x4UL                                /**< Bit mask for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE_DEFAULT            (_PRS_SWPULSE_CH2PULSE_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE                    (0x1UL << 3)                         /**< Channel 3 Pulse Generation */
+#define _PRS_SWPULSE_CH3PULSE_SHIFT             3                                    /**< Shift value for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_MASK              0x8UL                                /**< Bit mask for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE_DEFAULT            (_PRS_SWPULSE_CH3PULSE_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE                    (0x1UL << 4)                         /**< Channel 4 Pulse Generation */
+#define _PRS_SWPULSE_CH4PULSE_SHIFT             4                                    /**< Shift value for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_MASK              0x10UL                               /**< Bit mask for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE_DEFAULT            (_PRS_SWPULSE_CH4PULSE_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE                    (0x1UL << 5)                         /**< Channel 5 Pulse Generation */
+#define _PRS_SWPULSE_CH5PULSE_SHIFT             5                                    /**< Shift value for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_MASK              0x20UL                               /**< Bit mask for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE_DEFAULT            (_PRS_SWPULSE_CH5PULSE_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE                    (0x1UL << 6)                         /**< Channel 6 Pulse Generation */
+#define _PRS_SWPULSE_CH6PULSE_SHIFT             6                                    /**< Shift value for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_MASK              0x40UL                               /**< Bit mask for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE_DEFAULT            (_PRS_SWPULSE_CH6PULSE_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE                    (0x1UL << 7)                         /**< Channel 7 Pulse Generation */
+#define _PRS_SWPULSE_CH7PULSE_SHIFT             7                                    /**< Shift value for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_MASK              0x80UL                               /**< Bit mask for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE_DEFAULT            (_PRS_SWPULSE_CH7PULSE_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+
+/* Bit fields for PRS SWLEVEL */
+#define _PRS_SWLEVEL_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWLEVEL */
+#define _PRS_SWLEVEL_MASK                       0x000000FFUL                         /**< Mask for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL                    (0x1UL << 0)                         /**< Channel 0 Software Level */
+#define _PRS_SWLEVEL_CH0LEVEL_SHIFT             0                                    /**< Shift value for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_MASK              0x1UL                                /**< Bit mask for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL_DEFAULT            (_PRS_SWLEVEL_CH0LEVEL_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL                    (0x1UL << 1)                         /**< Channel 1 Software Level */
+#define _PRS_SWLEVEL_CH1LEVEL_SHIFT             1                                    /**< Shift value for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_MASK              0x2UL                                /**< Bit mask for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL_DEFAULT            (_PRS_SWLEVEL_CH1LEVEL_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL                    (0x1UL << 2)                         /**< Channel 2 Software Level */
+#define _PRS_SWLEVEL_CH2LEVEL_SHIFT             2                                    /**< Shift value for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_MASK              0x4UL                                /**< Bit mask for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL_DEFAULT            (_PRS_SWLEVEL_CH2LEVEL_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL                    (0x1UL << 3)                         /**< Channel 3 Software Level */
+#define _PRS_SWLEVEL_CH3LEVEL_SHIFT             3                                    /**< Shift value for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_MASK              0x8UL                                /**< Bit mask for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL_DEFAULT            (_PRS_SWLEVEL_CH3LEVEL_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL                    (0x1UL << 4)                         /**< Channel 4 Software Level */
+#define _PRS_SWLEVEL_CH4LEVEL_SHIFT             4                                    /**< Shift value for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_MASK              0x10UL                               /**< Bit mask for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL_DEFAULT            (_PRS_SWLEVEL_CH4LEVEL_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL                    (0x1UL << 5)                         /**< Channel 5 Software Level */
+#define _PRS_SWLEVEL_CH5LEVEL_SHIFT             5                                    /**< Shift value for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_MASK              0x20UL                               /**< Bit mask for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL_DEFAULT            (_PRS_SWLEVEL_CH5LEVEL_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL                    (0x1UL << 6)                         /**< Channel 6 Software Level */
+#define _PRS_SWLEVEL_CH6LEVEL_SHIFT             6                                    /**< Shift value for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_MASK              0x40UL                               /**< Bit mask for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL_DEFAULT            (_PRS_SWLEVEL_CH6LEVEL_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL                    (0x1UL << 7)                         /**< Channel 7 Software Level */
+#define _PRS_SWLEVEL_CH7LEVEL_SHIFT             7                                    /**< Shift value for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_MASK              0x80UL                               /**< Bit mask for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL_DEFAULT            (_PRS_SWLEVEL_CH7LEVEL_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+
+/* Bit fields for PRS ROUTE */
+#define _PRS_ROUTE_RESETVALUE                   0x00000000UL                       /**< Default value for PRS_ROUTE */
+#define _PRS_ROUTE_MASK                         0x0000070FUL                       /**< Mask for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN                        (0x1UL << 0)                       /**< CH0 Pin Enable */
+#define _PRS_ROUTE_CH0PEN_SHIFT                 0                                  /**< Shift value for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_MASK                  0x1UL                              /**< Bit mask for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN_DEFAULT                (_PRS_ROUTE_CH0PEN_DEFAULT << 0)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN                        (0x1UL << 1)                       /**< CH1 Pin Enable */
+#define _PRS_ROUTE_CH1PEN_SHIFT                 1                                  /**< Shift value for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_MASK                  0x2UL                              /**< Bit mask for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN_DEFAULT                (_PRS_ROUTE_CH1PEN_DEFAULT << 1)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN                        (0x1UL << 2)                       /**< CH2 Pin Enable */
+#define _PRS_ROUTE_CH2PEN_SHIFT                 2                                  /**< Shift value for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_MASK                  0x4UL                              /**< Bit mask for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN_DEFAULT                (_PRS_ROUTE_CH2PEN_DEFAULT << 2)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN                        (0x1UL << 3)                       /**< CH3 Pin Enable */
+#define _PRS_ROUTE_CH3PEN_SHIFT                 3                                  /**< Shift value for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_MASK                  0x8UL                              /**< Bit mask for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN_DEFAULT                (_PRS_ROUTE_CH3PEN_DEFAULT << 3)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_SHIFT               8                                  /**< Shift value for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_MASK                0x700UL                            /**< Bit mask for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_LOC0                0x00000000UL                       /**< Mode LOC0 for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_DEFAULT             0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_LOC1                0x00000001UL                       /**< Mode LOC1 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC0                 (_PRS_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_DEFAULT              (_PRS_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC1                 (_PRS_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for PRS_ROUTE */
+
+/* Bit fields for PRS CH_CTRL */
+#define _PRS_CH_CTRL_RESETVALUE                 0x00000000UL                                /**< Default value for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_MASK                       0x133F0007UL                                /**< Mask for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_SHIFT               0                                           /**< Shift value for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_MASK                0x7UL                                       /**< Bit mask for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_VCMPOUT             0x00000000UL                                /**< Mode VCMPOUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP0OUT            0x00000000UL                                /**< Mode ACMP0OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP1OUT            0x00000000UL                                /**< Mode ACMP1OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0UF            0x00000000UL                                /**< Mode TIMER0UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1UF            0x00000000UL                                /**< Mode TIMER1UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCOF               0x00000000UL                                /**< Mode RTCOF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN0            0x00000000UL                                /**< Mode GPIOPIN0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN8            0x00000000UL                                /**< Mode GPIOPIN8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH0         0x00000000UL                                /**< Mode LETIMER0CH0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES0     0x00000000UL                                /**< Mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES8     0x00000000UL                                /**< Mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC0         0x00000000UL                                /**< Mode LESENSEDEC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1TXC           0x00000001UL                                /**< Mode USART1TXC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0OF            0x00000001UL                                /**< Mode TIMER0OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1OF            0x00000001UL                                /**< Mode TIMER1OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP0            0x00000001UL                                /**< Mode RTCCOMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN1            0x00000001UL                                /**< Mode GPIOPIN1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN9            0x00000001UL                                /**< Mode GPIOPIN9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH1         0x00000001UL                                /**< Mode LETIMER0CH1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES1     0x00000001UL                                /**< Mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES9     0x00000001UL                                /**< Mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC1         0x00000001UL                                /**< Mode LESENSEDEC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1RXDATAV       0x00000002UL                                /**< Mode USART1RXDATAV for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC0           0x00000002UL                                /**< Mode TIMER0CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC0           0x00000002UL                                /**< Mode TIMER1CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP1            0x00000002UL                                /**< Mode RTCCOMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN2            0x00000002UL                                /**< Mode GPIOPIN2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN10           0x00000002UL                                /**< Mode GPIOPIN10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES2     0x00000002UL                                /**< Mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES10    0x00000002UL                                /**< Mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC2         0x00000002UL                                /**< Mode LESENSEDEC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC1           0x00000003UL                                /**< Mode TIMER0CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC1           0x00000003UL                                /**< Mode TIMER1CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN3            0x00000003UL                                /**< Mode GPIOPIN3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN11           0x00000003UL                                /**< Mode GPIOPIN11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES3     0x00000003UL                                /**< Mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES11    0x00000003UL                                /**< Mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC2           0x00000004UL                                /**< Mode TIMER0CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC2           0x00000004UL                                /**< Mode TIMER1CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN4            0x00000004UL                                /**< Mode GPIOPIN4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN12           0x00000004UL                                /**< Mode GPIOPIN12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES4     0x00000004UL                                /**< Mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES12    0x00000004UL                                /**< Mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN5            0x00000005UL                                /**< Mode GPIOPIN5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN13           0x00000005UL                                /**< Mode GPIOPIN13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES5     0x00000005UL                                /**< Mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES13    0x00000005UL                                /**< Mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN6            0x00000006UL                                /**< Mode GPIOPIN6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN14           0x00000006UL                                /**< Mode GPIOPIN14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES6     0x00000006UL                                /**< Mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES14    0x00000006UL                                /**< Mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN7            0x00000007UL                                /**< Mode GPIOPIN7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN15           0x00000007UL                                /**< Mode GPIOPIN15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES7     0x00000007UL                                /**< Mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES15    0x00000007UL                                /**< Mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_VCMPOUT              (_PRS_CH_CTRL_SIGSEL_VCMPOUT << 0)          /**< Shifted mode VCMPOUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP0OUT             (_PRS_CH_CTRL_SIGSEL_ACMP0OUT << 0)         /**< Shifted mode ACMP0OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP1OUT             (_PRS_CH_CTRL_SIGSEL_ACMP1OUT << 0)         /**< Shifted mode ACMP1OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0UF             (_PRS_CH_CTRL_SIGSEL_TIMER0UF << 0)         /**< Shifted mode TIMER0UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1UF             (_PRS_CH_CTRL_SIGSEL_TIMER1UF << 0)         /**< Shifted mode TIMER1UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCOF                (_PRS_CH_CTRL_SIGSEL_RTCOF << 0)            /**< Shifted mode RTCOF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN0             (_PRS_CH_CTRL_SIGSEL_GPIOPIN0 << 0)         /**< Shifted mode GPIOPIN0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN8             (_PRS_CH_CTRL_SIGSEL_GPIOPIN8 << 0)         /**< Shifted mode GPIOPIN8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH0          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH0 << 0)      /**< Shifted mode LETIMER0CH0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES0      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES0 << 0)  /**< Shifted mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES8      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES8 << 0)  /**< Shifted mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC0          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC0 << 0)      /**< Shifted mode LESENSEDEC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1TXC            (_PRS_CH_CTRL_SIGSEL_USART1TXC << 0)        /**< Shifted mode USART1TXC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0OF             (_PRS_CH_CTRL_SIGSEL_TIMER0OF << 0)         /**< Shifted mode TIMER0OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1OF             (_PRS_CH_CTRL_SIGSEL_TIMER1OF << 0)         /**< Shifted mode TIMER1OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP0             (_PRS_CH_CTRL_SIGSEL_RTCCOMP0 << 0)         /**< Shifted mode RTCCOMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN1             (_PRS_CH_CTRL_SIGSEL_GPIOPIN1 << 0)         /**< Shifted mode GPIOPIN1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN9             (_PRS_CH_CTRL_SIGSEL_GPIOPIN9 << 0)         /**< Shifted mode GPIOPIN9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH1          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH1 << 0)      /**< Shifted mode LETIMER0CH1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES1      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES1 << 0)  /**< Shifted mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES9      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES9 << 0)  /**< Shifted mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC1          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC1 << 0)      /**< Shifted mode LESENSEDEC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1RXDATAV        (_PRS_CH_CTRL_SIGSEL_USART1RXDATAV << 0)    /**< Shifted mode USART1RXDATAV for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC0            (_PRS_CH_CTRL_SIGSEL_TIMER0CC0 << 0)        /**< Shifted mode TIMER0CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC0            (_PRS_CH_CTRL_SIGSEL_TIMER1CC0 << 0)        /**< Shifted mode TIMER1CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP1             (_PRS_CH_CTRL_SIGSEL_RTCCOMP1 << 0)         /**< Shifted mode RTCCOMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN2             (_PRS_CH_CTRL_SIGSEL_GPIOPIN2 << 0)         /**< Shifted mode GPIOPIN2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN10            (_PRS_CH_CTRL_SIGSEL_GPIOPIN10 << 0)        /**< Shifted mode GPIOPIN10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES2      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES2 << 0)  /**< Shifted mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES10     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES10 << 0) /**< Shifted mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC2          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC2 << 0)      /**< Shifted mode LESENSEDEC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC1            (_PRS_CH_CTRL_SIGSEL_TIMER0CC1 << 0)        /**< Shifted mode TIMER0CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC1            (_PRS_CH_CTRL_SIGSEL_TIMER1CC1 << 0)        /**< Shifted mode TIMER1CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN3             (_PRS_CH_CTRL_SIGSEL_GPIOPIN3 << 0)         /**< Shifted mode GPIOPIN3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN11            (_PRS_CH_CTRL_SIGSEL_GPIOPIN11 << 0)        /**< Shifted mode GPIOPIN11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES3      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES3 << 0)  /**< Shifted mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES11     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES11 << 0) /**< Shifted mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC2            (_PRS_CH_CTRL_SIGSEL_TIMER0CC2 << 0)        /**< Shifted mode TIMER0CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC2            (_PRS_CH_CTRL_SIGSEL_TIMER1CC2 << 0)        /**< Shifted mode TIMER1CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN4             (_PRS_CH_CTRL_SIGSEL_GPIOPIN4 << 0)         /**< Shifted mode GPIOPIN4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN12            (_PRS_CH_CTRL_SIGSEL_GPIOPIN12 << 0)        /**< Shifted mode GPIOPIN12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES4      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES4 << 0)  /**< Shifted mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES12     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES12 << 0) /**< Shifted mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN5             (_PRS_CH_CTRL_SIGSEL_GPIOPIN5 << 0)         /**< Shifted mode GPIOPIN5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN13            (_PRS_CH_CTRL_SIGSEL_GPIOPIN13 << 0)        /**< Shifted mode GPIOPIN13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES5      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES5 << 0)  /**< Shifted mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES13     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES13 << 0) /**< Shifted mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN6             (_PRS_CH_CTRL_SIGSEL_GPIOPIN6 << 0)         /**< Shifted mode GPIOPIN6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN14            (_PRS_CH_CTRL_SIGSEL_GPIOPIN14 << 0)        /**< Shifted mode GPIOPIN14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES6      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES6 << 0)  /**< Shifted mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES14     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES14 << 0) /**< Shifted mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN7             (_PRS_CH_CTRL_SIGSEL_GPIOPIN7 << 0)         /**< Shifted mode GPIOPIN7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN15            (_PRS_CH_CTRL_SIGSEL_GPIOPIN15 << 0)        /**< Shifted mode GPIOPIN15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES7      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES7 << 0)  /**< Shifted mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES15     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES15 << 0) /**< Shifted mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_SHIFT            16                                          /**< Shift value for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_MASK             0x3F0000UL                                  /**< Bit mask for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_NONE             0x00000000UL                                /**< Mode NONE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_VCMP             0x00000001UL                                /**< Mode VCMP for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP0            0x00000002UL                                /**< Mode ACMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP1            0x00000003UL                                /**< Mode ACMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_USART1           0x00000011UL                                /**< Mode USART1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER0           0x0000001CUL                                /**< Mode TIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER1           0x0000001DUL                                /**< Mode TIMER1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_RTC              0x00000028UL                                /**< Mode RTC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOL            0x00000030UL                                /**< Mode GPIOL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOH            0x00000031UL                                /**< Mode GPIOH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LETIMER0         0x00000034UL                                /**< Mode LETIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEL         0x00000039UL                                /**< Mode LESENSEL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEH         0x0000003AUL                                /**< Mode LESENSEH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSED         0x0000003BUL                                /**< Mode LESENSED for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_NONE              (_PRS_CH_CTRL_SOURCESEL_NONE << 16)         /**< Shifted mode NONE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_VCMP              (_PRS_CH_CTRL_SOURCESEL_VCMP << 16)         /**< Shifted mode VCMP for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP0             (_PRS_CH_CTRL_SOURCESEL_ACMP0 << 16)        /**< Shifted mode ACMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP1             (_PRS_CH_CTRL_SOURCESEL_ACMP1 << 16)        /**< Shifted mode ACMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_USART1            (_PRS_CH_CTRL_SOURCESEL_USART1 << 16)       /**< Shifted mode USART1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER0            (_PRS_CH_CTRL_SOURCESEL_TIMER0 << 16)       /**< Shifted mode TIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER1            (_PRS_CH_CTRL_SOURCESEL_TIMER1 << 16)       /**< Shifted mode TIMER1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_RTC               (_PRS_CH_CTRL_SOURCESEL_RTC << 16)          /**< Shifted mode RTC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOL             (_PRS_CH_CTRL_SOURCESEL_GPIOL << 16)        /**< Shifted mode GPIOL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOH             (_PRS_CH_CTRL_SOURCESEL_GPIOH << 16)        /**< Shifted mode GPIOH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LETIMER0          (_PRS_CH_CTRL_SOURCESEL_LETIMER0 << 16)     /**< Shifted mode LETIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEL          (_PRS_CH_CTRL_SOURCESEL_LESENSEL << 16)     /**< Shifted mode LESENSEL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEH          (_PRS_CH_CTRL_SOURCESEL_LESENSEH << 16)     /**< Shifted mode LESENSEH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSED          (_PRS_CH_CTRL_SOURCESEL_LESENSED << 16)     /**< Shifted mode LESENSED for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_SHIFT                24                                          /**< Shift value for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_MASK                 0x3000000UL                                 /**< Bit mask for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_OFF                  0x00000000UL                                /**< Mode OFF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_POSEDGE              0x00000001UL                                /**< Mode POSEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_NEGEDGE              0x00000002UL                                /**< Mode NEGEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_BOTHEDGES            0x00000003UL                                /**< Mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_DEFAULT               (_PRS_CH_CTRL_EDSEL_DEFAULT << 24)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_OFF                   (_PRS_CH_CTRL_EDSEL_OFF << 24)              /**< Shifted mode OFF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_POSEDGE               (_PRS_CH_CTRL_EDSEL_POSEDGE << 24)          /**< Shifted mode POSEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_NEGEDGE               (_PRS_CH_CTRL_EDSEL_NEGEDGE << 24)          /**< Shifted mode NEGEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_BOTHEDGES             (_PRS_CH_CTRL_EDSEL_BOTHEDGES << 24)        /**< Shifted mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC                       (0x1UL << 28)                               /**< Asynchronous reflex */
+#define _PRS_CH_CTRL_ASYNC_SHIFT                28                                          /**< Shift value for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_MASK                 0x10000000UL                                /**< Bit mask for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC_DEFAULT               (_PRS_CH_CTRL_ASYNC_DEFAULT << 28)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+
+/** @} End of group EFM32TG108F8_PRS */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_UNLOCK EFM32TG108F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG108F8_UNLOCK */
+
+/** @} End of group EFM32TG108F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG108F8_Alternate_Function EFM32TG108F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG108F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG108F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG108F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg110f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg110f16.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG110F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG110F16_H
+#define EFM32TG110F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16 EFM32TG110F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_Core EFM32TG110F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG110F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_Part EFM32TG110F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG110F16)
+#define EFM32TG110F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG110F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG110F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG110F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_Peripheral_TypeDefs EFM32TG110F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_CMU EFM32TG110F16 CMU
+ * @brief EFM32TG110F16_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG110F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_Peripheral_Base EFM32TG110F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG110F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_Peripheral_Declaration  EFM32TG110F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG110F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_BitFields EFM32TG110F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_CMU_BitFields  EFM32TG110F16_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG110F16_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_UNLOCK EFM32TG110F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG110F16_UNLOCK */
+
+/** @} End of group EFM32TG110F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F16_Alternate_Function EFM32TG110F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG110F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG110F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG110F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg110f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg110f32.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG110F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG110F32_H
+#define EFM32TG110F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32 EFM32TG110F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_Core EFM32TG110F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG110F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_Part EFM32TG110F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG110F32)
+#define EFM32TG110F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG110F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG110F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG110F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_Peripheral_TypeDefs EFM32TG110F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_CMU EFM32TG110F32 CMU
+ * @brief EFM32TG110F32_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG110F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_Peripheral_Base EFM32TG110F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG110F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_Peripheral_Declaration  EFM32TG110F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG110F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_BitFields EFM32TG110F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_CMU_BitFields  EFM32TG110F32_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG110F32_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_UNLOCK EFM32TG110F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG110F32_UNLOCK */
+
+/** @} End of group EFM32TG110F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F32_Alternate_Function EFM32TG110F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG110F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG110F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG110F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg110f4.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg110f4.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG110F4
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG110F4_H
+#define EFM32TG110F4_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4 EFM32TG110F4
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_Core EFM32TG110F4 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG110F4_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_Part EFM32TG110F4 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG110F4)
+#define EFM32TG110F4    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG110F4" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG110F4 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00001000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG110F4_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_Peripheral_TypeDefs EFM32TG110F4 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_CMU EFM32TG110F4 CMU
+ * @brief EFM32TG110F4_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG110F4_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_Peripheral_Base EFM32TG110F4 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG110F4_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_Peripheral_Declaration  EFM32TG110F4 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG110F4_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_BitFields EFM32TG110F4 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_CMU_BitFields  EFM32TG110F4_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG110F4_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_UNLOCK EFM32TG110F4 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG110F4_UNLOCK */
+
+/** @} End of group EFM32TG110F4_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F4_Alternate_Function EFM32TG110F4 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG110F4_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG110F4  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG110F4_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg110f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg110f8.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG110F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG110F8_H
+#define EFM32TG110F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8 EFM32TG110F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_Core EFM32TG110F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG110F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_Part EFM32TG110F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG110F8)
+#define EFM32TG110F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG110F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG110F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG110F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_Peripheral_TypeDefs EFM32TG110F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_CMU EFM32TG110F8 CMU
+ * @brief EFM32TG110F8_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG110F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_Peripheral_Base EFM32TG110F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG110F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_Peripheral_Declaration  EFM32TG110F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG110F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_BitFields EFM32TG110F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_CMU_BitFields  EFM32TG110F8_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG110F8_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_UNLOCK EFM32TG110F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG110F8_UNLOCK */
+
+/** @} End of group EFM32TG110F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG110F8_Alternate_Function EFM32TG110F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG110F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG110F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG110F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg210f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg210f16.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG210F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG210F16_H
+#define EFM32TG210F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16 EFM32TG210F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_Core EFM32TG210F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG210F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_Part EFM32TG210F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG210F16)
+#define EFM32TG210F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG210F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG210F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG210F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_Peripheral_TypeDefs EFM32TG210F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_CMU EFM32TG210F16 CMU
+ * @brief EFM32TG210F16_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG210F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_Peripheral_Base EFM32TG210F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG210F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_Peripheral_Declaration  EFM32TG210F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG210F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_BitFields EFM32TG210F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_CMU_BitFields  EFM32TG210F16_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG210F16_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_UNLOCK EFM32TG210F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG210F16_UNLOCK */
+
+/** @} End of group EFM32TG210F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F16_Alternate_Function EFM32TG210F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG210F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG210F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG210F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg210f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg210f32.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG210F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG210F32_H
+#define EFM32TG210F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32 EFM32TG210F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_Core EFM32TG210F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG210F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_Part EFM32TG210F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG210F32)
+#define EFM32TG210F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG210F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG210F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG210F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_Peripheral_TypeDefs EFM32TG210F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_CMU EFM32TG210F32 CMU
+ * @brief EFM32TG210F32_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG210F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_Peripheral_Base EFM32TG210F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG210F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_Peripheral_Declaration  EFM32TG210F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG210F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_BitFields EFM32TG210F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_CMU_BitFields  EFM32TG210F32_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG210F32_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_UNLOCK EFM32TG210F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG210F32_UNLOCK */
+
+/** @} End of group EFM32TG210F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F32_Alternate_Function EFM32TG210F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG210F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG210F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG210F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg210f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg210f8.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG210F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG210F8_H
+#define EFM32TG210F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8 EFM32TG210F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_Core EFM32TG210F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG210F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_Part EFM32TG210F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG210F8)
+#define EFM32TG210F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG210F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG210F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG210F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_Peripheral_TypeDefs EFM32TG210F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_CMU EFM32TG210F8 CMU
+ * @brief EFM32TG210F8_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG210F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_Peripheral_Base EFM32TG210F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG210F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_Peripheral_Declaration  EFM32TG210F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG210F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_BitFields EFM32TG210F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_CMU_BitFields  EFM32TG210F8_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG210F8_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_UNLOCK EFM32TG210F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG210F8_UNLOCK */
+
+/** @} End of group EFM32TG210F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG210F8_Alternate_Function EFM32TG210F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG210F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG210F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG210F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg222f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg222f16.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG222F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG222F16_H
+#define EFM32TG222F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16 EFM32TG222F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_Core EFM32TG222F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG222F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_Part EFM32TG222F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG222F16)
+#define EFM32TG222F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG222F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG222F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG222F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_Peripheral_TypeDefs EFM32TG222F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_CMU EFM32TG222F16 CMU
+ * @brief EFM32TG222F16_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG222F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_Peripheral_Base EFM32TG222F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG222F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_Peripheral_Declaration  EFM32TG222F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG222F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_BitFields EFM32TG222F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_CMU_BitFields  EFM32TG222F16_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG222F16_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_UNLOCK EFM32TG222F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG222F16_UNLOCK */
+
+/** @} End of group EFM32TG222F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F16_Alternate_Function EFM32TG222F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG222F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG222F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG222F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg222f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg222f32.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG222F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG222F32_H
+#define EFM32TG222F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32 EFM32TG222F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_Core EFM32TG222F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG222F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_Part EFM32TG222F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG222F32)
+#define EFM32TG222F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG222F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG222F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG222F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_Peripheral_TypeDefs EFM32TG222F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_CMU EFM32TG222F32 CMU
+ * @brief EFM32TG222F32_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG222F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_Peripheral_Base EFM32TG222F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG222F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_Peripheral_Declaration  EFM32TG222F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG222F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_BitFields EFM32TG222F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_CMU_BitFields  EFM32TG222F32_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG222F32_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_UNLOCK EFM32TG222F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG222F32_UNLOCK */
+
+/** @} End of group EFM32TG222F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F32_Alternate_Function EFM32TG222F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG222F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG222F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG222F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg222f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg222f8.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG222F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG222F8_H
+#define EFM32TG222F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8 EFM32TG222F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_Core EFM32TG222F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG222F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_Part EFM32TG222F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG222F8)
+#define EFM32TG222F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG222F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG222F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG222F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_Peripheral_TypeDefs EFM32TG222F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_CMU EFM32TG222F8 CMU
+ * @brief EFM32TG222F8_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG222F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_Peripheral_Base EFM32TG222F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG222F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_Peripheral_Declaration  EFM32TG222F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG222F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_BitFields EFM32TG222F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_CMU_BitFields  EFM32TG222F8_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG222F8_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_UNLOCK EFM32TG222F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG222F8_UNLOCK */
+
+/** @} End of group EFM32TG222F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG222F8_Alternate_Function EFM32TG222F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG222F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG222F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG222F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg225f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg225f16.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG225F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG225F16_H
+#define EFM32TG225F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16 EFM32TG225F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_Core EFM32TG225F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG225F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_Part EFM32TG225F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG225F16)
+#define EFM32TG225F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG225F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG225F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG225F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_Peripheral_TypeDefs EFM32TG225F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_CMU EFM32TG225F16 CMU
+ * @brief EFM32TG225F16_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG225F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_Peripheral_Base EFM32TG225F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG225F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_Peripheral_Declaration  EFM32TG225F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG225F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_BitFields EFM32TG225F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_CMU_BitFields  EFM32TG225F16_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG225F16_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_UNLOCK EFM32TG225F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG225F16_UNLOCK */
+
+/** @} End of group EFM32TG225F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F16_Alternate_Function EFM32TG225F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG225F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG225F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG225F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg225f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg225f32.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG225F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG225F32_H
+#define EFM32TG225F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32 EFM32TG225F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_Core EFM32TG225F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG225F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_Part EFM32TG225F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG225F32)
+#define EFM32TG225F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG225F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG225F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG225F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_Peripheral_TypeDefs EFM32TG225F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_CMU EFM32TG225F32 CMU
+ * @brief EFM32TG225F32_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG225F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_Peripheral_Base EFM32TG225F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG225F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_Peripheral_Declaration  EFM32TG225F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG225F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_BitFields EFM32TG225F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_CMU_BitFields  EFM32TG225F32_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG225F32_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_UNLOCK EFM32TG225F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG225F32_UNLOCK */
+
+/** @} End of group EFM32TG225F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F32_Alternate_Function EFM32TG225F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG225F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG225F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG225F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg225f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg225f8.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG225F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG225F8_H
+#define EFM32TG225F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8 EFM32TG225F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_Core EFM32TG225F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG225F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_Part EFM32TG225F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG225F8)
+#define EFM32TG225F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG225F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG225F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG225F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_Peripheral_TypeDefs EFM32TG225F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_CMU EFM32TG225F8 CMU
+ * @brief EFM32TG225F8_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG225F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_Peripheral_Base EFM32TG225F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG225F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_Peripheral_Declaration  EFM32TG225F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG225F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_BitFields EFM32TG225F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_CMU_BitFields  EFM32TG225F8_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG225F8_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_UNLOCK EFM32TG225F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG225F8_UNLOCK */
+
+/** @} End of group EFM32TG225F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG225F8_Alternate_Function EFM32TG225F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG225F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG225F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG225F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg230f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg230f16.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG230F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG230F16_H
+#define EFM32TG230F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16 EFM32TG230F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_Core EFM32TG230F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG230F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_Part EFM32TG230F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG230F16)
+#define EFM32TG230F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG230F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG230F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG230F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_Peripheral_TypeDefs EFM32TG230F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_CMU EFM32TG230F16 CMU
+ * @brief EFM32TG230F16_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG230F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_Peripheral_Base EFM32TG230F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG230F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_Peripheral_Declaration  EFM32TG230F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG230F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_BitFields EFM32TG230F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_CMU_BitFields  EFM32TG230F16_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG230F16_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_UNLOCK EFM32TG230F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG230F16_UNLOCK */
+
+/** @} End of group EFM32TG230F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F16_Alternate_Function EFM32TG230F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG230F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG230F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG230F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg230f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg230f32.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG230F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG230F32_H
+#define EFM32TG230F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32 EFM32TG230F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_Core EFM32TG230F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG230F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_Part EFM32TG230F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG230F32)
+#define EFM32TG230F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG230F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG230F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG230F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_Peripheral_TypeDefs EFM32TG230F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_CMU EFM32TG230F32 CMU
+ * @brief EFM32TG230F32_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG230F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_Peripheral_Base EFM32TG230F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG230F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_Peripheral_Declaration  EFM32TG230F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG230F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_BitFields EFM32TG230F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_CMU_BitFields  EFM32TG230F32_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG230F32_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_UNLOCK EFM32TG230F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG230F32_UNLOCK */
+
+/** @} End of group EFM32TG230F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F32_Alternate_Function EFM32TG230F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG230F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG230F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG230F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg230f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg230f8.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG230F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG230F8_H
+#define EFM32TG230F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8 EFM32TG230F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_Core EFM32TG230F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG230F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_Part EFM32TG230F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG230F8)
+#define EFM32TG230F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG230F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG230F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG230F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_Peripheral_TypeDefs EFM32TG230F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_CMU EFM32TG230F8 CMU
+ * @brief EFM32TG230F8_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG230F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_Peripheral_Base EFM32TG230F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG230F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_Peripheral_Declaration  EFM32TG230F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG230F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_BitFields EFM32TG230F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_CMU_BitFields  EFM32TG230F8_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG230F8_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_UNLOCK EFM32TG230F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG230F8_UNLOCK */
+
+/** @} End of group EFM32TG230F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG230F8_Alternate_Function EFM32TG230F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG230F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG230F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG230F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg232f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg232f16.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG232F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG232F16_H
+#define EFM32TG232F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16 EFM32TG232F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_Core EFM32TG232F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG232F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_Part EFM32TG232F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG232F16)
+#define EFM32TG232F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG232F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG232F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG232F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_Peripheral_TypeDefs EFM32TG232F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_CMU EFM32TG232F16 CMU
+ * @brief EFM32TG232F16_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG232F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_Peripheral_Base EFM32TG232F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG232F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_Peripheral_Declaration  EFM32TG232F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG232F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_BitFields EFM32TG232F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_CMU_BitFields  EFM32TG232F16_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG232F16_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_UNLOCK EFM32TG232F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG232F16_UNLOCK */
+
+/** @} End of group EFM32TG232F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F16_Alternate_Function EFM32TG232F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG232F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG232F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG232F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg232f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg232f32.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG232F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG232F32_H
+#define EFM32TG232F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32 EFM32TG232F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_Core EFM32TG232F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG232F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_Part EFM32TG232F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG232F32)
+#define EFM32TG232F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG232F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG232F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG232F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_Peripheral_TypeDefs EFM32TG232F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_CMU EFM32TG232F32 CMU
+ * @brief EFM32TG232F32_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG232F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_Peripheral_Base EFM32TG232F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG232F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_Peripheral_Declaration  EFM32TG232F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG232F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_BitFields EFM32TG232F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_CMU_BitFields  EFM32TG232F32_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG232F32_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_UNLOCK EFM32TG232F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG232F32_UNLOCK */
+
+/** @} End of group EFM32TG232F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F32_Alternate_Function EFM32TG232F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG232F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG232F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG232F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg232f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg232f8.h
@@ -1,0 +1,1416 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG232F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG232F8_H
+#define EFM32TG232F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8 EFM32TG232F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_Core EFM32TG232F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG232F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_Part EFM32TG232F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG232F8)
+#define EFM32TG232F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG232F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG232F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG232F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_Peripheral_TypeDefs EFM32TG232F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_CMU EFM32TG232F8 CMU
+ * @brief EFM32TG232F8_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  uint32_t       RESERVED5[1U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG232F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_Peripheral_Base EFM32TG232F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG232F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_Peripheral_Declaration  EFM32TG232F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG232F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_BitFields EFM32TG232F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_CMU_BitFields  EFM32TG232F8_CMU Bit Fields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x00000007UL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00000FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG232F8_CMU */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_UNLOCK EFM32TG232F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG232F8_UNLOCK */
+
+/** @} End of group EFM32TG232F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG232F8_Alternate_Function EFM32TG232F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG232F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG232F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG232F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg822f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg822f16.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG822F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG822F16_H
+#define EFM32TG822F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F16 EFM32TG822F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F16_Core EFM32TG822F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG822F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F16_Part EFM32TG822F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG822F16)
+#define EFM32TG822F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG822F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG822F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG822F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F16_Peripheral_TypeDefs EFM32TG822F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG822F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F16_Peripheral_Base EFM32TG822F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG822F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F16_Peripheral_Declaration  EFM32TG822F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG822F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F16_BitFields EFM32TG822F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F16_UNLOCK EFM32TG822F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG822F16_UNLOCK */
+
+/** @} End of group EFM32TG822F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F16_Alternate_Function EFM32TG822F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG822F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG822F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG822F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg822f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg822f32.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG822F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG822F32_H
+#define EFM32TG822F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F32 EFM32TG822F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F32_Core EFM32TG822F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG822F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F32_Part EFM32TG822F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG822F32)
+#define EFM32TG822F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG822F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG822F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG822F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F32_Peripheral_TypeDefs EFM32TG822F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG822F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F32_Peripheral_Base EFM32TG822F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG822F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F32_Peripheral_Declaration  EFM32TG822F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG822F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F32_BitFields EFM32TG822F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F32_UNLOCK EFM32TG822F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG822F32_UNLOCK */
+
+/** @} End of group EFM32TG822F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F32_Alternate_Function EFM32TG822F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG822F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG822F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG822F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg822f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg822f8.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG822F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG822F8_H
+#define EFM32TG822F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F8 EFM32TG822F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F8_Core EFM32TG822F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG822F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F8_Part EFM32TG822F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG822F8)
+#define EFM32TG822F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG822F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG822F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG822F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F8_Peripheral_TypeDefs EFM32TG822F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG822F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F8_Peripheral_Base EFM32TG822F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG822F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F8_Peripheral_Declaration  EFM32TG822F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG822F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F8_BitFields EFM32TG822F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F8_UNLOCK EFM32TG822F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG822F8_UNLOCK */
+
+/** @} End of group EFM32TG822F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG822F8_Alternate_Function EFM32TG822F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG822F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG822F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG822F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg825f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg825f16.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG825F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG825F16_H
+#define EFM32TG825F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F16 EFM32TG825F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F16_Core EFM32TG825F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG825F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F16_Part EFM32TG825F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG825F16)
+#define EFM32TG825F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG825F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG825F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG825F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F16_Peripheral_TypeDefs EFM32TG825F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG825F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F16_Peripheral_Base EFM32TG825F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG825F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F16_Peripheral_Declaration  EFM32TG825F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG825F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F16_BitFields EFM32TG825F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F16_UNLOCK EFM32TG825F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG825F16_UNLOCK */
+
+/** @} End of group EFM32TG825F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F16_Alternate_Function EFM32TG825F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG825F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG825F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG825F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg825f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg825f32.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG825F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG825F32_H
+#define EFM32TG825F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F32 EFM32TG825F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F32_Core EFM32TG825F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG825F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F32_Part EFM32TG825F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG825F32)
+#define EFM32TG825F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG825F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG825F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG825F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F32_Peripheral_TypeDefs EFM32TG825F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG825F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F32_Peripheral_Base EFM32TG825F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG825F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F32_Peripheral_Declaration  EFM32TG825F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG825F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F32_BitFields EFM32TG825F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F32_UNLOCK EFM32TG825F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG825F32_UNLOCK */
+
+/** @} End of group EFM32TG825F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F32_Alternate_Function EFM32TG825F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG825F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG825F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG825F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg825f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg825f8.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG825F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG825F8_H
+#define EFM32TG825F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F8 EFM32TG825F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F8_Core EFM32TG825F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG825F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F8_Part EFM32TG825F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG825F8)
+#define EFM32TG825F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG825F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG825F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG825F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F8_Peripheral_TypeDefs EFM32TG825F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG825F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F8_Peripheral_Base EFM32TG825F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG825F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F8_Peripheral_Declaration  EFM32TG825F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG825F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F8_BitFields EFM32TG825F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F8_UNLOCK EFM32TG825F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG825F8_UNLOCK */
+
+/** @} End of group EFM32TG825F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG825F8_Alternate_Function EFM32TG825F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG825F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG825F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG825F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg840f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg840f16.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG840F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG840F16_H
+#define EFM32TG840F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F16 EFM32TG840F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F16_Core EFM32TG840F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG840F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F16_Part EFM32TG840F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG840F16)
+#define EFM32TG840F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG840F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG840F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG840F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F16_Peripheral_TypeDefs EFM32TG840F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG840F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F16_Peripheral_Base EFM32TG840F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG840F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F16_Peripheral_Declaration  EFM32TG840F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG840F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F16_BitFields EFM32TG840F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F16_UNLOCK EFM32TG840F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG840F16_UNLOCK */
+
+/** @} End of group EFM32TG840F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F16_Alternate_Function EFM32TG840F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG840F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG840F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG840F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg840f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg840f32.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG840F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG840F32_H
+#define EFM32TG840F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F32 EFM32TG840F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F32_Core EFM32TG840F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG840F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F32_Part EFM32TG840F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG840F32)
+#define EFM32TG840F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG840F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG840F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG840F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F32_Peripheral_TypeDefs EFM32TG840F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG840F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F32_Peripheral_Base EFM32TG840F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG840F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F32_Peripheral_Declaration  EFM32TG840F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG840F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F32_BitFields EFM32TG840F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F32_UNLOCK EFM32TG840F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG840F32_UNLOCK */
+
+/** @} End of group EFM32TG840F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F32_Alternate_Function EFM32TG840F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG840F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG840F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG840F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg840f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg840f8.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG840F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG840F8_H
+#define EFM32TG840F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F8 EFM32TG840F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F8_Core EFM32TG840F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG840F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F8_Part EFM32TG840F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG840F8)
+#define EFM32TG840F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG840F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG840F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG840F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F8_Peripheral_TypeDefs EFM32TG840F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG840F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F8_Peripheral_Base EFM32TG840F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG840F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F8_Peripheral_Declaration  EFM32TG840F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG840F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F8_BitFields EFM32TG840F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F8_UNLOCK EFM32TG840F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG840F8_UNLOCK */
+
+/** @} End of group EFM32TG840F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG840F8_Alternate_Function EFM32TG840F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG840F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG840F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG840F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg842f16.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg842f16.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG842F16
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG842F16_H
+#define EFM32TG842F16_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F16 EFM32TG842F16
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F16_Core EFM32TG842F16 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG842F16_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F16_Part EFM32TG842F16 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG842F16)
+#define EFM32TG842F16    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG842F16" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG842F16 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00004000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG842F16_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F16_Peripheral_TypeDefs EFM32TG842F16 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG842F16_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F16_Peripheral_Base EFM32TG842F16 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG842F16_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F16_Peripheral_Declaration  EFM32TG842F16 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG842F16_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F16_BitFields EFM32TG842F16 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F16_UNLOCK EFM32TG842F16 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG842F16_UNLOCK */
+
+/** @} End of group EFM32TG842F16_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F16_Alternate_Function EFM32TG842F16 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG842F16_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG842F16  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG842F16_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg842f32.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg842f32.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG842F32
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG842F32_H
+#define EFM32TG842F32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F32 EFM32TG842F32
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F32_Core EFM32TG842F32 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG842F32_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F32_Part EFM32TG842F32 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG842F32)
+#define EFM32TG842F32    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG842F32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG842F32 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00008000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00001000UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG842F32_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F32_Peripheral_TypeDefs EFM32TG842F32 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG842F32_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F32_Peripheral_Base EFM32TG842F32 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG842F32_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F32_Peripheral_Declaration  EFM32TG842F32 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG842F32_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F32_BitFields EFM32TG842F32 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F32_UNLOCK EFM32TG842F32 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG842F32_UNLOCK */
+
+/** @} End of group EFM32TG842F32_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F32_Alternate_Function EFM32TG842F32 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG842F32_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG842F32  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG842F32_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg842f8.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg842f8.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 Peripheral Access Layer Header File
+ *        for EFM EFM32TG842F8
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFM32TG842F8_H
+#define EFM32TG842F8_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F8 EFM32TG842F8
+ * @{
+ ******************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M3 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< -14 Cortex-M3 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< -13 Cortex-M3 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< -12 Cortex-M3 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< -11 Cortex-M3 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< -10 Cortex-M3 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< -5  Cortex-M3 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< -4  Cortex-M3 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< -2  Cortex-M3 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< -1  Cortex-M3 System Tick Interrupt       */
+
+/******  EFM32G Peripheral Interrupt Numbers ***********************************************/
+  DMA_IRQn              = 0,  /*!< 0 EFM32 DMA Interrupt */
+  GPIO_EVEN_IRQn        = 1,  /*!< 1 EFM32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 2,  /*!< 2 EFM32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 3,  /*!< 3 EFM32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 4,  /*!< 4 EFM32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 5,  /*!< 5 EFM32 ACMP0 Interrupt */
+  ADC0_IRQn             = 6,  /*!< 6 EFM32 ADC0 Interrupt */
+  DAC0_IRQn             = 7,  /*!< 7 EFM32 DAC0 Interrupt */
+  I2C0_IRQn             = 8,  /*!< 8 EFM32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 9,  /*!< 9 EFM32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 10, /*!< 10 EFM32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 11, /*!< 11 EFM32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 12, /*!< 12 EFM32 USART1_TX Interrupt */
+  LESENSE_IRQn          = 13, /*!< 13 EFM32 LESENSE Interrupt */
+  LEUART0_IRQn          = 14, /*!< 14 EFM32 LEUART0 Interrupt */
+  LETIMER0_IRQn         = 15, /*!< 15 EFM32 LETIMER0 Interrupt */
+  PCNT0_IRQn            = 16, /*!< 16 EFM32 PCNT0 Interrupt */
+  RTC_IRQn              = 17, /*!< 17 EFM32 RTC Interrupt */
+  CMU_IRQn              = 18, /*!< 18 EFM32 CMU Interrupt */
+  VCMP_IRQn             = 19, /*!< 19 EFM32 VCMP Interrupt */
+  LCD_IRQn              = 20, /*!< 20 EFM32 LCD Interrupt */
+  MSC_IRQn              = 21, /*!< 21 EFM32 MSC Interrupt */
+  AES_IRQn              = 22, /*!< 22 EFM32 AES Interrupt */
+} IRQn_Type;
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F8_Core EFM32TG842F8 Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ ******************************************************************************/
+#define __MPU_PRESENT             0U /**< MPU not present */
+#define __VTOR_PRESENT            1U /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3U /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0U /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFM32TG842F8_Core */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F8_Part EFM32TG842F8 Part
+ * @{
+ ******************************************************************************/
+
+/** Part family */
+#define _EFM32_TINY_FAMILY                      1  /**< Tiny Gecko EFM32TG MCU Family */
+#define _EFM_DEVICE                                /**< Silicon Labs EFM-type microcontroller */
+#define _SILICON_LABS_32B_SERIES_0                 /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                0  /**< Silicon Labs series number */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       73 /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_73       /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_32B_PLATFORM_1               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              1  /**< @deprecated Silicon Labs platform name */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFM32TG842F8)
+#define EFM32TG842F8    1 /**< Tiny Gecko Part  */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER          "EFM32TG842F8" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define RAM_MEM_BASE         (0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE         (0x40000UL)    /**< RAM available address space  */
+#define RAM_MEM_END          (0x2003FFFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS         (0x18UL)       /**< RAM used bits  */
+#define RAM_CODE_MEM_BASE    (0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE    (0x4000UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END     (0x10003FFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS    (0x14UL)       /**< RAM_CODE used bits  */
+#define PER_MEM_BASE         (0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE         (0xE0000UL)    /**< PER available address space  */
+#define PER_MEM_END          (0x400DFFFFUL) /**< PER end address  */
+#define PER_MEM_BITS         (0x20UL)       /**< PER used bits  */
+#define FLASH_MEM_BASE       (0x0UL)        /**< FLASH base address  */
+#define FLASH_MEM_SIZE       (0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END        (0xFFFFFFFUL)  /**< FLASH end address  */
+#define FLASH_MEM_BITS       (0x28UL)       /**< FLASH used bits  */
+#define AES_MEM_BASE         (0x400E0000UL) /**< AES base address  */
+#define AES_MEM_SIZE         (0x400UL)      /**< AES available address space  */
+#define AES_MEM_END          (0x400E03FFUL) /**< AES end address  */
+#define AES_MEM_BITS         (0x10UL)       /**< AES used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE     (0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE     (0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFM32TG842F8 */
+#define FLASH_BASE           (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE           (0x00002000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE      512U           /**< Flash Memory page size */
+#define SRAM_BASE            (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE            (0x00000800UL) /**< Available SRAM Memory */
+#define __CM3_REV            0x0201U        /**< Cortex-M3 Core revision r2p1 */
+#define PRS_CHAN_COUNT       8              /**< Number of PRS channels */
+#define DMA_CHAN_COUNT       8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT        23             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX           63U
+#define AFCHANLOC_MAX        7U
+/** Analog AF channels */
+#define AFACHAN_MAX          47U
+
+/* Part number capabilities */
+
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define DAC_PRESENT             /**< DAC is available in this part */
+#define DAC_COUNT             1 /**< 1 DACs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define AES_PRESENT             /**< AES is available in this part */
+#define AES_COUNT             1 /**< 1 AES available */
+#define DMA_PRESENT             /**< DMA is available in this part */
+#define DMA_COUNT             1 /**< 1 DMA available */
+#define LE_PRESENT              /**< LE is available in this part */
+#define LE_COUNT              1 /**< 1 LE available */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define LESENSE_PRESENT         /**< LESENSE is available in this part */
+#define LESENSE_COUNT         1 /**< 1 LESENSE available */
+#define RTC_PRESENT             /**< RTC is available in this part */
+#define RTC_COUNT             1 /**< 1 RTC available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define VCMP_PRESENT            /**< VCMP is available in this part */
+#define VCMP_COUNT            1 /**< 1 VCMP available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define OPAMP_PRESENT           /**< OPAMP is available in this part */
+#define OPAMP_COUNT           1 /**< 1 OPAMP available */
+#define LCD_PRESENT             /**< LCD is available in this part */
+#define LCD_COUNT             1 /**< 1 LCD available */
+#define HFXTAL_PRESENT          /**< HFXTAL is available in this part */
+#define HFXTAL_COUNT          1 /**< 1 HFXTAL available */
+#define LFXTAL_PRESENT          /**< LFXTAL is available in this part */
+#define LFXTAL_COUNT          1 /**< 1 LFXTAL available */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOG available */
+#define DBG_PRESENT             /**< DBG is available in this part */
+#define DBG_COUNT             1 /**< 1 DBG available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define ANALOG_PRESENT          /**< ANALOG is available in this part */
+#define ANALOG_COUNT          1 /**< 1 ANALOG available */
+
+#include "core_cm3.h"           /* Cortex-M3 processor and core peripherals */
+#include "system_efm32tg.h"       /* System Header */
+
+/** @} End of group EFM32TG842F8_Part */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F8_Peripheral_TypeDefs EFM32TG842F8 Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ ******************************************************************************/
+
+#include "efm32tg_aes.h"
+#include "efm32tg_dma_ch.h"
+#include "efm32tg_dma.h"
+#include "efm32tg_msc.h"
+#include "efm32tg_emu.h"
+#include "efm32tg_rmu.h"
+#include "efm32tg_cmu.h"
+#include "efm32tg_lesense_st.h"
+#include "efm32tg_lesense_buf.h"
+#include "efm32tg_lesense_ch.h"
+#include "efm32tg_lesense.h"
+#include "efm32tg_rtc.h"
+#include "efm32tg_acmp.h"
+#include "efm32tg_usart.h"
+#include "efm32tg_timer_cc.h"
+#include "efm32tg_timer.h"
+#include "efm32tg_gpio_p.h"
+#include "efm32tg_gpio.h"
+#include "efm32tg_vcmp.h"
+#include "efm32tg_prs_ch.h"
+#include "efm32tg_prs.h"
+#include "efm32tg_leuart.h"
+#include "efm32tg_letimer.h"
+#include "efm32tg_pcnt.h"
+#include "efm32tg_adc.h"
+#include "efm32tg_dac.h"
+#include "efm32tg_i2c.h"
+#include "efm32tg_lcd.h"
+#include "efm32tg_wdog.h"
+#include "efm32tg_dma_descriptor.h"
+#include "efm32tg_devinfo.h"
+#include "efm32tg_romtable.h"
+#include "efm32tg_calibrate.h"
+
+/** @} End of group EFM32TG842F8_Peripheral_TypeDefs */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F8_Peripheral_Base EFM32TG842F8 Peripheral Memory Map
+ * @{
+ ******************************************************************************/
+
+#define AES_BASE          (0x400E0000UL) /**< AES base address  */
+#define DMA_BASE          (0x400C2000UL) /**< DMA base address  */
+#define MSC_BASE          (0x400C0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400C6000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400CA000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400C8000UL) /**< CMU base address  */
+#define LESENSE_BASE      (0x4008C000UL) /**< LESENSE base address  */
+#define RTC_BASE          (0x40080000UL) /**< RTC base address  */
+#define ACMP0_BASE        (0x40001000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40001400UL) /**< ACMP1 base address  */
+#define USART0_BASE       (0x4000C000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x4000C400UL) /**< USART1 base address  */
+#define TIMER0_BASE       (0x40010000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40010400UL) /**< TIMER1 base address  */
+#define GPIO_BASE         (0x40006000UL) /**< GPIO base address  */
+#define VCMP_BASE         (0x40000000UL) /**< VCMP base address  */
+#define PRS_BASE          (0x400CC000UL) /**< PRS base address  */
+#define LEUART0_BASE      (0x40084000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40082000UL) /**< LETIMER0 base address  */
+#define PCNT0_BASE        (0x40086000UL) /**< PCNT0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define DAC0_BASE         (0x40004000UL) /**< DAC0 base address  */
+#define I2C0_BASE         (0x4000A000UL) /**< I2C0 base address  */
+#define LCD_BASE          (0x4008A000UL) /**< LCD base address  */
+#define WDOG_BASE         (0x40088000UL) /**< WDOG base address  */
+#define CALIBRATE_BASE    (0x0FE08000UL) /**< CALIBRATE base address */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFM32TG842F8_Peripheral_Base */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F8_Peripheral_Declaration  EFM32TG842F8 Peripheral Declarations
+ * @{
+ ******************************************************************************/
+
+#define AES          ((AES_TypeDef *) AES_BASE)             /**< AES base pointer */
+#define DMA          ((DMA_TypeDef *) DMA_BASE)             /**< DMA base pointer */
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define LESENSE      ((LESENSE_TypeDef *) LESENSE_BASE)     /**< LESENSE base pointer */
+#define RTC          ((RTC_TypeDef *) RTC_BASE)             /**< RTC base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define VCMP         ((VCMP_TypeDef *) VCMP_BASE)           /**< VCMP base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define DAC0         ((DAC_TypeDef *) DAC0_BASE)            /**< DAC0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define LCD          ((LCD_TypeDef *) LCD_BASE)             /**< LCD base pointer */
+#define WDOG         ((WDOG_TypeDef *) WDOG_BASE)           /**< WDOG base pointer */
+#define CALIBRATE    ((CALIBRATE_TypeDef *) CALIBRATE_BASE) /**< CALIBRATE base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFM32TG842F8_Peripheral_Declaration */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F8_BitFields EFM32TG842F8 Bit Fields
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_prs_signals.h"
+#include "efm32tg_dmareq.h"
+#include "efm32tg_dmactrl.h"
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F8_UNLOCK EFM32TG842F8 Unlock Codes
+ * @{
+ ******************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+
+/** @} End of group EFM32TG842F8_UNLOCK */
+
+/** @} End of group EFM32TG842F8_BitFields */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG842F8_Alternate_Function EFM32TG842F8 Alternate Function
+ * @{
+ ******************************************************************************/
+
+#include "efm32tg_af_ports.h"
+#include "efm32tg_af_pins.h"
+
+/** @} End of group EFM32TG842F8_Alternate_Function */
+
+/***************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ ******************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFM32TG842F8  */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFM32TG842F8_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_acmp.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_acmp.h
@@ -1,0 +1,338 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_ACMP register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_ACMP
+ * @brief EFM32TG_ACMP Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;     /**< Control Register  */
+  __IOM uint32_t INPUTSEL; /**< Input Selection Register  */
+  __IM uint32_t  STATUS;   /**< Status Register  */
+  __IOM uint32_t IEN;      /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;       /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;      /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;      /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t ROUTE;    /**< I/O Routing Register  */
+} ACMP_TypeDef;            /**< ACMP Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_ACMP_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for ACMP CTRL */
+#define _ACMP_CTRL_RESETVALUE              0x47000000UL                         /**< Default value for ACMP_CTRL */
+#define _ACMP_CTRL_MASK                    0xCF03077FUL                         /**< Mask for ACMP_CTRL */
+#define ACMP_CTRL_EN                       (0x1UL << 0)                         /**< Analog Comparator Enable */
+#define _ACMP_CTRL_EN_SHIFT                0                                    /**< Shift value for ACMP_EN */
+#define _ACMP_CTRL_EN_MASK                 0x1UL                                /**< Bit mask for ACMP_EN */
+#define _ACMP_CTRL_EN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_EN_DEFAULT               (_ACMP_CTRL_EN_DEFAULT << 0)         /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_MUXEN                    (0x1UL << 1)                         /**< Input Mux Enable */
+#define _ACMP_CTRL_MUXEN_SHIFT             1                                    /**< Shift value for ACMP_MUXEN */
+#define _ACMP_CTRL_MUXEN_MASK              0x2UL                                /**< Bit mask for ACMP_MUXEN */
+#define _ACMP_CTRL_MUXEN_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_MUXEN_DEFAULT            (_ACMP_CTRL_MUXEN_DEFAULT << 1)      /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_INACTVAL                 (0x1UL << 2)                         /**< Inactive Value */
+#define _ACMP_CTRL_INACTVAL_SHIFT          2                                    /**< Shift value for ACMP_INACTVAL */
+#define _ACMP_CTRL_INACTVAL_MASK           0x4UL                                /**< Bit mask for ACMP_INACTVAL */
+#define _ACMP_CTRL_INACTVAL_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_INACTVAL_LOW            0x00000000UL                         /**< Mode LOW for ACMP_CTRL */
+#define _ACMP_CTRL_INACTVAL_HIGH           0x00000001UL                         /**< Mode HIGH for ACMP_CTRL */
+#define ACMP_CTRL_INACTVAL_DEFAULT         (_ACMP_CTRL_INACTVAL_DEFAULT << 2)   /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_INACTVAL_LOW             (_ACMP_CTRL_INACTVAL_LOW << 2)       /**< Shifted mode LOW for ACMP_CTRL */
+#define ACMP_CTRL_INACTVAL_HIGH            (_ACMP_CTRL_INACTVAL_HIGH << 2)      /**< Shifted mode HIGH for ACMP_CTRL */
+#define ACMP_CTRL_GPIOINV                  (0x1UL << 3)                         /**< Comparator GPIO Output Invert */
+#define _ACMP_CTRL_GPIOINV_SHIFT           3                                    /**< Shift value for ACMP_GPIOINV */
+#define _ACMP_CTRL_GPIOINV_MASK            0x8UL                                /**< Bit mask for ACMP_GPIOINV */
+#define _ACMP_CTRL_GPIOINV_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_GPIOINV_NOTINV          0x00000000UL                         /**< Mode NOTINV for ACMP_CTRL */
+#define _ACMP_CTRL_GPIOINV_INV             0x00000001UL                         /**< Mode INV for ACMP_CTRL */
+#define ACMP_CTRL_GPIOINV_DEFAULT          (_ACMP_CTRL_GPIOINV_DEFAULT << 3)    /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_GPIOINV_NOTINV           (_ACMP_CTRL_GPIOINV_NOTINV << 3)     /**< Shifted mode NOTINV for ACMP_CTRL */
+#define ACMP_CTRL_GPIOINV_INV              (_ACMP_CTRL_GPIOINV_INV << 3)        /**< Shifted mode INV for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_SHIFT           4                                    /**< Shift value for ACMP_HYSTSEL */
+#define _ACMP_CTRL_HYSTSEL_MASK            0x70UL                               /**< Bit mask for ACMP_HYSTSEL */
+#define _ACMP_CTRL_HYSTSEL_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST0           0x00000000UL                         /**< Mode HYST0 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST1           0x00000001UL                         /**< Mode HYST1 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST2           0x00000002UL                         /**< Mode HYST2 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST3           0x00000003UL                         /**< Mode HYST3 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST4           0x00000004UL                         /**< Mode HYST4 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST5           0x00000005UL                         /**< Mode HYST5 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST6           0x00000006UL                         /**< Mode HYST6 for ACMP_CTRL */
+#define _ACMP_CTRL_HYSTSEL_HYST7           0x00000007UL                         /**< Mode HYST7 for ACMP_CTRL */
+#define ACMP_CTRL_HYSTSEL_DEFAULT          (_ACMP_CTRL_HYSTSEL_DEFAULT << 4)    /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_HYSTSEL_HYST0            (_ACMP_CTRL_HYSTSEL_HYST0 << 4)      /**< Shifted mode HYST0 for ACMP_CTRL */
+#define ACMP_CTRL_HYSTSEL_HYST1            (_ACMP_CTRL_HYSTSEL_HYST1 << 4)      /**< Shifted mode HYST1 for ACMP_CTRL */
+#define ACMP_CTRL_HYSTSEL_HYST2            (_ACMP_CTRL_HYSTSEL_HYST2 << 4)      /**< Shifted mode HYST2 for ACMP_CTRL */
+#define ACMP_CTRL_HYSTSEL_HYST3            (_ACMP_CTRL_HYSTSEL_HYST3 << 4)      /**< Shifted mode HYST3 for ACMP_CTRL */
+#define ACMP_CTRL_HYSTSEL_HYST4            (_ACMP_CTRL_HYSTSEL_HYST4 << 4)      /**< Shifted mode HYST4 for ACMP_CTRL */
+#define ACMP_CTRL_HYSTSEL_HYST5            (_ACMP_CTRL_HYSTSEL_HYST5 << 4)      /**< Shifted mode HYST5 for ACMP_CTRL */
+#define ACMP_CTRL_HYSTSEL_HYST6            (_ACMP_CTRL_HYSTSEL_HYST6 << 4)      /**< Shifted mode HYST6 for ACMP_CTRL */
+#define ACMP_CTRL_HYSTSEL_HYST7            (_ACMP_CTRL_HYSTSEL_HYST7 << 4)      /**< Shifted mode HYST7 for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_SHIFT          8                                    /**< Shift value for ACMP_WARMTIME */
+#define _ACMP_CTRL_WARMTIME_MASK           0x700UL                              /**< Bit mask for ACMP_WARMTIME */
+#define _ACMP_CTRL_WARMTIME_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_4CYCLES        0x00000000UL                         /**< Mode 4CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_8CYCLES        0x00000001UL                         /**< Mode 8CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_16CYCLES       0x00000002UL                         /**< Mode 16CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_32CYCLES       0x00000003UL                         /**< Mode 32CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_64CYCLES       0x00000004UL                         /**< Mode 64CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_128CYCLES      0x00000005UL                         /**< Mode 128CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_256CYCLES      0x00000006UL                         /**< Mode 256CYCLES for ACMP_CTRL */
+#define _ACMP_CTRL_WARMTIME_512CYCLES      0x00000007UL                         /**< Mode 512CYCLES for ACMP_CTRL */
+#define ACMP_CTRL_WARMTIME_DEFAULT         (_ACMP_CTRL_WARMTIME_DEFAULT << 8)   /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_WARMTIME_4CYCLES         (_ACMP_CTRL_WARMTIME_4CYCLES << 8)   /**< Shifted mode 4CYCLES for ACMP_CTRL */
+#define ACMP_CTRL_WARMTIME_8CYCLES         (_ACMP_CTRL_WARMTIME_8CYCLES << 8)   /**< Shifted mode 8CYCLES for ACMP_CTRL */
+#define ACMP_CTRL_WARMTIME_16CYCLES        (_ACMP_CTRL_WARMTIME_16CYCLES << 8)  /**< Shifted mode 16CYCLES for ACMP_CTRL */
+#define ACMP_CTRL_WARMTIME_32CYCLES        (_ACMP_CTRL_WARMTIME_32CYCLES << 8)  /**< Shifted mode 32CYCLES for ACMP_CTRL */
+#define ACMP_CTRL_WARMTIME_64CYCLES        (_ACMP_CTRL_WARMTIME_64CYCLES << 8)  /**< Shifted mode 64CYCLES for ACMP_CTRL */
+#define ACMP_CTRL_WARMTIME_128CYCLES       (_ACMP_CTRL_WARMTIME_128CYCLES << 8) /**< Shifted mode 128CYCLES for ACMP_CTRL */
+#define ACMP_CTRL_WARMTIME_256CYCLES       (_ACMP_CTRL_WARMTIME_256CYCLES << 8) /**< Shifted mode 256CYCLES for ACMP_CTRL */
+#define ACMP_CTRL_WARMTIME_512CYCLES       (_ACMP_CTRL_WARMTIME_512CYCLES << 8) /**< Shifted mode 512CYCLES for ACMP_CTRL */
+#define ACMP_CTRL_IRISE                    (0x1UL << 16)                        /**< Rising Edge Interrupt Sense */
+#define _ACMP_CTRL_IRISE_SHIFT             16                                   /**< Shift value for ACMP_IRISE */
+#define _ACMP_CTRL_IRISE_MASK              0x10000UL                            /**< Bit mask for ACMP_IRISE */
+#define _ACMP_CTRL_IRISE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_IRISE_DISABLED          0x00000000UL                         /**< Mode DISABLED for ACMP_CTRL */
+#define _ACMP_CTRL_IRISE_ENABLED           0x00000001UL                         /**< Mode ENABLED for ACMP_CTRL */
+#define ACMP_CTRL_IRISE_DEFAULT            (_ACMP_CTRL_IRISE_DEFAULT << 16)     /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_IRISE_DISABLED           (_ACMP_CTRL_IRISE_DISABLED << 16)    /**< Shifted mode DISABLED for ACMP_CTRL */
+#define ACMP_CTRL_IRISE_ENABLED            (_ACMP_CTRL_IRISE_ENABLED << 16)     /**< Shifted mode ENABLED for ACMP_CTRL */
+#define ACMP_CTRL_IFALL                    (0x1UL << 17)                        /**< Falling Edge Interrupt Sense */
+#define _ACMP_CTRL_IFALL_SHIFT             17                                   /**< Shift value for ACMP_IFALL */
+#define _ACMP_CTRL_IFALL_MASK              0x20000UL                            /**< Bit mask for ACMP_IFALL */
+#define _ACMP_CTRL_IFALL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define _ACMP_CTRL_IFALL_DISABLED          0x00000000UL                         /**< Mode DISABLED for ACMP_CTRL */
+#define _ACMP_CTRL_IFALL_ENABLED           0x00000001UL                         /**< Mode ENABLED for ACMP_CTRL */
+#define ACMP_CTRL_IFALL_DEFAULT            (_ACMP_CTRL_IFALL_DEFAULT << 17)     /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_IFALL_DISABLED           (_ACMP_CTRL_IFALL_DISABLED << 17)    /**< Shifted mode DISABLED for ACMP_CTRL */
+#define ACMP_CTRL_IFALL_ENABLED            (_ACMP_CTRL_IFALL_ENABLED << 17)     /**< Shifted mode ENABLED for ACMP_CTRL */
+#define _ACMP_CTRL_BIASPROG_SHIFT          24                                   /**< Shift value for ACMP_BIASPROG */
+#define _ACMP_CTRL_BIASPROG_MASK           0xF000000UL                          /**< Bit mask for ACMP_BIASPROG */
+#define _ACMP_CTRL_BIASPROG_DEFAULT        0x00000007UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_BIASPROG_DEFAULT         (_ACMP_CTRL_BIASPROG_DEFAULT << 24)  /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_HALFBIAS                 (0x1UL << 30)                        /**< Half Bias Current */
+#define _ACMP_CTRL_HALFBIAS_SHIFT          30                                   /**< Shift value for ACMP_HALFBIAS */
+#define _ACMP_CTRL_HALFBIAS_MASK           0x40000000UL                         /**< Bit mask for ACMP_HALFBIAS */
+#define _ACMP_CTRL_HALFBIAS_DEFAULT        0x00000001UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_HALFBIAS_DEFAULT         (_ACMP_CTRL_HALFBIAS_DEFAULT << 30)  /**< Shifted mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_FULLBIAS                 (0x1UL << 31)                        /**< Full Bias Current */
+#define _ACMP_CTRL_FULLBIAS_SHIFT          31                                   /**< Shift value for ACMP_FULLBIAS */
+#define _ACMP_CTRL_FULLBIAS_MASK           0x80000000UL                         /**< Bit mask for ACMP_FULLBIAS */
+#define _ACMP_CTRL_FULLBIAS_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for ACMP_CTRL */
+#define ACMP_CTRL_FULLBIAS_DEFAULT         (_ACMP_CTRL_FULLBIAS_DEFAULT << 31)  /**< Shifted mode DEFAULT for ACMP_CTRL */
+
+/* Bit fields for ACMP INPUTSEL */
+#define _ACMP_INPUTSEL_RESETVALUE          0x00010080UL                            /**< Default value for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_MASK                0x31013FF7UL                            /**< Mask for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_SHIFT        0                                       /**< Shift value for ACMP_POSSEL */
+#define _ACMP_INPUTSEL_POSSEL_MASK         0x7UL                                   /**< Bit mask for ACMP_POSSEL */
+#define _ACMP_INPUTSEL_POSSEL_DEFAULT      0x00000000UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH0          0x00000000UL                            /**< Mode CH0 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH1          0x00000001UL                            /**< Mode CH1 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH2          0x00000002UL                            /**< Mode CH2 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH3          0x00000003UL                            /**< Mode CH3 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH4          0x00000004UL                            /**< Mode CH4 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH5          0x00000005UL                            /**< Mode CH5 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH6          0x00000006UL                            /**< Mode CH6 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_POSSEL_CH7          0x00000007UL                            /**< Mode CH7 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_POSSEL_DEFAULT       (_ACMP_INPUTSEL_POSSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_POSSEL_CH0           (_ACMP_INPUTSEL_POSSEL_CH0 << 0)        /**< Shifted mode CH0 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_POSSEL_CH1           (_ACMP_INPUTSEL_POSSEL_CH1 << 0)        /**< Shifted mode CH1 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_POSSEL_CH2           (_ACMP_INPUTSEL_POSSEL_CH2 << 0)        /**< Shifted mode CH2 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_POSSEL_CH3           (_ACMP_INPUTSEL_POSSEL_CH3 << 0)        /**< Shifted mode CH3 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_POSSEL_CH4           (_ACMP_INPUTSEL_POSSEL_CH4 << 0)        /**< Shifted mode CH4 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_POSSEL_CH5           (_ACMP_INPUTSEL_POSSEL_CH5 << 0)        /**< Shifted mode CH5 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_POSSEL_CH6           (_ACMP_INPUTSEL_POSSEL_CH6 << 0)        /**< Shifted mode CH6 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_POSSEL_CH7           (_ACMP_INPUTSEL_POSSEL_CH7 << 0)        /**< Shifted mode CH7 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_SHIFT        4                                       /**< Shift value for ACMP_NEGSEL */
+#define _ACMP_INPUTSEL_NEGSEL_MASK         0xF0UL                                  /**< Bit mask for ACMP_NEGSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH0          0x00000000UL                            /**< Mode CH0 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH1          0x00000001UL                            /**< Mode CH1 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH2          0x00000002UL                            /**< Mode CH2 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH3          0x00000003UL                            /**< Mode CH3 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH4          0x00000004UL                            /**< Mode CH4 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH5          0x00000005UL                            /**< Mode CH5 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH6          0x00000006UL                            /**< Mode CH6 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CH7          0x00000007UL                            /**< Mode CH7 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_DEFAULT      0x00000008UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_1V25         0x00000008UL                            /**< Mode 1V25 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_2V5          0x00000009UL                            /**< Mode 2V5 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_VDD          0x0000000AUL                            /**< Mode VDD for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_CAPSENSE     0x0000000BUL                            /**< Mode CAPSENSE for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_DAC0CH0      0x0000000CUL                            /**< Mode DAC0CH0 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_NEGSEL_DAC0CH1      0x0000000DUL                            /**< Mode DAC0CH1 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_CH0           (_ACMP_INPUTSEL_NEGSEL_CH0 << 4)        /**< Shifted mode CH0 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_CH1           (_ACMP_INPUTSEL_NEGSEL_CH1 << 4)        /**< Shifted mode CH1 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_CH2           (_ACMP_INPUTSEL_NEGSEL_CH2 << 4)        /**< Shifted mode CH2 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_CH3           (_ACMP_INPUTSEL_NEGSEL_CH3 << 4)        /**< Shifted mode CH3 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_CH4           (_ACMP_INPUTSEL_NEGSEL_CH4 << 4)        /**< Shifted mode CH4 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_CH5           (_ACMP_INPUTSEL_NEGSEL_CH5 << 4)        /**< Shifted mode CH5 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_CH6           (_ACMP_INPUTSEL_NEGSEL_CH6 << 4)        /**< Shifted mode CH6 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_CH7           (_ACMP_INPUTSEL_NEGSEL_CH7 << 4)        /**< Shifted mode CH7 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_DEFAULT       (_ACMP_INPUTSEL_NEGSEL_DEFAULT << 4)    /**< Shifted mode DEFAULT for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_1V25          (_ACMP_INPUTSEL_NEGSEL_1V25 << 4)       /**< Shifted mode 1V25 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_2V5           (_ACMP_INPUTSEL_NEGSEL_2V5 << 4)        /**< Shifted mode 2V5 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_VDD           (_ACMP_INPUTSEL_NEGSEL_VDD << 4)        /**< Shifted mode VDD for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_CAPSENSE      (_ACMP_INPUTSEL_NEGSEL_CAPSENSE << 4)   /**< Shifted mode CAPSENSE for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_DAC0CH0       (_ACMP_INPUTSEL_NEGSEL_DAC0CH0 << 4)    /**< Shifted mode DAC0CH0 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_NEGSEL_DAC0CH1       (_ACMP_INPUTSEL_NEGSEL_DAC0CH1 << 4)    /**< Shifted mode DAC0CH1 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_VDDLEVEL_SHIFT      8                                       /**< Shift value for ACMP_VDDLEVEL */
+#define _ACMP_INPUTSEL_VDDLEVEL_MASK       0x3F00UL                                /**< Bit mask for ACMP_VDDLEVEL */
+#define _ACMP_INPUTSEL_VDDLEVEL_DEFAULT    0x00000000UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_VDDLEVEL_DEFAULT     (_ACMP_INPUTSEL_VDDLEVEL_DEFAULT << 8)  /**< Shifted mode DEFAULT for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_LPREF                (0x1UL << 16)                           /**< Low Power Reference Mode */
+#define _ACMP_INPUTSEL_LPREF_SHIFT         16                                      /**< Shift value for ACMP_LPREF */
+#define _ACMP_INPUTSEL_LPREF_MASK          0x10000UL                               /**< Bit mask for ACMP_LPREF */
+#define _ACMP_INPUTSEL_LPREF_DEFAULT       0x00000001UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_LPREF_DEFAULT        (_ACMP_INPUTSEL_LPREF_DEFAULT << 16)    /**< Shifted mode DEFAULT for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_CSRESEN              (0x1UL << 24)                           /**< Capacitive Sense Mode Internal Resistor Enable */
+#define _ACMP_INPUTSEL_CSRESEN_SHIFT       24                                      /**< Shift value for ACMP_CSRESEN */
+#define _ACMP_INPUTSEL_CSRESEN_MASK        0x1000000UL                             /**< Bit mask for ACMP_CSRESEN */
+#define _ACMP_INPUTSEL_CSRESEN_DEFAULT     0x00000000UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_CSRESEN_DEFAULT      (_ACMP_INPUTSEL_CSRESEN_DEFAULT << 24)  /**< Shifted mode DEFAULT for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_SHIFT      28                                      /**< Shift value for ACMP_CSRESSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_MASK       0x30000000UL                            /**< Bit mask for ACMP_CSRESSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_DEFAULT    0x00000000UL                            /**< Mode DEFAULT for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_RES0       0x00000000UL                            /**< Mode RES0 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_RES1       0x00000001UL                            /**< Mode RES1 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_RES2       0x00000002UL                            /**< Mode RES2 for ACMP_INPUTSEL */
+#define _ACMP_INPUTSEL_CSRESSEL_RES3       0x00000003UL                            /**< Mode RES3 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_CSRESSEL_DEFAULT     (_ACMP_INPUTSEL_CSRESSEL_DEFAULT << 28) /**< Shifted mode DEFAULT for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_CSRESSEL_RES0        (_ACMP_INPUTSEL_CSRESSEL_RES0 << 28)    /**< Shifted mode RES0 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_CSRESSEL_RES1        (_ACMP_INPUTSEL_CSRESSEL_RES1 << 28)    /**< Shifted mode RES1 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_CSRESSEL_RES2        (_ACMP_INPUTSEL_CSRESSEL_RES2 << 28)    /**< Shifted mode RES2 for ACMP_INPUTSEL */
+#define ACMP_INPUTSEL_CSRESSEL_RES3        (_ACMP_INPUTSEL_CSRESSEL_RES3 << 28)    /**< Shifted mode RES3 for ACMP_INPUTSEL */
+
+/* Bit fields for ACMP STATUS */
+#define _ACMP_STATUS_RESETVALUE            0x00000000UL                        /**< Default value for ACMP_STATUS */
+#define _ACMP_STATUS_MASK                  0x00000003UL                        /**< Mask for ACMP_STATUS */
+#define ACMP_STATUS_ACMPACT                (0x1UL << 0)                        /**< Analog Comparator Active */
+#define _ACMP_STATUS_ACMPACT_SHIFT         0                                   /**< Shift value for ACMP_ACMPACT */
+#define _ACMP_STATUS_ACMPACT_MASK          0x1UL                               /**< Bit mask for ACMP_ACMPACT */
+#define _ACMP_STATUS_ACMPACT_DEFAULT       0x00000000UL                        /**< Mode DEFAULT for ACMP_STATUS */
+#define ACMP_STATUS_ACMPACT_DEFAULT        (_ACMP_STATUS_ACMPACT_DEFAULT << 0) /**< Shifted mode DEFAULT for ACMP_STATUS */
+#define ACMP_STATUS_ACMPOUT                (0x1UL << 1)                        /**< Analog Comparator Output */
+#define _ACMP_STATUS_ACMPOUT_SHIFT         1                                   /**< Shift value for ACMP_ACMPOUT */
+#define _ACMP_STATUS_ACMPOUT_MASK          0x2UL                               /**< Bit mask for ACMP_ACMPOUT */
+#define _ACMP_STATUS_ACMPOUT_DEFAULT       0x00000000UL                        /**< Mode DEFAULT for ACMP_STATUS */
+#define ACMP_STATUS_ACMPOUT_DEFAULT        (_ACMP_STATUS_ACMPOUT_DEFAULT << 1) /**< Shifted mode DEFAULT for ACMP_STATUS */
+
+/* Bit fields for ACMP IEN */
+#define _ACMP_IEN_RESETVALUE               0x00000000UL                    /**< Default value for ACMP_IEN */
+#define _ACMP_IEN_MASK                     0x00000003UL                    /**< Mask for ACMP_IEN */
+#define ACMP_IEN_EDGE                      (0x1UL << 0)                    /**< Edge Trigger Interrupt Enable */
+#define _ACMP_IEN_EDGE_SHIFT               0                               /**< Shift value for ACMP_EDGE */
+#define _ACMP_IEN_EDGE_MASK                0x1UL                           /**< Bit mask for ACMP_EDGE */
+#define _ACMP_IEN_EDGE_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for ACMP_IEN */
+#define ACMP_IEN_EDGE_DEFAULT              (_ACMP_IEN_EDGE_DEFAULT << 0)   /**< Shifted mode DEFAULT for ACMP_IEN */
+#define ACMP_IEN_WARMUP                    (0x1UL << 1)                    /**< Warm-up Interrupt Enable */
+#define _ACMP_IEN_WARMUP_SHIFT             1                               /**< Shift value for ACMP_WARMUP */
+#define _ACMP_IEN_WARMUP_MASK              0x2UL                           /**< Bit mask for ACMP_WARMUP */
+#define _ACMP_IEN_WARMUP_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for ACMP_IEN */
+#define ACMP_IEN_WARMUP_DEFAULT            (_ACMP_IEN_WARMUP_DEFAULT << 1) /**< Shifted mode DEFAULT for ACMP_IEN */
+
+/* Bit fields for ACMP IF */
+#define _ACMP_IF_RESETVALUE                0x00000000UL                   /**< Default value for ACMP_IF */
+#define _ACMP_IF_MASK                      0x00000003UL                   /**< Mask for ACMP_IF */
+#define ACMP_IF_EDGE                       (0x1UL << 0)                   /**< Edge Triggered Interrupt Flag */
+#define _ACMP_IF_EDGE_SHIFT                0                              /**< Shift value for ACMP_EDGE */
+#define _ACMP_IF_EDGE_MASK                 0x1UL                          /**< Bit mask for ACMP_EDGE */
+#define _ACMP_IF_EDGE_DEFAULT              0x00000000UL                   /**< Mode DEFAULT for ACMP_IF */
+#define ACMP_IF_EDGE_DEFAULT               (_ACMP_IF_EDGE_DEFAULT << 0)   /**< Shifted mode DEFAULT for ACMP_IF */
+#define ACMP_IF_WARMUP                     (0x1UL << 1)                   /**< Warm-up Interrupt Flag */
+#define _ACMP_IF_WARMUP_SHIFT              1                              /**< Shift value for ACMP_WARMUP */
+#define _ACMP_IF_WARMUP_MASK               0x2UL                          /**< Bit mask for ACMP_WARMUP */
+#define _ACMP_IF_WARMUP_DEFAULT            0x00000000UL                   /**< Mode DEFAULT for ACMP_IF */
+#define ACMP_IF_WARMUP_DEFAULT             (_ACMP_IF_WARMUP_DEFAULT << 1) /**< Shifted mode DEFAULT for ACMP_IF */
+
+/* Bit fields for ACMP IFS */
+#define _ACMP_IFS_RESETVALUE               0x00000000UL                    /**< Default value for ACMP_IFS */
+#define _ACMP_IFS_MASK                     0x00000003UL                    /**< Mask for ACMP_IFS */
+#define ACMP_IFS_EDGE                      (0x1UL << 0)                    /**< Edge Triggered Interrupt Flag Set */
+#define _ACMP_IFS_EDGE_SHIFT               0                               /**< Shift value for ACMP_EDGE */
+#define _ACMP_IFS_EDGE_MASK                0x1UL                           /**< Bit mask for ACMP_EDGE */
+#define _ACMP_IFS_EDGE_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for ACMP_IFS */
+#define ACMP_IFS_EDGE_DEFAULT              (_ACMP_IFS_EDGE_DEFAULT << 0)   /**< Shifted mode DEFAULT for ACMP_IFS */
+#define ACMP_IFS_WARMUP                    (0x1UL << 1)                    /**< Warm-up Interrupt Flag Set */
+#define _ACMP_IFS_WARMUP_SHIFT             1                               /**< Shift value for ACMP_WARMUP */
+#define _ACMP_IFS_WARMUP_MASK              0x2UL                           /**< Bit mask for ACMP_WARMUP */
+#define _ACMP_IFS_WARMUP_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for ACMP_IFS */
+#define ACMP_IFS_WARMUP_DEFAULT            (_ACMP_IFS_WARMUP_DEFAULT << 1) /**< Shifted mode DEFAULT for ACMP_IFS */
+
+/* Bit fields for ACMP IFC */
+#define _ACMP_IFC_RESETVALUE               0x00000000UL                    /**< Default value for ACMP_IFC */
+#define _ACMP_IFC_MASK                     0x00000003UL                    /**< Mask for ACMP_IFC */
+#define ACMP_IFC_EDGE                      (0x1UL << 0)                    /**< Edge Triggered Interrupt Flag Clear */
+#define _ACMP_IFC_EDGE_SHIFT               0                               /**< Shift value for ACMP_EDGE */
+#define _ACMP_IFC_EDGE_MASK                0x1UL                           /**< Bit mask for ACMP_EDGE */
+#define _ACMP_IFC_EDGE_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for ACMP_IFC */
+#define ACMP_IFC_EDGE_DEFAULT              (_ACMP_IFC_EDGE_DEFAULT << 0)   /**< Shifted mode DEFAULT for ACMP_IFC */
+#define ACMP_IFC_WARMUP                    (0x1UL << 1)                    /**< Warm-up Interrupt Flag Clear */
+#define _ACMP_IFC_WARMUP_SHIFT             1                               /**< Shift value for ACMP_WARMUP */
+#define _ACMP_IFC_WARMUP_MASK              0x2UL                           /**< Bit mask for ACMP_WARMUP */
+#define _ACMP_IFC_WARMUP_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for ACMP_IFC */
+#define ACMP_IFC_WARMUP_DEFAULT            (_ACMP_IFC_WARMUP_DEFAULT << 1) /**< Shifted mode DEFAULT for ACMP_IFC */
+
+/* Bit fields for ACMP ROUTE */
+#define _ACMP_ROUTE_RESETVALUE             0x00000000UL                        /**< Default value for ACMP_ROUTE */
+#define _ACMP_ROUTE_MASK                   0x00000701UL                        /**< Mask for ACMP_ROUTE */
+#define ACMP_ROUTE_ACMPPEN                 (0x1UL << 0)                        /**< ACMP Output Pin Enable */
+#define _ACMP_ROUTE_ACMPPEN_SHIFT          0                                   /**< Shift value for ACMP_ACMPPEN */
+#define _ACMP_ROUTE_ACMPPEN_MASK           0x1UL                               /**< Bit mask for ACMP_ACMPPEN */
+#define _ACMP_ROUTE_ACMPPEN_DEFAULT        0x00000000UL                        /**< Mode DEFAULT for ACMP_ROUTE */
+#define ACMP_ROUTE_ACMPPEN_DEFAULT         (_ACMP_ROUTE_ACMPPEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for ACMP_ROUTE */
+#define _ACMP_ROUTE_LOCATION_SHIFT         8                                   /**< Shift value for ACMP_LOCATION */
+#define _ACMP_ROUTE_LOCATION_MASK          0x700UL                             /**< Bit mask for ACMP_LOCATION */
+#define _ACMP_ROUTE_LOCATION_LOC0          0x00000000UL                        /**< Mode LOC0 for ACMP_ROUTE */
+#define _ACMP_ROUTE_LOCATION_DEFAULT       0x00000000UL                        /**< Mode DEFAULT for ACMP_ROUTE */
+#define _ACMP_ROUTE_LOCATION_LOC1          0x00000001UL                        /**< Mode LOC1 for ACMP_ROUTE */
+#define _ACMP_ROUTE_LOCATION_LOC2          0x00000002UL                        /**< Mode LOC2 for ACMP_ROUTE */
+#define ACMP_ROUTE_LOCATION_LOC0           (_ACMP_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for ACMP_ROUTE */
+#define ACMP_ROUTE_LOCATION_DEFAULT        (_ACMP_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for ACMP_ROUTE */
+#define ACMP_ROUTE_LOCATION_LOC1           (_ACMP_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for ACMP_ROUTE */
+#define ACMP_ROUTE_LOCATION_LOC2           (_ACMP_ROUTE_LOCATION_LOC2 << 8)    /**< Shifted mode LOC2 for ACMP_ROUTE */
+
+/** @} End of group EFM32TG_ACMP */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_adc.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_adc.h
@@ -1,0 +1,660 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_ADC register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_ADC
+ * @brief EFM32TG_ADC Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t SINGLECTRL;    /**< Single Sample Control Register  */
+  __IOM uint32_t SCANCTRL;      /**< Scan Control Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IM uint32_t  SINGLEDATA;    /**< Single Conversion Result Data  */
+  __IM uint32_t  SCANDATA;      /**< Scan Conversion Result Data  */
+  __IM uint32_t  SINGLEDATAP;   /**< Single Conversion Result Data Peek Register  */
+  __IM uint32_t  SCANDATAP;     /**< Scan Sequence Result Data Peek Register  */
+  __IOM uint32_t CAL;           /**< Calibration Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t BIASPROG;      /**< Bias Programming Register  */
+} ADC_TypeDef;                  /**< ADC Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_ADC_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for ADC CTRL */
+#define _ADC_CTRL_RESETVALUE                    0x001F0000UL                                /**< Default value for ADC_CTRL */
+#define _ADC_CTRL_MASK                          0x0F1F7F3BUL                                /**< Mask for ADC_CTRL */
+#define _ADC_CTRL_WARMUPMODE_SHIFT              0                                           /**< Shift value for ADC_WARMUPMODE */
+#define _ADC_CTRL_WARMUPMODE_MASK               0x3UL                                       /**< Bit mask for ADC_WARMUPMODE */
+#define _ADC_CTRL_WARMUPMODE_DEFAULT            0x00000000UL                                /**< Mode DEFAULT for ADC_CTRL */
+#define _ADC_CTRL_WARMUPMODE_NORMAL             0x00000000UL                                /**< Mode NORMAL for ADC_CTRL */
+#define _ADC_CTRL_WARMUPMODE_FASTBG             0x00000001UL                                /**< Mode FASTBG for ADC_CTRL */
+#define _ADC_CTRL_WARMUPMODE_KEEPSCANREFWARM    0x00000002UL                                /**< Mode KEEPSCANREFWARM for ADC_CTRL */
+#define _ADC_CTRL_WARMUPMODE_KEEPADCWARM        0x00000003UL                                /**< Mode KEEPADCWARM for ADC_CTRL */
+#define ADC_CTRL_WARMUPMODE_DEFAULT             (_ADC_CTRL_WARMUPMODE_DEFAULT << 0)         /**< Shifted mode DEFAULT for ADC_CTRL */
+#define ADC_CTRL_WARMUPMODE_NORMAL              (_ADC_CTRL_WARMUPMODE_NORMAL << 0)          /**< Shifted mode NORMAL for ADC_CTRL */
+#define ADC_CTRL_WARMUPMODE_FASTBG              (_ADC_CTRL_WARMUPMODE_FASTBG << 0)          /**< Shifted mode FASTBG for ADC_CTRL */
+#define ADC_CTRL_WARMUPMODE_KEEPSCANREFWARM     (_ADC_CTRL_WARMUPMODE_KEEPSCANREFWARM << 0) /**< Shifted mode KEEPSCANREFWARM for ADC_CTRL */
+#define ADC_CTRL_WARMUPMODE_KEEPADCWARM         (_ADC_CTRL_WARMUPMODE_KEEPADCWARM << 0)     /**< Shifted mode KEEPADCWARM for ADC_CTRL */
+#define ADC_CTRL_TAILGATE                       (0x1UL << 3)                                /**< Conversion Tailgating */
+#define _ADC_CTRL_TAILGATE_SHIFT                3                                           /**< Shift value for ADC_TAILGATE */
+#define _ADC_CTRL_TAILGATE_MASK                 0x8UL                                       /**< Bit mask for ADC_TAILGATE */
+#define _ADC_CTRL_TAILGATE_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for ADC_CTRL */
+#define ADC_CTRL_TAILGATE_DEFAULT               (_ADC_CTRL_TAILGATE_DEFAULT << 3)           /**< Shifted mode DEFAULT for ADC_CTRL */
+#define _ADC_CTRL_LPFMODE_SHIFT                 4                                           /**< Shift value for ADC_LPFMODE */
+#define _ADC_CTRL_LPFMODE_MASK                  0x30UL                                      /**< Bit mask for ADC_LPFMODE */
+#define _ADC_CTRL_LPFMODE_DEFAULT               0x00000000UL                                /**< Mode DEFAULT for ADC_CTRL */
+#define _ADC_CTRL_LPFMODE_BYPASS                0x00000000UL                                /**< Mode BYPASS for ADC_CTRL */
+#define _ADC_CTRL_LPFMODE_DECAP                 0x00000001UL                                /**< Mode DECAP for ADC_CTRL */
+#define _ADC_CTRL_LPFMODE_RCFILT                0x00000002UL                                /**< Mode RCFILT for ADC_CTRL */
+#define ADC_CTRL_LPFMODE_DEFAULT                (_ADC_CTRL_LPFMODE_DEFAULT << 4)            /**< Shifted mode DEFAULT for ADC_CTRL */
+#define ADC_CTRL_LPFMODE_BYPASS                 (_ADC_CTRL_LPFMODE_BYPASS << 4)             /**< Shifted mode BYPASS for ADC_CTRL */
+#define ADC_CTRL_LPFMODE_DECAP                  (_ADC_CTRL_LPFMODE_DECAP << 4)              /**< Shifted mode DECAP for ADC_CTRL */
+#define ADC_CTRL_LPFMODE_RCFILT                 (_ADC_CTRL_LPFMODE_RCFILT << 4)             /**< Shifted mode RCFILT for ADC_CTRL */
+#define _ADC_CTRL_PRESC_SHIFT                   8                                           /**< Shift value for ADC_PRESC */
+#define _ADC_CTRL_PRESC_MASK                    0x7F00UL                                    /**< Bit mask for ADC_PRESC */
+#define _ADC_CTRL_PRESC_DEFAULT                 0x00000000UL                                /**< Mode DEFAULT for ADC_CTRL */
+#define _ADC_CTRL_PRESC_NODIVISION              0x00000000UL                                /**< Mode NODIVISION for ADC_CTRL */
+#define ADC_CTRL_PRESC_DEFAULT                  (_ADC_CTRL_PRESC_DEFAULT << 8)              /**< Shifted mode DEFAULT for ADC_CTRL */
+#define ADC_CTRL_PRESC_NODIVISION               (_ADC_CTRL_PRESC_NODIVISION << 8)           /**< Shifted mode NODIVISION for ADC_CTRL */
+#define _ADC_CTRL_TIMEBASE_SHIFT                16                                          /**< Shift value for ADC_TIMEBASE */
+#define _ADC_CTRL_TIMEBASE_MASK                 0x1F0000UL                                  /**< Bit mask for ADC_TIMEBASE */
+#define _ADC_CTRL_TIMEBASE_DEFAULT              0x0000001FUL                                /**< Mode DEFAULT for ADC_CTRL */
+#define ADC_CTRL_TIMEBASE_DEFAULT               (_ADC_CTRL_TIMEBASE_DEFAULT << 16)          /**< Shifted mode DEFAULT for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_SHIFT                 24                                          /**< Shift value for ADC_OVSRSEL */
+#define _ADC_CTRL_OVSRSEL_MASK                  0xF000000UL                                 /**< Bit mask for ADC_OVSRSEL */
+#define _ADC_CTRL_OVSRSEL_DEFAULT               0x00000000UL                                /**< Mode DEFAULT for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X2                    0x00000000UL                                /**< Mode X2 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X4                    0x00000001UL                                /**< Mode X4 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X8                    0x00000002UL                                /**< Mode X8 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X16                   0x00000003UL                                /**< Mode X16 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X32                   0x00000004UL                                /**< Mode X32 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X64                   0x00000005UL                                /**< Mode X64 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X128                  0x00000006UL                                /**< Mode X128 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X256                  0x00000007UL                                /**< Mode X256 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X512                  0x00000008UL                                /**< Mode X512 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X1024                 0x00000009UL                                /**< Mode X1024 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X2048                 0x0000000AUL                                /**< Mode X2048 for ADC_CTRL */
+#define _ADC_CTRL_OVSRSEL_X4096                 0x0000000BUL                                /**< Mode X4096 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_DEFAULT                (_ADC_CTRL_OVSRSEL_DEFAULT << 24)           /**< Shifted mode DEFAULT for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X2                     (_ADC_CTRL_OVSRSEL_X2 << 24)                /**< Shifted mode X2 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X4                     (_ADC_CTRL_OVSRSEL_X4 << 24)                /**< Shifted mode X4 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X8                     (_ADC_CTRL_OVSRSEL_X8 << 24)                /**< Shifted mode X8 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X16                    (_ADC_CTRL_OVSRSEL_X16 << 24)               /**< Shifted mode X16 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X32                    (_ADC_CTRL_OVSRSEL_X32 << 24)               /**< Shifted mode X32 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X64                    (_ADC_CTRL_OVSRSEL_X64 << 24)               /**< Shifted mode X64 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X128                   (_ADC_CTRL_OVSRSEL_X128 << 24)              /**< Shifted mode X128 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X256                   (_ADC_CTRL_OVSRSEL_X256 << 24)              /**< Shifted mode X256 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X512                   (_ADC_CTRL_OVSRSEL_X512 << 24)              /**< Shifted mode X512 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X1024                  (_ADC_CTRL_OVSRSEL_X1024 << 24)             /**< Shifted mode X1024 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X2048                  (_ADC_CTRL_OVSRSEL_X2048 << 24)             /**< Shifted mode X2048 for ADC_CTRL */
+#define ADC_CTRL_OVSRSEL_X4096                  (_ADC_CTRL_OVSRSEL_X4096 << 24)             /**< Shifted mode X4096 for ADC_CTRL */
+
+/* Bit fields for ADC CMD */
+#define _ADC_CMD_RESETVALUE                     0x00000000UL                        /**< Default value for ADC_CMD */
+#define _ADC_CMD_MASK                           0x0000000FUL                        /**< Mask for ADC_CMD */
+#define ADC_CMD_SINGLESTART                     (0x1UL << 0)                        /**< Single Conversion Start */
+#define _ADC_CMD_SINGLESTART_SHIFT              0                                   /**< Shift value for ADC_SINGLESTART */
+#define _ADC_CMD_SINGLESTART_MASK               0x1UL                               /**< Bit mask for ADC_SINGLESTART */
+#define _ADC_CMD_SINGLESTART_DEFAULT            0x00000000UL                        /**< Mode DEFAULT for ADC_CMD */
+#define ADC_CMD_SINGLESTART_DEFAULT             (_ADC_CMD_SINGLESTART_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_CMD */
+#define ADC_CMD_SINGLESTOP                      (0x1UL << 1)                        /**< Single Conversion Stop */
+#define _ADC_CMD_SINGLESTOP_SHIFT               1                                   /**< Shift value for ADC_SINGLESTOP */
+#define _ADC_CMD_SINGLESTOP_MASK                0x2UL                               /**< Bit mask for ADC_SINGLESTOP */
+#define _ADC_CMD_SINGLESTOP_DEFAULT             0x00000000UL                        /**< Mode DEFAULT for ADC_CMD */
+#define ADC_CMD_SINGLESTOP_DEFAULT              (_ADC_CMD_SINGLESTOP_DEFAULT << 1)  /**< Shifted mode DEFAULT for ADC_CMD */
+#define ADC_CMD_SCANSTART                       (0x1UL << 2)                        /**< Scan Sequence Start */
+#define _ADC_CMD_SCANSTART_SHIFT                2                                   /**< Shift value for ADC_SCANSTART */
+#define _ADC_CMD_SCANSTART_MASK                 0x4UL                               /**< Bit mask for ADC_SCANSTART */
+#define _ADC_CMD_SCANSTART_DEFAULT              0x00000000UL                        /**< Mode DEFAULT for ADC_CMD */
+#define ADC_CMD_SCANSTART_DEFAULT               (_ADC_CMD_SCANSTART_DEFAULT << 2)   /**< Shifted mode DEFAULT for ADC_CMD */
+#define ADC_CMD_SCANSTOP                        (0x1UL << 3)                        /**< Scan Sequence Stop */
+#define _ADC_CMD_SCANSTOP_SHIFT                 3                                   /**< Shift value for ADC_SCANSTOP */
+#define _ADC_CMD_SCANSTOP_MASK                  0x8UL                               /**< Bit mask for ADC_SCANSTOP */
+#define _ADC_CMD_SCANSTOP_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for ADC_CMD */
+#define ADC_CMD_SCANSTOP_DEFAULT                (_ADC_CMD_SCANSTOP_DEFAULT << 3)    /**< Shifted mode DEFAULT for ADC_CMD */
+
+/* Bit fields for ADC STATUS */
+#define _ADC_STATUS_RESETVALUE                  0x00000000UL                             /**< Default value for ADC_STATUS */
+#define _ADC_STATUS_MASK                        0x07031303UL                             /**< Mask for ADC_STATUS */
+#define ADC_STATUS_SINGLEACT                    (0x1UL << 0)                             /**< Single Conversion Active */
+#define _ADC_STATUS_SINGLEACT_SHIFT             0                                        /**< Shift value for ADC_SINGLEACT */
+#define _ADC_STATUS_SINGLEACT_MASK              0x1UL                                    /**< Bit mask for ADC_SINGLEACT */
+#define _ADC_STATUS_SINGLEACT_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SINGLEACT_DEFAULT            (_ADC_STATUS_SINGLEACT_DEFAULT << 0)     /**< Shifted mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SCANACT                      (0x1UL << 1)                             /**< Scan Conversion Active */
+#define _ADC_STATUS_SCANACT_SHIFT               1                                        /**< Shift value for ADC_SCANACT */
+#define _ADC_STATUS_SCANACT_MASK                0x2UL                                    /**< Bit mask for ADC_SCANACT */
+#define _ADC_STATUS_SCANACT_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SCANACT_DEFAULT              (_ADC_STATUS_SCANACT_DEFAULT << 1)       /**< Shifted mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SINGLEREFWARM                (0x1UL << 8)                             /**< Single Reference Warmed Up */
+#define _ADC_STATUS_SINGLEREFWARM_SHIFT         8                                        /**< Shift value for ADC_SINGLEREFWARM */
+#define _ADC_STATUS_SINGLEREFWARM_MASK          0x100UL                                  /**< Bit mask for ADC_SINGLEREFWARM */
+#define _ADC_STATUS_SINGLEREFWARM_DEFAULT       0x00000000UL                             /**< Mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SINGLEREFWARM_DEFAULT        (_ADC_STATUS_SINGLEREFWARM_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SCANREFWARM                  (0x1UL << 9)                             /**< Scan Reference Warmed Up */
+#define _ADC_STATUS_SCANREFWARM_SHIFT           9                                        /**< Shift value for ADC_SCANREFWARM */
+#define _ADC_STATUS_SCANREFWARM_MASK            0x200UL                                  /**< Bit mask for ADC_SCANREFWARM */
+#define _ADC_STATUS_SCANREFWARM_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SCANREFWARM_DEFAULT          (_ADC_STATUS_SCANREFWARM_DEFAULT << 9)   /**< Shifted mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_WARM                         (0x1UL << 12)                            /**< ADC Warmed Up */
+#define _ADC_STATUS_WARM_SHIFT                  12                                       /**< Shift value for ADC_WARM */
+#define _ADC_STATUS_WARM_MASK                   0x1000UL                                 /**< Bit mask for ADC_WARM */
+#define _ADC_STATUS_WARM_DEFAULT                0x00000000UL                             /**< Mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_WARM_DEFAULT                 (_ADC_STATUS_WARM_DEFAULT << 12)         /**< Shifted mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SINGLEDV                     (0x1UL << 16)                            /**< Single Sample Data Valid */
+#define _ADC_STATUS_SINGLEDV_SHIFT              16                                       /**< Shift value for ADC_SINGLEDV */
+#define _ADC_STATUS_SINGLEDV_MASK               0x10000UL                                /**< Bit mask for ADC_SINGLEDV */
+#define _ADC_STATUS_SINGLEDV_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SINGLEDV_DEFAULT             (_ADC_STATUS_SINGLEDV_DEFAULT << 16)     /**< Shifted mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SCANDV                       (0x1UL << 17)                            /**< Scan Data Valid */
+#define _ADC_STATUS_SCANDV_SHIFT                17                                       /**< Shift value for ADC_SCANDV */
+#define _ADC_STATUS_SCANDV_MASK                 0x20000UL                                /**< Bit mask for ADC_SCANDV */
+#define _ADC_STATUS_SCANDV_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SCANDV_DEFAULT               (_ADC_STATUS_SCANDV_DEFAULT << 17)       /**< Shifted mode DEFAULT for ADC_STATUS */
+#define _ADC_STATUS_SCANDATASRC_SHIFT           24                                       /**< Shift value for ADC_SCANDATASRC */
+#define _ADC_STATUS_SCANDATASRC_MASK            0x7000000UL                              /**< Bit mask for ADC_SCANDATASRC */
+#define _ADC_STATUS_SCANDATASRC_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for ADC_STATUS */
+#define _ADC_STATUS_SCANDATASRC_CH0             0x00000000UL                             /**< Mode CH0 for ADC_STATUS */
+#define _ADC_STATUS_SCANDATASRC_CH1             0x00000001UL                             /**< Mode CH1 for ADC_STATUS */
+#define _ADC_STATUS_SCANDATASRC_CH2             0x00000002UL                             /**< Mode CH2 for ADC_STATUS */
+#define _ADC_STATUS_SCANDATASRC_CH3             0x00000003UL                             /**< Mode CH3 for ADC_STATUS */
+#define _ADC_STATUS_SCANDATASRC_CH4             0x00000004UL                             /**< Mode CH4 for ADC_STATUS */
+#define _ADC_STATUS_SCANDATASRC_CH5             0x00000005UL                             /**< Mode CH5 for ADC_STATUS */
+#define _ADC_STATUS_SCANDATASRC_CH6             0x00000006UL                             /**< Mode CH6 for ADC_STATUS */
+#define _ADC_STATUS_SCANDATASRC_CH7             0x00000007UL                             /**< Mode CH7 for ADC_STATUS */
+#define ADC_STATUS_SCANDATASRC_DEFAULT          (_ADC_STATUS_SCANDATASRC_DEFAULT << 24)  /**< Shifted mode DEFAULT for ADC_STATUS */
+#define ADC_STATUS_SCANDATASRC_CH0              (_ADC_STATUS_SCANDATASRC_CH0 << 24)      /**< Shifted mode CH0 for ADC_STATUS */
+#define ADC_STATUS_SCANDATASRC_CH1              (_ADC_STATUS_SCANDATASRC_CH1 << 24)      /**< Shifted mode CH1 for ADC_STATUS */
+#define ADC_STATUS_SCANDATASRC_CH2              (_ADC_STATUS_SCANDATASRC_CH2 << 24)      /**< Shifted mode CH2 for ADC_STATUS */
+#define ADC_STATUS_SCANDATASRC_CH3              (_ADC_STATUS_SCANDATASRC_CH3 << 24)      /**< Shifted mode CH3 for ADC_STATUS */
+#define ADC_STATUS_SCANDATASRC_CH4              (_ADC_STATUS_SCANDATASRC_CH4 << 24)      /**< Shifted mode CH4 for ADC_STATUS */
+#define ADC_STATUS_SCANDATASRC_CH5              (_ADC_STATUS_SCANDATASRC_CH5 << 24)      /**< Shifted mode CH5 for ADC_STATUS */
+#define ADC_STATUS_SCANDATASRC_CH6              (_ADC_STATUS_SCANDATASRC_CH6 << 24)      /**< Shifted mode CH6 for ADC_STATUS */
+#define ADC_STATUS_SCANDATASRC_CH7              (_ADC_STATUS_SCANDATASRC_CH7 << 24)      /**< Shifted mode CH7 for ADC_STATUS */
+
+/* Bit fields for ADC SINGLECTRL */
+#define _ADC_SINGLECTRL_RESETVALUE              0x00000000UL                             /**< Default value for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_MASK                    0x71F70F37UL                             /**< Mask for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REP                      (0x1UL << 0)                             /**< Single Sample Repetitive Mode */
+#define _ADC_SINGLECTRL_REP_SHIFT               0                                        /**< Shift value for ADC_REP */
+#define _ADC_SINGLECTRL_REP_MASK                0x1UL                                    /**< Bit mask for ADC_REP */
+#define _ADC_SINGLECTRL_REP_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REP_DEFAULT              (_ADC_SINGLECTRL_REP_DEFAULT << 0)       /**< Shifted mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_DIFF                     (0x1UL << 1)                             /**< Single Sample Differential Mode */
+#define _ADC_SINGLECTRL_DIFF_SHIFT              1                                        /**< Shift value for ADC_DIFF */
+#define _ADC_SINGLECTRL_DIFF_MASK               0x2UL                                    /**< Bit mask for ADC_DIFF */
+#define _ADC_SINGLECTRL_DIFF_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_DIFF_DEFAULT             (_ADC_SINGLECTRL_DIFF_DEFAULT << 1)      /**< Shifted mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_ADJ                      (0x1UL << 2)                             /**< Single Sample Result Adjustment */
+#define _ADC_SINGLECTRL_ADJ_SHIFT               2                                        /**< Shift value for ADC_ADJ */
+#define _ADC_SINGLECTRL_ADJ_MASK                0x4UL                                    /**< Bit mask for ADC_ADJ */
+#define _ADC_SINGLECTRL_ADJ_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_ADJ_RIGHT               0x00000000UL                             /**< Mode RIGHT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_ADJ_LEFT                0x00000001UL                             /**< Mode LEFT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_ADJ_DEFAULT              (_ADC_SINGLECTRL_ADJ_DEFAULT << 2)       /**< Shifted mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_ADJ_RIGHT                (_ADC_SINGLECTRL_ADJ_RIGHT << 2)         /**< Shifted mode RIGHT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_ADJ_LEFT                 (_ADC_SINGLECTRL_ADJ_LEFT << 2)          /**< Shifted mode LEFT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_RES_SHIFT               4                                        /**< Shift value for ADC_RES */
+#define _ADC_SINGLECTRL_RES_MASK                0x30UL                                   /**< Bit mask for ADC_RES */
+#define _ADC_SINGLECTRL_RES_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_RES_12BIT               0x00000000UL                             /**< Mode 12BIT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_RES_8BIT                0x00000001UL                             /**< Mode 8BIT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_RES_6BIT                0x00000002UL                             /**< Mode 6BIT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_RES_OVS                 0x00000003UL                             /**< Mode OVS for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_RES_DEFAULT              (_ADC_SINGLECTRL_RES_DEFAULT << 4)       /**< Shifted mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_RES_12BIT                (_ADC_SINGLECTRL_RES_12BIT << 4)         /**< Shifted mode 12BIT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_RES_8BIT                 (_ADC_SINGLECTRL_RES_8BIT << 4)          /**< Shifted mode 8BIT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_RES_6BIT                 (_ADC_SINGLECTRL_RES_6BIT << 4)          /**< Shifted mode 6BIT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_RES_OVS                  (_ADC_SINGLECTRL_RES_OVS << 4)           /**< Shifted mode OVS for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_SHIFT          8                                        /**< Shift value for ADC_INPUTSEL */
+#define _ADC_SINGLECTRL_INPUTSEL_MASK           0xF00UL                                  /**< Bit mask for ADC_INPUTSEL */
+#define _ADC_SINGLECTRL_INPUTSEL_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH0CH1         0x00000000UL                             /**< Mode CH0CH1 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH0            0x00000000UL                             /**< Mode CH0 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH2CH3         0x00000001UL                             /**< Mode CH2CH3 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH1            0x00000001UL                             /**< Mode CH1 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH4CH5         0x00000002UL                             /**< Mode CH4CH5 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH2            0x00000002UL                             /**< Mode CH2 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH6CH7         0x00000003UL                             /**< Mode CH6CH7 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH3            0x00000003UL                             /**< Mode CH3 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_DIFF0          0x00000004UL                             /**< Mode DIFF0 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH4            0x00000004UL                             /**< Mode CH4 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH5            0x00000005UL                             /**< Mode CH5 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH6            0x00000006UL                             /**< Mode CH6 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_CH7            0x00000007UL                             /**< Mode CH7 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_TEMP           0x00000008UL                             /**< Mode TEMP for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_VDDDIV3        0x00000009UL                             /**< Mode VDDDIV3 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_VDD            0x0000000AUL                             /**< Mode VDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_VSS            0x0000000BUL                             /**< Mode VSS for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_VREFDIV2       0x0000000CUL                             /**< Mode VREFDIV2 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_DAC0OUT0       0x0000000DUL                             /**< Mode DAC0OUT0 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_INPUTSEL_DAC0OUT1       0x0000000EUL                             /**< Mode DAC0OUT1 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_DEFAULT         (_ADC_SINGLECTRL_INPUTSEL_DEFAULT << 8)  /**< Shifted mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH0CH1          (_ADC_SINGLECTRL_INPUTSEL_CH0CH1 << 8)   /**< Shifted mode CH0CH1 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH0             (_ADC_SINGLECTRL_INPUTSEL_CH0 << 8)      /**< Shifted mode CH0 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH2CH3          (_ADC_SINGLECTRL_INPUTSEL_CH2CH3 << 8)   /**< Shifted mode CH2CH3 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH1             (_ADC_SINGLECTRL_INPUTSEL_CH1 << 8)      /**< Shifted mode CH1 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH4CH5          (_ADC_SINGLECTRL_INPUTSEL_CH4CH5 << 8)   /**< Shifted mode CH4CH5 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH2             (_ADC_SINGLECTRL_INPUTSEL_CH2 << 8)      /**< Shifted mode CH2 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH6CH7          (_ADC_SINGLECTRL_INPUTSEL_CH6CH7 << 8)   /**< Shifted mode CH6CH7 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH3             (_ADC_SINGLECTRL_INPUTSEL_CH3 << 8)      /**< Shifted mode CH3 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_DIFF0           (_ADC_SINGLECTRL_INPUTSEL_DIFF0 << 8)    /**< Shifted mode DIFF0 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH4             (_ADC_SINGLECTRL_INPUTSEL_CH4 << 8)      /**< Shifted mode CH4 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH5             (_ADC_SINGLECTRL_INPUTSEL_CH5 << 8)      /**< Shifted mode CH5 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH6             (_ADC_SINGLECTRL_INPUTSEL_CH6 << 8)      /**< Shifted mode CH6 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_CH7             (_ADC_SINGLECTRL_INPUTSEL_CH7 << 8)      /**< Shifted mode CH7 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_TEMP            (_ADC_SINGLECTRL_INPUTSEL_TEMP << 8)     /**< Shifted mode TEMP for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_VDDDIV3         (_ADC_SINGLECTRL_INPUTSEL_VDDDIV3 << 8)  /**< Shifted mode VDDDIV3 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_VDD             (_ADC_SINGLECTRL_INPUTSEL_VDD << 8)      /**< Shifted mode VDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_VSS             (_ADC_SINGLECTRL_INPUTSEL_VSS << 8)      /**< Shifted mode VSS for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_VREFDIV2        (_ADC_SINGLECTRL_INPUTSEL_VREFDIV2 << 8) /**< Shifted mode VREFDIV2 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_DAC0OUT0        (_ADC_SINGLECTRL_INPUTSEL_DAC0OUT0 << 8) /**< Shifted mode DAC0OUT0 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_INPUTSEL_DAC0OUT1        (_ADC_SINGLECTRL_INPUTSEL_DAC0OUT1 << 8) /**< Shifted mode DAC0OUT1 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_REF_SHIFT               16                                       /**< Shift value for ADC_REF */
+#define _ADC_SINGLECTRL_REF_MASK                0x70000UL                                /**< Bit mask for ADC_REF */
+#define _ADC_SINGLECTRL_REF_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_REF_1V25                0x00000000UL                             /**< Mode 1V25 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_REF_2V5                 0x00000001UL                             /**< Mode 2V5 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_REF_VDD                 0x00000002UL                             /**< Mode VDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_REF_5VDIFF              0x00000003UL                             /**< Mode 5VDIFF for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_REF_EXTSINGLE           0x00000004UL                             /**< Mode EXTSINGLE for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_REF_2XEXTDIFF           0x00000005UL                             /**< Mode 2XEXTDIFF for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_REF_2XVDD               0x00000006UL                             /**< Mode 2XVDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REF_DEFAULT              (_ADC_SINGLECTRL_REF_DEFAULT << 16)      /**< Shifted mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REF_1V25                 (_ADC_SINGLECTRL_REF_1V25 << 16)         /**< Shifted mode 1V25 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REF_2V5                  (_ADC_SINGLECTRL_REF_2V5 << 16)          /**< Shifted mode 2V5 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REF_VDD                  (_ADC_SINGLECTRL_REF_VDD << 16)          /**< Shifted mode VDD for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REF_5VDIFF               (_ADC_SINGLECTRL_REF_5VDIFF << 16)       /**< Shifted mode 5VDIFF for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REF_EXTSINGLE            (_ADC_SINGLECTRL_REF_EXTSINGLE << 16)    /**< Shifted mode EXTSINGLE for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REF_2XEXTDIFF            (_ADC_SINGLECTRL_REF_2XEXTDIFF << 16)    /**< Shifted mode 2XEXTDIFF for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_REF_2XVDD                (_ADC_SINGLECTRL_REF_2XVDD << 16)        /**< Shifted mode 2XVDD for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_SHIFT                20                                       /**< Shift value for ADC_AT */
+#define _ADC_SINGLECTRL_AT_MASK                 0xF00000UL                               /**< Bit mask for ADC_AT */
+#define _ADC_SINGLECTRL_AT_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_1CYCLE               0x00000000UL                             /**< Mode 1CYCLE for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_2CYCLES              0x00000001UL                             /**< Mode 2CYCLES for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_4CYCLES              0x00000002UL                             /**< Mode 4CYCLES for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_8CYCLES              0x00000003UL                             /**< Mode 8CYCLES for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_16CYCLES             0x00000004UL                             /**< Mode 16CYCLES for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_32CYCLES             0x00000005UL                             /**< Mode 32CYCLES for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_64CYCLES             0x00000006UL                             /**< Mode 64CYCLES for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_128CYCLES            0x00000007UL                             /**< Mode 128CYCLES for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_AT_256CYCLES            0x00000008UL                             /**< Mode 256CYCLES for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_DEFAULT               (_ADC_SINGLECTRL_AT_DEFAULT << 20)       /**< Shifted mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_1CYCLE                (_ADC_SINGLECTRL_AT_1CYCLE << 20)        /**< Shifted mode 1CYCLE for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_2CYCLES               (_ADC_SINGLECTRL_AT_2CYCLES << 20)       /**< Shifted mode 2CYCLES for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_4CYCLES               (_ADC_SINGLECTRL_AT_4CYCLES << 20)       /**< Shifted mode 4CYCLES for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_8CYCLES               (_ADC_SINGLECTRL_AT_8CYCLES << 20)       /**< Shifted mode 8CYCLES for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_16CYCLES              (_ADC_SINGLECTRL_AT_16CYCLES << 20)      /**< Shifted mode 16CYCLES for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_32CYCLES              (_ADC_SINGLECTRL_AT_32CYCLES << 20)      /**< Shifted mode 32CYCLES for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_64CYCLES              (_ADC_SINGLECTRL_AT_64CYCLES << 20)      /**< Shifted mode 64CYCLES for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_128CYCLES             (_ADC_SINGLECTRL_AT_128CYCLES << 20)     /**< Shifted mode 128CYCLES for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_AT_256CYCLES             (_ADC_SINGLECTRL_AT_256CYCLES << 20)     /**< Shifted mode 256CYCLES for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSEN                    (0x1UL << 24)                            /**< Single Sample PRS Trigger Enable */
+#define _ADC_SINGLECTRL_PRSEN_SHIFT             24                                       /**< Shift value for ADC_PRSEN */
+#define _ADC_SINGLECTRL_PRSEN_MASK              0x1000000UL                              /**< Bit mask for ADC_PRSEN */
+#define _ADC_SINGLECTRL_PRSEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSEN_DEFAULT            (_ADC_SINGLECTRL_PRSEN_DEFAULT << 24)    /**< Shifted mode DEFAULT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_PRSSEL_SHIFT            28                                       /**< Shift value for ADC_PRSSEL */
+#define _ADC_SINGLECTRL_PRSSEL_MASK             0x70000000UL                             /**< Bit mask for ADC_PRSSEL */
+#define _ADC_SINGLECTRL_PRSSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_PRSSEL_PRSCH0           0x00000000UL                             /**< Mode PRSCH0 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_PRSSEL_PRSCH1           0x00000001UL                             /**< Mode PRSCH1 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_PRSSEL_PRSCH2           0x00000002UL                             /**< Mode PRSCH2 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_PRSSEL_PRSCH3           0x00000003UL                             /**< Mode PRSCH3 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_PRSSEL_PRSCH4           0x00000004UL                             /**< Mode PRSCH4 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_PRSSEL_PRSCH5           0x00000005UL                             /**< Mode PRSCH5 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_PRSSEL_PRSCH6           0x00000006UL                             /**< Mode PRSCH6 for ADC_SINGLECTRL */
+#define _ADC_SINGLECTRL_PRSSEL_PRSCH7           0x00000007UL                             /**< Mode PRSCH7 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSSEL_DEFAULT           (_ADC_SINGLECTRL_PRSSEL_DEFAULT << 28)   /**< Shifted mode DEFAULT for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSSEL_PRSCH0            (_ADC_SINGLECTRL_PRSSEL_PRSCH0 << 28)    /**< Shifted mode PRSCH0 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSSEL_PRSCH1            (_ADC_SINGLECTRL_PRSSEL_PRSCH1 << 28)    /**< Shifted mode PRSCH1 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSSEL_PRSCH2            (_ADC_SINGLECTRL_PRSSEL_PRSCH2 << 28)    /**< Shifted mode PRSCH2 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSSEL_PRSCH3            (_ADC_SINGLECTRL_PRSSEL_PRSCH3 << 28)    /**< Shifted mode PRSCH3 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSSEL_PRSCH4            (_ADC_SINGLECTRL_PRSSEL_PRSCH4 << 28)    /**< Shifted mode PRSCH4 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSSEL_PRSCH5            (_ADC_SINGLECTRL_PRSSEL_PRSCH5 << 28)    /**< Shifted mode PRSCH5 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSSEL_PRSCH6            (_ADC_SINGLECTRL_PRSSEL_PRSCH6 << 28)    /**< Shifted mode PRSCH6 for ADC_SINGLECTRL */
+#define ADC_SINGLECTRL_PRSSEL_PRSCH7            (_ADC_SINGLECTRL_PRSSEL_PRSCH7 << 28)    /**< Shifted mode PRSCH7 for ADC_SINGLECTRL */
+
+/* Bit fields for ADC SCANCTRL */
+#define _ADC_SCANCTRL_RESETVALUE                0x00000000UL                           /**< Default value for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_MASK                      0x71F7FF37UL                           /**< Mask for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REP                        (0x1UL << 0)                           /**< Scan Sequence Repetitive Mode */
+#define _ADC_SCANCTRL_REP_SHIFT                 0                                      /**< Shift value for ADC_REP */
+#define _ADC_SCANCTRL_REP_MASK                  0x1UL                                  /**< Bit mask for ADC_REP */
+#define _ADC_SCANCTRL_REP_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REP_DEFAULT                (_ADC_SCANCTRL_REP_DEFAULT << 0)       /**< Shifted mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_DIFF                       (0x1UL << 1)                           /**< Scan Sequence Differential Mode */
+#define _ADC_SCANCTRL_DIFF_SHIFT                1                                      /**< Shift value for ADC_DIFF */
+#define _ADC_SCANCTRL_DIFF_MASK                 0x2UL                                  /**< Bit mask for ADC_DIFF */
+#define _ADC_SCANCTRL_DIFF_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_DIFF_DEFAULT               (_ADC_SCANCTRL_DIFF_DEFAULT << 1)      /**< Shifted mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_ADJ                        (0x1UL << 2)                           /**< Scan Sequence Result Adjustment */
+#define _ADC_SCANCTRL_ADJ_SHIFT                 2                                      /**< Shift value for ADC_ADJ */
+#define _ADC_SCANCTRL_ADJ_MASK                  0x4UL                                  /**< Bit mask for ADC_ADJ */
+#define _ADC_SCANCTRL_ADJ_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_ADJ_RIGHT                 0x00000000UL                           /**< Mode RIGHT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_ADJ_LEFT                  0x00000001UL                           /**< Mode LEFT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_ADJ_DEFAULT                (_ADC_SCANCTRL_ADJ_DEFAULT << 2)       /**< Shifted mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_ADJ_RIGHT                  (_ADC_SCANCTRL_ADJ_RIGHT << 2)         /**< Shifted mode RIGHT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_ADJ_LEFT                   (_ADC_SCANCTRL_ADJ_LEFT << 2)          /**< Shifted mode LEFT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_RES_SHIFT                 4                                      /**< Shift value for ADC_RES */
+#define _ADC_SCANCTRL_RES_MASK                  0x30UL                                 /**< Bit mask for ADC_RES */
+#define _ADC_SCANCTRL_RES_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_RES_12BIT                 0x00000000UL                           /**< Mode 12BIT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_RES_8BIT                  0x00000001UL                           /**< Mode 8BIT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_RES_6BIT                  0x00000002UL                           /**< Mode 6BIT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_RES_OVS                   0x00000003UL                           /**< Mode OVS for ADC_SCANCTRL */
+#define ADC_SCANCTRL_RES_DEFAULT                (_ADC_SCANCTRL_RES_DEFAULT << 4)       /**< Shifted mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_RES_12BIT                  (_ADC_SCANCTRL_RES_12BIT << 4)         /**< Shifted mode 12BIT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_RES_8BIT                   (_ADC_SCANCTRL_RES_8BIT << 4)          /**< Shifted mode 8BIT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_RES_6BIT                   (_ADC_SCANCTRL_RES_6BIT << 4)          /**< Shifted mode 6BIT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_RES_OVS                    (_ADC_SCANCTRL_RES_OVS << 4)           /**< Shifted mode OVS for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_SHIFT           8                                      /**< Shift value for ADC_INPUTMASK */
+#define _ADC_SCANCTRL_INPUTMASK_MASK            0xFF00UL                               /**< Bit mask for ADC_INPUTMASK */
+#define _ADC_SCANCTRL_INPUTMASK_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH0CH1          0x00000001UL                           /**< Mode CH0CH1 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH0             0x00000001UL                           /**< Mode CH0 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH2CH3          0x00000002UL                           /**< Mode CH2CH3 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH1             0x00000002UL                           /**< Mode CH1 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH4CH5          0x00000004UL                           /**< Mode CH4CH5 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH2             0x00000004UL                           /**< Mode CH2 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH6CH7          0x00000008UL                           /**< Mode CH6CH7 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH3             0x00000008UL                           /**< Mode CH3 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH4             0x00000010UL                           /**< Mode CH4 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH5             0x00000020UL                           /**< Mode CH5 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH6             0x00000040UL                           /**< Mode CH6 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_INPUTMASK_CH7             0x00000080UL                           /**< Mode CH7 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_DEFAULT          (_ADC_SCANCTRL_INPUTMASK_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH0CH1           (_ADC_SCANCTRL_INPUTMASK_CH0CH1 << 8)  /**< Shifted mode CH0CH1 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH0              (_ADC_SCANCTRL_INPUTMASK_CH0 << 8)     /**< Shifted mode CH0 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH2CH3           (_ADC_SCANCTRL_INPUTMASK_CH2CH3 << 8)  /**< Shifted mode CH2CH3 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH1              (_ADC_SCANCTRL_INPUTMASK_CH1 << 8)     /**< Shifted mode CH1 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH4CH5           (_ADC_SCANCTRL_INPUTMASK_CH4CH5 << 8)  /**< Shifted mode CH4CH5 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH2              (_ADC_SCANCTRL_INPUTMASK_CH2 << 8)     /**< Shifted mode CH2 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH6CH7           (_ADC_SCANCTRL_INPUTMASK_CH6CH7 << 8)  /**< Shifted mode CH6CH7 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH3              (_ADC_SCANCTRL_INPUTMASK_CH3 << 8)     /**< Shifted mode CH3 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH4              (_ADC_SCANCTRL_INPUTMASK_CH4 << 8)     /**< Shifted mode CH4 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH5              (_ADC_SCANCTRL_INPUTMASK_CH5 << 8)     /**< Shifted mode CH5 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH6              (_ADC_SCANCTRL_INPUTMASK_CH6 << 8)     /**< Shifted mode CH6 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_INPUTMASK_CH7              (_ADC_SCANCTRL_INPUTMASK_CH7 << 8)     /**< Shifted mode CH7 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_REF_SHIFT                 16                                     /**< Shift value for ADC_REF */
+#define _ADC_SCANCTRL_REF_MASK                  0x70000UL                              /**< Bit mask for ADC_REF */
+#define _ADC_SCANCTRL_REF_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_REF_1V25                  0x00000000UL                           /**< Mode 1V25 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_REF_2V5                   0x00000001UL                           /**< Mode 2V5 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_REF_VDD                   0x00000002UL                           /**< Mode VDD for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_REF_5VDIFF                0x00000003UL                           /**< Mode 5VDIFF for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_REF_EXTSINGLE             0x00000004UL                           /**< Mode EXTSINGLE for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_REF_2XEXTDIFF             0x00000005UL                           /**< Mode 2XEXTDIFF for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_REF_2XVDD                 0x00000006UL                           /**< Mode 2XVDD for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REF_DEFAULT                (_ADC_SCANCTRL_REF_DEFAULT << 16)      /**< Shifted mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REF_1V25                   (_ADC_SCANCTRL_REF_1V25 << 16)         /**< Shifted mode 1V25 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REF_2V5                    (_ADC_SCANCTRL_REF_2V5 << 16)          /**< Shifted mode 2V5 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REF_VDD                    (_ADC_SCANCTRL_REF_VDD << 16)          /**< Shifted mode VDD for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REF_5VDIFF                 (_ADC_SCANCTRL_REF_5VDIFF << 16)       /**< Shifted mode 5VDIFF for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REF_EXTSINGLE              (_ADC_SCANCTRL_REF_EXTSINGLE << 16)    /**< Shifted mode EXTSINGLE for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REF_2XEXTDIFF              (_ADC_SCANCTRL_REF_2XEXTDIFF << 16)    /**< Shifted mode 2XEXTDIFF for ADC_SCANCTRL */
+#define ADC_SCANCTRL_REF_2XVDD                  (_ADC_SCANCTRL_REF_2XVDD << 16)        /**< Shifted mode 2XVDD for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_SHIFT                  20                                     /**< Shift value for ADC_AT */
+#define _ADC_SCANCTRL_AT_MASK                   0xF00000UL                             /**< Bit mask for ADC_AT */
+#define _ADC_SCANCTRL_AT_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_1CYCLE                 0x00000000UL                           /**< Mode 1CYCLE for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_2CYCLES                0x00000001UL                           /**< Mode 2CYCLES for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_4CYCLES                0x00000002UL                           /**< Mode 4CYCLES for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_8CYCLES                0x00000003UL                           /**< Mode 8CYCLES for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_16CYCLES               0x00000004UL                           /**< Mode 16CYCLES for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_32CYCLES               0x00000005UL                           /**< Mode 32CYCLES for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_64CYCLES               0x00000006UL                           /**< Mode 64CYCLES for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_128CYCLES              0x00000007UL                           /**< Mode 128CYCLES for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_AT_256CYCLES              0x00000008UL                           /**< Mode 256CYCLES for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_DEFAULT                 (_ADC_SCANCTRL_AT_DEFAULT << 20)       /**< Shifted mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_1CYCLE                  (_ADC_SCANCTRL_AT_1CYCLE << 20)        /**< Shifted mode 1CYCLE for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_2CYCLES                 (_ADC_SCANCTRL_AT_2CYCLES << 20)       /**< Shifted mode 2CYCLES for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_4CYCLES                 (_ADC_SCANCTRL_AT_4CYCLES << 20)       /**< Shifted mode 4CYCLES for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_8CYCLES                 (_ADC_SCANCTRL_AT_8CYCLES << 20)       /**< Shifted mode 8CYCLES for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_16CYCLES                (_ADC_SCANCTRL_AT_16CYCLES << 20)      /**< Shifted mode 16CYCLES for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_32CYCLES                (_ADC_SCANCTRL_AT_32CYCLES << 20)      /**< Shifted mode 32CYCLES for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_64CYCLES                (_ADC_SCANCTRL_AT_64CYCLES << 20)      /**< Shifted mode 64CYCLES for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_128CYCLES               (_ADC_SCANCTRL_AT_128CYCLES << 20)     /**< Shifted mode 128CYCLES for ADC_SCANCTRL */
+#define ADC_SCANCTRL_AT_256CYCLES               (_ADC_SCANCTRL_AT_256CYCLES << 20)     /**< Shifted mode 256CYCLES for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSEN                      (0x1UL << 24)                          /**< Scan Sequence PRS Trigger Enable */
+#define _ADC_SCANCTRL_PRSEN_SHIFT               24                                     /**< Shift value for ADC_PRSEN */
+#define _ADC_SCANCTRL_PRSEN_MASK                0x1000000UL                            /**< Bit mask for ADC_PRSEN */
+#define _ADC_SCANCTRL_PRSEN_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSEN_DEFAULT              (_ADC_SCANCTRL_PRSEN_DEFAULT << 24)    /**< Shifted mode DEFAULT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_PRSSEL_SHIFT              28                                     /**< Shift value for ADC_PRSSEL */
+#define _ADC_SCANCTRL_PRSSEL_MASK               0x70000000UL                           /**< Bit mask for ADC_PRSSEL */
+#define _ADC_SCANCTRL_PRSSEL_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_PRSSEL_PRSCH0             0x00000000UL                           /**< Mode PRSCH0 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_PRSSEL_PRSCH1             0x00000001UL                           /**< Mode PRSCH1 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_PRSSEL_PRSCH2             0x00000002UL                           /**< Mode PRSCH2 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_PRSSEL_PRSCH3             0x00000003UL                           /**< Mode PRSCH3 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_PRSSEL_PRSCH4             0x00000004UL                           /**< Mode PRSCH4 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_PRSSEL_PRSCH5             0x00000005UL                           /**< Mode PRSCH5 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_PRSSEL_PRSCH6             0x00000006UL                           /**< Mode PRSCH6 for ADC_SCANCTRL */
+#define _ADC_SCANCTRL_PRSSEL_PRSCH7             0x00000007UL                           /**< Mode PRSCH7 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSSEL_DEFAULT             (_ADC_SCANCTRL_PRSSEL_DEFAULT << 28)   /**< Shifted mode DEFAULT for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSSEL_PRSCH0              (_ADC_SCANCTRL_PRSSEL_PRSCH0 << 28)    /**< Shifted mode PRSCH0 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSSEL_PRSCH1              (_ADC_SCANCTRL_PRSSEL_PRSCH1 << 28)    /**< Shifted mode PRSCH1 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSSEL_PRSCH2              (_ADC_SCANCTRL_PRSSEL_PRSCH2 << 28)    /**< Shifted mode PRSCH2 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSSEL_PRSCH3              (_ADC_SCANCTRL_PRSSEL_PRSCH3 << 28)    /**< Shifted mode PRSCH3 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSSEL_PRSCH4              (_ADC_SCANCTRL_PRSSEL_PRSCH4 << 28)    /**< Shifted mode PRSCH4 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSSEL_PRSCH5              (_ADC_SCANCTRL_PRSSEL_PRSCH5 << 28)    /**< Shifted mode PRSCH5 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSSEL_PRSCH6              (_ADC_SCANCTRL_PRSSEL_PRSCH6 << 28)    /**< Shifted mode PRSCH6 for ADC_SCANCTRL */
+#define ADC_SCANCTRL_PRSSEL_PRSCH7              (_ADC_SCANCTRL_PRSSEL_PRSCH7 << 28)    /**< Shifted mode PRSCH7 for ADC_SCANCTRL */
+
+/* Bit fields for ADC IEN */
+#define _ADC_IEN_RESETVALUE                     0x00000000UL                     /**< Default value for ADC_IEN */
+#define _ADC_IEN_MASK                           0x00000303UL                     /**< Mask for ADC_IEN */
+#define ADC_IEN_SINGLE                          (0x1UL << 0)                     /**< Single Conversion Complete Interrupt Enable */
+#define _ADC_IEN_SINGLE_SHIFT                   0                                /**< Shift value for ADC_SINGLE */
+#define _ADC_IEN_SINGLE_MASK                    0x1UL                            /**< Bit mask for ADC_SINGLE */
+#define _ADC_IEN_SINGLE_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for ADC_IEN */
+#define ADC_IEN_SINGLE_DEFAULT                  (_ADC_IEN_SINGLE_DEFAULT << 0)   /**< Shifted mode DEFAULT for ADC_IEN */
+#define ADC_IEN_SCAN                            (0x1UL << 1)                     /**< Scan Conversion Complete Interrupt Enable */
+#define _ADC_IEN_SCAN_SHIFT                     1                                /**< Shift value for ADC_SCAN */
+#define _ADC_IEN_SCAN_MASK                      0x2UL                            /**< Bit mask for ADC_SCAN */
+#define _ADC_IEN_SCAN_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for ADC_IEN */
+#define ADC_IEN_SCAN_DEFAULT                    (_ADC_IEN_SCAN_DEFAULT << 1)     /**< Shifted mode DEFAULT for ADC_IEN */
+#define ADC_IEN_SINGLEOF                        (0x1UL << 8)                     /**< Single Result Overflow Interrupt Enable */
+#define _ADC_IEN_SINGLEOF_SHIFT                 8                                /**< Shift value for ADC_SINGLEOF */
+#define _ADC_IEN_SINGLEOF_MASK                  0x100UL                          /**< Bit mask for ADC_SINGLEOF */
+#define _ADC_IEN_SINGLEOF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for ADC_IEN */
+#define ADC_IEN_SINGLEOF_DEFAULT                (_ADC_IEN_SINGLEOF_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_IEN */
+#define ADC_IEN_SCANOF                          (0x1UL << 9)                     /**< Scan Result Overflow Interrupt Enable */
+#define _ADC_IEN_SCANOF_SHIFT                   9                                /**< Shift value for ADC_SCANOF */
+#define _ADC_IEN_SCANOF_MASK                    0x200UL                          /**< Bit mask for ADC_SCANOF */
+#define _ADC_IEN_SCANOF_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for ADC_IEN */
+#define ADC_IEN_SCANOF_DEFAULT                  (_ADC_IEN_SCANOF_DEFAULT << 9)   /**< Shifted mode DEFAULT for ADC_IEN */
+
+/* Bit fields for ADC IF */
+#define _ADC_IF_RESETVALUE                      0x00000000UL                    /**< Default value for ADC_IF */
+#define _ADC_IF_MASK                            0x00000303UL                    /**< Mask for ADC_IF */
+#define ADC_IF_SINGLE                           (0x1UL << 0)                    /**< Single Conversion Complete Interrupt Flag */
+#define _ADC_IF_SINGLE_SHIFT                    0                               /**< Shift value for ADC_SINGLE */
+#define _ADC_IF_SINGLE_MASK                     0x1UL                           /**< Bit mask for ADC_SINGLE */
+#define _ADC_IF_SINGLE_DEFAULT                  0x00000000UL                    /**< Mode DEFAULT for ADC_IF */
+#define ADC_IF_SINGLE_DEFAULT                   (_ADC_IF_SINGLE_DEFAULT << 0)   /**< Shifted mode DEFAULT for ADC_IF */
+#define ADC_IF_SCAN                             (0x1UL << 1)                    /**< Scan Conversion Complete Interrupt Flag */
+#define _ADC_IF_SCAN_SHIFT                      1                               /**< Shift value for ADC_SCAN */
+#define _ADC_IF_SCAN_MASK                       0x2UL                           /**< Bit mask for ADC_SCAN */
+#define _ADC_IF_SCAN_DEFAULT                    0x00000000UL                    /**< Mode DEFAULT for ADC_IF */
+#define ADC_IF_SCAN_DEFAULT                     (_ADC_IF_SCAN_DEFAULT << 1)     /**< Shifted mode DEFAULT for ADC_IF */
+#define ADC_IF_SINGLEOF                         (0x1UL << 8)                    /**< Single Result Overflow Interrupt Flag */
+#define _ADC_IF_SINGLEOF_SHIFT                  8                               /**< Shift value for ADC_SINGLEOF */
+#define _ADC_IF_SINGLEOF_MASK                   0x100UL                         /**< Bit mask for ADC_SINGLEOF */
+#define _ADC_IF_SINGLEOF_DEFAULT                0x00000000UL                    /**< Mode DEFAULT for ADC_IF */
+#define ADC_IF_SINGLEOF_DEFAULT                 (_ADC_IF_SINGLEOF_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_IF */
+#define ADC_IF_SCANOF                           (0x1UL << 9)                    /**< Scan Result Overflow Interrupt Flag */
+#define _ADC_IF_SCANOF_SHIFT                    9                               /**< Shift value for ADC_SCANOF */
+#define _ADC_IF_SCANOF_MASK                     0x200UL                         /**< Bit mask for ADC_SCANOF */
+#define _ADC_IF_SCANOF_DEFAULT                  0x00000000UL                    /**< Mode DEFAULT for ADC_IF */
+#define ADC_IF_SCANOF_DEFAULT                   (_ADC_IF_SCANOF_DEFAULT << 9)   /**< Shifted mode DEFAULT for ADC_IF */
+
+/* Bit fields for ADC IFS */
+#define _ADC_IFS_RESETVALUE                     0x00000000UL                     /**< Default value for ADC_IFS */
+#define _ADC_IFS_MASK                           0x00000303UL                     /**< Mask for ADC_IFS */
+#define ADC_IFS_SINGLE                          (0x1UL << 0)                     /**< Single Conversion Complete Interrupt Flag Set */
+#define _ADC_IFS_SINGLE_SHIFT                   0                                /**< Shift value for ADC_SINGLE */
+#define _ADC_IFS_SINGLE_MASK                    0x1UL                            /**< Bit mask for ADC_SINGLE */
+#define _ADC_IFS_SINGLE_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for ADC_IFS */
+#define ADC_IFS_SINGLE_DEFAULT                  (_ADC_IFS_SINGLE_DEFAULT << 0)   /**< Shifted mode DEFAULT for ADC_IFS */
+#define ADC_IFS_SCAN                            (0x1UL << 1)                     /**< Scan Conversion Complete Interrupt Flag Set */
+#define _ADC_IFS_SCAN_SHIFT                     1                                /**< Shift value for ADC_SCAN */
+#define _ADC_IFS_SCAN_MASK                      0x2UL                            /**< Bit mask for ADC_SCAN */
+#define _ADC_IFS_SCAN_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for ADC_IFS */
+#define ADC_IFS_SCAN_DEFAULT                    (_ADC_IFS_SCAN_DEFAULT << 1)     /**< Shifted mode DEFAULT for ADC_IFS */
+#define ADC_IFS_SINGLEOF                        (0x1UL << 8)                     /**< Single Result Overflow Interrupt Flag Set */
+#define _ADC_IFS_SINGLEOF_SHIFT                 8                                /**< Shift value for ADC_SINGLEOF */
+#define _ADC_IFS_SINGLEOF_MASK                  0x100UL                          /**< Bit mask for ADC_SINGLEOF */
+#define _ADC_IFS_SINGLEOF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for ADC_IFS */
+#define ADC_IFS_SINGLEOF_DEFAULT                (_ADC_IFS_SINGLEOF_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_IFS */
+#define ADC_IFS_SCANOF                          (0x1UL << 9)                     /**< Scan Result Overflow Interrupt Flag Set */
+#define _ADC_IFS_SCANOF_SHIFT                   9                                /**< Shift value for ADC_SCANOF */
+#define _ADC_IFS_SCANOF_MASK                    0x200UL                          /**< Bit mask for ADC_SCANOF */
+#define _ADC_IFS_SCANOF_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for ADC_IFS */
+#define ADC_IFS_SCANOF_DEFAULT                  (_ADC_IFS_SCANOF_DEFAULT << 9)   /**< Shifted mode DEFAULT for ADC_IFS */
+
+/* Bit fields for ADC IFC */
+#define _ADC_IFC_RESETVALUE                     0x00000000UL                     /**< Default value for ADC_IFC */
+#define _ADC_IFC_MASK                           0x00000303UL                     /**< Mask for ADC_IFC */
+#define ADC_IFC_SINGLE                          (0x1UL << 0)                     /**< Single Conversion Complete Interrupt Flag Clear */
+#define _ADC_IFC_SINGLE_SHIFT                   0                                /**< Shift value for ADC_SINGLE */
+#define _ADC_IFC_SINGLE_MASK                    0x1UL                            /**< Bit mask for ADC_SINGLE */
+#define _ADC_IFC_SINGLE_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for ADC_IFC */
+#define ADC_IFC_SINGLE_DEFAULT                  (_ADC_IFC_SINGLE_DEFAULT << 0)   /**< Shifted mode DEFAULT for ADC_IFC */
+#define ADC_IFC_SCAN                            (0x1UL << 1)                     /**< Scan Conversion Complete Interrupt Flag Clear */
+#define _ADC_IFC_SCAN_SHIFT                     1                                /**< Shift value for ADC_SCAN */
+#define _ADC_IFC_SCAN_MASK                      0x2UL                            /**< Bit mask for ADC_SCAN */
+#define _ADC_IFC_SCAN_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for ADC_IFC */
+#define ADC_IFC_SCAN_DEFAULT                    (_ADC_IFC_SCAN_DEFAULT << 1)     /**< Shifted mode DEFAULT for ADC_IFC */
+#define ADC_IFC_SINGLEOF                        (0x1UL << 8)                     /**< Single Result Overflow Interrupt Flag Clear */
+#define _ADC_IFC_SINGLEOF_SHIFT                 8                                /**< Shift value for ADC_SINGLEOF */
+#define _ADC_IFC_SINGLEOF_MASK                  0x100UL                          /**< Bit mask for ADC_SINGLEOF */
+#define _ADC_IFC_SINGLEOF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for ADC_IFC */
+#define ADC_IFC_SINGLEOF_DEFAULT                (_ADC_IFC_SINGLEOF_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_IFC */
+#define ADC_IFC_SCANOF                          (0x1UL << 9)                     /**< Scan Result Overflow Interrupt Flag Clear */
+#define _ADC_IFC_SCANOF_SHIFT                   9                                /**< Shift value for ADC_SCANOF */
+#define _ADC_IFC_SCANOF_MASK                    0x200UL                          /**< Bit mask for ADC_SCANOF */
+#define _ADC_IFC_SCANOF_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for ADC_IFC */
+#define ADC_IFC_SCANOF_DEFAULT                  (_ADC_IFC_SCANOF_DEFAULT << 9)   /**< Shifted mode DEFAULT for ADC_IFC */
+
+/* Bit fields for ADC SINGLEDATA */
+#define _ADC_SINGLEDATA_RESETVALUE              0x00000000UL                        /**< Default value for ADC_SINGLEDATA */
+#define _ADC_SINGLEDATA_MASK                    0xFFFFFFFFUL                        /**< Mask for ADC_SINGLEDATA */
+#define _ADC_SINGLEDATA_DATA_SHIFT              0                                   /**< Shift value for ADC_DATA */
+#define _ADC_SINGLEDATA_DATA_MASK               0xFFFFFFFFUL                        /**< Bit mask for ADC_DATA */
+#define _ADC_SINGLEDATA_DATA_DEFAULT            0x00000000UL                        /**< Mode DEFAULT for ADC_SINGLEDATA */
+#define ADC_SINGLEDATA_DATA_DEFAULT             (_ADC_SINGLEDATA_DATA_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_SINGLEDATA */
+
+/* Bit fields for ADC SCANDATA */
+#define _ADC_SCANDATA_RESETVALUE                0x00000000UL                      /**< Default value for ADC_SCANDATA */
+#define _ADC_SCANDATA_MASK                      0xFFFFFFFFUL                      /**< Mask for ADC_SCANDATA */
+#define _ADC_SCANDATA_DATA_SHIFT                0                                 /**< Shift value for ADC_DATA */
+#define _ADC_SCANDATA_DATA_MASK                 0xFFFFFFFFUL                      /**< Bit mask for ADC_DATA */
+#define _ADC_SCANDATA_DATA_DEFAULT              0x00000000UL                      /**< Mode DEFAULT for ADC_SCANDATA */
+#define ADC_SCANDATA_DATA_DEFAULT               (_ADC_SCANDATA_DATA_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_SCANDATA */
+
+/* Bit fields for ADC SINGLEDATAP */
+#define _ADC_SINGLEDATAP_RESETVALUE             0x00000000UL                          /**< Default value for ADC_SINGLEDATAP */
+#define _ADC_SINGLEDATAP_MASK                   0xFFFFFFFFUL                          /**< Mask for ADC_SINGLEDATAP */
+#define _ADC_SINGLEDATAP_DATAP_SHIFT            0                                     /**< Shift value for ADC_DATAP */
+#define _ADC_SINGLEDATAP_DATAP_MASK             0xFFFFFFFFUL                          /**< Bit mask for ADC_DATAP */
+#define _ADC_SINGLEDATAP_DATAP_DEFAULT          0x00000000UL                          /**< Mode DEFAULT for ADC_SINGLEDATAP */
+#define ADC_SINGLEDATAP_DATAP_DEFAULT           (_ADC_SINGLEDATAP_DATAP_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_SINGLEDATAP */
+
+/* Bit fields for ADC SCANDATAP */
+#define _ADC_SCANDATAP_RESETVALUE               0x00000000UL                        /**< Default value for ADC_SCANDATAP */
+#define _ADC_SCANDATAP_MASK                     0xFFFFFFFFUL                        /**< Mask for ADC_SCANDATAP */
+#define _ADC_SCANDATAP_DATAP_SHIFT              0                                   /**< Shift value for ADC_DATAP */
+#define _ADC_SCANDATAP_DATAP_MASK               0xFFFFFFFFUL                        /**< Bit mask for ADC_DATAP */
+#define _ADC_SCANDATAP_DATAP_DEFAULT            0x00000000UL                        /**< Mode DEFAULT for ADC_SCANDATAP */
+#define ADC_SCANDATAP_DATAP_DEFAULT             (_ADC_SCANDATAP_DATAP_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_SCANDATAP */
+
+/* Bit fields for ADC CAL */
+#define _ADC_CAL_RESETVALUE                     0x3F003F00UL                         /**< Default value for ADC_CAL */
+#define _ADC_CAL_MASK                           0x7F7F7F7FUL                         /**< Mask for ADC_CAL */
+#define _ADC_CAL_SINGLEOFFSET_SHIFT             0                                    /**< Shift value for ADC_SINGLEOFFSET */
+#define _ADC_CAL_SINGLEOFFSET_MASK              0x7FUL                               /**< Bit mask for ADC_SINGLEOFFSET */
+#define _ADC_CAL_SINGLEOFFSET_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for ADC_CAL */
+#define ADC_CAL_SINGLEOFFSET_DEFAULT            (_ADC_CAL_SINGLEOFFSET_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_CAL */
+#define _ADC_CAL_SINGLEGAIN_SHIFT               8                                    /**< Shift value for ADC_SINGLEGAIN */
+#define _ADC_CAL_SINGLEGAIN_MASK                0x7F00UL                             /**< Bit mask for ADC_SINGLEGAIN */
+#define _ADC_CAL_SINGLEGAIN_DEFAULT             0x0000003FUL                         /**< Mode DEFAULT for ADC_CAL */
+#define ADC_CAL_SINGLEGAIN_DEFAULT              (_ADC_CAL_SINGLEGAIN_DEFAULT << 8)   /**< Shifted mode DEFAULT for ADC_CAL */
+#define _ADC_CAL_SCANOFFSET_SHIFT               16                                   /**< Shift value for ADC_SCANOFFSET */
+#define _ADC_CAL_SCANOFFSET_MASK                0x7F0000UL                           /**< Bit mask for ADC_SCANOFFSET */
+#define _ADC_CAL_SCANOFFSET_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for ADC_CAL */
+#define ADC_CAL_SCANOFFSET_DEFAULT              (_ADC_CAL_SCANOFFSET_DEFAULT << 16)  /**< Shifted mode DEFAULT for ADC_CAL */
+#define _ADC_CAL_SCANGAIN_SHIFT                 24                                   /**< Shift value for ADC_SCANGAIN */
+#define _ADC_CAL_SCANGAIN_MASK                  0x7F000000UL                         /**< Bit mask for ADC_SCANGAIN */
+#define _ADC_CAL_SCANGAIN_DEFAULT               0x0000003FUL                         /**< Mode DEFAULT for ADC_CAL */
+#define ADC_CAL_SCANGAIN_DEFAULT                (_ADC_CAL_SCANGAIN_DEFAULT << 24)    /**< Shifted mode DEFAULT for ADC_CAL */
+
+/* Bit fields for ADC BIASPROG */
+#define _ADC_BIASPROG_RESETVALUE                0x00000747UL                          /**< Default value for ADC_BIASPROG */
+#define _ADC_BIASPROG_MASK                      0x00000F4FUL                          /**< Mask for ADC_BIASPROG */
+#define _ADC_BIASPROG_BIASPROG_SHIFT            0                                     /**< Shift value for ADC_BIASPROG */
+#define _ADC_BIASPROG_BIASPROG_MASK             0xFUL                                 /**< Bit mask for ADC_BIASPROG */
+#define _ADC_BIASPROG_BIASPROG_DEFAULT          0x00000007UL                          /**< Mode DEFAULT for ADC_BIASPROG */
+#define ADC_BIASPROG_BIASPROG_DEFAULT           (_ADC_BIASPROG_BIASPROG_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_BIASPROG */
+#define ADC_BIASPROG_HALFBIAS                   (0x1UL << 6)                          /**< Half Bias Current */
+#define _ADC_BIASPROG_HALFBIAS_SHIFT            6                                     /**< Shift value for ADC_HALFBIAS */
+#define _ADC_BIASPROG_HALFBIAS_MASK             0x40UL                                /**< Bit mask for ADC_HALFBIAS */
+#define _ADC_BIASPROG_HALFBIAS_DEFAULT          0x00000001UL                          /**< Mode DEFAULT for ADC_BIASPROG */
+#define ADC_BIASPROG_HALFBIAS_DEFAULT           (_ADC_BIASPROG_HALFBIAS_DEFAULT << 6) /**< Shifted mode DEFAULT for ADC_BIASPROG */
+#define _ADC_BIASPROG_COMPBIAS_SHIFT            8                                     /**< Shift value for ADC_COMPBIAS */
+#define _ADC_BIASPROG_COMPBIAS_MASK             0xF00UL                               /**< Bit mask for ADC_COMPBIAS */
+#define _ADC_BIASPROG_COMPBIAS_DEFAULT          0x00000007UL                          /**< Mode DEFAULT for ADC_BIASPROG */
+#define ADC_BIASPROG_COMPBIAS_DEFAULT           (_ADC_BIASPROG_COMPBIAS_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_BIASPROG */
+
+/** @} End of group EFM32TG_ADC */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_aes.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_aes.h
@@ -1,0 +1,246 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_AES register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_AES
+ * @brief EFM32TG_AES Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t DATA;          /**< DATA Register  */
+  __IOM uint32_t XORDATA;       /**< XORDATA Register  */
+  uint32_t       RESERVED0[3U]; /**< Reserved for future use **/
+  __IOM uint32_t KEYLA;         /**< KEY Low Register  */
+  __IOM uint32_t KEYLB;         /**< KEY Low Register  */
+  __IOM uint32_t KEYLC;         /**< KEY Low Register  */
+  __IOM uint32_t KEYLD;         /**< KEY Low Register  */
+  __IOM uint32_t KEYHA;         /**< KEY High Register  */
+  __IOM uint32_t KEYHB;         /**< KEY High Register  */
+  __IOM uint32_t KEYHC;         /**< KEY High Register  */
+  __IOM uint32_t KEYHD;         /**< KEY High Register  */
+} AES_TypeDef;                  /**< AES Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_AES_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for AES CTRL */
+#define _AES_CTRL_RESETVALUE            0x00000000UL                       /**< Default value for AES_CTRL */
+#define _AES_CTRL_MASK                  0x00000077UL                       /**< Mask for AES_CTRL */
+#define AES_CTRL_DECRYPT                (0x1UL << 0)                       /**< Decryption/Encryption Mode */
+#define _AES_CTRL_DECRYPT_SHIFT         0                                  /**< Shift value for AES_DECRYPT */
+#define _AES_CTRL_DECRYPT_MASK          0x1UL                              /**< Bit mask for AES_DECRYPT */
+#define _AES_CTRL_DECRYPT_DEFAULT       0x00000000UL                       /**< Mode DEFAULT for AES_CTRL */
+#define AES_CTRL_DECRYPT_DEFAULT        (_AES_CTRL_DECRYPT_DEFAULT << 0)   /**< Shifted mode DEFAULT for AES_CTRL */
+#define AES_CTRL_AES256                 (0x1UL << 1)                       /**< AES-256 Mode */
+#define _AES_CTRL_AES256_SHIFT          1                                  /**< Shift value for AES_AES256 */
+#define _AES_CTRL_AES256_MASK           0x2UL                              /**< Bit mask for AES_AES256 */
+#define _AES_CTRL_AES256_DEFAULT        0x00000000UL                       /**< Mode DEFAULT for AES_CTRL */
+#define AES_CTRL_AES256_DEFAULT         (_AES_CTRL_AES256_DEFAULT << 1)    /**< Shifted mode DEFAULT for AES_CTRL */
+#define AES_CTRL_KEYBUFEN               (0x1UL << 2)                       /**< Key Buffer Enable */
+#define _AES_CTRL_KEYBUFEN_SHIFT        2                                  /**< Shift value for AES_KEYBUFEN */
+#define _AES_CTRL_KEYBUFEN_MASK         0x4UL                              /**< Bit mask for AES_KEYBUFEN */
+#define _AES_CTRL_KEYBUFEN_DEFAULT      0x00000000UL                       /**< Mode DEFAULT for AES_CTRL */
+#define AES_CTRL_KEYBUFEN_DEFAULT       (_AES_CTRL_KEYBUFEN_DEFAULT << 2)  /**< Shifted mode DEFAULT for AES_CTRL */
+#define AES_CTRL_DATASTART              (0x1UL << 4)                       /**< AES_DATA Write Start */
+#define _AES_CTRL_DATASTART_SHIFT       4                                  /**< Shift value for AES_DATASTART */
+#define _AES_CTRL_DATASTART_MASK        0x10UL                             /**< Bit mask for AES_DATASTART */
+#define _AES_CTRL_DATASTART_DEFAULT     0x00000000UL                       /**< Mode DEFAULT for AES_CTRL */
+#define AES_CTRL_DATASTART_DEFAULT      (_AES_CTRL_DATASTART_DEFAULT << 4) /**< Shifted mode DEFAULT for AES_CTRL */
+#define AES_CTRL_XORSTART               (0x1UL << 5)                       /**< AES_XORDATA Write Start */
+#define _AES_CTRL_XORSTART_SHIFT        5                                  /**< Shift value for AES_XORSTART */
+#define _AES_CTRL_XORSTART_MASK         0x20UL                             /**< Bit mask for AES_XORSTART */
+#define _AES_CTRL_XORSTART_DEFAULT      0x00000000UL                       /**< Mode DEFAULT for AES_CTRL */
+#define AES_CTRL_XORSTART_DEFAULT       (_AES_CTRL_XORSTART_DEFAULT << 5)  /**< Shifted mode DEFAULT for AES_CTRL */
+#define AES_CTRL_BYTEORDER              (0x1UL << 6)                       /**< Configure byte order in data and key registers */
+#define _AES_CTRL_BYTEORDER_SHIFT       6                                  /**< Shift value for AES_BYTEORDER */
+#define _AES_CTRL_BYTEORDER_MASK        0x40UL                             /**< Bit mask for AES_BYTEORDER */
+#define _AES_CTRL_BYTEORDER_DEFAULT     0x00000000UL                       /**< Mode DEFAULT for AES_CTRL */
+#define AES_CTRL_BYTEORDER_DEFAULT      (_AES_CTRL_BYTEORDER_DEFAULT << 6) /**< Shifted mode DEFAULT for AES_CTRL */
+
+/* Bit fields for AES CMD */
+#define _AES_CMD_RESETVALUE             0x00000000UL                  /**< Default value for AES_CMD */
+#define _AES_CMD_MASK                   0x00000003UL                  /**< Mask for AES_CMD */
+#define AES_CMD_START                   (0x1UL << 0)                  /**< Encryption/Decryption Start */
+#define _AES_CMD_START_SHIFT            0                             /**< Shift value for AES_START */
+#define _AES_CMD_START_MASK             0x1UL                         /**< Bit mask for AES_START */
+#define _AES_CMD_START_DEFAULT          0x00000000UL                  /**< Mode DEFAULT for AES_CMD */
+#define AES_CMD_START_DEFAULT           (_AES_CMD_START_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_CMD */
+#define AES_CMD_STOP                    (0x1UL << 1)                  /**< Encryption/Decryption Stop */
+#define _AES_CMD_STOP_SHIFT             1                             /**< Shift value for AES_STOP */
+#define _AES_CMD_STOP_MASK              0x2UL                         /**< Bit mask for AES_STOP */
+#define _AES_CMD_STOP_DEFAULT           0x00000000UL                  /**< Mode DEFAULT for AES_CMD */
+#define AES_CMD_STOP_DEFAULT            (_AES_CMD_STOP_DEFAULT << 1)  /**< Shifted mode DEFAULT for AES_CMD */
+
+/* Bit fields for AES STATUS */
+#define _AES_STATUS_RESETVALUE          0x00000000UL                       /**< Default value for AES_STATUS */
+#define _AES_STATUS_MASK                0x00000001UL                       /**< Mask for AES_STATUS */
+#define AES_STATUS_RUNNING              (0x1UL << 0)                       /**< AES Running */
+#define _AES_STATUS_RUNNING_SHIFT       0                                  /**< Shift value for AES_RUNNING */
+#define _AES_STATUS_RUNNING_MASK        0x1UL                              /**< Bit mask for AES_RUNNING */
+#define _AES_STATUS_RUNNING_DEFAULT     0x00000000UL                       /**< Mode DEFAULT for AES_STATUS */
+#define AES_STATUS_RUNNING_DEFAULT      (_AES_STATUS_RUNNING_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_STATUS */
+
+/* Bit fields for AES IEN */
+#define _AES_IEN_RESETVALUE             0x00000000UL                 /**< Default value for AES_IEN */
+#define _AES_IEN_MASK                   0x00000001UL                 /**< Mask for AES_IEN */
+#define AES_IEN_DONE                    (0x1UL << 0)                 /**< Encryption/Decryption Done Interrupt Enable */
+#define _AES_IEN_DONE_SHIFT             0                            /**< Shift value for AES_DONE */
+#define _AES_IEN_DONE_MASK              0x1UL                        /**< Bit mask for AES_DONE */
+#define _AES_IEN_DONE_DEFAULT           0x00000000UL                 /**< Mode DEFAULT for AES_IEN */
+#define AES_IEN_DONE_DEFAULT            (_AES_IEN_DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_IEN */
+
+/* Bit fields for AES IF */
+#define _AES_IF_RESETVALUE              0x00000000UL                /**< Default value for AES_IF */
+#define _AES_IF_MASK                    0x00000001UL                /**< Mask for AES_IF */
+#define AES_IF_DONE                     (0x1UL << 0)                /**< Encryption/Decryption Done Interrupt Flag */
+#define _AES_IF_DONE_SHIFT              0                           /**< Shift value for AES_DONE */
+#define _AES_IF_DONE_MASK               0x1UL                       /**< Bit mask for AES_DONE */
+#define _AES_IF_DONE_DEFAULT            0x00000000UL                /**< Mode DEFAULT for AES_IF */
+#define AES_IF_DONE_DEFAULT             (_AES_IF_DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_IF */
+
+/* Bit fields for AES IFS */
+#define _AES_IFS_RESETVALUE             0x00000000UL                 /**< Default value for AES_IFS */
+#define _AES_IFS_MASK                   0x00000001UL                 /**< Mask for AES_IFS */
+#define AES_IFS_DONE                    (0x1UL << 0)                 /**< Encryption/Decryption Done Interrupt Flag Set */
+#define _AES_IFS_DONE_SHIFT             0                            /**< Shift value for AES_DONE */
+#define _AES_IFS_DONE_MASK              0x1UL                        /**< Bit mask for AES_DONE */
+#define _AES_IFS_DONE_DEFAULT           0x00000000UL                 /**< Mode DEFAULT for AES_IFS */
+#define AES_IFS_DONE_DEFAULT            (_AES_IFS_DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_IFS */
+
+/* Bit fields for AES IFC */
+#define _AES_IFC_RESETVALUE             0x00000000UL                 /**< Default value for AES_IFC */
+#define _AES_IFC_MASK                   0x00000001UL                 /**< Mask for AES_IFC */
+#define AES_IFC_DONE                    (0x1UL << 0)                 /**< Encryption/Decryption Done Interrupt Flag Clear */
+#define _AES_IFC_DONE_SHIFT             0                            /**< Shift value for AES_DONE */
+#define _AES_IFC_DONE_MASK              0x1UL                        /**< Bit mask for AES_DONE */
+#define _AES_IFC_DONE_DEFAULT           0x00000000UL                 /**< Mode DEFAULT for AES_IFC */
+#define AES_IFC_DONE_DEFAULT            (_AES_IFC_DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_IFC */
+
+/* Bit fields for AES DATA */
+#define _AES_DATA_RESETVALUE            0x00000000UL                  /**< Default value for AES_DATA */
+#define _AES_DATA_MASK                  0xFFFFFFFFUL                  /**< Mask for AES_DATA */
+#define _AES_DATA_DATA_SHIFT            0                             /**< Shift value for AES_DATA */
+#define _AES_DATA_DATA_MASK             0xFFFFFFFFUL                  /**< Bit mask for AES_DATA */
+#define _AES_DATA_DATA_DEFAULT          0x00000000UL                  /**< Mode DEFAULT for AES_DATA */
+#define AES_DATA_DATA_DEFAULT           (_AES_DATA_DATA_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_DATA */
+
+/* Bit fields for AES XORDATA */
+#define _AES_XORDATA_RESETVALUE         0x00000000UL                        /**< Default value for AES_XORDATA */
+#define _AES_XORDATA_MASK               0xFFFFFFFFUL                        /**< Mask for AES_XORDATA */
+#define _AES_XORDATA_XORDATA_SHIFT      0                                   /**< Shift value for AES_XORDATA */
+#define _AES_XORDATA_XORDATA_MASK       0xFFFFFFFFUL                        /**< Bit mask for AES_XORDATA */
+#define _AES_XORDATA_XORDATA_DEFAULT    0x00000000UL                        /**< Mode DEFAULT for AES_XORDATA */
+#define AES_XORDATA_XORDATA_DEFAULT     (_AES_XORDATA_XORDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_XORDATA */
+
+/* Bit fields for AES KEYLA */
+#define _AES_KEYLA_RESETVALUE           0x00000000UL                    /**< Default value for AES_KEYLA */
+#define _AES_KEYLA_MASK                 0xFFFFFFFFUL                    /**< Mask for AES_KEYLA */
+#define _AES_KEYLA_KEYLA_SHIFT          0                               /**< Shift value for AES_KEYLA */
+#define _AES_KEYLA_KEYLA_MASK           0xFFFFFFFFUL                    /**< Bit mask for AES_KEYLA */
+#define _AES_KEYLA_KEYLA_DEFAULT        0x00000000UL                    /**< Mode DEFAULT for AES_KEYLA */
+#define AES_KEYLA_KEYLA_DEFAULT         (_AES_KEYLA_KEYLA_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_KEYLA */
+
+/* Bit fields for AES KEYLB */
+#define _AES_KEYLB_RESETVALUE           0x00000000UL                    /**< Default value for AES_KEYLB */
+#define _AES_KEYLB_MASK                 0xFFFFFFFFUL                    /**< Mask for AES_KEYLB */
+#define _AES_KEYLB_KEYLB_SHIFT          0                               /**< Shift value for AES_KEYLB */
+#define _AES_KEYLB_KEYLB_MASK           0xFFFFFFFFUL                    /**< Bit mask for AES_KEYLB */
+#define _AES_KEYLB_KEYLB_DEFAULT        0x00000000UL                    /**< Mode DEFAULT for AES_KEYLB */
+#define AES_KEYLB_KEYLB_DEFAULT         (_AES_KEYLB_KEYLB_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_KEYLB */
+
+/* Bit fields for AES KEYLC */
+#define _AES_KEYLC_RESETVALUE           0x00000000UL                    /**< Default value for AES_KEYLC */
+#define _AES_KEYLC_MASK                 0xFFFFFFFFUL                    /**< Mask for AES_KEYLC */
+#define _AES_KEYLC_KEYLC_SHIFT          0                               /**< Shift value for AES_KEYLC */
+#define _AES_KEYLC_KEYLC_MASK           0xFFFFFFFFUL                    /**< Bit mask for AES_KEYLC */
+#define _AES_KEYLC_KEYLC_DEFAULT        0x00000000UL                    /**< Mode DEFAULT for AES_KEYLC */
+#define AES_KEYLC_KEYLC_DEFAULT         (_AES_KEYLC_KEYLC_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_KEYLC */
+
+/* Bit fields for AES KEYLD */
+#define _AES_KEYLD_RESETVALUE           0x00000000UL                    /**< Default value for AES_KEYLD */
+#define _AES_KEYLD_MASK                 0xFFFFFFFFUL                    /**< Mask for AES_KEYLD */
+#define _AES_KEYLD_KEYLD_SHIFT          0                               /**< Shift value for AES_KEYLD */
+#define _AES_KEYLD_KEYLD_MASK           0xFFFFFFFFUL                    /**< Bit mask for AES_KEYLD */
+#define _AES_KEYLD_KEYLD_DEFAULT        0x00000000UL                    /**< Mode DEFAULT for AES_KEYLD */
+#define AES_KEYLD_KEYLD_DEFAULT         (_AES_KEYLD_KEYLD_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_KEYLD */
+
+/* Bit fields for AES KEYHA */
+#define _AES_KEYHA_RESETVALUE           0x00000000UL                    /**< Default value for AES_KEYHA */
+#define _AES_KEYHA_MASK                 0xFFFFFFFFUL                    /**< Mask for AES_KEYHA */
+#define _AES_KEYHA_KEYHA_SHIFT          0                               /**< Shift value for AES_KEYHA */
+#define _AES_KEYHA_KEYHA_MASK           0xFFFFFFFFUL                    /**< Bit mask for AES_KEYHA */
+#define _AES_KEYHA_KEYHA_DEFAULT        0x00000000UL                    /**< Mode DEFAULT for AES_KEYHA */
+#define AES_KEYHA_KEYHA_DEFAULT         (_AES_KEYHA_KEYHA_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_KEYHA */
+
+/* Bit fields for AES KEYHB */
+#define _AES_KEYHB_RESETVALUE           0x00000000UL                    /**< Default value for AES_KEYHB */
+#define _AES_KEYHB_MASK                 0xFFFFFFFFUL                    /**< Mask for AES_KEYHB */
+#define _AES_KEYHB_KEYHB_SHIFT          0                               /**< Shift value for AES_KEYHB */
+#define _AES_KEYHB_KEYHB_MASK           0xFFFFFFFFUL                    /**< Bit mask for AES_KEYHB */
+#define _AES_KEYHB_KEYHB_DEFAULT        0x00000000UL                    /**< Mode DEFAULT for AES_KEYHB */
+#define AES_KEYHB_KEYHB_DEFAULT         (_AES_KEYHB_KEYHB_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_KEYHB */
+
+/* Bit fields for AES KEYHC */
+#define _AES_KEYHC_RESETVALUE           0x00000000UL                    /**< Default value for AES_KEYHC */
+#define _AES_KEYHC_MASK                 0xFFFFFFFFUL                    /**< Mask for AES_KEYHC */
+#define _AES_KEYHC_KEYHC_SHIFT          0                               /**< Shift value for AES_KEYHC */
+#define _AES_KEYHC_KEYHC_MASK           0xFFFFFFFFUL                    /**< Bit mask for AES_KEYHC */
+#define _AES_KEYHC_KEYHC_DEFAULT        0x00000000UL                    /**< Mode DEFAULT for AES_KEYHC */
+#define AES_KEYHC_KEYHC_DEFAULT         (_AES_KEYHC_KEYHC_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_KEYHC */
+
+/* Bit fields for AES KEYHD */
+#define _AES_KEYHD_RESETVALUE           0x00000000UL                    /**< Default value for AES_KEYHD */
+#define _AES_KEYHD_MASK                 0xFFFFFFFFUL                    /**< Mask for AES_KEYHD */
+#define _AES_KEYHD_KEYHD_SHIFT          0                               /**< Shift value for AES_KEYHD */
+#define _AES_KEYHD_KEYHD_MASK           0xFFFFFFFFUL                    /**< Bit mask for AES_KEYHD */
+#define _AES_KEYHD_KEYHD_DEFAULT        0x00000000UL                    /**< Mode DEFAULT for AES_KEYHD */
+#define AES_KEYHD_KEYHD_DEFAULT         (_AES_KEYHD_KEYHD_DEFAULT << 0) /**< Shifted mode DEFAULT for AES_KEYHD */
+
+/** @} End of group EFM32TG_AES */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_af_pins.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_af_pins.h
@@ -1,0 +1,111 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_AF_PINS register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_AF_Pins
+ * @{
+ ******************************************************************************/
+
+#define AF_CMU_CLK0_PIN(i)          ((i) == 0 ? 2 : (i) == 1 ? 12 : (i) == 2 ? 7 :  -1)                                                              /**< Pin number for AF_CMU_CLK0 location number i */
+#define AF_CMU_CLK1_PIN(i)          ((i) == 0 ? 1 : (i) == 1 ? 8 : (i) == 2 ? 12 :  -1)                                                              /**< Pin number for AF_CMU_CLK1 location number i */
+#define AF_LESENSE_CH0_PIN(i)       ((i) == 0 ? 0 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH0 location number i */
+#define AF_LESENSE_CH1_PIN(i)       ((i) == 0 ? 1 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH1 location number i */
+#define AF_LESENSE_CH2_PIN(i)       ((i) == 0 ? 2 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH2 location number i */
+#define AF_LESENSE_CH3_PIN(i)       ((i) == 0 ? 3 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH3 location number i */
+#define AF_LESENSE_CH4_PIN(i)       ((i) == 0 ? 4 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH4 location number i */
+#define AF_LESENSE_CH5_PIN(i)       ((i) == 0 ? 5 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH5 location number i */
+#define AF_LESENSE_CH6_PIN(i)       ((i) == 0 ? 6 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH6 location number i */
+#define AF_LESENSE_CH7_PIN(i)       ((i) == 0 ? 7 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH7 location number i */
+#define AF_LESENSE_CH8_PIN(i)       ((i) == 0 ? 8 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH8 location number i */
+#define AF_LESENSE_CH9_PIN(i)       ((i) == 0 ? 9 :  -1)                                                                                             /**< Pin number for AF_LESENSE_CH9 location number i */
+#define AF_LESENSE_CH10_PIN(i)      ((i) == 0 ? 10 :  -1)                                                                                            /**< Pin number for AF_LESENSE_CH10 location number i */
+#define AF_LESENSE_CH11_PIN(i)      ((i) == 0 ? 11 :  -1)                                                                                            /**< Pin number for AF_LESENSE_CH11 location number i */
+#define AF_LESENSE_CH12_PIN(i)      ((i) == 0 ? 12 :  -1)                                                                                            /**< Pin number for AF_LESENSE_CH12 location number i */
+#define AF_LESENSE_CH13_PIN(i)      ((i) == 0 ? 13 :  -1)                                                                                            /**< Pin number for AF_LESENSE_CH13 location number i */
+#define AF_LESENSE_CH14_PIN(i)      ((i) == 0 ? 14 :  -1)                                                                                            /**< Pin number for AF_LESENSE_CH14 location number i */
+#define AF_LESENSE_CH15_PIN(i)      ((i) == 0 ? 15 :  -1)                                                                                            /**< Pin number for AF_LESENSE_CH15 location number i */
+#define AF_LESENSE_ALTEX0_PIN(i)    ((i) == 0 ? 6 :  -1)                                                                                             /**< Pin number for AF_LESENSE_ALTEX0 location number i */
+#define AF_LESENSE_ALTEX1_PIN(i)    ((i) == 0 ? 7 :  -1)                                                                                             /**< Pin number for AF_LESENSE_ALTEX1 location number i */
+#define AF_LESENSE_ALTEX2_PIN(i)    ((i) == 0 ? 3 :  -1)                                                                                             /**< Pin number for AF_LESENSE_ALTEX2 location number i */
+#define AF_LESENSE_ALTEX3_PIN(i)    ((i) == 0 ? 4 :  -1)                                                                                             /**< Pin number for AF_LESENSE_ALTEX3 location number i */
+#define AF_LESENSE_ALTEX4_PIN(i)    ((i) == 0 ? 5 :  -1)                                                                                             /**< Pin number for AF_LESENSE_ALTEX4 location number i */
+#define AF_LESENSE_ALTEX5_PIN(i)    ((i) == 0 ? 11 :  -1)                                                                                            /**< Pin number for AF_LESENSE_ALTEX5 location number i */
+#define AF_LESENSE_ALTEX6_PIN(i)    ((i) == 0 ? 12 :  -1)                                                                                            /**< Pin number for AF_LESENSE_ALTEX6 location number i */
+#define AF_LESENSE_ALTEX7_PIN(i)    ((i) == 0 ? 13 :  -1)                                                                                            /**< Pin number for AF_LESENSE_ALTEX7 location number i */
+#define AF_ACMP0_OUT_PIN(i)         ((i) == 0 ? 13 : (i) == 1 ? -1 : (i) == 2 ? 6 :  -1)                                                             /**< Pin number for AF_ACMP0_OUT location number i */
+#define AF_ACMP1_OUT_PIN(i)         ((i) == 0 ? 2 : (i) == 1 ? -1 : (i) == 2 ? 7 :  -1)                                                              /**< Pin number for AF_ACMP1_OUT location number i */
+#define AF_USART0_TX_PIN(i)         ((i) == 0 ? 10 : (i) == 1 ? 7 : (i) == 2 ? 11 : (i) == 3 ? 13 : (i) == 4 ? 7 : (i) == 5 ? 0 :  -1)               /**< Pin number for AF_USART0_TX location number i */
+#define AF_USART0_RX_PIN(i)         ((i) == 0 ? 11 : (i) == 1 ? 6 : (i) == 2 ? 10 : (i) == 3 ? 12 : (i) == 4 ? 8 : (i) == 5 ? 1 :  -1)               /**< Pin number for AF_USART0_RX location number i */
+#define AF_USART0_CLK_PIN(i)        ((i) == 0 ? 12 : (i) == 1 ? 5 : (i) == 2 ? 9 : (i) == 3 ? 15 : (i) == 4 ? 13 : (i) == 5 ? 13 :  -1)              /**< Pin number for AF_USART0_CLK location number i */
+#define AF_USART0_CS_PIN(i)         ((i) == 0 ? 13 : (i) == 1 ? 4 : (i) == 2 ? 8 : (i) == 3 ? 14 : (i) == 4 ? 14 : (i) == 5 ? 14 :  -1)              /**< Pin number for AF_USART0_CS location number i */
+#define AF_USART1_TX_PIN(i)         ((i) == 0 ? 0 : (i) == 1 ? 0 : (i) == 2 ? 7 :  -1)                                                               /**< Pin number for AF_USART1_TX location number i */
+#define AF_USART1_RX_PIN(i)         ((i) == 0 ? 1 : (i) == 1 ? 1 : (i) == 2 ? 6 :  -1)                                                               /**< Pin number for AF_USART1_RX location number i */
+#define AF_USART1_CLK_PIN(i)        ((i) == 0 ? 7 : (i) == 1 ? 2 : (i) == 2 ? 0 :  -1)                                                               /**< Pin number for AF_USART1_CLK location number i */
+#define AF_USART1_CS_PIN(i)         ((i) == 0 ? 8 : (i) == 1 ? 3 : (i) == 2 ? 1 :  -1)                                                               /**< Pin number for AF_USART1_CS location number i */
+#define AF_TIMER0_CC0_PIN(i)        ((i) == 0 ? 0 : (i) == 1 ? 0 : (i) == 2 ? -1 : (i) == 3 ? 1 : (i) == 4 ? 0 : (i) == 5 ? 0 :  -1)                 /**< Pin number for AF_TIMER0_CC0 location number i */
+#define AF_TIMER0_CC1_PIN(i)        ((i) == 0 ? 1 : (i) == 1 ? 1 : (i) == 2 ? -1 : (i) == 3 ? 2 : (i) == 4 ? 0 : (i) == 5 ? 1 :  -1)                 /**< Pin number for AF_TIMER0_CC1 location number i */
+#define AF_TIMER0_CC2_PIN(i)        ((i) == 0 ? 2 : (i) == 1 ? 2 : (i) == 2 ? -1 : (i) == 3 ? 3 : (i) == 4 ? 1 : (i) == 5 ? 2 :  -1)                 /**< Pin number for AF_TIMER0_CC2 location number i */
+#define AF_TIMER0_CDTI0_PIN(i)      (-1)                                                                                                             /**< Pin number for AF_TIMER0_CDTI0 location number i */
+#define AF_TIMER0_CDTI1_PIN(i)      (-1)                                                                                                             /**< Pin number for AF_TIMER0_CDTI1 location number i */
+#define AF_TIMER0_CDTI2_PIN(i)      (-1)                                                                                                             /**< Pin number for AF_TIMER0_CDTI2 location number i */
+#define AF_TIMER1_CC0_PIN(i)        ((i) == 0 ? 13 : (i) == 1 ? 10 : (i) == 2 ? -1 : (i) == 3 ? 7 : (i) == 4 ? 6 :  -1)                              /**< Pin number for AF_TIMER1_CC0 location number i */
+#define AF_TIMER1_CC1_PIN(i)        ((i) == 0 ? 14 : (i) == 1 ? 11 : (i) == 2 ? -1 : (i) == 3 ? 8 : (i) == 4 ? 7 :  -1)                              /**< Pin number for AF_TIMER1_CC1 location number i */
+#define AF_TIMER1_CC2_PIN(i)        ((i) == 0 ? 15 : (i) == 1 ? 12 : (i) == 2 ? -1 : (i) == 3 ? 11 : (i) == 4 ? 13 :  -1)                            /**< Pin number for AF_TIMER1_CC2 location number i */
+#define AF_TIMER1_CDTI0_PIN(i)      (-1)                                                                                                             /**< Pin number for AF_TIMER1_CDTI0 location number i */
+#define AF_TIMER1_CDTI1_PIN(i)      (-1)                                                                                                             /**< Pin number for AF_TIMER1_CDTI1 location number i */
+#define AF_TIMER1_CDTI2_PIN(i)      (-1)                                                                                                             /**< Pin number for AF_TIMER1_CDTI2 location number i */
+#define AF_PRS_CH0_PIN(i)           ((i) == 0 ? 0 : (i) == 1 ? 3 :  -1)                                                                              /**< Pin number for AF_PRS_CH0 location number i */
+#define AF_PRS_CH1_PIN(i)           ((i) == 0 ? 1 : (i) == 1 ? 4 :  -1)                                                                              /**< Pin number for AF_PRS_CH1 location number i */
+#define AF_PRS_CH2_PIN(i)           ((i) == 0 ? 0 : (i) == 1 ? 5 :  -1)                                                                              /**< Pin number for AF_PRS_CH2 location number i */
+#define AF_PRS_CH3_PIN(i)           ((i) == 0 ? 1 : (i) == 1 ? 8 :  -1)                                                                              /**< Pin number for AF_PRS_CH3 location number i */
+#define AF_LEUART0_TX_PIN(i)        ((i) == 0 ? 4 : (i) == 1 ? 13 : (i) == 2 ? 14 : (i) == 3 ? 0 : (i) == 4 ? 2 :  -1)                               /**< Pin number for AF_LEUART0_TX location number i */
+#define AF_LEUART0_RX_PIN(i)        ((i) == 0 ? 5 : (i) == 1 ? 14 : (i) == 2 ? 15 : (i) == 3 ? 1 : (i) == 4 ? 0 :  -1)                               /**< Pin number for AF_LEUART0_RX location number i */
+#define AF_LETIMER0_OUT0_PIN(i)     ((i) == 0 ? 6 : (i) == 1 ? 11 : (i) == 2 ? 0 : (i) == 3 ? 4 :  -1)                                               /**< Pin number for AF_LETIMER0_OUT0 location number i */
+#define AF_LETIMER0_OUT1_PIN(i)     ((i) == 0 ? 7 : (i) == 1 ? 12 : (i) == 2 ? 1 : (i) == 3 ? 5 :  -1)                                               /**< Pin number for AF_LETIMER0_OUT1 location number i */
+#define AF_PCNT0_S0IN_PIN(i)        ((i) == 0 ? 13 : (i) == 1 ? -1 : (i) == 2 ? 0 : (i) == 3 ? 6 :  -1)                                              /**< Pin number for AF_PCNT0_S0IN location number i */
+#define AF_PCNT0_S1IN_PIN(i)        ((i) == 0 ? 14 : (i) == 1 ? -1 : (i) == 2 ? 1 : (i) == 3 ? 7 :  -1)                                              /**< Pin number for AF_PCNT0_S1IN location number i */
+#define AF_I2C0_SDA_PIN(i)          ((i) == 0 ? 0 : (i) == 1 ? 6 : (i) == 2 ? 6 : (i) == 3 ? -1 : (i) == 4 ? 0 : (i) == 5 ? 0 : (i) == 6 ? 12 :  -1) /**< Pin number for AF_I2C0_SDA location number i */
+#define AF_I2C0_SCL_PIN(i)          ((i) == 0 ? 1 : (i) == 1 ? 7 : (i) == 2 ? 7 : (i) == 3 ? -1 : (i) == 4 ? 1 : (i) == 5 ? 1 : (i) == 6 ? 13 :  -1) /**< Pin number for AF_I2C0_SCL location number i */
+#define AF_DBG_SWO_PIN(i)           ((i) == 0 ? 2 : (i) == 1 ? 15 :  -1)                                                                             /**< Pin number for AF_DBG_SWO location number i */
+#define AF_DBG_SWDIO_PIN(i)         ((i) == 0 ? 1 : (i) == 1 ? 1 :  -1)                                                                              /**< Pin number for AF_DBG_SWDIO location number i */
+#define AF_DBG_SWCLK_PIN(i)         ((i) == 0 ? 0 : (i) == 1 ? 0 :  -1)                                                                              /**< Pin number for AF_DBG_SWCLK location number i */
+
+/** @} End of group EFM32TG_AF_Pins */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_af_ports.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_af_ports.h
@@ -1,0 +1,111 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_AF_PORTS register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_AF_Ports
+ * @{
+ ******************************************************************************/
+
+#define AF_CMU_CLK0_PORT(i)          ((i) == 0 ? 0 : (i) == 1 ? 2 : (i) == 2 ? 3 :  -1)                                                              /**< Port number for AF_CMU_CLK0 location number i */
+#define AF_CMU_CLK1_PORT(i)          ((i) == 0 ? 0 : (i) == 1 ? 3 : (i) == 2 ? 4 :  -1)                                                              /**< Port number for AF_CMU_CLK1 location number i */
+#define AF_LESENSE_CH0_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH0 location number i */
+#define AF_LESENSE_CH1_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH1 location number i */
+#define AF_LESENSE_CH2_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH2 location number i */
+#define AF_LESENSE_CH3_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH3 location number i */
+#define AF_LESENSE_CH4_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH4 location number i */
+#define AF_LESENSE_CH5_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH5 location number i */
+#define AF_LESENSE_CH6_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH6 location number i */
+#define AF_LESENSE_CH7_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH7 location number i */
+#define AF_LESENSE_CH8_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH8 location number i */
+#define AF_LESENSE_CH9_PORT(i)       ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH9 location number i */
+#define AF_LESENSE_CH10_PORT(i)      ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH10 location number i */
+#define AF_LESENSE_CH11_PORT(i)      ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH11 location number i */
+#define AF_LESENSE_CH12_PORT(i)      ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH12 location number i */
+#define AF_LESENSE_CH13_PORT(i)      ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH13 location number i */
+#define AF_LESENSE_CH14_PORT(i)      ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH14 location number i */
+#define AF_LESENSE_CH15_PORT(i)      ((i) == 0 ? 2 :  -1)                                                                                            /**< Port number for AF_LESENSE_CH15 location number i */
+#define AF_LESENSE_ALTEX0_PORT(i)    ((i) == 0 ? 3 :  -1)                                                                                            /**< Port number for AF_LESENSE_ALTEX0 location number i */
+#define AF_LESENSE_ALTEX1_PORT(i)    ((i) == 0 ? 3 :  -1)                                                                                            /**< Port number for AF_LESENSE_ALTEX1 location number i */
+#define AF_LESENSE_ALTEX2_PORT(i)    ((i) == 0 ? 0 :  -1)                                                                                            /**< Port number for AF_LESENSE_ALTEX2 location number i */
+#define AF_LESENSE_ALTEX3_PORT(i)    ((i) == 0 ? 0 :  -1)                                                                                            /**< Port number for AF_LESENSE_ALTEX3 location number i */
+#define AF_LESENSE_ALTEX4_PORT(i)    ((i) == 0 ? 0 :  -1)                                                                                            /**< Port number for AF_LESENSE_ALTEX4 location number i */
+#define AF_LESENSE_ALTEX5_PORT(i)    ((i) == 0 ? 4 :  -1)                                                                                            /**< Port number for AF_LESENSE_ALTEX5 location number i */
+#define AF_LESENSE_ALTEX6_PORT(i)    ((i) == 0 ? 4 :  -1)                                                                                            /**< Port number for AF_LESENSE_ALTEX6 location number i */
+#define AF_LESENSE_ALTEX7_PORT(i)    ((i) == 0 ? 4 :  -1)                                                                                            /**< Port number for AF_LESENSE_ALTEX7 location number i */
+#define AF_ACMP0_OUT_PORT(i)         ((i) == 0 ? 4 : (i) == 1 ? -1 : (i) == 2 ? 3 :  -1)                                                             /**< Port number for AF_ACMP0_OUT location number i */
+#define AF_ACMP1_OUT_PORT(i)         ((i) == 0 ? 5 : (i) == 1 ? -1 : (i) == 2 ? 3 :  -1)                                                             /**< Port number for AF_ACMP1_OUT location number i */
+#define AF_USART0_TX_PORT(i)         ((i) == 0 ? 4 : (i) == 1 ? 4 : (i) == 2 ? 2 : (i) == 3 ? 4 : (i) == 4 ? 1 : (i) == 5 ? 2 :  -1)                 /**< Port number for AF_USART0_TX location number i */
+#define AF_USART0_RX_PORT(i)         ((i) == 0 ? 4 : (i) == 1 ? 4 : (i) == 2 ? 2 : (i) == 3 ? 4 : (i) == 4 ? 1 : (i) == 5 ? 2 :  -1)                 /**< Port number for AF_USART0_RX location number i */
+#define AF_USART0_CLK_PORT(i)        ((i) == 0 ? 4 : (i) == 1 ? 4 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 1 : (i) == 5 ? 1 :  -1)                 /**< Port number for AF_USART0_CLK location number i */
+#define AF_USART0_CS_PORT(i)         ((i) == 0 ? 4 : (i) == 1 ? 4 : (i) == 2 ? 2 : (i) == 3 ? 2 : (i) == 4 ? 1 : (i) == 5 ? 1 :  -1)                 /**< Port number for AF_USART0_CS location number i */
+#define AF_USART1_TX_PORT(i)         ((i) == 0 ? 2 : (i) == 1 ? 3 : (i) == 2 ? 3 :  -1)                                                              /**< Port number for AF_USART1_TX location number i */
+#define AF_USART1_RX_PORT(i)         ((i) == 0 ? 2 : (i) == 1 ? 3 : (i) == 2 ? 3 :  -1)                                                              /**< Port number for AF_USART1_RX location number i */
+#define AF_USART1_CLK_PORT(i)        ((i) == 0 ? 1 : (i) == 1 ? 3 : (i) == 2 ? 5 :  -1)                                                              /**< Port number for AF_USART1_CLK location number i */
+#define AF_USART1_CS_PORT(i)         ((i) == 0 ? 1 : (i) == 1 ? 3 : (i) == 2 ? 5 :  -1)                                                              /**< Port number for AF_USART1_CS location number i */
+#define AF_TIMER0_CC0_PORT(i)        ((i) == 0 ? 0 : (i) == 1 ? 0 : (i) == 2 ? -1 : (i) == 3 ? 3 : (i) == 4 ? 0 : (i) == 5 ? 5 :  -1)                /**< Port number for AF_TIMER0_CC0 location number i */
+#define AF_TIMER0_CC1_PORT(i)        ((i) == 0 ? 0 : (i) == 1 ? 0 : (i) == 2 ? -1 : (i) == 3 ? 3 : (i) == 4 ? 2 : (i) == 5 ? 5 :  -1)                /**< Port number for AF_TIMER0_CC1 location number i */
+#define AF_TIMER0_CC2_PORT(i)        ((i) == 0 ? 0 : (i) == 1 ? 0 : (i) == 2 ? -1 : (i) == 3 ? 3 : (i) == 4 ? 2 : (i) == 5 ? 5 :  -1)                /**< Port number for AF_TIMER0_CC2 location number i */
+#define AF_TIMER0_CDTI0_PORT(i)      (-1)                                                                                                            /**< Port number for AF_TIMER0_CDTI0 location number i */
+#define AF_TIMER0_CDTI1_PORT(i)      (-1)                                                                                                            /**< Port number for AF_TIMER0_CDTI1 location number i */
+#define AF_TIMER0_CDTI2_PORT(i)      (-1)                                                                                                            /**< Port number for AF_TIMER0_CDTI2 location number i */
+#define AF_TIMER1_CC0_PORT(i)        ((i) == 0 ? 2 : (i) == 1 ? 4 : (i) == 2 ? -1 : (i) == 3 ? 1 : (i) == 4 ? 3 :  -1)                               /**< Port number for AF_TIMER1_CC0 location number i */
+#define AF_TIMER1_CC1_PORT(i)        ((i) == 0 ? 2 : (i) == 1 ? 4 : (i) == 2 ? -1 : (i) == 3 ? 1 : (i) == 4 ? 3 :  -1)                               /**< Port number for AF_TIMER1_CC1 location number i */
+#define AF_TIMER1_CC2_PORT(i)        ((i) == 0 ? 2 : (i) == 1 ? 4 : (i) == 2 ? -1 : (i) == 3 ? 1 : (i) == 4 ? 2 :  -1)                               /**< Port number for AF_TIMER1_CC2 location number i */
+#define AF_TIMER1_CDTI0_PORT(i)      (-1)                                                                                                            /**< Port number for AF_TIMER1_CDTI0 location number i */
+#define AF_TIMER1_CDTI1_PORT(i)      (-1)                                                                                                            /**< Port number for AF_TIMER1_CDTI1 location number i */
+#define AF_TIMER1_CDTI2_PORT(i)      (-1)                                                                                                            /**< Port number for AF_TIMER1_CDTI2 location number i */
+#define AF_PRS_CH0_PORT(i)           ((i) == 0 ? 0 : (i) == 1 ? 5 :  -1)                                                                             /**< Port number for AF_PRS_CH0 location number i */
+#define AF_PRS_CH1_PORT(i)           ((i) == 0 ? 0 : (i) == 1 ? 5 :  -1)                                                                             /**< Port number for AF_PRS_CH1 location number i */
+#define AF_PRS_CH2_PORT(i)           ((i) == 0 ? 2 : (i) == 1 ? 5 :  -1)                                                                             /**< Port number for AF_PRS_CH2 location number i */
+#define AF_PRS_CH3_PORT(i)           ((i) == 0 ? 2 : (i) == 1 ? 4 :  -1)                                                                             /**< Port number for AF_PRS_CH3 location number i */
+#define AF_LEUART0_TX_PORT(i)        ((i) == 0 ? 3 : (i) == 1 ? 1 : (i) == 2 ? 4 : (i) == 3 ? 5 : (i) == 4 ? 5 :  -1)                                /**< Port number for AF_LEUART0_TX location number i */
+#define AF_LEUART0_RX_PORT(i)        ((i) == 0 ? 3 : (i) == 1 ? 1 : (i) == 2 ? 4 : (i) == 3 ? 5 : (i) == 4 ? 0 :  -1)                                /**< Port number for AF_LEUART0_RX location number i */
+#define AF_LETIMER0_OUT0_PORT(i)     ((i) == 0 ? 3 : (i) == 1 ? 1 : (i) == 2 ? 5 : (i) == 3 ? 2 :  -1)                                               /**< Port number for AF_LETIMER0_OUT0 location number i */
+#define AF_LETIMER0_OUT1_PORT(i)     ((i) == 0 ? 3 : (i) == 1 ? 1 : (i) == 2 ? 5 : (i) == 3 ? 2 :  -1)                                               /**< Port number for AF_LETIMER0_OUT1 location number i */
+#define AF_PCNT0_S0IN_PORT(i)        ((i) == 0 ? 2 : (i) == 1 ? -1 : (i) == 2 ? 2 : (i) == 3 ? 3 :  -1)                                              /**< Port number for AF_PCNT0_S0IN location number i */
+#define AF_PCNT0_S1IN_PORT(i)        ((i) == 0 ? 2 : (i) == 1 ? -1 : (i) == 2 ? 2 : (i) == 3 ? 3 :  -1)                                              /**< Port number for AF_PCNT0_S1IN location number i */
+#define AF_I2C0_SDA_PORT(i)          ((i) == 0 ? 0 : (i) == 1 ? 3 : (i) == 2 ? 2 : (i) == 3 ? -1 : (i) == 4 ? 2 : (i) == 5 ? 5 : (i) == 6 ? 4 :  -1) /**< Port number for AF_I2C0_SDA location number i */
+#define AF_I2C0_SCL_PORT(i)          ((i) == 0 ? 0 : (i) == 1 ? 3 : (i) == 2 ? 2 : (i) == 3 ? -1 : (i) == 4 ? 2 : (i) == 5 ? 5 : (i) == 6 ? 4 :  -1) /**< Port number for AF_I2C0_SCL location number i */
+#define AF_DBG_SWO_PORT(i)           ((i) == 0 ? 5 : (i) == 1 ? 2 :  -1)                                                                             /**< Port number for AF_DBG_SWO location number i */
+#define AF_DBG_SWDIO_PORT(i)         ((i) == 0 ? 5 : (i) == 1 ? 5 :  -1)                                                                             /**< Port number for AF_DBG_SWDIO location number i */
+#define AF_DBG_SWCLK_PORT(i)         ((i) == 0 ? 5 : (i) == 1 ? 5 :  -1)                                                                             /**< Port number for AF_DBG_SWCLK location number i */
+
+/** @} End of group EFM32TG_AF_Ports */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_calibrate.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_calibrate.h
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_CALIBRATE register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_CALIBRATE
+ * @{
+ ******************************************************************************/
+#define CALIBRATE_MAX_REGISTERS    50 /**< Max number of address/value pairs for calibration */
+
+typedef struct {
+  __IM uint32_t ADDRESS; /**< Address of calibration register */
+  __IM uint32_t VALUE;   /**< Default value for calibration register */
+} CALIBRATE_TypeDef;     /** @} */
+
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_cmu.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_cmu.h
@@ -1,0 +1,1099 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_CMU register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_CMU
+ * @brief EFM32TG_CMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< CMU Control Register  */
+  __IOM uint32_t HFCORECLKDIV;  /**< High Frequency Core Clock Division Register  */
+  __IOM uint32_t HFPERCLKDIV;   /**< High Frequency Peripheral Clock Division Register  */
+  __IOM uint32_t HFRCOCTRL;     /**< HFRCO Control Register  */
+  __IOM uint32_t LFRCOCTRL;     /**< LFRCO Control Register  */
+  __IOM uint32_t AUXHFRCOCTRL;  /**< AUXHFRCO Control Register  */
+  __IOM uint32_t CALCTRL;       /**< Calibration Control Register  */
+  __IOM uint32_t CALCNT;        /**< Calibration Counter Register  */
+  __IOM uint32_t OSCENCMD;      /**< Oscillator Enable/Disable Command Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IOM uint32_t LFCLKSEL;      /**< Low Frequency Clock Select Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t HFCORECLKEN0;  /**< High Frequency Core Clock Enable Register 0  */
+  __IOM uint32_t HFPERCLKEN0;   /**< High Frequency Peripheral Clock Enable Register 0  */
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IOM uint32_t LFACLKEN0;     /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  uint32_t       RESERVED1[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBCLKEN0;     /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFAPRESC0;     /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  uint32_t       RESERVED3[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LFBPRESC0;     /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
+  uint32_t       RESERVED4[1U]; /**< Reserved for future use **/
+  __IOM uint32_t PCNTCTRL;      /**< PCNT Control Register  */
+  __IOM uint32_t LCDCTRL;       /**< LCD Control Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+} CMU_TypeDef;                  /**< CMU Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_CMU_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for CMU CTRL */
+#define _CMU_CTRL_RESETVALUE                       0x000C262CUL                             /**< Default value for CMU_CTRL */
+#define _CMU_CTRL_MASK                             0x17FE3EEFUL                             /**< Mask for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_SHIFT                   0                                        /**< Shift value for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_MASK                    0x3UL                                    /**< Bit mask for CMU_HFXOMODE */
+#define _CMU_CTRL_HFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DEFAULT                  (_CMU_CTRL_HFXOMODE_DEFAULT << 0)        /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_XTAL                     (_CMU_CTRL_HFXOMODE_XTAL << 0)           /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_BUFEXTCLK                (_CMU_CTRL_HFXOMODE_BUFEXTCLK << 0)      /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_HFXOMODE_DIGEXTCLK                (_CMU_CTRL_HFXOMODE_DIGEXTCLK << 0)      /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_SHIFT                  2                                        /**< Shift value for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_MASK                   0xCUL                                    /**< Bit mask for CMU_HFXOBOOST */
+#define _CMU_CTRL_HFXOBOOST_50PCENT                0x00000000UL                             /**< Mode 50PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_70PCENT                0x00000001UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_80PCENT                0x00000002UL                             /**< Mode 80PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_DEFAULT                0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBOOST_100PCENT               0x00000003UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_50PCENT                 (_CMU_CTRL_HFXOBOOST_50PCENT << 2)       /**< Shifted mode 50PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_70PCENT                 (_CMU_CTRL_HFXOBOOST_70PCENT << 2)       /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_80PCENT                 (_CMU_CTRL_HFXOBOOST_80PCENT << 2)       /**< Shifted mode 80PCENT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_DEFAULT                 (_CMU_CTRL_HFXOBOOST_DEFAULT << 2)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBOOST_100PCENT                (_CMU_CTRL_HFXOBOOST_100PCENT << 2)      /**< Shifted mode 100PCENT for CMU_CTRL */
+#define _CMU_CTRL_HFXOBUFCUR_SHIFT                 5                                        /**< Shift value for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_MASK                  0x60UL                                   /**< Bit mask for CMU_HFXOBUFCUR */
+#define _CMU_CTRL_HFXOBUFCUR_DEFAULT               0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOBUFCUR_DEFAULT                (_CMU_CTRL_HFXOBUFCUR_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN                   (0x1UL << 7)                             /**< HFXO Glitch Detector Enable */
+#define _CMU_CTRL_HFXOGLITCHDETEN_SHIFT            7                                        /**< Shift value for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_MASK             0x80UL                                   /**< Bit mask for CMU_HFXOGLITCHDETEN */
+#define _CMU_CTRL_HFXOGLITCHDETEN_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOGLITCHDETEN_DEFAULT           (_CMU_CTRL_HFXOGLITCHDETEN_DEFAULT << 7) /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_SHIFT                9                                        /**< Shift value for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_MASK                 0x600UL                                  /**< Bit mask for CMU_HFXOTIMEOUT */
+#define _CMU_CTRL_HFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_256CYCLES            0x00000001UL                             /**< Mode 256CYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_1KCYCLES             0x00000002UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_HFXOTIMEOUT_16KCYCLES            0x00000003UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_8CYCLES               (_CMU_CTRL_HFXOTIMEOUT_8CYCLES << 9)     /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_256CYCLES             (_CMU_CTRL_HFXOTIMEOUT_256CYCLES << 9)   /**< Shifted mode 256CYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_HFXOTIMEOUT_1KCYCLES << 9)    /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_DEFAULT               (_CMU_CTRL_HFXOTIMEOUT_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_HFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_HFXOTIMEOUT_16KCYCLES << 9)   /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_SHIFT                   11                                       /**< Shift value for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_MASK                    0x1800UL                                 /**< Bit mask for CMU_LFXOMODE */
+#define _CMU_CTRL_LFXOMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_XTAL                    0x00000000UL                             /**< Mode XTAL for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_BUFEXTCLK               0x00000001UL                             /**< Mode BUFEXTCLK for CMU_CTRL */
+#define _CMU_CTRL_LFXOMODE_DIGEXTCLK               0x00000002UL                             /**< Mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DEFAULT                  (_CMU_CTRL_LFXOMODE_DEFAULT << 11)       /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_XTAL                     (_CMU_CTRL_LFXOMODE_XTAL << 11)          /**< Shifted mode XTAL for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_BUFEXTCLK                (_CMU_CTRL_LFXOMODE_BUFEXTCLK << 11)     /**< Shifted mode BUFEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOMODE_DIGEXTCLK                (_CMU_CTRL_LFXOMODE_DIGEXTCLK << 11)     /**< Shifted mode DIGEXTCLK for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST                         (0x1UL << 13)                            /**< LFXO Start-up Boost Current */
+#define _CMU_CTRL_LFXOBOOST_SHIFT                  13                                       /**< Shift value for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_MASK                   0x2000UL                                 /**< Bit mask for CMU_LFXOBOOST */
+#define _CMU_CTRL_LFXOBOOST_70PCENT                0x00000000UL                             /**< Mode 70PCENT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_DEFAULT                0x00000001UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOBOOST_100PCENT               0x00000001UL                             /**< Mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_70PCENT                 (_CMU_CTRL_LFXOBOOST_70PCENT << 13)      /**< Shifted mode 70PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_DEFAULT                 (_CMU_CTRL_LFXOBOOST_DEFAULT << 13)      /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBOOST_100PCENT                (_CMU_CTRL_LFXOBOOST_100PCENT << 13)     /**< Shifted mode 100PCENT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR                        (0x1UL << 17)                            /**< LFXO Boost Buffer Current */
+#define _CMU_CTRL_LFXOBUFCUR_SHIFT                 17                                       /**< Shift value for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_MASK                  0x20000UL                                /**< Bit mask for CMU_LFXOBUFCUR */
+#define _CMU_CTRL_LFXOBUFCUR_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOBUFCUR_DEFAULT                (_CMU_CTRL_LFXOBUFCUR_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_SHIFT                18                                       /**< Shift value for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_MASK                 0xC0000UL                                /**< Bit mask for CMU_LFXOTIMEOUT */
+#define _CMU_CTRL_LFXOTIMEOUT_8CYCLES              0x00000000UL                             /**< Mode 8CYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_1KCYCLES             0x00000001UL                             /**< Mode 1KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_16KCYCLES            0x00000002UL                             /**< Mode 16KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_DEFAULT              0x00000003UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_LFXOTIMEOUT_32KCYCLES            0x00000003UL                             /**< Mode 32KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_8CYCLES               (_CMU_CTRL_LFXOTIMEOUT_8CYCLES << 18)    /**< Shifted mode 8CYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_1KCYCLES              (_CMU_CTRL_LFXOTIMEOUT_1KCYCLES << 18)   /**< Shifted mode 1KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_16KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_16KCYCLES << 18)  /**< Shifted mode 16KCYCLES for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_DEFAULT               (_CMU_CTRL_LFXOTIMEOUT_DEFAULT << 18)    /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_LFXOTIMEOUT_32KCYCLES             (_CMU_CTRL_LFXOTIMEOUT_32KCYCLES << 18)  /**< Shifted mode 32KCYCLES for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_SHIFT                 20                                       /**< Shift value for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_MASK                  0x700000UL                               /**< Bit mask for CMU_CLKOUTSEL0 */
+#define _CMU_CTRL_CLKOUTSEL0_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFRCO                 0x00000000UL                             /**< Mode HFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFXO                  0x00000001UL                             /**< Mode HFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK2                0x00000002UL                             /**< Mode HFCLK2 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK4                0x00000003UL                             /**< Mode HFCLK4 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK8                0x00000004UL                             /**< Mode HFCLK8 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_HFCLK16               0x00000005UL                             /**< Mode HFCLK16 for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_ULFRCO                0x00000006UL                             /**< Mode ULFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL0_AUXHFRCO              0x00000007UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_DEFAULT                (_CMU_CTRL_CLKOUTSEL0_DEFAULT << 20)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFRCO                  (_CMU_CTRL_CLKOUTSEL0_HFRCO << 20)       /**< Shifted mode HFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFXO                   (_CMU_CTRL_CLKOUTSEL0_HFXO << 20)        /**< Shifted mode HFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK2                 (_CMU_CTRL_CLKOUTSEL0_HFCLK2 << 20)      /**< Shifted mode HFCLK2 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK4                 (_CMU_CTRL_CLKOUTSEL0_HFCLK4 << 20)      /**< Shifted mode HFCLK4 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK8                 (_CMU_CTRL_CLKOUTSEL0_HFCLK8 << 20)      /**< Shifted mode HFCLK8 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_HFCLK16                (_CMU_CTRL_CLKOUTSEL0_HFCLK16 << 20)     /**< Shifted mode HFCLK16 for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_ULFRCO                 (_CMU_CTRL_CLKOUTSEL0_ULFRCO << 20)      /**< Shifted mode ULFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL0_AUXHFRCO               (_CMU_CTRL_CLKOUTSEL0_AUXHFRCO << 20)    /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_SHIFT                 23                                       /**< Shift value for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_MASK                  0x7800000UL                              /**< Bit mask for CMU_CLKOUTSEL1 */
+#define _CMU_CTRL_CLKOUTSEL1_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCO                 0x00000000UL                             /**< Mode LFRCO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXO                  0x00000001UL                             /**< Mode LFXO for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFCLK                 0x00000002UL                             /**< Mode HFCLK for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFXOQ                 0x00000003UL                             /**< Mode LFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFXOQ                 0x00000004UL                             /**< Mode HFXOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_LFRCOQ                0x00000005UL                             /**< Mode LFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_HFRCOQ                0x00000006UL                             /**< Mode HFRCOQ for CMU_CTRL */
+#define _CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ             0x00000007UL                             /**< Mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_DEFAULT                (_CMU_CTRL_CLKOUTSEL1_DEFAULT << 23)     /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCO                  (_CMU_CTRL_CLKOUTSEL1_LFRCO << 23)       /**< Shifted mode LFRCO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXO                   (_CMU_CTRL_CLKOUTSEL1_LFXO << 23)        /**< Shifted mode LFXO for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFCLK                  (_CMU_CTRL_CLKOUTSEL1_HFCLK << 23)       /**< Shifted mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFXOQ                  (_CMU_CTRL_CLKOUTSEL1_LFXOQ << 23)       /**< Shifted mode LFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFXOQ                  (_CMU_CTRL_CLKOUTSEL1_HFXOQ << 23)       /**< Shifted mode HFXOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_LFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_LFRCOQ << 23)      /**< Shifted mode LFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_HFRCOQ                 (_CMU_CTRL_CLKOUTSEL1_HFRCOQ << 23)      /**< Shifted mode HFRCOQ for CMU_CTRL */
+#define CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ              (_CMU_CTRL_CLKOUTSEL1_AUXHFRCOQ << 23)   /**< Shifted mode AUXHFRCOQ for CMU_CTRL */
+#define CMU_CTRL_DBGCLK                            (0x1UL << 28)                            /**< Debug Clock */
+#define _CMU_CTRL_DBGCLK_SHIFT                     28                                       /**< Shift value for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_MASK                      0x10000000UL                             /**< Bit mask for CMU_DBGCLK */
+#define _CMU_CTRL_DBGCLK_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_AUXHFRCO                  0x00000000UL                             /**< Mode AUXHFRCO for CMU_CTRL */
+#define _CMU_CTRL_DBGCLK_HFCLK                     0x00000001UL                             /**< Mode HFCLK for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_DEFAULT                    (_CMU_CTRL_DBGCLK_DEFAULT << 28)         /**< Shifted mode DEFAULT for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_AUXHFRCO                   (_CMU_CTRL_DBGCLK_AUXHFRCO << 28)        /**< Shifted mode AUXHFRCO for CMU_CTRL */
+#define CMU_CTRL_DBGCLK_HFCLK                      (_CMU_CTRL_DBGCLK_HFCLK << 28)           /**< Shifted mode HFCLK for CMU_CTRL */
+
+/* Bit fields for CMU HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_RESETVALUE               0x00000000UL                                   /**< Default value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_MASK                     0x0000000FUL                                   /**< Mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT       0                                              /**< Shift value for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK        0xFUL                                          /**< Bit mask for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT     0x00000000UL                                   /**< Mode DEFAULT for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK       0x00000000UL                                   /**< Mode HFCLK for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2      0x00000001UL                                   /**< Mode HFCLK2 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4      0x00000002UL                                   /**< Mode HFCLK4 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8      0x00000003UL                                   /**< Mode HFCLK8 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16     0x00000004UL                                   /**< Mode HFCLK16 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32     0x00000005UL                                   /**< Mode HFCLK32 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64     0x00000006UL                                   /**< Mode HFCLK64 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128    0x00000007UL                                   /**< Mode HFCLK128 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256    0x00000008UL                                   /**< Mode HFCLK256 for CMU_HFCORECLKDIV */
+#define _CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512    0x00000009UL                                   /**< Mode HFCLK512 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT      (_CMU_HFCORECLKDIV_HFCORECLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK        (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8       (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64      (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFCORECLKDIV */
+#define CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512     (_CMU_HFCORECLKDIV_HFCORECLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFCORECLKDIV */
+
+/* Bit fields for CMU HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_RESETVALUE                0x00000100UL                                 /**< Default value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_MASK                      0x0000010FUL                                 /**< Mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_SHIFT         0                                            /**< Shift value for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_MASK          0xFUL                                        /**< Bit mask for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT       0x00000000UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK         0x00000000UL                                 /**< Mode HFCLK for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2        0x00000001UL                                 /**< Mode HFCLK2 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4        0x00000002UL                                 /**< Mode HFCLK4 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8        0x00000003UL                                 /**< Mode HFCLK8 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16       0x00000004UL                                 /**< Mode HFCLK16 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32       0x00000005UL                                 /**< Mode HFCLK32 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64       0x00000006UL                                 /**< Mode HFCLK64 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128      0x00000007UL                                 /**< Mode HFCLK128 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256      0x00000008UL                                 /**< Mode HFCLK256 for CMU_HFPERCLKDIV */
+#define _CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512      0x00000009UL                                 /**< Mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT        (_CMU_HFPERCLKDIV_HFPERCLKDIV_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK          (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK << 0)    /**< Shifted mode HFCLK for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK2 << 0)   /**< Shifted mode HFCLK2 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK4 << 0)   /**< Shifted mode HFCLK4 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8         (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK8 << 0)   /**< Shifted mode HFCLK8 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK16 << 0)  /**< Shifted mode HFCLK16 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK32 << 0)  /**< Shifted mode HFCLK32 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64        (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK64 << 0)  /**< Shifted mode HFCLK64 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK128 << 0) /**< Shifted mode HFCLK128 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK256 << 0) /**< Shifted mode HFCLK256 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512       (_CMU_HFPERCLKDIV_HFPERCLKDIV_HFCLK512 << 0) /**< Shifted mode HFCLK512 for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN                 (0x1UL << 8)                                 /**< HFPERCLK Enable */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_SHIFT          8                                            /**< Shift value for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_MASK           0x100UL                                      /**< Bit mask for CMU_HFPERCLKEN */
+#define _CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT        0x00000001UL                                 /**< Mode DEFAULT for CMU_HFPERCLKDIV */
+#define CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT         (_CMU_HFPERCLKDIV_HFPERCLKEN_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_HFPERCLKDIV */
+
+/* Bit fields for CMU HFRCOCTRL */
+#define _CMU_HFRCOCTRL_RESETVALUE                  0x00000380UL                           /**< Default value for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_MASK                        0x0001F7FFUL                           /**< Mask for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_TUNING_SHIFT                0                                      /**< Shift value for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_MASK                 0xFFUL                                 /**< Bit mask for CMU_TUNING */
+#define _CMU_HFRCOCTRL_TUNING_DEFAULT              0x00000080UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_TUNING_DEFAULT               (_CMU_HFRCOCTRL_TUNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_SHIFT                  8                                      /**< Shift value for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_MASK                   0x700UL                                /**< Bit mask for CMU_BAND */
+#define _CMU_HFRCOCTRL_BAND_1MHZ                   0x00000000UL                           /**< Mode 1MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_7MHZ                   0x00000001UL                           /**< Mode 7MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_11MHZ                  0x00000002UL                           /**< Mode 11MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_DEFAULT                0x00000003UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_14MHZ                  0x00000003UL                           /**< Mode 14MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_21MHZ                  0x00000004UL                           /**< Mode 21MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_BAND_28MHZ                  0x00000005UL                           /**< Mode 28MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_1MHZ                    (_CMU_HFRCOCTRL_BAND_1MHZ << 8)        /**< Shifted mode 1MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_7MHZ                    (_CMU_HFRCOCTRL_BAND_7MHZ << 8)        /**< Shifted mode 7MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_11MHZ                   (_CMU_HFRCOCTRL_BAND_11MHZ << 8)       /**< Shifted mode 11MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_DEFAULT                 (_CMU_HFRCOCTRL_BAND_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_14MHZ                   (_CMU_HFRCOCTRL_BAND_14MHZ << 8)       /**< Shifted mode 14MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_21MHZ                   (_CMU_HFRCOCTRL_BAND_21MHZ << 8)       /**< Shifted mode 21MHZ for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_BAND_28MHZ                   (_CMU_HFRCOCTRL_BAND_28MHZ << 8)       /**< Shifted mode 28MHZ for CMU_HFRCOCTRL */
+#define _CMU_HFRCOCTRL_SUDELAY_SHIFT               12                                     /**< Shift value for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_MASK                0x1F000UL                              /**< Bit mask for CMU_SUDELAY */
+#define _CMU_HFRCOCTRL_SUDELAY_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFRCOCTRL */
+#define CMU_HFRCOCTRL_SUDELAY_DEFAULT              (_CMU_HFRCOCTRL_SUDELAY_DEFAULT << 12) /**< Shifted mode DEFAULT for CMU_HFRCOCTRL */
+
+/* Bit fields for CMU LFRCOCTRL */
+#define _CMU_LFRCOCTRL_RESETVALUE                  0x00000040UL                         /**< Default value for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_MASK                        0x0000007FUL                         /**< Mask for CMU_LFRCOCTRL */
+#define _CMU_LFRCOCTRL_TUNING_SHIFT                0                                    /**< Shift value for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_MASK                 0x7FUL                               /**< Bit mask for CMU_TUNING */
+#define _CMU_LFRCOCTRL_TUNING_DEFAULT              0x00000040UL                         /**< Mode DEFAULT for CMU_LFRCOCTRL */
+#define CMU_LFRCOCTRL_TUNING_DEFAULT               (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
+
+/* Bit fields for CMU AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_RESETVALUE               0x00000080UL                            /**< Default value for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_MASK                     0x000007FFUL                            /**< Mask for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_TUNING_SHIFT             0                                       /**< Shift value for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_MASK              0xFFUL                                  /**< Bit mask for CMU_TUNING */
+#define _CMU_AUXHFRCOCTRL_TUNING_DEFAULT           0x00000080UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_TUNING_DEFAULT            (_CMU_AUXHFRCOCTRL_TUNING_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_SHIFT               8                                       /**< Shift value for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_MASK                0x700UL                                 /**< Bit mask for CMU_BAND */
+#define _CMU_AUXHFRCOCTRL_BAND_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_14MHZ               0x00000000UL                            /**< Mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_11MHZ               0x00000001UL                            /**< Mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_7MHZ                0x00000002UL                            /**< Mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_1MHZ                0x00000003UL                            /**< Mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_28MHZ               0x00000006UL                            /**< Mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define _CMU_AUXHFRCOCTRL_BAND_21MHZ               0x00000007UL                            /**< Mode 21MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_DEFAULT              (_CMU_AUXHFRCOCTRL_BAND_DEFAULT << 8)   /**< Shifted mode DEFAULT for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_14MHZ                (_CMU_AUXHFRCOCTRL_BAND_14MHZ << 8)     /**< Shifted mode 14MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_11MHZ                (_CMU_AUXHFRCOCTRL_BAND_11MHZ << 8)     /**< Shifted mode 11MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_7MHZ                 (_CMU_AUXHFRCOCTRL_BAND_7MHZ << 8)      /**< Shifted mode 7MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_1MHZ                 (_CMU_AUXHFRCOCTRL_BAND_1MHZ << 8)      /**< Shifted mode 1MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_28MHZ                (_CMU_AUXHFRCOCTRL_BAND_28MHZ << 8)     /**< Shifted mode 28MHZ for CMU_AUXHFRCOCTRL */
+#define CMU_AUXHFRCOCTRL_BAND_21MHZ                (_CMU_AUXHFRCOCTRL_BAND_21MHZ << 8)     /**< Shifted mode 21MHZ for CMU_AUXHFRCOCTRL */
+
+/* Bit fields for CMU CALCTRL */
+#define _CMU_CALCTRL_RESETVALUE                    0x00000000UL                         /**< Default value for CMU_CALCTRL */
+#define _CMU_CALCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_SHIFT                   0                                    /**< Shift value for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_MASK                    0x7UL                                /**< Bit mask for CMU_UPSEL */
+#define _CMU_CALCTRL_UPSEL_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFXO                    0x00000000UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFXO                    0x00000001UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_HFRCO                   0x00000002UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_LFRCO                   0x00000003UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_UPSEL_AUXHFRCO                0x00000004UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_DEFAULT                  (_CMU_CALCTRL_UPSEL_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFXO                     (_CMU_CALCTRL_UPSEL_HFXO << 0)       /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFXO                     (_CMU_CALCTRL_UPSEL_LFXO << 0)       /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_HFRCO                    (_CMU_CALCTRL_UPSEL_HFRCO << 0)      /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_LFRCO                    (_CMU_CALCTRL_UPSEL_LFRCO << 0)      /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_UPSEL_AUXHFRCO                 (_CMU_CALCTRL_UPSEL_AUXHFRCO << 0)   /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_SHIFT                 3                                    /**< Shift value for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_MASK                  0x38UL                               /**< Bit mask for CMU_DOWNSEL */
+#define _CMU_CALCTRL_DOWNSEL_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFCLK                 0x00000000UL                         /**< Mode HFCLK for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFXO                  0x00000001UL                         /**< Mode HFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFXO                  0x00000002UL                         /**< Mode LFXO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_HFRCO                 0x00000003UL                         /**< Mode HFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_LFRCO                 0x00000004UL                         /**< Mode LFRCO for CMU_CALCTRL */
+#define _CMU_CALCTRL_DOWNSEL_AUXHFRCO              0x00000005UL                         /**< Mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_DEFAULT                (_CMU_CALCTRL_DOWNSEL_DEFAULT << 3)  /**< Shifted mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFCLK                  (_CMU_CALCTRL_DOWNSEL_HFCLK << 3)    /**< Shifted mode HFCLK for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFXO                   (_CMU_CALCTRL_DOWNSEL_HFXO << 3)     /**< Shifted mode HFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFXO                   (_CMU_CALCTRL_DOWNSEL_LFXO << 3)     /**< Shifted mode LFXO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_HFRCO                  (_CMU_CALCTRL_DOWNSEL_HFRCO << 3)    /**< Shifted mode HFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_LFRCO                  (_CMU_CALCTRL_DOWNSEL_LFRCO << 3)    /**< Shifted mode LFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_DOWNSEL_AUXHFRCO               (_CMU_CALCTRL_DOWNSEL_AUXHFRCO << 3) /**< Shifted mode AUXHFRCO for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT                           (0x1UL << 6)                         /**< Continuous Calibration */
+#define _CMU_CALCTRL_CONT_SHIFT                    6                                    /**< Shift value for CMU_CONT */
+#define _CMU_CALCTRL_CONT_MASK                     0x40UL                               /**< Bit mask for CMU_CONT */
+#define _CMU_CALCTRL_CONT_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_CALCTRL */
+#define CMU_CALCTRL_CONT_DEFAULT                   (_CMU_CALCTRL_CONT_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_CALCTRL */
+
+/* Bit fields for CMU CALCNT */
+#define _CMU_CALCNT_RESETVALUE                     0x00000000UL                      /**< Default value for CMU_CALCNT */
+#define _CMU_CALCNT_MASK                           0x000FFFFFUL                      /**< Mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_SHIFT                   0                                 /**< Shift value for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_MASK                    0xFFFFFUL                         /**< Bit mask for CMU_CALCNT */
+#define _CMU_CALCNT_CALCNT_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for CMU_CALCNT */
+#define CMU_CALCNT_CALCNT_DEFAULT                  (_CMU_CALCNT_CALCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CALCNT */
+
+/* Bit fields for CMU OSCENCMD */
+#define _CMU_OSCENCMD_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_OSCENCMD */
+#define _CMU_OSCENCMD_MASK                         0x000003FFUL                             /**< Mask for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN                       (0x1UL << 0)                             /**< HFRCO Enable */
+#define _CMU_OSCENCMD_HFRCOEN_SHIFT                0                                        /**< Shift value for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_MASK                 0x1UL                                    /**< Bit mask for CMU_HFRCOEN */
+#define _CMU_OSCENCMD_HFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCOEN_DEFAULT               (_CMU_OSCENCMD_HFRCOEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS                      (0x1UL << 1)                             /**< HFRCO Disable */
+#define _CMU_OSCENCMD_HFRCODIS_SHIFT               1                                        /**< Shift value for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_MASK                0x2UL                                    /**< Bit mask for CMU_HFRCODIS */
+#define _CMU_OSCENCMD_HFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFRCODIS_DEFAULT              (_CMU_OSCENCMD_HFRCODIS_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN                        (0x1UL << 2)                             /**< HFXO Enable */
+#define _CMU_OSCENCMD_HFXOEN_SHIFT                 2                                        /**< Shift value for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_MASK                  0x4UL                                    /**< Bit mask for CMU_HFXOEN */
+#define _CMU_OSCENCMD_HFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXOEN_DEFAULT                (_CMU_OSCENCMD_HFXOEN_DEFAULT << 2)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS                       (0x1UL << 3)                             /**< HFXO Disable */
+#define _CMU_OSCENCMD_HFXODIS_SHIFT                3                                        /**< Shift value for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_MASK                 0x8UL                                    /**< Bit mask for CMU_HFXODIS */
+#define _CMU_OSCENCMD_HFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_HFXODIS_DEFAULT               (_CMU_OSCENCMD_HFXODIS_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN                    (0x1UL << 4)                             /**< AUXHFRCO Enable */
+#define _CMU_OSCENCMD_AUXHFRCOEN_SHIFT             4                                        /**< Shift value for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_MASK              0x10UL                                   /**< Bit mask for CMU_AUXHFRCOEN */
+#define _CMU_OSCENCMD_AUXHFRCOEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCOEN_DEFAULT            (_CMU_OSCENCMD_AUXHFRCOEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS                   (0x1UL << 5)                             /**< AUXHFRCO Disable */
+#define _CMU_OSCENCMD_AUXHFRCODIS_SHIFT            5                                        /**< Shift value for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_MASK             0x20UL                                   /**< Bit mask for CMU_AUXHFRCODIS */
+#define _CMU_OSCENCMD_AUXHFRCODIS_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_AUXHFRCODIS_DEFAULT           (_CMU_OSCENCMD_AUXHFRCODIS_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN                       (0x1UL << 6)                             /**< LFRCO Enable */
+#define _CMU_OSCENCMD_LFRCOEN_SHIFT                6                                        /**< Shift value for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_MASK                 0x40UL                                   /**< Bit mask for CMU_LFRCOEN */
+#define _CMU_OSCENCMD_LFRCOEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCOEN_DEFAULT               (_CMU_OSCENCMD_LFRCOEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS                      (0x1UL << 7)                             /**< LFRCO Disable */
+#define _CMU_OSCENCMD_LFRCODIS_SHIFT               7                                        /**< Shift value for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_MASK                0x80UL                                   /**< Bit mask for CMU_LFRCODIS */
+#define _CMU_OSCENCMD_LFRCODIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFRCODIS_DEFAULT              (_CMU_OSCENCMD_LFRCODIS_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN                        (0x1UL << 8)                             /**< LFXO Enable */
+#define _CMU_OSCENCMD_LFXOEN_SHIFT                 8                                        /**< Shift value for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_MASK                  0x100UL                                  /**< Bit mask for CMU_LFXOEN */
+#define _CMU_OSCENCMD_LFXOEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXOEN_DEFAULT                (_CMU_OSCENCMD_LFXOEN_DEFAULT << 8)      /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS                       (0x1UL << 9)                             /**< LFXO Disable */
+#define _CMU_OSCENCMD_LFXODIS_SHIFT                9                                        /**< Shift value for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_MASK                 0x200UL                                  /**< Bit mask for CMU_LFXODIS */
+#define _CMU_OSCENCMD_LFXODIS_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for CMU_OSCENCMD */
+#define CMU_OSCENCMD_LFXODIS_DEFAULT               (_CMU_OSCENCMD_LFXODIS_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_OSCENCMD */
+
+/* Bit fields for CMU CMD */
+#define _CMU_CMD_RESETVALUE                        0x00000000UL                     /**< Default value for CMU_CMD */
+#define _CMU_CMD_MASK                              0x0000001FUL                     /**< Mask for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_SHIFT                    0                                /**< Shift value for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_MASK                     0x7UL                            /**< Bit mask for CMU_HFCLKSEL */
+#define _CMU_CMD_HFCLKSEL_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFRCO                    0x00000001UL                     /**< Mode HFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_HFXO                     0x00000002UL                     /**< Mode HFXO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFRCO                    0x00000003UL                     /**< Mode LFRCO for CMU_CMD */
+#define _CMU_CMD_HFCLKSEL_LFXO                     0x00000004UL                     /**< Mode LFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_DEFAULT                   (_CMU_CMD_HFCLKSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFRCO                     (_CMU_CMD_HFCLKSEL_HFRCO << 0)   /**< Shifted mode HFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_HFXO                      (_CMU_CMD_HFCLKSEL_HFXO << 0)    /**< Shifted mode HFXO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFRCO                     (_CMU_CMD_HFCLKSEL_LFRCO << 0)   /**< Shifted mode LFRCO for CMU_CMD */
+#define CMU_CMD_HFCLKSEL_LFXO                      (_CMU_CMD_HFCLKSEL_LFXO << 0)    /**< Shifted mode LFXO for CMU_CMD */
+#define CMU_CMD_CALSTART                           (0x1UL << 3)                     /**< Calibration Start */
+#define _CMU_CMD_CALSTART_SHIFT                    3                                /**< Shift value for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_MASK                     0x8UL                            /**< Bit mask for CMU_CALSTART */
+#define _CMU_CMD_CALSTART_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTART_DEFAULT                   (_CMU_CMD_CALSTART_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP                            (0x1UL << 4)                     /**< Calibration Stop */
+#define _CMU_CMD_CALSTOP_SHIFT                     4                                /**< Shift value for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_MASK                      0x10UL                           /**< Bit mask for CMU_CALSTOP */
+#define _CMU_CMD_CALSTOP_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for CMU_CMD */
+#define CMU_CMD_CALSTOP_DEFAULT                    (_CMU_CMD_CALSTOP_DEFAULT << 4)  /**< Shifted mode DEFAULT for CMU_CMD */
+
+/* Bit fields for CMU LFCLKSEL */
+#define _CMU_LFCLKSEL_RESETVALUE                   0x00000005UL                             /**< Default value for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_MASK                         0x0011000FUL                             /**< Mask for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_SHIFT                    0                                        /**< Shift value for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_MASK                     0x3UL                                    /**< Bit mask for CMU_LFA */
+#define _CMU_LFCLKSEL_LFA_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DISABLED                  (_CMU_LFCLKSEL_LFA_DISABLED << 0)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_DEFAULT                   (_CMU_LFCLKSEL_LFA_DEFAULT << 0)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFRCO                     (_CMU_LFCLKSEL_LFA_LFRCO << 0)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_LFXO                      (_CMU_LFCLKSEL_LFA_LFXO << 0)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFA_HFCORECLKLEDIV2 << 0) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_SHIFT                    2                                        /**< Shift value for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_MASK                     0xCUL                                    /**< Bit mask for CMU_LFB */
+#define _CMU_LFCLKSEL_LFB_DISABLED                 0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_DEFAULT                  0x00000001UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFRCO                    0x00000001UL                             /**< Mode LFRCO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_LFXO                     0x00000002UL                             /**< Mode LFXO for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2          0x00000003UL                             /**< Mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DISABLED                  (_CMU_LFCLKSEL_LFB_DISABLED << 2)        /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_DEFAULT                   (_CMU_LFCLKSEL_LFB_DEFAULT << 2)         /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFRCO                     (_CMU_LFCLKSEL_LFB_LFRCO << 2)           /**< Shifted mode LFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_LFXO                      (_CMU_LFCLKSEL_LFB_LFXO << 2)            /**< Shifted mode LFXO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2           (_CMU_LFCLKSEL_LFB_HFCORECLKLEDIV2 << 2) /**< Shifted mode HFCORECLKLEDIV2 for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE                          (0x1UL << 16)                            /**< Clock Select for LFA Extended */
+#define _CMU_LFCLKSEL_LFAE_SHIFT                   16                                       /**< Shift value for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_MASK                    0x10000UL                                /**< Bit mask for CMU_LFAE */
+#define _CMU_LFCLKSEL_LFAE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFAE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DEFAULT                  (_CMU_LFCLKSEL_LFAE_DEFAULT << 16)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_DISABLED                 (_CMU_LFCLKSEL_LFAE_DISABLED << 16)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFAE_ULFRCO                   (_CMU_LFCLKSEL_LFAE_ULFRCO << 16)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE                          (0x1UL << 20)                            /**< Clock Select for LFB Extended */
+#define _CMU_LFCLKSEL_LFBE_SHIFT                   20                                       /**< Shift value for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_MASK                    0x100000UL                               /**< Bit mask for CMU_LFBE */
+#define _CMU_LFCLKSEL_LFBE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_DISABLED                0x00000000UL                             /**< Mode DISABLED for CMU_LFCLKSEL */
+#define _CMU_LFCLKSEL_LFBE_ULFRCO                  0x00000001UL                             /**< Mode ULFRCO for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DEFAULT                  (_CMU_LFCLKSEL_LFBE_DEFAULT << 20)       /**< Shifted mode DEFAULT for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_DISABLED                 (_CMU_LFCLKSEL_LFBE_DISABLED << 20)      /**< Shifted mode DISABLED for CMU_LFCLKSEL */
+#define CMU_LFCLKSEL_LFBE_ULFRCO                   (_CMU_LFCLKSEL_LFBE_ULFRCO << 20)        /**< Shifted mode ULFRCO for CMU_LFCLKSEL */
+
+/* Bit fields for CMU STATUS */
+#define _CMU_STATUS_RESETVALUE                     0x00000403UL                           /**< Default value for CMU_STATUS */
+#define _CMU_STATUS_MASK                           0x00007FFFUL                           /**< Mask for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS                        (0x1UL << 0)                           /**< HFRCO Enable Status */
+#define _CMU_STATUS_HFRCOENS_SHIFT                 0                                      /**< Shift value for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_MASK                  0x1UL                                  /**< Bit mask for CMU_HFRCOENS */
+#define _CMU_STATUS_HFRCOENS_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOENS_DEFAULT                (_CMU_STATUS_HFRCOENS_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY                        (0x1UL << 1)                           /**< HFRCO Ready */
+#define _CMU_STATUS_HFRCORDY_SHIFT                 1                                      /**< Shift value for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_MASK                  0x2UL                                  /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_STATUS_HFRCORDY_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCORDY_DEFAULT                (_CMU_STATUS_HFRCORDY_DEFAULT << 1)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS                         (0x1UL << 2)                           /**< HFXO Enable Status */
+#define _CMU_STATUS_HFXOENS_SHIFT                  2                                      /**< Shift value for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_MASK                   0x4UL                                  /**< Bit mask for CMU_HFXOENS */
+#define _CMU_STATUS_HFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOENS_DEFAULT                 (_CMU_STATUS_HFXOENS_DEFAULT << 2)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY                         (0x1UL << 3)                           /**< HFXO Ready */
+#define _CMU_STATUS_HFXORDY_SHIFT                  3                                      /**< Shift value for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_MASK                   0x8UL                                  /**< Bit mask for CMU_HFXORDY */
+#define _CMU_STATUS_HFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXORDY_DEFAULT                 (_CMU_STATUS_HFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS                     (0x1UL << 4)                           /**< AUXHFRCO Enable Status */
+#define _CMU_STATUS_AUXHFRCOENS_SHIFT              4                                      /**< Shift value for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_MASK               0x10UL                                 /**< Bit mask for CMU_AUXHFRCOENS */
+#define _CMU_STATUS_AUXHFRCOENS_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCOENS_DEFAULT             (_CMU_STATUS_AUXHFRCOENS_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY                     (0x1UL << 5)                           /**< AUXHFRCO Ready */
+#define _CMU_STATUS_AUXHFRCORDY_SHIFT              5                                      /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_MASK               0x20UL                                 /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_STATUS_AUXHFRCORDY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_AUXHFRCORDY_DEFAULT             (_CMU_STATUS_AUXHFRCORDY_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS                        (0x1UL << 6)                           /**< LFRCO Enable Status */
+#define _CMU_STATUS_LFRCOENS_SHIFT                 6                                      /**< Shift value for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_MASK                  0x40UL                                 /**< Bit mask for CMU_LFRCOENS */
+#define _CMU_STATUS_LFRCOENS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOENS_DEFAULT                (_CMU_STATUS_LFRCOENS_DEFAULT << 6)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY                        (0x1UL << 7)                           /**< LFRCO Ready */
+#define _CMU_STATUS_LFRCORDY_SHIFT                 7                                      /**< Shift value for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_MASK                  0x80UL                                 /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_STATUS_LFRCORDY_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCORDY_DEFAULT                (_CMU_STATUS_LFRCORDY_DEFAULT << 7)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS                         (0x1UL << 8)                           /**< LFXO Enable Status */
+#define _CMU_STATUS_LFXOENS_SHIFT                  8                                      /**< Shift value for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_MASK                   0x100UL                                /**< Bit mask for CMU_LFXOENS */
+#define _CMU_STATUS_LFXOENS_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOENS_DEFAULT                 (_CMU_STATUS_LFXOENS_DEFAULT << 8)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY                         (0x1UL << 9)                           /**< LFXO Ready */
+#define _CMU_STATUS_LFXORDY_SHIFT                  9                                      /**< Shift value for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_MASK                   0x200UL                                /**< Bit mask for CMU_LFXORDY */
+#define _CMU_STATUS_LFXORDY_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXORDY_DEFAULT                 (_CMU_STATUS_LFXORDY_DEFAULT << 9)     /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL                        (0x1UL << 10)                          /**< HFRCO Selected */
+#define _CMU_STATUS_HFRCOSEL_SHIFT                 10                                     /**< Shift value for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_MASK                  0x400UL                                /**< Bit mask for CMU_HFRCOSEL */
+#define _CMU_STATUS_HFRCOSEL_DEFAULT               0x00000001UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFRCOSEL_DEFAULT                (_CMU_STATUS_HFRCOSEL_DEFAULT << 10)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL                         (0x1UL << 11)                          /**< HFXO Selected */
+#define _CMU_STATUS_HFXOSEL_SHIFT                  11                                     /**< Shift value for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_MASK                   0x800UL                                /**< Bit mask for CMU_HFXOSEL */
+#define _CMU_STATUS_HFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_HFXOSEL_DEFAULT                 (_CMU_STATUS_HFXOSEL_DEFAULT << 11)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL                        (0x1UL << 12)                          /**< LFRCO Selected */
+#define _CMU_STATUS_LFRCOSEL_SHIFT                 12                                     /**< Shift value for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_MASK                  0x1000UL                               /**< Bit mask for CMU_LFRCOSEL */
+#define _CMU_STATUS_LFRCOSEL_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFRCOSEL_DEFAULT                (_CMU_STATUS_LFRCOSEL_DEFAULT << 12)   /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL                         (0x1UL << 13)                          /**< LFXO Selected */
+#define _CMU_STATUS_LFXOSEL_SHIFT                  13                                     /**< Shift value for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_MASK                   0x2000UL                               /**< Bit mask for CMU_LFXOSEL */
+#define _CMU_STATUS_LFXOSEL_DEFAULT                0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_LFXOSEL_DEFAULT                 (_CMU_STATUS_LFXOSEL_DEFAULT << 13)    /**< Shifted mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY                          (0x1UL << 14)                          /**< Calibration Busy */
+#define _CMU_STATUS_CALBSY_SHIFT                   14                                     /**< Shift value for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_MASK                    0x4000UL                               /**< Bit mask for CMU_CALBSY */
+#define _CMU_STATUS_CALBSY_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_STATUS */
+#define CMU_STATUS_CALBSY_DEFAULT                  (_CMU_STATUS_CALBSY_DEFAULT << 14)     /**< Shifted mode DEFAULT for CMU_STATUS */
+
+/* Bit fields for CMU IF */
+#define _CMU_IF_RESETVALUE                         0x00000001UL                       /**< Default value for CMU_IF */
+#define _CMU_IF_MASK                               0x0000007FUL                       /**< Mask for CMU_IF */
+#define CMU_IF_HFRCORDY                            (0x1UL << 0)                       /**< HFRCO Ready Interrupt Flag */
+#define _CMU_IF_HFRCORDY_SHIFT                     0                                  /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_MASK                      0x1UL                              /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IF_HFRCORDY_DEFAULT                   0x00000001UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFRCORDY_DEFAULT                    (_CMU_IF_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY                             (0x1UL << 1)                       /**< HFXO Ready Interrupt Flag */
+#define _CMU_IF_HFXORDY_SHIFT                      1                                  /**< Shift value for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_MASK                       0x2UL                              /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IF_HFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_HFXORDY_DEFAULT                     (_CMU_IF_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY                            (0x1UL << 2)                       /**< LFRCO Ready Interrupt Flag */
+#define _CMU_IF_LFRCORDY_SHIFT                     2                                  /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_MASK                      0x4UL                              /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IF_LFRCORDY_DEFAULT                   0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFRCORDY_DEFAULT                    (_CMU_IF_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY                             (0x1UL << 3)                       /**< LFXO Ready Interrupt Flag */
+#define _CMU_IF_LFXORDY_SHIFT                      3                                  /**< Shift value for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_MASK                       0x8UL                              /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IF_LFXORDY_DEFAULT                    0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_LFXORDY_DEFAULT                     (_CMU_IF_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY                         (0x1UL << 4)                       /**< AUXHFRCO Ready Interrupt Flag */
+#define _CMU_IF_AUXHFRCORDY_SHIFT                  4                                  /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_MASK                   0x10UL                             /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IF_AUXHFRCORDY_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_AUXHFRCORDY_DEFAULT                 (_CMU_IF_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY                              (0x1UL << 5)                       /**< Calibration Ready Interrupt Flag */
+#define _CMU_IF_CALRDY_SHIFT                       5                                  /**< Shift value for CMU_CALRDY */
+#define _CMU_IF_CALRDY_MASK                        0x20UL                             /**< Bit mask for CMU_CALRDY */
+#define _CMU_IF_CALRDY_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALRDY_DEFAULT                      (_CMU_IF_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF                               (0x1UL << 6)                       /**< Calibration Overflow Interrupt Flag */
+#define _CMU_IF_CALOF_SHIFT                        6                                  /**< Shift value for CMU_CALOF */
+#define _CMU_IF_CALOF_MASK                         0x40UL                             /**< Bit mask for CMU_CALOF */
+#define _CMU_IF_CALOF_DEFAULT                      0x00000000UL                       /**< Mode DEFAULT for CMU_IF */
+#define CMU_IF_CALOF_DEFAULT                       (_CMU_IF_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IF */
+
+/* Bit fields for CMU IFS */
+#define _CMU_IFS_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFS */
+#define _CMU_IFS_MASK                              0x0000007FUL                        /**< Mask for CMU_IFS */
+#define CMU_IFS_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFS_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFRCORDY_DEFAULT                   (_CMU_IFS_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFS_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_HFXORDY_DEFAULT                    (_CMU_IFS_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFS_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFRCORDY_DEFAULT                   (_CMU_IFS_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Set */
+#define _CMU_IFS_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFS_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_LFXORDY_DEFAULT                    (_CMU_IFS_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Set */
+#define _CMU_IFS_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFS_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_AUXHFRCORDY_DEFAULT                (_CMU_IFS_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Set */
+#define _CMU_IFS_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFS_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALRDY_DEFAULT                     (_CMU_IFS_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Set */
+#define _CMU_IFS_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFS_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFS_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFS */
+#define CMU_IFS_CALOF_DEFAULT                      (_CMU_IFS_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFS */
+
+/* Bit fields for CMU IFC */
+#define _CMU_IFC_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IFC */
+#define _CMU_IFC_MASK                              0x0000007FUL                        /**< Mask for CMU_IFC */
+#define CMU_IFC_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IFC_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFRCORDY_DEFAULT                   (_CMU_IFC_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IFC_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_HFXORDY_DEFAULT                    (_CMU_IFC_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IFC_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFRCORDY_DEFAULT                   (_CMU_IFC_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Flag Clear */
+#define _CMU_IFC_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IFC_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_LFXORDY_DEFAULT                    (_CMU_IFC_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Flag Clear */
+#define _CMU_IFC_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IFC_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_AUXHFRCORDY_DEFAULT                (_CMU_IFC_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Flag Clear */
+#define _CMU_IFC_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IFC_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALRDY_DEFAULT                     (_CMU_IFC_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Flag Clear */
+#define _CMU_IFC_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IFC_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IFC_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IFC */
+#define CMU_IFC_CALOF_DEFAULT                      (_CMU_IFC_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IFC */
+
+/* Bit fields for CMU IEN */
+#define _CMU_IEN_RESETVALUE                        0x00000000UL                        /**< Default value for CMU_IEN */
+#define _CMU_IEN_MASK                              0x0000007FUL                        /**< Mask for CMU_IEN */
+#define CMU_IEN_HFRCORDY                           (0x1UL << 0)                        /**< HFRCO Ready Interrupt Enable */
+#define _CMU_IEN_HFRCORDY_SHIFT                    0                                   /**< Shift value for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_MASK                     0x1UL                               /**< Bit mask for CMU_HFRCORDY */
+#define _CMU_IEN_HFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFRCORDY_DEFAULT                   (_CMU_IEN_HFRCORDY_DEFAULT << 0)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY                            (0x1UL << 1)                        /**< HFXO Ready Interrupt Enable */
+#define _CMU_IEN_HFXORDY_SHIFT                     1                                   /**< Shift value for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_MASK                      0x2UL                               /**< Bit mask for CMU_HFXORDY */
+#define _CMU_IEN_HFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_HFXORDY_DEFAULT                    (_CMU_IEN_HFXORDY_DEFAULT << 1)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY                           (0x1UL << 2)                        /**< LFRCO Ready Interrupt Enable */
+#define _CMU_IEN_LFRCORDY_SHIFT                    2                                   /**< Shift value for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_MASK                     0x4UL                               /**< Bit mask for CMU_LFRCORDY */
+#define _CMU_IEN_LFRCORDY_DEFAULT                  0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFRCORDY_DEFAULT                   (_CMU_IEN_LFRCORDY_DEFAULT << 2)    /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY                            (0x1UL << 3)                        /**< LFXO Ready Interrupt Enable */
+#define _CMU_IEN_LFXORDY_SHIFT                     3                                   /**< Shift value for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_MASK                      0x8UL                               /**< Bit mask for CMU_LFXORDY */
+#define _CMU_IEN_LFXORDY_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_LFXORDY_DEFAULT                    (_CMU_IEN_LFXORDY_DEFAULT << 3)     /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY                        (0x1UL << 4)                        /**< AUXHFRCO Ready Interrupt Enable */
+#define _CMU_IEN_AUXHFRCORDY_SHIFT                 4                                   /**< Shift value for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_MASK                  0x10UL                              /**< Bit mask for CMU_AUXHFRCORDY */
+#define _CMU_IEN_AUXHFRCORDY_DEFAULT               0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_AUXHFRCORDY_DEFAULT                (_CMU_IEN_AUXHFRCORDY_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY                             (0x1UL << 5)                        /**< Calibration Ready Interrupt Enable */
+#define _CMU_IEN_CALRDY_SHIFT                      5                                   /**< Shift value for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_MASK                       0x20UL                              /**< Bit mask for CMU_CALRDY */
+#define _CMU_IEN_CALRDY_DEFAULT                    0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALRDY_DEFAULT                     (_CMU_IEN_CALRDY_DEFAULT << 5)      /**< Shifted mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF                              (0x1UL << 6)                        /**< Calibration Overflow Interrupt Enable */
+#define _CMU_IEN_CALOF_SHIFT                       6                                   /**< Shift value for CMU_CALOF */
+#define _CMU_IEN_CALOF_MASK                        0x40UL                              /**< Bit mask for CMU_CALOF */
+#define _CMU_IEN_CALOF_DEFAULT                     0x00000000UL                        /**< Mode DEFAULT for CMU_IEN */
+#define CMU_IEN_CALOF_DEFAULT                      (_CMU_IEN_CALOF_DEFAULT << 6)       /**< Shifted mode DEFAULT for CMU_IEN */
+
+/* Bit fields for CMU HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_RESETVALUE               0x00000000UL                         /**< Default value for CMU_HFCORECLKEN0 */
+#define _CMU_HFCORECLKEN0_MASK                     0x00000007UL                         /**< Mask for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES                       (0x1UL << 0)                         /**< Advanced Encryption Standard Accelerator Clock Enable */
+#define _CMU_HFCORECLKEN0_AES_SHIFT                0                                    /**< Shift value for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_MASK                 0x1UL                                /**< Bit mask for CMU_AES */
+#define _CMU_HFCORECLKEN0_AES_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_AES_DEFAULT               (_CMU_HFCORECLKEN0_AES_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA                       (0x1UL << 1)                         /**< Direct Memory Access Controller Clock Enable */
+#define _CMU_HFCORECLKEN0_DMA_SHIFT                1                                    /**< Shift value for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_MASK                 0x2UL                                /**< Bit mask for CMU_DMA */
+#define _CMU_HFCORECLKEN0_DMA_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_DMA_DEFAULT               (_CMU_HFCORECLKEN0_DMA_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE                        (0x1UL << 2)                         /**< Low Energy Peripheral Interface Clock Enable */
+#define _CMU_HFCORECLKEN0_LE_SHIFT                 2                                    /**< Shift value for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_MASK                  0x4UL                                /**< Bit mask for CMU_LE */
+#define _CMU_HFCORECLKEN0_LE_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for CMU_HFCORECLKEN0 */
+#define CMU_HFCORECLKEN0_LE_DEFAULT                (_CMU_HFCORECLKEN0_LE_DEFAULT << 2)  /**< Shifted mode DEFAULT for CMU_HFCORECLKEN0 */
+
+/* Bit fields for CMU HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_RESETVALUE                0x00000000UL                           /**< Default value for CMU_HFPERCLKEN0 */
+#define _CMU_HFPERCLKEN0_MASK                      0x00000FFFUL                           /**< Mask for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0                      (0x1UL << 0)                           /**< Analog Comparator 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP0_SHIFT               0                                      /**< Shift value for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_MASK                0x1UL                                  /**< Bit mask for CMU_ACMP0 */
+#define _CMU_HFPERCLKEN0_ACMP0_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP0_DEFAULT              (_CMU_HFPERCLKEN0_ACMP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1                      (0x1UL << 1)                           /**< Analog Comparator 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_ACMP1_SHIFT               1                                      /**< Shift value for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_MASK                0x2UL                                  /**< Bit mask for CMU_ACMP1 */
+#define _CMU_HFPERCLKEN0_ACMP1_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ACMP1_DEFAULT              (_CMU_HFPERCLKEN0_ACMP1_DEFAULT << 1)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0                     (0x1UL << 2)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART0_SHIFT              2                                      /**< Shift value for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_MASK               0x4UL                                  /**< Bit mask for CMU_USART0 */
+#define _CMU_HFPERCLKEN0_USART0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART0_DEFAULT             (_CMU_HFPERCLKEN0_USART0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1                     (0x1UL << 3)                           /**< Universal Synchronous/Asynchronous Receiver/Transmitter 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_USART1_SHIFT              3                                      /**< Shift value for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_MASK               0x8UL                                  /**< Bit mask for CMU_USART1 */
+#define _CMU_HFPERCLKEN0_USART1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_USART1_DEFAULT             (_CMU_HFPERCLKEN0_USART1_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0                     (0x1UL << 4)                           /**< Timer 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER0_SHIFT              4                                      /**< Shift value for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_MASK               0x10UL                                 /**< Bit mask for CMU_TIMER0 */
+#define _CMU_HFPERCLKEN0_TIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER0_DEFAULT             (_CMU_HFPERCLKEN0_TIMER0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1                     (0x1UL << 5)                           /**< Timer 1 Clock Enable */
+#define _CMU_HFPERCLKEN0_TIMER1_SHIFT              5                                      /**< Shift value for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_MASK               0x20UL                                 /**< Bit mask for CMU_TIMER1 */
+#define _CMU_HFPERCLKEN0_TIMER1_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_TIMER1_DEFAULT             (_CMU_HFPERCLKEN0_TIMER1_DEFAULT << 5) /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO                       (0x1UL << 6)                           /**< General purpose Input/Output Clock Enable */
+#define _CMU_HFPERCLKEN0_GPIO_SHIFT                6                                      /**< Shift value for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_MASK                 0x40UL                                 /**< Bit mask for CMU_GPIO */
+#define _CMU_HFPERCLKEN0_GPIO_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_GPIO_DEFAULT               (_CMU_HFPERCLKEN0_GPIO_DEFAULT << 6)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP                       (0x1UL << 7)                           /**< Voltage Comparator Clock Enable */
+#define _CMU_HFPERCLKEN0_VCMP_SHIFT                7                                      /**< Shift value for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_MASK                 0x80UL                                 /**< Bit mask for CMU_VCMP */
+#define _CMU_HFPERCLKEN0_VCMP_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_VCMP_DEFAULT               (_CMU_HFPERCLKEN0_VCMP_DEFAULT << 7)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS                        (0x1UL << 8)                           /**< Peripheral Reflex System Clock Enable */
+#define _CMU_HFPERCLKEN0_PRS_SHIFT                 8                                      /**< Shift value for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_MASK                  0x100UL                                /**< Bit mask for CMU_PRS */
+#define _CMU_HFPERCLKEN0_PRS_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_PRS_DEFAULT                (_CMU_HFPERCLKEN0_PRS_DEFAULT << 8)    /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0                       (0x1UL << 9)                           /**< Analog to Digital Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_ADC0_SHIFT                9                                      /**< Shift value for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_MASK                 0x200UL                                /**< Bit mask for CMU_ADC0 */
+#define _CMU_HFPERCLKEN0_ADC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_ADC0_DEFAULT               (_CMU_HFPERCLKEN0_ADC0_DEFAULT << 9)   /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0                       (0x1UL << 10)                          /**< Digital to Analog Converter 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_DAC0_SHIFT                10                                     /**< Shift value for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_MASK                 0x400UL                                /**< Bit mask for CMU_DAC0 */
+#define _CMU_HFPERCLKEN0_DAC0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_DAC0_DEFAULT               (_CMU_HFPERCLKEN0_DAC0_DEFAULT << 10)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0                       (0x1UL << 11)                          /**< I2C 0 Clock Enable */
+#define _CMU_HFPERCLKEN0_I2C0_SHIFT                11                                     /**< Shift value for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_MASK                 0x800UL                                /**< Bit mask for CMU_I2C0 */
+#define _CMU_HFPERCLKEN0_I2C0_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for CMU_HFPERCLKEN0 */
+#define CMU_HFPERCLKEN0_I2C0_DEFAULT               (_CMU_HFPERCLKEN0_I2C0_DEFAULT << 11)  /**< Shifted mode DEFAULT for CMU_HFPERCLKEN0 */
+
+/* Bit fields for CMU SYNCBUSY */
+#define _CMU_SYNCBUSY_RESETVALUE                   0x00000000UL                           /**< Default value for CMU_SYNCBUSY */
+#define _CMU_SYNCBUSY_MASK                         0x00000055UL                           /**< Mask for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0                     (0x1UL << 0)                           /**< Low Frequency A Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFACLKEN0_SHIFT              0                                      /**< Shift value for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_MASK               0x1UL                                  /**< Bit mask for CMU_LFACLKEN0 */
+#define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFACLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0                     (0x1UL << 2)                           /**< Low Frequency A Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFAPRESC0_SHIFT              2                                      /**< Shift value for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_MASK               0x4UL                                  /**< Bit mask for CMU_LFAPRESC0 */
+#define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFAPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFAPRESC0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0                     (0x1UL << 4)                           /**< Low Frequency B Clock Enable 0 Busy */
+#define _CMU_SYNCBUSY_LFBCLKEN0_SHIFT              4                                      /**< Shift value for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_MASK               0x10UL                                 /**< Bit mask for CMU_LFBCLKEN0 */
+#define _CMU_SYNCBUSY_LFBCLKEN0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBCLKEN0_DEFAULT             (_CMU_SYNCBUSY_LFBCLKEN0_DEFAULT << 4) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0                     (0x1UL << 6)                           /**< Low Frequency B Prescaler 0 Busy */
+#define _CMU_SYNCBUSY_LFBPRESC0_SHIFT              6                                      /**< Shift value for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_MASK               0x40UL                                 /**< Bit mask for CMU_LFBPRESC0 */
+#define _CMU_SYNCBUSY_LFBPRESC0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_SYNCBUSY */
+#define CMU_SYNCBUSY_LFBPRESC0_DEFAULT             (_CMU_SYNCBUSY_LFBPRESC0_DEFAULT << 6) /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
+
+/* Bit fields for CMU FREEZE */
+#define _CMU_FREEZE_RESETVALUE                     0x00000000UL                         /**< Default value for CMU_FREEZE */
+#define _CMU_FREEZE_MASK                           0x00000001UL                         /**< Mask for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE                       (0x1UL << 0)                         /**< Register Update Freeze */
+#define _CMU_FREEZE_REGFREEZE_SHIFT                0                                    /**< Shift value for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_MASK                 0x1UL                                /**< Bit mask for CMU_REGFREEZE */
+#define _CMU_FREEZE_REGFREEZE_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_UPDATE               0x00000000UL                         /**< Mode UPDATE for CMU_FREEZE */
+#define _CMU_FREEZE_REGFREEZE_FREEZE               0x00000001UL                         /**< Mode FREEZE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_DEFAULT               (_CMU_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_UPDATE                (_CMU_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for CMU_FREEZE */
+#define CMU_FREEZE_REGFREEZE_FREEZE                (_CMU_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for CMU_FREEZE */
+
+/* Bit fields for CMU LFACLKEN0 */
+#define _CMU_LFACLKEN0_RESETVALUE                  0x00000000UL                           /**< Default value for CMU_LFACLKEN0 */
+#define _CMU_LFACLKEN0_MASK                        0x0000000FUL                           /**< Mask for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE                      (0x1UL << 0)                           /**< Low Energy Sensor Interface Clock Enable */
+#define _CMU_LFACLKEN0_LESENSE_SHIFT               0                                      /**< Shift value for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_MASK                0x1UL                                  /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFACLKEN0_LESENSE_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LESENSE_DEFAULT              (_CMU_LFACLKEN0_LESENSE_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC                          (0x1UL << 1)                           /**< Real-Time Counter Clock Enable */
+#define _CMU_LFACLKEN0_RTC_SHIFT                   1                                      /**< Shift value for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_MASK                    0x2UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFACLKEN0_RTC_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_RTC_DEFAULT                  (_CMU_LFACLKEN0_RTC_DEFAULT << 1)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0                     (0x1UL << 2)                           /**< Low Energy Timer 0 Clock Enable */
+#define _CMU_LFACLKEN0_LETIMER0_SHIFT              2                                      /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_MASK               0x4UL                                  /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFACLKEN0_LETIMER0_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LETIMER0_DEFAULT             (_CMU_LFACLKEN0_LETIMER0_DEFAULT << 2) /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LCD                          (0x1UL << 3)                           /**< Liquid Crystal Display Controller Clock Enable */
+#define _CMU_LFACLKEN0_LCD_SHIFT                   3                                      /**< Shift value for CMU_LCD */
+#define _CMU_LFACLKEN0_LCD_MASK                    0x8UL                                  /**< Bit mask for CMU_LCD */
+#define _CMU_LFACLKEN0_LCD_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for CMU_LFACLKEN0 */
+#define CMU_LFACLKEN0_LCD_DEFAULT                  (_CMU_LFACLKEN0_LCD_DEFAULT << 3)      /**< Shifted mode DEFAULT for CMU_LFACLKEN0 */
+
+/* Bit fields for CMU LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_RESETVALUE                  0x00000000UL                          /**< Default value for CMU_LFBCLKEN0 */
+#define _CMU_LFBCLKEN0_MASK                        0x00000001UL                          /**< Mask for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0                      (0x1UL << 0)                          /**< Low Energy UART 0 Clock Enable */
+#define _CMU_LFBCLKEN0_LEUART0_SHIFT               0                                     /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_MASK                0x1UL                                 /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBCLKEN0_LEUART0_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for CMU_LFBCLKEN0 */
+#define CMU_LFBCLKEN0_LEUART0_DEFAULT              (_CMU_LFBCLKEN0_LEUART0_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_LFBCLKEN0 */
+
+/* Bit fields for CMU LFAPRESC0 */
+#define _CMU_LFAPRESC0_RESETVALUE                  0x00000000UL                            /**< Default value for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_MASK                        0x00003FF3UL                            /**< Mask for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_SHIFT               0                                       /**< Shift value for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_MASK                0x3UL                                   /**< Bit mask for CMU_LESENSE */
+#define _CMU_LFAPRESC0_LESENSE_DIV1                0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV2                0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV4                0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LESENSE_DIV8                0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV1                 (_CMU_LFAPRESC0_LESENSE_DIV1 << 0)      /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV2                 (_CMU_LFAPRESC0_LESENSE_DIV2 << 0)      /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV4                 (_CMU_LFAPRESC0_LESENSE_DIV4 << 0)      /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LESENSE_DIV8                 (_CMU_LFAPRESC0_LESENSE_DIV8 << 0)      /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_SHIFT                   4                                       /**< Shift value for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_MASK                    0xF0UL                                  /**< Bit mask for CMU_RTC */
+#define _CMU_LFAPRESC0_RTC_DIV1                    0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2                    0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4                    0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8                    0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16                   0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32                   0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV64                   0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV128                  0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV256                  0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV512                  0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV1024                 0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV2048                 0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV4096                 0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV8192                 0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV16384                0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_RTC_DIV32768                0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1                     (_CMU_LFAPRESC0_RTC_DIV1 << 4)          /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2                     (_CMU_LFAPRESC0_RTC_DIV2 << 4)          /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4                     (_CMU_LFAPRESC0_RTC_DIV4 << 4)          /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8                     (_CMU_LFAPRESC0_RTC_DIV8 << 4)          /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16                    (_CMU_LFAPRESC0_RTC_DIV16 << 4)         /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32                    (_CMU_LFAPRESC0_RTC_DIV32 << 4)         /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV64                    (_CMU_LFAPRESC0_RTC_DIV64 << 4)         /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV128                   (_CMU_LFAPRESC0_RTC_DIV128 << 4)        /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV256                   (_CMU_LFAPRESC0_RTC_DIV256 << 4)        /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV512                   (_CMU_LFAPRESC0_RTC_DIV512 << 4)        /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV1024                  (_CMU_LFAPRESC0_RTC_DIV1024 << 4)       /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV2048                  (_CMU_LFAPRESC0_RTC_DIV2048 << 4)       /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV4096                  (_CMU_LFAPRESC0_RTC_DIV4096 << 4)       /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV8192                  (_CMU_LFAPRESC0_RTC_DIV8192 << 4)       /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV16384                 (_CMU_LFAPRESC0_RTC_DIV16384 << 4)      /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_RTC_DIV32768                 (_CMU_LFAPRESC0_RTC_DIV32768 << 4)      /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_SHIFT              8                                       /**< Shift value for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_MASK               0xF00UL                                 /**< Bit mask for CMU_LETIMER0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1               0x00000000UL                            /**< Mode DIV1 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2               0x00000001UL                            /**< Mode DIV2 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4               0x00000002UL                            /**< Mode DIV4 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8               0x00000003UL                            /**< Mode DIV8 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16              0x00000004UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32              0x00000005UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV64              0x00000006UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV128             0x00000007UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV256             0x00000008UL                            /**< Mode DIV256 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV512             0x00000009UL                            /**< Mode DIV512 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV1024            0x0000000AUL                            /**< Mode DIV1024 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV2048            0x0000000BUL                            /**< Mode DIV2048 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV4096            0x0000000CUL                            /**< Mode DIV4096 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV8192            0x0000000DUL                            /**< Mode DIV8192 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV16384           0x0000000EUL                            /**< Mode DIV16384 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LETIMER0_DIV32768           0x0000000FUL                            /**< Mode DIV32768 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1                (_CMU_LFAPRESC0_LETIMER0_DIV1 << 8)     /**< Shifted mode DIV1 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2                (_CMU_LFAPRESC0_LETIMER0_DIV2 << 8)     /**< Shifted mode DIV2 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4                (_CMU_LFAPRESC0_LETIMER0_DIV4 << 8)     /**< Shifted mode DIV4 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8                (_CMU_LFAPRESC0_LETIMER0_DIV8 << 8)     /**< Shifted mode DIV8 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16               (_CMU_LFAPRESC0_LETIMER0_DIV16 << 8)    /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32               (_CMU_LFAPRESC0_LETIMER0_DIV32 << 8)    /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV64               (_CMU_LFAPRESC0_LETIMER0_DIV64 << 8)    /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV128              (_CMU_LFAPRESC0_LETIMER0_DIV128 << 8)   /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV256              (_CMU_LFAPRESC0_LETIMER0_DIV256 << 8)   /**< Shifted mode DIV256 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV512              (_CMU_LFAPRESC0_LETIMER0_DIV512 << 8)   /**< Shifted mode DIV512 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV1024             (_CMU_LFAPRESC0_LETIMER0_DIV1024 << 8)  /**< Shifted mode DIV1024 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV2048             (_CMU_LFAPRESC0_LETIMER0_DIV2048 << 8)  /**< Shifted mode DIV2048 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV4096             (_CMU_LFAPRESC0_LETIMER0_DIV4096 << 8)  /**< Shifted mode DIV4096 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV8192             (_CMU_LFAPRESC0_LETIMER0_DIV8192 << 8)  /**< Shifted mode DIV8192 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV16384            (_CMU_LFAPRESC0_LETIMER0_DIV16384 << 8) /**< Shifted mode DIV16384 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LETIMER0_DIV32768            (_CMU_LFAPRESC0_LETIMER0_DIV32768 << 8) /**< Shifted mode DIV32768 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LCD_SHIFT                   12                                      /**< Shift value for CMU_LCD */
+#define _CMU_LFAPRESC0_LCD_MASK                    0x3000UL                                /**< Bit mask for CMU_LCD */
+#define _CMU_LFAPRESC0_LCD_DIV16                   0x00000000UL                            /**< Mode DIV16 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LCD_DIV32                   0x00000001UL                            /**< Mode DIV32 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LCD_DIV64                   0x00000002UL                            /**< Mode DIV64 for CMU_LFAPRESC0 */
+#define _CMU_LFAPRESC0_LCD_DIV128                  0x00000003UL                            /**< Mode DIV128 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LCD_DIV16                    (_CMU_LFAPRESC0_LCD_DIV16 << 12)        /**< Shifted mode DIV16 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LCD_DIV32                    (_CMU_LFAPRESC0_LCD_DIV32 << 12)        /**< Shifted mode DIV32 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LCD_DIV64                    (_CMU_LFAPRESC0_LCD_DIV64 << 12)        /**< Shifted mode DIV64 for CMU_LFAPRESC0 */
+#define CMU_LFAPRESC0_LCD_DIV128                   (_CMU_LFAPRESC0_LCD_DIV128 << 12)       /**< Shifted mode DIV128 for CMU_LFAPRESC0 */
+
+/* Bit fields for CMU LFBPRESC0 */
+#define _CMU_LFBPRESC0_RESETVALUE                  0x00000000UL                       /**< Default value for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_MASK                        0x00000003UL                       /**< Mask for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_SHIFT               0                                  /**< Shift value for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_MASK                0x3UL                              /**< Bit mask for CMU_LEUART0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV1                0x00000000UL                       /**< Mode DIV1 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV2                0x00000001UL                       /**< Mode DIV2 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV4                0x00000002UL                       /**< Mode DIV4 for CMU_LFBPRESC0 */
+#define _CMU_LFBPRESC0_LEUART0_DIV8                0x00000003UL                       /**< Mode DIV8 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV1                 (_CMU_LFBPRESC0_LEUART0_DIV1 << 0) /**< Shifted mode DIV1 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV2                 (_CMU_LFBPRESC0_LEUART0_DIV2 << 0) /**< Shifted mode DIV2 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV4                 (_CMU_LFBPRESC0_LEUART0_DIV4 << 0) /**< Shifted mode DIV4 for CMU_LFBPRESC0 */
+#define CMU_LFBPRESC0_LEUART0_DIV8                 (_CMU_LFBPRESC0_LEUART0_DIV8 << 0) /**< Shifted mode DIV8 for CMU_LFBPRESC0 */
+
+/* Bit fields for CMU PCNTCTRL */
+#define _CMU_PCNTCTRL_RESETVALUE                   0x00000000UL                             /**< Default value for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_MASK                         0x00000003UL                             /**< Mask for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN                    (0x1UL << 0)                             /**< PCNT0 Clock Enable */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_SHIFT             0                                        /**< Shift value for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_MASK              0x1UL                                    /**< Bit mask for CMU_PCNT0CLKEN */
+#define _CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT            (_CMU_PCNTCTRL_PCNT0CLKEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL                   (0x1UL << 1)                             /**< PCNT0 Clock Select */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_SHIFT            1                                        /**< Shift value for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_MASK             0x2UL                                    /**< Bit mask for CMU_PCNT0CLKSEL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK           0x00000000UL                             /**< Mode LFACLK for CMU_PCNTCTRL */
+#define _CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0          0x00000001UL                             /**< Mode PCNT0S0 for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT           (_CMU_PCNTCTRL_PCNT0CLKSEL_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK            (_CMU_PCNTCTRL_PCNT0CLKSEL_LFACLK << 1)  /**< Shifted mode LFACLK for CMU_PCNTCTRL */
+#define CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0           (_CMU_PCNTCTRL_PCNT0CLKSEL_PCNT0S0 << 1) /**< Shifted mode PCNT0S0 for CMU_PCNTCTRL */
+
+/* Bit fields for CMU LCDCTRL */
+#define _CMU_LCDCTRL_RESETVALUE                    0x00000020UL                         /**< Default value for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_MASK                          0x0000007FUL                         /**< Mask for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_FDIV_SHIFT                    0                                    /**< Shift value for CMU_FDIV */
+#define _CMU_LCDCTRL_FDIV_MASK                     0x7UL                                /**< Bit mask for CMU_FDIV */
+#define _CMU_LCDCTRL_FDIV_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for CMU_LCDCTRL */
+#define CMU_LCDCTRL_FDIV_DEFAULT                   (_CMU_LCDCTRL_FDIV_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBOOSTEN                       (0x1UL << 3)                         /**< Voltage Boost Enable */
+#define _CMU_LCDCTRL_VBOOSTEN_SHIFT                3                                    /**< Shift value for CMU_VBOOSTEN */
+#define _CMU_LCDCTRL_VBOOSTEN_MASK                 0x8UL                                /**< Bit mask for CMU_VBOOSTEN */
+#define _CMU_LCDCTRL_VBOOSTEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBOOSTEN_DEFAULT               (_CMU_LCDCTRL_VBOOSTEN_DEFAULT << 3) /**< Shifted mode DEFAULT for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_VBFDIV_SHIFT                  4                                    /**< Shift value for CMU_VBFDIV */
+#define _CMU_LCDCTRL_VBFDIV_MASK                   0x70UL                               /**< Bit mask for CMU_VBFDIV */
+#define _CMU_LCDCTRL_VBFDIV_DIV1                   0x00000000UL                         /**< Mode DIV1 for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_VBFDIV_DIV2                   0x00000001UL                         /**< Mode DIV2 for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_VBFDIV_DEFAULT                0x00000002UL                         /**< Mode DEFAULT for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_VBFDIV_DIV4                   0x00000002UL                         /**< Mode DIV4 for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_VBFDIV_DIV8                   0x00000003UL                         /**< Mode DIV8 for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_VBFDIV_DIV16                  0x00000004UL                         /**< Mode DIV16 for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_VBFDIV_DIV32                  0x00000005UL                         /**< Mode DIV32 for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_VBFDIV_DIV64                  0x00000006UL                         /**< Mode DIV64 for CMU_LCDCTRL */
+#define _CMU_LCDCTRL_VBFDIV_DIV128                 0x00000007UL                         /**< Mode DIV128 for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBFDIV_DIV1                    (_CMU_LCDCTRL_VBFDIV_DIV1 << 4)      /**< Shifted mode DIV1 for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBFDIV_DIV2                    (_CMU_LCDCTRL_VBFDIV_DIV2 << 4)      /**< Shifted mode DIV2 for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBFDIV_DEFAULT                 (_CMU_LCDCTRL_VBFDIV_DEFAULT << 4)   /**< Shifted mode DEFAULT for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBFDIV_DIV4                    (_CMU_LCDCTRL_VBFDIV_DIV4 << 4)      /**< Shifted mode DIV4 for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBFDIV_DIV8                    (_CMU_LCDCTRL_VBFDIV_DIV8 << 4)      /**< Shifted mode DIV8 for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBFDIV_DIV16                   (_CMU_LCDCTRL_VBFDIV_DIV16 << 4)     /**< Shifted mode DIV16 for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBFDIV_DIV32                   (_CMU_LCDCTRL_VBFDIV_DIV32 << 4)     /**< Shifted mode DIV32 for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBFDIV_DIV64                   (_CMU_LCDCTRL_VBFDIV_DIV64 << 4)     /**< Shifted mode DIV64 for CMU_LCDCTRL */
+#define CMU_LCDCTRL_VBFDIV_DIV128                  (_CMU_LCDCTRL_VBFDIV_DIV128 << 4)    /**< Shifted mode DIV128 for CMU_LCDCTRL */
+
+/* Bit fields for CMU ROUTE */
+#define _CMU_ROUTE_RESETVALUE                      0x00000000UL                         /**< Default value for CMU_ROUTE */
+#define _CMU_ROUTE_MASK                            0x0000001FUL                         /**< Mask for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN                       (0x1UL << 0)                         /**< CLKOUT0 Pin Enable */
+#define _CMU_ROUTE_CLKOUT0PEN_SHIFT                0                                    /**< Shift value for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_MASK                 0x1UL                                /**< Bit mask for CMU_CLKOUT0PEN */
+#define _CMU_ROUTE_CLKOUT0PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT0PEN_DEFAULT               (_CMU_ROUTE_CLKOUT0PEN_DEFAULT << 0) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN                       (0x1UL << 1)                         /**< CLKOUT1 Pin Enable */
+#define _CMU_ROUTE_CLKOUT1PEN_SHIFT                1                                    /**< Shift value for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_MASK                 0x2UL                                /**< Bit mask for CMU_CLKOUT1PEN */
+#define _CMU_ROUTE_CLKOUT1PEN_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_CLKOUT1PEN_DEFAULT               (_CMU_ROUTE_CLKOUT1PEN_DEFAULT << 1) /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_SHIFT                  2                                    /**< Shift value for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_MASK                   0x1CUL                               /**< Bit mask for CMU_LOCATION */
+#define _CMU_ROUTE_LOCATION_LOC0                   0x00000000UL                         /**< Mode LOC0 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC1                   0x00000001UL                         /**< Mode LOC1 for CMU_ROUTE */
+#define _CMU_ROUTE_LOCATION_LOC2                   0x00000002UL                         /**< Mode LOC2 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC0                    (_CMU_ROUTE_LOCATION_LOC0 << 2)      /**< Shifted mode LOC0 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_DEFAULT                 (_CMU_ROUTE_LOCATION_DEFAULT << 2)   /**< Shifted mode DEFAULT for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC1                    (_CMU_ROUTE_LOCATION_LOC1 << 2)      /**< Shifted mode LOC1 for CMU_ROUTE */
+#define CMU_ROUTE_LOCATION_LOC2                    (_CMU_ROUTE_LOCATION_LOC2 << 2)      /**< Shifted mode LOC2 for CMU_ROUTE */
+
+/* Bit fields for CMU LOCK */
+#define _CMU_LOCK_RESETVALUE                       0x00000000UL                      /**< Default value for CMU_LOCK */
+#define _CMU_LOCK_MASK                             0x0000FFFFUL                      /**< Mask for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_SHIFT                    0                                 /**< Shift value for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_MASK                     0xFFFFUL                          /**< Bit mask for CMU_LOCKKEY */
+#define _CMU_LOCK_LOCKKEY_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCKED                 0x00000000UL                      /**< Mode UNLOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCK                     0x00000000UL                      /**< Mode LOCK for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_LOCKED                   0x00000001UL                      /**< Mode LOCKED for CMU_LOCK */
+#define _CMU_LOCK_LOCKKEY_UNLOCK                   0x0000580EUL                      /**< Mode UNLOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_DEFAULT                   (_CMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCKED                  (_CMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCK                      (_CMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_LOCKED                    (_CMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for CMU_LOCK */
+#define CMU_LOCK_LOCKKEY_UNLOCK                    (_CMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for CMU_LOCK */
+
+/** @} End of group EFM32TG_CMU */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dac.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dac.h
@@ -1,0 +1,783 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_DAC register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_DAC
+ * @brief EFM32TG_DAC Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CH0CTRL;       /**< Channel 0 Control Register  */
+  __IOM uint32_t CH1CTRL;       /**< Channel 1 Control Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t CH0DATA;       /**< Channel 0 Data Register  */
+  __IOM uint32_t CH1DATA;       /**< Channel 1 Data Register  */
+  __IOM uint32_t COMBDATA;      /**< Combined Data Register  */
+  __IOM uint32_t CAL;           /**< Calibration Register  */
+  __IOM uint32_t BIASPROG;      /**< Bias Programming Register  */
+  uint32_t       RESERVED0[8U]; /**< Reserved for future use **/
+  __IOM uint32_t OPACTRL;       /**< Operational Amplifier Control Register  */
+  __IOM uint32_t OPAOFFSET;     /**< Operational Amplifier Offset Register  */
+  __IOM uint32_t OPA0MUX;       /**< Operational Amplifier Mux Configuration Register  */
+  __IOM uint32_t OPA1MUX;       /**< Operational Amplifier Mux Configuration Register  */
+  __IOM uint32_t OPA2MUX;       /**< Operational Amplifier Mux Configuration Register  */
+} DAC_TypeDef;                  /**< DAC Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_DAC_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for DAC CTRL */
+#define _DAC_CTRL_RESETVALUE                  0x00000010UL                         /**< Default value for DAC_CTRL */
+#define _DAC_CTRL_MASK                        0x003703FFUL                         /**< Mask for DAC_CTRL */
+#define DAC_CTRL_DIFF                         (0x1UL << 0)                         /**< Differential Mode */
+#define _DAC_CTRL_DIFF_SHIFT                  0                                    /**< Shift value for DAC_DIFF */
+#define _DAC_CTRL_DIFF_MASK                   0x1UL                                /**< Bit mask for DAC_DIFF */
+#define _DAC_CTRL_DIFF_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_DIFF_DEFAULT                 (_DAC_CTRL_DIFF_DEFAULT << 0)        /**< Shifted mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_SINEMODE                     (0x1UL << 1)                         /**< Sine Mode */
+#define _DAC_CTRL_SINEMODE_SHIFT              1                                    /**< Shift value for DAC_SINEMODE */
+#define _DAC_CTRL_SINEMODE_MASK               0x2UL                                /**< Bit mask for DAC_SINEMODE */
+#define _DAC_CTRL_SINEMODE_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_SINEMODE_DEFAULT             (_DAC_CTRL_SINEMODE_DEFAULT << 1)    /**< Shifted mode DEFAULT for DAC_CTRL */
+#define _DAC_CTRL_CONVMODE_SHIFT              2                                    /**< Shift value for DAC_CONVMODE */
+#define _DAC_CTRL_CONVMODE_MASK               0xCUL                                /**< Bit mask for DAC_CONVMODE */
+#define _DAC_CTRL_CONVMODE_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for DAC_CTRL */
+#define _DAC_CTRL_CONVMODE_CONTINUOUS         0x00000000UL                         /**< Mode CONTINUOUS for DAC_CTRL */
+#define _DAC_CTRL_CONVMODE_SAMPLEHOLD         0x00000001UL                         /**< Mode SAMPLEHOLD for DAC_CTRL */
+#define _DAC_CTRL_CONVMODE_SAMPLEOFF          0x00000002UL                         /**< Mode SAMPLEOFF for DAC_CTRL */
+#define DAC_CTRL_CONVMODE_DEFAULT             (_DAC_CTRL_CONVMODE_DEFAULT << 2)    /**< Shifted mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_CONVMODE_CONTINUOUS          (_DAC_CTRL_CONVMODE_CONTINUOUS << 2) /**< Shifted mode CONTINUOUS for DAC_CTRL */
+#define DAC_CTRL_CONVMODE_SAMPLEHOLD          (_DAC_CTRL_CONVMODE_SAMPLEHOLD << 2) /**< Shifted mode SAMPLEHOLD for DAC_CTRL */
+#define DAC_CTRL_CONVMODE_SAMPLEOFF           (_DAC_CTRL_CONVMODE_SAMPLEOFF << 2)  /**< Shifted mode SAMPLEOFF for DAC_CTRL */
+#define _DAC_CTRL_OUTMODE_SHIFT               4                                    /**< Shift value for DAC_OUTMODE */
+#define _DAC_CTRL_OUTMODE_MASK                0x30UL                               /**< Bit mask for DAC_OUTMODE */
+#define _DAC_CTRL_OUTMODE_DISABLE             0x00000000UL                         /**< Mode DISABLE for DAC_CTRL */
+#define _DAC_CTRL_OUTMODE_DEFAULT             0x00000001UL                         /**< Mode DEFAULT for DAC_CTRL */
+#define _DAC_CTRL_OUTMODE_PIN                 0x00000001UL                         /**< Mode PIN for DAC_CTRL */
+#define _DAC_CTRL_OUTMODE_ADC                 0x00000002UL                         /**< Mode ADC for DAC_CTRL */
+#define _DAC_CTRL_OUTMODE_PINADC              0x00000003UL                         /**< Mode PINADC for DAC_CTRL */
+#define DAC_CTRL_OUTMODE_DISABLE              (_DAC_CTRL_OUTMODE_DISABLE << 4)     /**< Shifted mode DISABLE for DAC_CTRL */
+#define DAC_CTRL_OUTMODE_DEFAULT              (_DAC_CTRL_OUTMODE_DEFAULT << 4)     /**< Shifted mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_OUTMODE_PIN                  (_DAC_CTRL_OUTMODE_PIN << 4)         /**< Shifted mode PIN for DAC_CTRL */
+#define DAC_CTRL_OUTMODE_ADC                  (_DAC_CTRL_OUTMODE_ADC << 4)         /**< Shifted mode ADC for DAC_CTRL */
+#define DAC_CTRL_OUTMODE_PINADC               (_DAC_CTRL_OUTMODE_PINADC << 4)      /**< Shifted mode PINADC for DAC_CTRL */
+#define DAC_CTRL_OUTENPRS                     (0x1UL << 6)                         /**< PRS Controlled Output Enable */
+#define _DAC_CTRL_OUTENPRS_SHIFT              6                                    /**< Shift value for DAC_OUTENPRS */
+#define _DAC_CTRL_OUTENPRS_MASK               0x40UL                               /**< Bit mask for DAC_OUTENPRS */
+#define _DAC_CTRL_OUTENPRS_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_OUTENPRS_DEFAULT             (_DAC_CTRL_OUTENPRS_DEFAULT << 6)    /**< Shifted mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_CH0PRESCRST                  (0x1UL << 7)                         /**< Channel 0 Start Reset Prescaler */
+#define _DAC_CTRL_CH0PRESCRST_SHIFT           7                                    /**< Shift value for DAC_CH0PRESCRST */
+#define _DAC_CTRL_CH0PRESCRST_MASK            0x80UL                               /**< Bit mask for DAC_CH0PRESCRST */
+#define _DAC_CTRL_CH0PRESCRST_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_CH0PRESCRST_DEFAULT          (_DAC_CTRL_CH0PRESCRST_DEFAULT << 7) /**< Shifted mode DEFAULT for DAC_CTRL */
+#define _DAC_CTRL_REFSEL_SHIFT                8                                    /**< Shift value for DAC_REFSEL */
+#define _DAC_CTRL_REFSEL_MASK                 0x300UL                              /**< Bit mask for DAC_REFSEL */
+#define _DAC_CTRL_REFSEL_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for DAC_CTRL */
+#define _DAC_CTRL_REFSEL_1V25                 0x00000000UL                         /**< Mode 1V25 for DAC_CTRL */
+#define _DAC_CTRL_REFSEL_2V5                  0x00000001UL                         /**< Mode 2V5 for DAC_CTRL */
+#define _DAC_CTRL_REFSEL_VDD                  0x00000002UL                         /**< Mode VDD for DAC_CTRL */
+#define DAC_CTRL_REFSEL_DEFAULT               (_DAC_CTRL_REFSEL_DEFAULT << 8)      /**< Shifted mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_REFSEL_1V25                  (_DAC_CTRL_REFSEL_1V25 << 8)         /**< Shifted mode 1V25 for DAC_CTRL */
+#define DAC_CTRL_REFSEL_2V5                   (_DAC_CTRL_REFSEL_2V5 << 8)          /**< Shifted mode 2V5 for DAC_CTRL */
+#define DAC_CTRL_REFSEL_VDD                   (_DAC_CTRL_REFSEL_VDD << 8)          /**< Shifted mode VDD for DAC_CTRL */
+#define _DAC_CTRL_PRESC_SHIFT                 16                                   /**< Shift value for DAC_PRESC */
+#define _DAC_CTRL_PRESC_MASK                  0x70000UL                            /**< Bit mask for DAC_PRESC */
+#define _DAC_CTRL_PRESC_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for DAC_CTRL */
+#define _DAC_CTRL_PRESC_NODIVISION            0x00000000UL                         /**< Mode NODIVISION for DAC_CTRL */
+#define DAC_CTRL_PRESC_DEFAULT                (_DAC_CTRL_PRESC_DEFAULT << 16)      /**< Shifted mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_PRESC_NODIVISION             (_DAC_CTRL_PRESC_NODIVISION << 16)   /**< Shifted mode NODIVISION for DAC_CTRL */
+#define _DAC_CTRL_REFRSEL_SHIFT               20                                   /**< Shift value for DAC_REFRSEL */
+#define _DAC_CTRL_REFRSEL_MASK                0x300000UL                           /**< Bit mask for DAC_REFRSEL */
+#define _DAC_CTRL_REFRSEL_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for DAC_CTRL */
+#define _DAC_CTRL_REFRSEL_8CYCLES             0x00000000UL                         /**< Mode 8CYCLES for DAC_CTRL */
+#define _DAC_CTRL_REFRSEL_16CYCLES            0x00000001UL                         /**< Mode 16CYCLES for DAC_CTRL */
+#define _DAC_CTRL_REFRSEL_32CYCLES            0x00000002UL                         /**< Mode 32CYCLES for DAC_CTRL */
+#define _DAC_CTRL_REFRSEL_64CYCLES            0x00000003UL                         /**< Mode 64CYCLES for DAC_CTRL */
+#define DAC_CTRL_REFRSEL_DEFAULT              (_DAC_CTRL_REFRSEL_DEFAULT << 20)    /**< Shifted mode DEFAULT for DAC_CTRL */
+#define DAC_CTRL_REFRSEL_8CYCLES              (_DAC_CTRL_REFRSEL_8CYCLES << 20)    /**< Shifted mode 8CYCLES for DAC_CTRL */
+#define DAC_CTRL_REFRSEL_16CYCLES             (_DAC_CTRL_REFRSEL_16CYCLES << 20)   /**< Shifted mode 16CYCLES for DAC_CTRL */
+#define DAC_CTRL_REFRSEL_32CYCLES             (_DAC_CTRL_REFRSEL_32CYCLES << 20)   /**< Shifted mode 32CYCLES for DAC_CTRL */
+#define DAC_CTRL_REFRSEL_64CYCLES             (_DAC_CTRL_REFRSEL_64CYCLES << 20)   /**< Shifted mode 64CYCLES for DAC_CTRL */
+
+/* Bit fields for DAC STATUS */
+#define _DAC_STATUS_RESETVALUE                0x00000000UL                     /**< Default value for DAC_STATUS */
+#define _DAC_STATUS_MASK                      0x00000003UL                     /**< Mask for DAC_STATUS */
+#define DAC_STATUS_CH0DV                      (0x1UL << 0)                     /**< Channel 0 Data Valid */
+#define _DAC_STATUS_CH0DV_SHIFT               0                                /**< Shift value for DAC_CH0DV */
+#define _DAC_STATUS_CH0DV_MASK                0x1UL                            /**< Bit mask for DAC_CH0DV */
+#define _DAC_STATUS_CH0DV_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for DAC_STATUS */
+#define DAC_STATUS_CH0DV_DEFAULT              (_DAC_STATUS_CH0DV_DEFAULT << 0) /**< Shifted mode DEFAULT for DAC_STATUS */
+#define DAC_STATUS_CH1DV                      (0x1UL << 1)                     /**< Channel 1 Data Valid */
+#define _DAC_STATUS_CH1DV_SHIFT               1                                /**< Shift value for DAC_CH1DV */
+#define _DAC_STATUS_CH1DV_MASK                0x2UL                            /**< Bit mask for DAC_CH1DV */
+#define _DAC_STATUS_CH1DV_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for DAC_STATUS */
+#define DAC_STATUS_CH1DV_DEFAULT              (_DAC_STATUS_CH1DV_DEFAULT << 1) /**< Shifted mode DEFAULT for DAC_STATUS */
+
+/* Bit fields for DAC CH0CTRL */
+#define _DAC_CH0CTRL_RESETVALUE               0x00000000UL                       /**< Default value for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_MASK                     0x00000077UL                       /**< Mask for DAC_CH0CTRL */
+#define DAC_CH0CTRL_EN                        (0x1UL << 0)                       /**< Channel 0 Enable */
+#define _DAC_CH0CTRL_EN_SHIFT                 0                                  /**< Shift value for DAC_EN */
+#define _DAC_CH0CTRL_EN_MASK                  0x1UL                              /**< Bit mask for DAC_EN */
+#define _DAC_CH0CTRL_EN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for DAC_CH0CTRL */
+#define DAC_CH0CTRL_EN_DEFAULT                (_DAC_CH0CTRL_EN_DEFAULT << 0)     /**< Shifted mode DEFAULT for DAC_CH0CTRL */
+#define DAC_CH0CTRL_REFREN                    (0x1UL << 1)                       /**< Channel 0 Automatic Refresh Enable */
+#define _DAC_CH0CTRL_REFREN_SHIFT             1                                  /**< Shift value for DAC_REFREN */
+#define _DAC_CH0CTRL_REFREN_MASK              0x2UL                              /**< Bit mask for DAC_REFREN */
+#define _DAC_CH0CTRL_REFREN_DEFAULT           0x00000000UL                       /**< Mode DEFAULT for DAC_CH0CTRL */
+#define DAC_CH0CTRL_REFREN_DEFAULT            (_DAC_CH0CTRL_REFREN_DEFAULT << 1) /**< Shifted mode DEFAULT for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSEN                     (0x1UL << 2)                       /**< Channel 0 PRS Trigger Enable */
+#define _DAC_CH0CTRL_PRSEN_SHIFT              2                                  /**< Shift value for DAC_PRSEN */
+#define _DAC_CH0CTRL_PRSEN_MASK               0x4UL                              /**< Bit mask for DAC_PRSEN */
+#define _DAC_CH0CTRL_PRSEN_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSEN_DEFAULT             (_DAC_CH0CTRL_PRSEN_DEFAULT << 2)  /**< Shifted mode DEFAULT for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_PRSSEL_SHIFT             4                                  /**< Shift value for DAC_PRSSEL */
+#define _DAC_CH0CTRL_PRSSEL_MASK              0x70UL                             /**< Bit mask for DAC_PRSSEL */
+#define _DAC_CH0CTRL_PRSSEL_DEFAULT           0x00000000UL                       /**< Mode DEFAULT for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_PRSSEL_PRSCH0            0x00000000UL                       /**< Mode PRSCH0 for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_PRSSEL_PRSCH1            0x00000001UL                       /**< Mode PRSCH1 for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_PRSSEL_PRSCH2            0x00000002UL                       /**< Mode PRSCH2 for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_PRSSEL_PRSCH3            0x00000003UL                       /**< Mode PRSCH3 for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_PRSSEL_PRSCH4            0x00000004UL                       /**< Mode PRSCH4 for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_PRSSEL_PRSCH5            0x00000005UL                       /**< Mode PRSCH5 for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_PRSSEL_PRSCH6            0x00000006UL                       /**< Mode PRSCH6 for DAC_CH0CTRL */
+#define _DAC_CH0CTRL_PRSSEL_PRSCH7            0x00000007UL                       /**< Mode PRSCH7 for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSSEL_DEFAULT            (_DAC_CH0CTRL_PRSSEL_DEFAULT << 4) /**< Shifted mode DEFAULT for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSSEL_PRSCH0             (_DAC_CH0CTRL_PRSSEL_PRSCH0 << 4)  /**< Shifted mode PRSCH0 for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSSEL_PRSCH1             (_DAC_CH0CTRL_PRSSEL_PRSCH1 << 4)  /**< Shifted mode PRSCH1 for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSSEL_PRSCH2             (_DAC_CH0CTRL_PRSSEL_PRSCH2 << 4)  /**< Shifted mode PRSCH2 for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSSEL_PRSCH3             (_DAC_CH0CTRL_PRSSEL_PRSCH3 << 4)  /**< Shifted mode PRSCH3 for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSSEL_PRSCH4             (_DAC_CH0CTRL_PRSSEL_PRSCH4 << 4)  /**< Shifted mode PRSCH4 for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSSEL_PRSCH5             (_DAC_CH0CTRL_PRSSEL_PRSCH5 << 4)  /**< Shifted mode PRSCH5 for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSSEL_PRSCH6             (_DAC_CH0CTRL_PRSSEL_PRSCH6 << 4)  /**< Shifted mode PRSCH6 for DAC_CH0CTRL */
+#define DAC_CH0CTRL_PRSSEL_PRSCH7             (_DAC_CH0CTRL_PRSSEL_PRSCH7 << 4)  /**< Shifted mode PRSCH7 for DAC_CH0CTRL */
+
+/* Bit fields for DAC CH1CTRL */
+#define _DAC_CH1CTRL_RESETVALUE               0x00000000UL                       /**< Default value for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_MASK                     0x00000077UL                       /**< Mask for DAC_CH1CTRL */
+#define DAC_CH1CTRL_EN                        (0x1UL << 0)                       /**< Channel 1 Enable */
+#define _DAC_CH1CTRL_EN_SHIFT                 0                                  /**< Shift value for DAC_EN */
+#define _DAC_CH1CTRL_EN_MASK                  0x1UL                              /**< Bit mask for DAC_EN */
+#define _DAC_CH1CTRL_EN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for DAC_CH1CTRL */
+#define DAC_CH1CTRL_EN_DEFAULT                (_DAC_CH1CTRL_EN_DEFAULT << 0)     /**< Shifted mode DEFAULT for DAC_CH1CTRL */
+#define DAC_CH1CTRL_REFREN                    (0x1UL << 1)                       /**< Channel 1 Automatic Refresh Enable */
+#define _DAC_CH1CTRL_REFREN_SHIFT             1                                  /**< Shift value for DAC_REFREN */
+#define _DAC_CH1CTRL_REFREN_MASK              0x2UL                              /**< Bit mask for DAC_REFREN */
+#define _DAC_CH1CTRL_REFREN_DEFAULT           0x00000000UL                       /**< Mode DEFAULT for DAC_CH1CTRL */
+#define DAC_CH1CTRL_REFREN_DEFAULT            (_DAC_CH1CTRL_REFREN_DEFAULT << 1) /**< Shifted mode DEFAULT for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSEN                     (0x1UL << 2)                       /**< Channel 1 PRS Trigger Enable */
+#define _DAC_CH1CTRL_PRSEN_SHIFT              2                                  /**< Shift value for DAC_PRSEN */
+#define _DAC_CH1CTRL_PRSEN_MASK               0x4UL                              /**< Bit mask for DAC_PRSEN */
+#define _DAC_CH1CTRL_PRSEN_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSEN_DEFAULT             (_DAC_CH1CTRL_PRSEN_DEFAULT << 2)  /**< Shifted mode DEFAULT for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_PRSSEL_SHIFT             4                                  /**< Shift value for DAC_PRSSEL */
+#define _DAC_CH1CTRL_PRSSEL_MASK              0x70UL                             /**< Bit mask for DAC_PRSSEL */
+#define _DAC_CH1CTRL_PRSSEL_DEFAULT           0x00000000UL                       /**< Mode DEFAULT for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_PRSSEL_PRSCH0            0x00000000UL                       /**< Mode PRSCH0 for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_PRSSEL_PRSCH1            0x00000001UL                       /**< Mode PRSCH1 for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_PRSSEL_PRSCH2            0x00000002UL                       /**< Mode PRSCH2 for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_PRSSEL_PRSCH3            0x00000003UL                       /**< Mode PRSCH3 for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_PRSSEL_PRSCH4            0x00000004UL                       /**< Mode PRSCH4 for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_PRSSEL_PRSCH5            0x00000005UL                       /**< Mode PRSCH5 for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_PRSSEL_PRSCH6            0x00000006UL                       /**< Mode PRSCH6 for DAC_CH1CTRL */
+#define _DAC_CH1CTRL_PRSSEL_PRSCH7            0x00000007UL                       /**< Mode PRSCH7 for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSSEL_DEFAULT            (_DAC_CH1CTRL_PRSSEL_DEFAULT << 4) /**< Shifted mode DEFAULT for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSSEL_PRSCH0             (_DAC_CH1CTRL_PRSSEL_PRSCH0 << 4)  /**< Shifted mode PRSCH0 for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSSEL_PRSCH1             (_DAC_CH1CTRL_PRSSEL_PRSCH1 << 4)  /**< Shifted mode PRSCH1 for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSSEL_PRSCH2             (_DAC_CH1CTRL_PRSSEL_PRSCH2 << 4)  /**< Shifted mode PRSCH2 for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSSEL_PRSCH3             (_DAC_CH1CTRL_PRSSEL_PRSCH3 << 4)  /**< Shifted mode PRSCH3 for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSSEL_PRSCH4             (_DAC_CH1CTRL_PRSSEL_PRSCH4 << 4)  /**< Shifted mode PRSCH4 for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSSEL_PRSCH5             (_DAC_CH1CTRL_PRSSEL_PRSCH5 << 4)  /**< Shifted mode PRSCH5 for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSSEL_PRSCH6             (_DAC_CH1CTRL_PRSSEL_PRSCH6 << 4)  /**< Shifted mode PRSCH6 for DAC_CH1CTRL */
+#define DAC_CH1CTRL_PRSSEL_PRSCH7             (_DAC_CH1CTRL_PRSSEL_PRSCH7 << 4)  /**< Shifted mode PRSCH7 for DAC_CH1CTRL */
+
+/* Bit fields for DAC IEN */
+#define _DAC_IEN_RESETVALUE                   0x00000000UL                  /**< Default value for DAC_IEN */
+#define _DAC_IEN_MASK                         0x00000033UL                  /**< Mask for DAC_IEN */
+#define DAC_IEN_CH0                           (0x1UL << 0)                  /**< Channel 0 Conversion Complete Interrupt Enable */
+#define _DAC_IEN_CH0_SHIFT                    0                             /**< Shift value for DAC_CH0 */
+#define _DAC_IEN_CH0_MASK                     0x1UL                         /**< Bit mask for DAC_CH0 */
+#define _DAC_IEN_CH0_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for DAC_IEN */
+#define DAC_IEN_CH0_DEFAULT                   (_DAC_IEN_CH0_DEFAULT << 0)   /**< Shifted mode DEFAULT for DAC_IEN */
+#define DAC_IEN_CH1                           (0x1UL << 1)                  /**< Channel 1 Conversion Complete Interrupt Enable */
+#define _DAC_IEN_CH1_SHIFT                    1                             /**< Shift value for DAC_CH1 */
+#define _DAC_IEN_CH1_MASK                     0x2UL                         /**< Bit mask for DAC_CH1 */
+#define _DAC_IEN_CH1_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for DAC_IEN */
+#define DAC_IEN_CH1_DEFAULT                   (_DAC_IEN_CH1_DEFAULT << 1)   /**< Shifted mode DEFAULT for DAC_IEN */
+#define DAC_IEN_CH0UF                         (0x1UL << 4)                  /**< Channel 0 Conversion Data Underflow Interrupt Enable */
+#define _DAC_IEN_CH0UF_SHIFT                  4                             /**< Shift value for DAC_CH0UF */
+#define _DAC_IEN_CH0UF_MASK                   0x10UL                        /**< Bit mask for DAC_CH0UF */
+#define _DAC_IEN_CH0UF_DEFAULT                0x00000000UL                  /**< Mode DEFAULT for DAC_IEN */
+#define DAC_IEN_CH0UF_DEFAULT                 (_DAC_IEN_CH0UF_DEFAULT << 4) /**< Shifted mode DEFAULT for DAC_IEN */
+#define DAC_IEN_CH1UF                         (0x1UL << 5)                  /**< Channel 1 Conversion Data Underflow Interrupt Enable */
+#define _DAC_IEN_CH1UF_SHIFT                  5                             /**< Shift value for DAC_CH1UF */
+#define _DAC_IEN_CH1UF_MASK                   0x20UL                        /**< Bit mask for DAC_CH1UF */
+#define _DAC_IEN_CH1UF_DEFAULT                0x00000000UL                  /**< Mode DEFAULT for DAC_IEN */
+#define DAC_IEN_CH1UF_DEFAULT                 (_DAC_IEN_CH1UF_DEFAULT << 5) /**< Shifted mode DEFAULT for DAC_IEN */
+
+/* Bit fields for DAC IF */
+#define _DAC_IF_RESETVALUE                    0x00000000UL                 /**< Default value for DAC_IF */
+#define _DAC_IF_MASK                          0x00000033UL                 /**< Mask for DAC_IF */
+#define DAC_IF_CH0                            (0x1UL << 0)                 /**< Channel 0 Conversion Complete Interrupt Flag */
+#define _DAC_IF_CH0_SHIFT                     0                            /**< Shift value for DAC_CH0 */
+#define _DAC_IF_CH0_MASK                      0x1UL                        /**< Bit mask for DAC_CH0 */
+#define _DAC_IF_CH0_DEFAULT                   0x00000000UL                 /**< Mode DEFAULT for DAC_IF */
+#define DAC_IF_CH0_DEFAULT                    (_DAC_IF_CH0_DEFAULT << 0)   /**< Shifted mode DEFAULT for DAC_IF */
+#define DAC_IF_CH1                            (0x1UL << 1)                 /**< Channel 1 Conversion Complete Interrupt Flag */
+#define _DAC_IF_CH1_SHIFT                     1                            /**< Shift value for DAC_CH1 */
+#define _DAC_IF_CH1_MASK                      0x2UL                        /**< Bit mask for DAC_CH1 */
+#define _DAC_IF_CH1_DEFAULT                   0x00000000UL                 /**< Mode DEFAULT for DAC_IF */
+#define DAC_IF_CH1_DEFAULT                    (_DAC_IF_CH1_DEFAULT << 1)   /**< Shifted mode DEFAULT for DAC_IF */
+#define DAC_IF_CH0UF                          (0x1UL << 4)                 /**< Channel 0 Data Underflow Interrupt Flag */
+#define _DAC_IF_CH0UF_SHIFT                   4                            /**< Shift value for DAC_CH0UF */
+#define _DAC_IF_CH0UF_MASK                    0x10UL                       /**< Bit mask for DAC_CH0UF */
+#define _DAC_IF_CH0UF_DEFAULT                 0x00000000UL                 /**< Mode DEFAULT for DAC_IF */
+#define DAC_IF_CH0UF_DEFAULT                  (_DAC_IF_CH0UF_DEFAULT << 4) /**< Shifted mode DEFAULT for DAC_IF */
+#define DAC_IF_CH1UF                          (0x1UL << 5)                 /**< Channel 1 Data Underflow Interrupt Flag */
+#define _DAC_IF_CH1UF_SHIFT                   5                            /**< Shift value for DAC_CH1UF */
+#define _DAC_IF_CH1UF_MASK                    0x20UL                       /**< Bit mask for DAC_CH1UF */
+#define _DAC_IF_CH1UF_DEFAULT                 0x00000000UL                 /**< Mode DEFAULT for DAC_IF */
+#define DAC_IF_CH1UF_DEFAULT                  (_DAC_IF_CH1UF_DEFAULT << 5) /**< Shifted mode DEFAULT for DAC_IF */
+
+/* Bit fields for DAC IFS */
+#define _DAC_IFS_RESETVALUE                   0x00000000UL                  /**< Default value for DAC_IFS */
+#define _DAC_IFS_MASK                         0x00000033UL                  /**< Mask for DAC_IFS */
+#define DAC_IFS_CH0                           (0x1UL << 0)                  /**< Channel 0 Conversion Complete Interrupt Flag Set */
+#define _DAC_IFS_CH0_SHIFT                    0                             /**< Shift value for DAC_CH0 */
+#define _DAC_IFS_CH0_MASK                     0x1UL                         /**< Bit mask for DAC_CH0 */
+#define _DAC_IFS_CH0_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for DAC_IFS */
+#define DAC_IFS_CH0_DEFAULT                   (_DAC_IFS_CH0_DEFAULT << 0)   /**< Shifted mode DEFAULT for DAC_IFS */
+#define DAC_IFS_CH1                           (0x1UL << 1)                  /**< Channel 1 Conversion Complete Interrupt Flag Set */
+#define _DAC_IFS_CH1_SHIFT                    1                             /**< Shift value for DAC_CH1 */
+#define _DAC_IFS_CH1_MASK                     0x2UL                         /**< Bit mask for DAC_CH1 */
+#define _DAC_IFS_CH1_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for DAC_IFS */
+#define DAC_IFS_CH1_DEFAULT                   (_DAC_IFS_CH1_DEFAULT << 1)   /**< Shifted mode DEFAULT for DAC_IFS */
+#define DAC_IFS_CH0UF                         (0x1UL << 4)                  /**< Channel 0 Data Underflow Interrupt Flag Set */
+#define _DAC_IFS_CH0UF_SHIFT                  4                             /**< Shift value for DAC_CH0UF */
+#define _DAC_IFS_CH0UF_MASK                   0x10UL                        /**< Bit mask for DAC_CH0UF */
+#define _DAC_IFS_CH0UF_DEFAULT                0x00000000UL                  /**< Mode DEFAULT for DAC_IFS */
+#define DAC_IFS_CH0UF_DEFAULT                 (_DAC_IFS_CH0UF_DEFAULT << 4) /**< Shifted mode DEFAULT for DAC_IFS */
+#define DAC_IFS_CH1UF                         (0x1UL << 5)                  /**< Channel 1 Data Underflow Interrupt Flag Set */
+#define _DAC_IFS_CH1UF_SHIFT                  5                             /**< Shift value for DAC_CH1UF */
+#define _DAC_IFS_CH1UF_MASK                   0x20UL                        /**< Bit mask for DAC_CH1UF */
+#define _DAC_IFS_CH1UF_DEFAULT                0x00000000UL                  /**< Mode DEFAULT for DAC_IFS */
+#define DAC_IFS_CH1UF_DEFAULT                 (_DAC_IFS_CH1UF_DEFAULT << 5) /**< Shifted mode DEFAULT for DAC_IFS */
+
+/* Bit fields for DAC IFC */
+#define _DAC_IFC_RESETVALUE                   0x00000000UL                  /**< Default value for DAC_IFC */
+#define _DAC_IFC_MASK                         0x00000033UL                  /**< Mask for DAC_IFC */
+#define DAC_IFC_CH0                           (0x1UL << 0)                  /**< Channel 0 Conversion Complete Interrupt Flag Clear */
+#define _DAC_IFC_CH0_SHIFT                    0                             /**< Shift value for DAC_CH0 */
+#define _DAC_IFC_CH0_MASK                     0x1UL                         /**< Bit mask for DAC_CH0 */
+#define _DAC_IFC_CH0_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for DAC_IFC */
+#define DAC_IFC_CH0_DEFAULT                   (_DAC_IFC_CH0_DEFAULT << 0)   /**< Shifted mode DEFAULT for DAC_IFC */
+#define DAC_IFC_CH1                           (0x1UL << 1)                  /**< Channel 1 Conversion Complete Interrupt Flag Clear */
+#define _DAC_IFC_CH1_SHIFT                    1                             /**< Shift value for DAC_CH1 */
+#define _DAC_IFC_CH1_MASK                     0x2UL                         /**< Bit mask for DAC_CH1 */
+#define _DAC_IFC_CH1_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for DAC_IFC */
+#define DAC_IFC_CH1_DEFAULT                   (_DAC_IFC_CH1_DEFAULT << 1)   /**< Shifted mode DEFAULT for DAC_IFC */
+#define DAC_IFC_CH0UF                         (0x1UL << 4)                  /**< Channel 0 Data Underflow Interrupt Flag Clear */
+#define _DAC_IFC_CH0UF_SHIFT                  4                             /**< Shift value for DAC_CH0UF */
+#define _DAC_IFC_CH0UF_MASK                   0x10UL                        /**< Bit mask for DAC_CH0UF */
+#define _DAC_IFC_CH0UF_DEFAULT                0x00000000UL                  /**< Mode DEFAULT for DAC_IFC */
+#define DAC_IFC_CH0UF_DEFAULT                 (_DAC_IFC_CH0UF_DEFAULT << 4) /**< Shifted mode DEFAULT for DAC_IFC */
+#define DAC_IFC_CH1UF                         (0x1UL << 5)                  /**< Channel 1 Data Underflow Interrupt Flag Clear */
+#define _DAC_IFC_CH1UF_SHIFT                  5                             /**< Shift value for DAC_CH1UF */
+#define _DAC_IFC_CH1UF_MASK                   0x20UL                        /**< Bit mask for DAC_CH1UF */
+#define _DAC_IFC_CH1UF_DEFAULT                0x00000000UL                  /**< Mode DEFAULT for DAC_IFC */
+#define DAC_IFC_CH1UF_DEFAULT                 (_DAC_IFC_CH1UF_DEFAULT << 5) /**< Shifted mode DEFAULT for DAC_IFC */
+
+/* Bit fields for DAC CH0DATA */
+#define _DAC_CH0DATA_RESETVALUE               0x00000000UL                     /**< Default value for DAC_CH0DATA */
+#define _DAC_CH0DATA_MASK                     0x00000FFFUL                     /**< Mask for DAC_CH0DATA */
+#define _DAC_CH0DATA_DATA_SHIFT               0                                /**< Shift value for DAC_DATA */
+#define _DAC_CH0DATA_DATA_MASK                0xFFFUL                          /**< Bit mask for DAC_DATA */
+#define _DAC_CH0DATA_DATA_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for DAC_CH0DATA */
+#define DAC_CH0DATA_DATA_DEFAULT              (_DAC_CH0DATA_DATA_DEFAULT << 0) /**< Shifted mode DEFAULT for DAC_CH0DATA */
+
+/* Bit fields for DAC CH1DATA */
+#define _DAC_CH1DATA_RESETVALUE               0x00000000UL                     /**< Default value for DAC_CH1DATA */
+#define _DAC_CH1DATA_MASK                     0x00000FFFUL                     /**< Mask for DAC_CH1DATA */
+#define _DAC_CH1DATA_DATA_SHIFT               0                                /**< Shift value for DAC_DATA */
+#define _DAC_CH1DATA_DATA_MASK                0xFFFUL                          /**< Bit mask for DAC_DATA */
+#define _DAC_CH1DATA_DATA_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for DAC_CH1DATA */
+#define DAC_CH1DATA_DATA_DEFAULT              (_DAC_CH1DATA_DATA_DEFAULT << 0) /**< Shifted mode DEFAULT for DAC_CH1DATA */
+
+/* Bit fields for DAC COMBDATA */
+#define _DAC_COMBDATA_RESETVALUE              0x00000000UL                          /**< Default value for DAC_COMBDATA */
+#define _DAC_COMBDATA_MASK                    0x0FFF0FFFUL                          /**< Mask for DAC_COMBDATA */
+#define _DAC_COMBDATA_CH0DATA_SHIFT           0                                     /**< Shift value for DAC_CH0DATA */
+#define _DAC_COMBDATA_CH0DATA_MASK            0xFFFUL                               /**< Bit mask for DAC_CH0DATA */
+#define _DAC_COMBDATA_CH0DATA_DEFAULT         0x00000000UL                          /**< Mode DEFAULT for DAC_COMBDATA */
+#define DAC_COMBDATA_CH0DATA_DEFAULT          (_DAC_COMBDATA_CH0DATA_DEFAULT << 0)  /**< Shifted mode DEFAULT for DAC_COMBDATA */
+#define _DAC_COMBDATA_CH1DATA_SHIFT           16                                    /**< Shift value for DAC_CH1DATA */
+#define _DAC_COMBDATA_CH1DATA_MASK            0xFFF0000UL                           /**< Bit mask for DAC_CH1DATA */
+#define _DAC_COMBDATA_CH1DATA_DEFAULT         0x00000000UL                          /**< Mode DEFAULT for DAC_COMBDATA */
+#define DAC_COMBDATA_CH1DATA_DEFAULT          (_DAC_COMBDATA_CH1DATA_DEFAULT << 16) /**< Shifted mode DEFAULT for DAC_COMBDATA */
+
+/* Bit fields for DAC CAL */
+#define _DAC_CAL_RESETVALUE                   0x00400000UL                      /**< Default value for DAC_CAL */
+#define _DAC_CAL_MASK                         0x007F3F3FUL                      /**< Mask for DAC_CAL */
+#define _DAC_CAL_CH0OFFSET_SHIFT              0                                 /**< Shift value for DAC_CH0OFFSET */
+#define _DAC_CAL_CH0OFFSET_MASK               0x3FUL                            /**< Bit mask for DAC_CH0OFFSET */
+#define _DAC_CAL_CH0OFFSET_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for DAC_CAL */
+#define DAC_CAL_CH0OFFSET_DEFAULT             (_DAC_CAL_CH0OFFSET_DEFAULT << 0) /**< Shifted mode DEFAULT for DAC_CAL */
+#define _DAC_CAL_CH1OFFSET_SHIFT              8                                 /**< Shift value for DAC_CH1OFFSET */
+#define _DAC_CAL_CH1OFFSET_MASK               0x3F00UL                          /**< Bit mask for DAC_CH1OFFSET */
+#define _DAC_CAL_CH1OFFSET_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for DAC_CAL */
+#define DAC_CAL_CH1OFFSET_DEFAULT             (_DAC_CAL_CH1OFFSET_DEFAULT << 8) /**< Shifted mode DEFAULT for DAC_CAL */
+#define _DAC_CAL_GAIN_SHIFT                   16                                /**< Shift value for DAC_GAIN */
+#define _DAC_CAL_GAIN_MASK                    0x7F0000UL                        /**< Bit mask for DAC_GAIN */
+#define _DAC_CAL_GAIN_DEFAULT                 0x00000040UL                      /**< Mode DEFAULT for DAC_CAL */
+#define DAC_CAL_GAIN_DEFAULT                  (_DAC_CAL_GAIN_DEFAULT << 16)     /**< Shifted mode DEFAULT for DAC_CAL */
+
+/* Bit fields for DAC BIASPROG */
+#define _DAC_BIASPROG_RESETVALUE              0x00004747UL                               /**< Default value for DAC_BIASPROG */
+#define _DAC_BIASPROG_MASK                    0x00004F4FUL                               /**< Mask for DAC_BIASPROG */
+#define _DAC_BIASPROG_BIASPROG_SHIFT          0                                          /**< Shift value for DAC_BIASPROG */
+#define _DAC_BIASPROG_BIASPROG_MASK           0xFUL                                      /**< Bit mask for DAC_BIASPROG */
+#define _DAC_BIASPROG_BIASPROG_DEFAULT        0x00000007UL                               /**< Mode DEFAULT for DAC_BIASPROG */
+#define DAC_BIASPROG_BIASPROG_DEFAULT         (_DAC_BIASPROG_BIASPROG_DEFAULT << 0)      /**< Shifted mode DEFAULT for DAC_BIASPROG */
+#define DAC_BIASPROG_HALFBIAS                 (0x1UL << 6)                               /**< Half Bias Current */
+#define _DAC_BIASPROG_HALFBIAS_SHIFT          6                                          /**< Shift value for DAC_HALFBIAS */
+#define _DAC_BIASPROG_HALFBIAS_MASK           0x40UL                                     /**< Bit mask for DAC_HALFBIAS */
+#define _DAC_BIASPROG_HALFBIAS_DEFAULT        0x00000001UL                               /**< Mode DEFAULT for DAC_BIASPROG */
+#define DAC_BIASPROG_HALFBIAS_DEFAULT         (_DAC_BIASPROG_HALFBIAS_DEFAULT << 6)      /**< Shifted mode DEFAULT for DAC_BIASPROG */
+#define _DAC_BIASPROG_OPA2BIASPROG_SHIFT      8                                          /**< Shift value for DAC_OPA2BIASPROG */
+#define _DAC_BIASPROG_OPA2BIASPROG_MASK       0xF00UL                                    /**< Bit mask for DAC_OPA2BIASPROG */
+#define _DAC_BIASPROG_OPA2BIASPROG_DEFAULT    0x00000007UL                               /**< Mode DEFAULT for DAC_BIASPROG */
+#define DAC_BIASPROG_OPA2BIASPROG_DEFAULT     (_DAC_BIASPROG_OPA2BIASPROG_DEFAULT << 8)  /**< Shifted mode DEFAULT for DAC_BIASPROG */
+#define DAC_BIASPROG_OPA2HALFBIAS             (0x1UL << 14)                              /**< Half Bias Current */
+#define _DAC_BIASPROG_OPA2HALFBIAS_SHIFT      14                                         /**< Shift value for DAC_OPA2HALFBIAS */
+#define _DAC_BIASPROG_OPA2HALFBIAS_MASK       0x4000UL                                   /**< Bit mask for DAC_OPA2HALFBIAS */
+#define _DAC_BIASPROG_OPA2HALFBIAS_DEFAULT    0x00000001UL                               /**< Mode DEFAULT for DAC_BIASPROG */
+#define DAC_BIASPROG_OPA2HALFBIAS_DEFAULT     (_DAC_BIASPROG_OPA2HALFBIAS_DEFAULT << 14) /**< Shifted mode DEFAULT for DAC_BIASPROG */
+
+/* Bit fields for DAC OPACTRL */
+#define _DAC_OPACTRL_RESETVALUE               0x00000000UL                            /**< Default value for DAC_OPACTRL */
+#define _DAC_OPACTRL_MASK                     0x01C3F1C7UL                            /**< Mask for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA0EN                    (0x1UL << 0)                            /**< OPA0 Enable */
+#define _DAC_OPACTRL_OPA0EN_SHIFT             0                                       /**< Shift value for DAC_OPA0EN */
+#define _DAC_OPACTRL_OPA0EN_MASK              0x1UL                                   /**< Bit mask for DAC_OPA0EN */
+#define _DAC_OPACTRL_OPA0EN_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA0EN_DEFAULT            (_DAC_OPACTRL_OPA0EN_DEFAULT << 0)      /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA1EN                    (0x1UL << 1)                            /**< OPA1 Enable */
+#define _DAC_OPACTRL_OPA1EN_SHIFT             1                                       /**< Shift value for DAC_OPA1EN */
+#define _DAC_OPACTRL_OPA1EN_MASK              0x2UL                                   /**< Bit mask for DAC_OPA1EN */
+#define _DAC_OPACTRL_OPA1EN_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA1EN_DEFAULT            (_DAC_OPACTRL_OPA1EN_DEFAULT << 1)      /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA2EN                    (0x1UL << 2)                            /**< OPA2 Enable */
+#define _DAC_OPACTRL_OPA2EN_SHIFT             2                                       /**< Shift value for DAC_OPA2EN */
+#define _DAC_OPACTRL_OPA2EN_MASK              0x4UL                                   /**< Bit mask for DAC_OPA2EN */
+#define _DAC_OPACTRL_OPA2EN_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA2EN_DEFAULT            (_DAC_OPACTRL_OPA2EN_DEFAULT << 2)      /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA0HCMDIS                (0x1UL << 6)                            /**< High Common Mode Disable. */
+#define _DAC_OPACTRL_OPA0HCMDIS_SHIFT         6                                       /**< Shift value for DAC_OPA0HCMDIS */
+#define _DAC_OPACTRL_OPA0HCMDIS_MASK          0x40UL                                  /**< Bit mask for DAC_OPA0HCMDIS */
+#define _DAC_OPACTRL_OPA0HCMDIS_DEFAULT       0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA0HCMDIS_DEFAULT        (_DAC_OPACTRL_OPA0HCMDIS_DEFAULT << 6)  /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA1HCMDIS                (0x1UL << 7)                            /**< High Common Mode Disable. */
+#define _DAC_OPACTRL_OPA1HCMDIS_SHIFT         7                                       /**< Shift value for DAC_OPA1HCMDIS */
+#define _DAC_OPACTRL_OPA1HCMDIS_MASK          0x80UL                                  /**< Bit mask for DAC_OPA1HCMDIS */
+#define _DAC_OPACTRL_OPA1HCMDIS_DEFAULT       0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA1HCMDIS_DEFAULT        (_DAC_OPACTRL_OPA1HCMDIS_DEFAULT << 7)  /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA2HCMDIS                (0x1UL << 8)                            /**< High Common Mode Disable. */
+#define _DAC_OPACTRL_OPA2HCMDIS_SHIFT         8                                       /**< Shift value for DAC_OPA2HCMDIS */
+#define _DAC_OPACTRL_OPA2HCMDIS_MASK          0x100UL                                 /**< Bit mask for DAC_OPA2HCMDIS */
+#define _DAC_OPACTRL_OPA2HCMDIS_DEFAULT       0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA2HCMDIS_DEFAULT        (_DAC_OPACTRL_OPA2HCMDIS_DEFAULT << 8)  /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define _DAC_OPACTRL_OPA0LPFDIS_SHIFT         12                                      /**< Shift value for DAC_OPA0LPFDIS */
+#define _DAC_OPACTRL_OPA0LPFDIS_MASK          0x3000UL                                /**< Bit mask for DAC_OPA0LPFDIS */
+#define _DAC_OPACTRL_OPA0LPFDIS_DEFAULT       0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define _DAC_OPACTRL_OPA0LPFDIS_PLPFDIS       0x00000001UL                            /**< Mode PLPFDIS for DAC_OPACTRL */
+#define _DAC_OPACTRL_OPA0LPFDIS_NLPFDIS       0x00000002UL                            /**< Mode NLPFDIS for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA0LPFDIS_DEFAULT        (_DAC_OPACTRL_OPA0LPFDIS_DEFAULT << 12) /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA0LPFDIS_PLPFDIS        (_DAC_OPACTRL_OPA0LPFDIS_PLPFDIS << 12) /**< Shifted mode PLPFDIS for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA0LPFDIS_NLPFDIS        (_DAC_OPACTRL_OPA0LPFDIS_NLPFDIS << 12) /**< Shifted mode NLPFDIS for DAC_OPACTRL */
+#define _DAC_OPACTRL_OPA1LPFDIS_SHIFT         14                                      /**< Shift value for DAC_OPA1LPFDIS */
+#define _DAC_OPACTRL_OPA1LPFDIS_MASK          0xC000UL                                /**< Bit mask for DAC_OPA1LPFDIS */
+#define _DAC_OPACTRL_OPA1LPFDIS_DEFAULT       0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define _DAC_OPACTRL_OPA1LPFDIS_PLPFDIS       0x00000001UL                            /**< Mode PLPFDIS for DAC_OPACTRL */
+#define _DAC_OPACTRL_OPA1LPFDIS_NLPFDIS       0x00000002UL                            /**< Mode NLPFDIS for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA1LPFDIS_DEFAULT        (_DAC_OPACTRL_OPA1LPFDIS_DEFAULT << 14) /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA1LPFDIS_PLPFDIS        (_DAC_OPACTRL_OPA1LPFDIS_PLPFDIS << 14) /**< Shifted mode PLPFDIS for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA1LPFDIS_NLPFDIS        (_DAC_OPACTRL_OPA1LPFDIS_NLPFDIS << 14) /**< Shifted mode NLPFDIS for DAC_OPACTRL */
+#define _DAC_OPACTRL_OPA2LPFDIS_SHIFT         16                                      /**< Shift value for DAC_OPA2LPFDIS */
+#define _DAC_OPACTRL_OPA2LPFDIS_MASK          0x30000UL                               /**< Bit mask for DAC_OPA2LPFDIS */
+#define _DAC_OPACTRL_OPA2LPFDIS_DEFAULT       0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define _DAC_OPACTRL_OPA2LPFDIS_PLPFDIS       0x00000001UL                            /**< Mode PLPFDIS for DAC_OPACTRL */
+#define _DAC_OPACTRL_OPA2LPFDIS_NLPFDIS       0x00000002UL                            /**< Mode NLPFDIS for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA2LPFDIS_DEFAULT        (_DAC_OPACTRL_OPA2LPFDIS_DEFAULT << 16) /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA2LPFDIS_PLPFDIS        (_DAC_OPACTRL_OPA2LPFDIS_PLPFDIS << 16) /**< Shifted mode PLPFDIS for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA2LPFDIS_NLPFDIS        (_DAC_OPACTRL_OPA2LPFDIS_NLPFDIS << 16) /**< Shifted mode NLPFDIS for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA0SHORT                 (0x1UL << 22)                           /**< Short the non-inverting and inverting input. */
+#define _DAC_OPACTRL_OPA0SHORT_SHIFT          22                                      /**< Shift value for DAC_OPA0SHORT */
+#define _DAC_OPACTRL_OPA0SHORT_MASK           0x400000UL                              /**< Bit mask for DAC_OPA0SHORT */
+#define _DAC_OPACTRL_OPA0SHORT_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA0SHORT_DEFAULT         (_DAC_OPACTRL_OPA0SHORT_DEFAULT << 22)  /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA1SHORT                 (0x1UL << 23)                           /**< Short the non-inverting and inverting input. */
+#define _DAC_OPACTRL_OPA1SHORT_SHIFT          23                                      /**< Shift value for DAC_OPA1SHORT */
+#define _DAC_OPACTRL_OPA1SHORT_MASK           0x800000UL                              /**< Bit mask for DAC_OPA1SHORT */
+#define _DAC_OPACTRL_OPA1SHORT_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA1SHORT_DEFAULT         (_DAC_OPACTRL_OPA1SHORT_DEFAULT << 23)  /**< Shifted mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA2SHORT                 (0x1UL << 24)                           /**< Short the non-inverting and inverting input. */
+#define _DAC_OPACTRL_OPA2SHORT_SHIFT          24                                      /**< Shift value for DAC_OPA2SHORT */
+#define _DAC_OPACTRL_OPA2SHORT_MASK           0x1000000UL                             /**< Bit mask for DAC_OPA2SHORT */
+#define _DAC_OPACTRL_OPA2SHORT_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for DAC_OPACTRL */
+#define DAC_OPACTRL_OPA2SHORT_DEFAULT         (_DAC_OPACTRL_OPA2SHORT_DEFAULT << 24)  /**< Shifted mode DEFAULT for DAC_OPACTRL */
+
+/* Bit fields for DAC OPAOFFSET */
+#define _DAC_OPAOFFSET_RESETVALUE             0x00000020UL                             /**< Default value for DAC_OPAOFFSET */
+#define _DAC_OPAOFFSET_MASK                   0x0000003FUL                             /**< Mask for DAC_OPAOFFSET */
+#define _DAC_OPAOFFSET_OPA2OFFSET_SHIFT       0                                        /**< Shift value for DAC_OPA2OFFSET */
+#define _DAC_OPAOFFSET_OPA2OFFSET_MASK        0x3FUL                                   /**< Bit mask for DAC_OPA2OFFSET */
+#define _DAC_OPAOFFSET_OPA2OFFSET_DEFAULT     0x00000020UL                             /**< Mode DEFAULT for DAC_OPAOFFSET */
+#define DAC_OPAOFFSET_OPA2OFFSET_DEFAULT      (_DAC_OPAOFFSET_OPA2OFFSET_DEFAULT << 0) /**< Shifted mode DEFAULT for DAC_OPAOFFSET */
+
+/* Bit fields for DAC OPA0MUX */
+#define _DAC_OPA0MUX_RESETVALUE               0x00400000UL                         /**< Default value for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_MASK                     0x74C7F737UL                         /**< Mask for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_POSSEL_SHIFT             0                                    /**< Shift value for DAC_POSSEL */
+#define _DAC_OPA0MUX_POSSEL_MASK              0x7UL                                /**< Bit mask for DAC_POSSEL */
+#define _DAC_OPA0MUX_POSSEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_POSSEL_DISABLE           0x00000000UL                         /**< Mode DISABLE for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_POSSEL_DAC               0x00000001UL                         /**< Mode DAC for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_POSSEL_POSPAD            0x00000002UL                         /**< Mode POSPAD for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_POSSEL_OPA0INP           0x00000003UL                         /**< Mode OPA0INP for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_POSSEL_OPATAP            0x00000004UL                         /**< Mode OPATAP for DAC_OPA0MUX */
+#define DAC_OPA0MUX_POSSEL_DEFAULT            (_DAC_OPA0MUX_POSSEL_DEFAULT << 0)   /**< Shifted mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_POSSEL_DISABLE            (_DAC_OPA0MUX_POSSEL_DISABLE << 0)   /**< Shifted mode DISABLE for DAC_OPA0MUX */
+#define DAC_OPA0MUX_POSSEL_DAC                (_DAC_OPA0MUX_POSSEL_DAC << 0)       /**< Shifted mode DAC for DAC_OPA0MUX */
+#define DAC_OPA0MUX_POSSEL_POSPAD             (_DAC_OPA0MUX_POSSEL_POSPAD << 0)    /**< Shifted mode POSPAD for DAC_OPA0MUX */
+#define DAC_OPA0MUX_POSSEL_OPA0INP            (_DAC_OPA0MUX_POSSEL_OPA0INP << 0)   /**< Shifted mode OPA0INP for DAC_OPA0MUX */
+#define DAC_OPA0MUX_POSSEL_OPATAP             (_DAC_OPA0MUX_POSSEL_OPATAP << 0)    /**< Shifted mode OPATAP for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_NEGSEL_SHIFT             4                                    /**< Shift value for DAC_NEGSEL */
+#define _DAC_OPA0MUX_NEGSEL_MASK              0x30UL                               /**< Bit mask for DAC_NEGSEL */
+#define _DAC_OPA0MUX_NEGSEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_NEGSEL_DISABLE           0x00000000UL                         /**< Mode DISABLE for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_NEGSEL_UG                0x00000001UL                         /**< Mode UG for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_NEGSEL_OPATAP            0x00000002UL                         /**< Mode OPATAP for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_NEGSEL_NEGPAD            0x00000003UL                         /**< Mode NEGPAD for DAC_OPA0MUX */
+#define DAC_OPA0MUX_NEGSEL_DEFAULT            (_DAC_OPA0MUX_NEGSEL_DEFAULT << 4)   /**< Shifted mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_NEGSEL_DISABLE            (_DAC_OPA0MUX_NEGSEL_DISABLE << 4)   /**< Shifted mode DISABLE for DAC_OPA0MUX */
+#define DAC_OPA0MUX_NEGSEL_UG                 (_DAC_OPA0MUX_NEGSEL_UG << 4)        /**< Shifted mode UG for DAC_OPA0MUX */
+#define DAC_OPA0MUX_NEGSEL_OPATAP             (_DAC_OPA0MUX_NEGSEL_OPATAP << 4)    /**< Shifted mode OPATAP for DAC_OPA0MUX */
+#define DAC_OPA0MUX_NEGSEL_NEGPAD             (_DAC_OPA0MUX_NEGSEL_NEGPAD << 4)    /**< Shifted mode NEGPAD for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESINMUX_SHIFT           8                                    /**< Shift value for DAC_RESINMUX */
+#define _DAC_OPA0MUX_RESINMUX_MASK            0x700UL                              /**< Bit mask for DAC_RESINMUX */
+#define _DAC_OPA0MUX_RESINMUX_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESINMUX_DISABLE         0x00000000UL                         /**< Mode DISABLE for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESINMUX_OPA0INP         0x00000001UL                         /**< Mode OPA0INP for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESINMUX_NEGPAD          0x00000002UL                         /**< Mode NEGPAD for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESINMUX_POSPAD          0x00000003UL                         /**< Mode POSPAD for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESINMUX_VSS             0x00000004UL                         /**< Mode VSS for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESINMUX_DEFAULT          (_DAC_OPA0MUX_RESINMUX_DEFAULT << 8) /**< Shifted mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESINMUX_DISABLE          (_DAC_OPA0MUX_RESINMUX_DISABLE << 8) /**< Shifted mode DISABLE for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESINMUX_OPA0INP          (_DAC_OPA0MUX_RESINMUX_OPA0INP << 8) /**< Shifted mode OPA0INP for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESINMUX_NEGPAD           (_DAC_OPA0MUX_RESINMUX_NEGPAD << 8)  /**< Shifted mode NEGPAD for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESINMUX_POSPAD           (_DAC_OPA0MUX_RESINMUX_POSPAD << 8)  /**< Shifted mode POSPAD for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESINMUX_VSS              (_DAC_OPA0MUX_RESINMUX_VSS << 8)     /**< Shifted mode VSS for DAC_OPA0MUX */
+#define DAC_OPA0MUX_PPEN                      (0x1UL << 12)                        /**< OPA0 Positive Pad Input Enable */
+#define _DAC_OPA0MUX_PPEN_SHIFT               12                                   /**< Shift value for DAC_PPEN */
+#define _DAC_OPA0MUX_PPEN_MASK                0x1000UL                             /**< Bit mask for DAC_PPEN */
+#define _DAC_OPA0MUX_PPEN_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_PPEN_DEFAULT              (_DAC_OPA0MUX_PPEN_DEFAULT << 12)    /**< Shifted mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_NPEN                      (0x1UL << 13)                        /**< OPA0 Negative Pad Input Enable */
+#define _DAC_OPA0MUX_NPEN_SHIFT               13                                   /**< Shift value for DAC_NPEN */
+#define _DAC_OPA0MUX_NPEN_MASK                0x2000UL                             /**< Bit mask for DAC_NPEN */
+#define _DAC_OPA0MUX_NPEN_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_NPEN_DEFAULT              (_DAC_OPA0MUX_NPEN_DEFAULT << 13)    /**< Shifted mode DEFAULT for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTPEN_SHIFT             14                                   /**< Shift value for DAC_OUTPEN */
+#define _DAC_OPA0MUX_OUTPEN_MASK              0x7C000UL                            /**< Bit mask for DAC_OUTPEN */
+#define _DAC_OPA0MUX_OUTPEN_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTPEN_OUT0              0x00000001UL                         /**< Mode OUT0 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTPEN_OUT1              0x00000002UL                         /**< Mode OUT1 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTPEN_OUT2              0x00000004UL                         /**< Mode OUT2 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTPEN_OUT3              0x00000008UL                         /**< Mode OUT3 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTPEN_OUT4              0x00000010UL                         /**< Mode OUT4 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTPEN_DEFAULT            (_DAC_OPA0MUX_OUTPEN_DEFAULT << 14)  /**< Shifted mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTPEN_OUT0               (_DAC_OPA0MUX_OUTPEN_OUT0 << 14)     /**< Shifted mode OUT0 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTPEN_OUT1               (_DAC_OPA0MUX_OUTPEN_OUT1 << 14)     /**< Shifted mode OUT1 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTPEN_OUT2               (_DAC_OPA0MUX_OUTPEN_OUT2 << 14)     /**< Shifted mode OUT2 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTPEN_OUT3               (_DAC_OPA0MUX_OUTPEN_OUT3 << 14)     /**< Shifted mode OUT3 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTPEN_OUT4               (_DAC_OPA0MUX_OUTPEN_OUT4 << 14)     /**< Shifted mode OUT4 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTMODE_SHIFT            22                                   /**< Shift value for DAC_OUTMODE */
+#define _DAC_OPA0MUX_OUTMODE_MASK             0xC00000UL                           /**< Bit mask for DAC_OUTMODE */
+#define _DAC_OPA0MUX_OUTMODE_DISABLE          0x00000000UL                         /**< Mode DISABLE for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTMODE_DEFAULT          0x00000001UL                         /**< Mode DEFAULT for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTMODE_MAIN             0x00000001UL                         /**< Mode MAIN for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTMODE_ALT              0x00000002UL                         /**< Mode ALT for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_OUTMODE_ALL              0x00000003UL                         /**< Mode ALL for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTMODE_DISABLE           (_DAC_OPA0MUX_OUTMODE_DISABLE << 22) /**< Shifted mode DISABLE for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTMODE_DEFAULT           (_DAC_OPA0MUX_OUTMODE_DEFAULT << 22) /**< Shifted mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTMODE_MAIN              (_DAC_OPA0MUX_OUTMODE_MAIN << 22)    /**< Shifted mode MAIN for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTMODE_ALT               (_DAC_OPA0MUX_OUTMODE_ALT << 22)     /**< Shifted mode ALT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_OUTMODE_ALL               (_DAC_OPA0MUX_OUTMODE_ALL << 22)     /**< Shifted mode ALL for DAC_OPA0MUX */
+#define DAC_OPA0MUX_NEXTOUT                   (0x1UL << 26)                        /**< OPA0 Next Enable */
+#define _DAC_OPA0MUX_NEXTOUT_SHIFT            26                                   /**< Shift value for DAC_NEXTOUT */
+#define _DAC_OPA0MUX_NEXTOUT_MASK             0x4000000UL                          /**< Bit mask for DAC_NEXTOUT */
+#define _DAC_OPA0MUX_NEXTOUT_DEFAULT          0x00000000UL                         /**< Mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_NEXTOUT_DEFAULT           (_DAC_OPA0MUX_NEXTOUT_DEFAULT << 26) /**< Shifted mode DEFAULT for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESSEL_SHIFT             28                                   /**< Shift value for DAC_RESSEL */
+#define _DAC_OPA0MUX_RESSEL_MASK              0x70000000UL                         /**< Bit mask for DAC_RESSEL */
+#define _DAC_OPA0MUX_RESSEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESSEL_RES0              0x00000000UL                         /**< Mode RES0 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESSEL_RES1              0x00000001UL                         /**< Mode RES1 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESSEL_RES2              0x00000002UL                         /**< Mode RES2 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESSEL_RES3              0x00000003UL                         /**< Mode RES3 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESSEL_RES4              0x00000004UL                         /**< Mode RES4 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESSEL_RES5              0x00000005UL                         /**< Mode RES5 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESSEL_RES6              0x00000006UL                         /**< Mode RES6 for DAC_OPA0MUX */
+#define _DAC_OPA0MUX_RESSEL_RES7              0x00000007UL                         /**< Mode RES7 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESSEL_DEFAULT            (_DAC_OPA0MUX_RESSEL_DEFAULT << 28)  /**< Shifted mode DEFAULT for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESSEL_RES0               (_DAC_OPA0MUX_RESSEL_RES0 << 28)     /**< Shifted mode RES0 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESSEL_RES1               (_DAC_OPA0MUX_RESSEL_RES1 << 28)     /**< Shifted mode RES1 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESSEL_RES2               (_DAC_OPA0MUX_RESSEL_RES2 << 28)     /**< Shifted mode RES2 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESSEL_RES3               (_DAC_OPA0MUX_RESSEL_RES3 << 28)     /**< Shifted mode RES3 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESSEL_RES4               (_DAC_OPA0MUX_RESSEL_RES4 << 28)     /**< Shifted mode RES4 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESSEL_RES5               (_DAC_OPA0MUX_RESSEL_RES5 << 28)     /**< Shifted mode RES5 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESSEL_RES6               (_DAC_OPA0MUX_RESSEL_RES6 << 28)     /**< Shifted mode RES6 for DAC_OPA0MUX */
+#define DAC_OPA0MUX_RESSEL_RES7               (_DAC_OPA0MUX_RESSEL_RES7 << 28)     /**< Shifted mode RES7 for DAC_OPA0MUX */
+
+/* Bit fields for DAC OPA1MUX */
+#define _DAC_OPA1MUX_RESETVALUE               0x00000000UL                         /**< Default value for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_MASK                     0x74C7F737UL                         /**< Mask for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_POSSEL_SHIFT             0                                    /**< Shift value for DAC_POSSEL */
+#define _DAC_OPA1MUX_POSSEL_MASK              0x7UL                                /**< Bit mask for DAC_POSSEL */
+#define _DAC_OPA1MUX_POSSEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_POSSEL_DISABLE           0x00000000UL                         /**< Mode DISABLE for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_POSSEL_DAC               0x00000001UL                         /**< Mode DAC for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_POSSEL_POSPAD            0x00000002UL                         /**< Mode POSPAD for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_POSSEL_OPA0INP           0x00000003UL                         /**< Mode OPA0INP for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_POSSEL_OPATAP            0x00000004UL                         /**< Mode OPATAP for DAC_OPA1MUX */
+#define DAC_OPA1MUX_POSSEL_DEFAULT            (_DAC_OPA1MUX_POSSEL_DEFAULT << 0)   /**< Shifted mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_POSSEL_DISABLE            (_DAC_OPA1MUX_POSSEL_DISABLE << 0)   /**< Shifted mode DISABLE for DAC_OPA1MUX */
+#define DAC_OPA1MUX_POSSEL_DAC                (_DAC_OPA1MUX_POSSEL_DAC << 0)       /**< Shifted mode DAC for DAC_OPA1MUX */
+#define DAC_OPA1MUX_POSSEL_POSPAD             (_DAC_OPA1MUX_POSSEL_POSPAD << 0)    /**< Shifted mode POSPAD for DAC_OPA1MUX */
+#define DAC_OPA1MUX_POSSEL_OPA0INP            (_DAC_OPA1MUX_POSSEL_OPA0INP << 0)   /**< Shifted mode OPA0INP for DAC_OPA1MUX */
+#define DAC_OPA1MUX_POSSEL_OPATAP             (_DAC_OPA1MUX_POSSEL_OPATAP << 0)    /**< Shifted mode OPATAP for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_NEGSEL_SHIFT             4                                    /**< Shift value for DAC_NEGSEL */
+#define _DAC_OPA1MUX_NEGSEL_MASK              0x30UL                               /**< Bit mask for DAC_NEGSEL */
+#define _DAC_OPA1MUX_NEGSEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_NEGSEL_DISABLE           0x00000000UL                         /**< Mode DISABLE for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_NEGSEL_UG                0x00000001UL                         /**< Mode UG for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_NEGSEL_OPATAP            0x00000002UL                         /**< Mode OPATAP for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_NEGSEL_NEGPAD            0x00000003UL                         /**< Mode NEGPAD for DAC_OPA1MUX */
+#define DAC_OPA1MUX_NEGSEL_DEFAULT            (_DAC_OPA1MUX_NEGSEL_DEFAULT << 4)   /**< Shifted mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_NEGSEL_DISABLE            (_DAC_OPA1MUX_NEGSEL_DISABLE << 4)   /**< Shifted mode DISABLE for DAC_OPA1MUX */
+#define DAC_OPA1MUX_NEGSEL_UG                 (_DAC_OPA1MUX_NEGSEL_UG << 4)        /**< Shifted mode UG for DAC_OPA1MUX */
+#define DAC_OPA1MUX_NEGSEL_OPATAP             (_DAC_OPA1MUX_NEGSEL_OPATAP << 4)    /**< Shifted mode OPATAP for DAC_OPA1MUX */
+#define DAC_OPA1MUX_NEGSEL_NEGPAD             (_DAC_OPA1MUX_NEGSEL_NEGPAD << 4)    /**< Shifted mode NEGPAD for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESINMUX_SHIFT           8                                    /**< Shift value for DAC_RESINMUX */
+#define _DAC_OPA1MUX_RESINMUX_MASK            0x700UL                              /**< Bit mask for DAC_RESINMUX */
+#define _DAC_OPA1MUX_RESINMUX_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESINMUX_DISABLE         0x00000000UL                         /**< Mode DISABLE for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESINMUX_OPA0INP         0x00000001UL                         /**< Mode OPA0INP for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESINMUX_NEGPAD          0x00000002UL                         /**< Mode NEGPAD for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESINMUX_POSPAD          0x00000003UL                         /**< Mode POSPAD for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESINMUX_VSS             0x00000004UL                         /**< Mode VSS for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESINMUX_DEFAULT          (_DAC_OPA1MUX_RESINMUX_DEFAULT << 8) /**< Shifted mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESINMUX_DISABLE          (_DAC_OPA1MUX_RESINMUX_DISABLE << 8) /**< Shifted mode DISABLE for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESINMUX_OPA0INP          (_DAC_OPA1MUX_RESINMUX_OPA0INP << 8) /**< Shifted mode OPA0INP for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESINMUX_NEGPAD           (_DAC_OPA1MUX_RESINMUX_NEGPAD << 8)  /**< Shifted mode NEGPAD for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESINMUX_POSPAD           (_DAC_OPA1MUX_RESINMUX_POSPAD << 8)  /**< Shifted mode POSPAD for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESINMUX_VSS              (_DAC_OPA1MUX_RESINMUX_VSS << 8)     /**< Shifted mode VSS for DAC_OPA1MUX */
+#define DAC_OPA1MUX_PPEN                      (0x1UL << 12)                        /**< OPA1 Positive Pad Input Enable */
+#define _DAC_OPA1MUX_PPEN_SHIFT               12                                   /**< Shift value for DAC_PPEN */
+#define _DAC_OPA1MUX_PPEN_MASK                0x1000UL                             /**< Bit mask for DAC_PPEN */
+#define _DAC_OPA1MUX_PPEN_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_PPEN_DEFAULT              (_DAC_OPA1MUX_PPEN_DEFAULT << 12)    /**< Shifted mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_NPEN                      (0x1UL << 13)                        /**< OPA1 Negative Pad Input Enable */
+#define _DAC_OPA1MUX_NPEN_SHIFT               13                                   /**< Shift value for DAC_NPEN */
+#define _DAC_OPA1MUX_NPEN_MASK                0x2000UL                             /**< Bit mask for DAC_NPEN */
+#define _DAC_OPA1MUX_NPEN_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_NPEN_DEFAULT              (_DAC_OPA1MUX_NPEN_DEFAULT << 13)    /**< Shifted mode DEFAULT for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTPEN_SHIFT             14                                   /**< Shift value for DAC_OUTPEN */
+#define _DAC_OPA1MUX_OUTPEN_MASK              0x7C000UL                            /**< Bit mask for DAC_OUTPEN */
+#define _DAC_OPA1MUX_OUTPEN_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTPEN_OUT0              0x00000001UL                         /**< Mode OUT0 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTPEN_OUT1              0x00000002UL                         /**< Mode OUT1 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTPEN_OUT2              0x00000004UL                         /**< Mode OUT2 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTPEN_OUT3              0x00000008UL                         /**< Mode OUT3 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTPEN_OUT4              0x00000010UL                         /**< Mode OUT4 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTPEN_DEFAULT            (_DAC_OPA1MUX_OUTPEN_DEFAULT << 14)  /**< Shifted mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTPEN_OUT0               (_DAC_OPA1MUX_OUTPEN_OUT0 << 14)     /**< Shifted mode OUT0 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTPEN_OUT1               (_DAC_OPA1MUX_OUTPEN_OUT1 << 14)     /**< Shifted mode OUT1 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTPEN_OUT2               (_DAC_OPA1MUX_OUTPEN_OUT2 << 14)     /**< Shifted mode OUT2 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTPEN_OUT3               (_DAC_OPA1MUX_OUTPEN_OUT3 << 14)     /**< Shifted mode OUT3 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTPEN_OUT4               (_DAC_OPA1MUX_OUTPEN_OUT4 << 14)     /**< Shifted mode OUT4 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTMODE_SHIFT            22                                   /**< Shift value for DAC_OUTMODE */
+#define _DAC_OPA1MUX_OUTMODE_MASK             0xC00000UL                           /**< Bit mask for DAC_OUTMODE */
+#define _DAC_OPA1MUX_OUTMODE_DEFAULT          0x00000000UL                         /**< Mode DEFAULT for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTMODE_DISABLE          0x00000000UL                         /**< Mode DISABLE for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTMODE_MAIN             0x00000001UL                         /**< Mode MAIN for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTMODE_ALT              0x00000002UL                         /**< Mode ALT for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_OUTMODE_ALL              0x00000003UL                         /**< Mode ALL for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTMODE_DEFAULT           (_DAC_OPA1MUX_OUTMODE_DEFAULT << 22) /**< Shifted mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTMODE_DISABLE           (_DAC_OPA1MUX_OUTMODE_DISABLE << 22) /**< Shifted mode DISABLE for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTMODE_MAIN              (_DAC_OPA1MUX_OUTMODE_MAIN << 22)    /**< Shifted mode MAIN for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTMODE_ALT               (_DAC_OPA1MUX_OUTMODE_ALT << 22)     /**< Shifted mode ALT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_OUTMODE_ALL               (_DAC_OPA1MUX_OUTMODE_ALL << 22)     /**< Shifted mode ALL for DAC_OPA1MUX */
+#define DAC_OPA1MUX_NEXTOUT                   (0x1UL << 26)                        /**< OPA1 Next Enable */
+#define _DAC_OPA1MUX_NEXTOUT_SHIFT            26                                   /**< Shift value for DAC_NEXTOUT */
+#define _DAC_OPA1MUX_NEXTOUT_MASK             0x4000000UL                          /**< Bit mask for DAC_NEXTOUT */
+#define _DAC_OPA1MUX_NEXTOUT_DEFAULT          0x00000000UL                         /**< Mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_NEXTOUT_DEFAULT           (_DAC_OPA1MUX_NEXTOUT_DEFAULT << 26) /**< Shifted mode DEFAULT for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESSEL_SHIFT             28                                   /**< Shift value for DAC_RESSEL */
+#define _DAC_OPA1MUX_RESSEL_MASK              0x70000000UL                         /**< Bit mask for DAC_RESSEL */
+#define _DAC_OPA1MUX_RESSEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESSEL_RES0              0x00000000UL                         /**< Mode RES0 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESSEL_RES1              0x00000001UL                         /**< Mode RES1 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESSEL_RES2              0x00000002UL                         /**< Mode RES2 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESSEL_RES3              0x00000003UL                         /**< Mode RES3 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESSEL_RES4              0x00000004UL                         /**< Mode RES4 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESSEL_RES5              0x00000005UL                         /**< Mode RES5 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESSEL_RES6              0x00000006UL                         /**< Mode RES6 for DAC_OPA1MUX */
+#define _DAC_OPA1MUX_RESSEL_RES7              0x00000007UL                         /**< Mode RES7 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESSEL_DEFAULT            (_DAC_OPA1MUX_RESSEL_DEFAULT << 28)  /**< Shifted mode DEFAULT for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESSEL_RES0               (_DAC_OPA1MUX_RESSEL_RES0 << 28)     /**< Shifted mode RES0 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESSEL_RES1               (_DAC_OPA1MUX_RESSEL_RES1 << 28)     /**< Shifted mode RES1 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESSEL_RES2               (_DAC_OPA1MUX_RESSEL_RES2 << 28)     /**< Shifted mode RES2 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESSEL_RES3               (_DAC_OPA1MUX_RESSEL_RES3 << 28)     /**< Shifted mode RES3 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESSEL_RES4               (_DAC_OPA1MUX_RESSEL_RES4 << 28)     /**< Shifted mode RES4 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESSEL_RES5               (_DAC_OPA1MUX_RESSEL_RES5 << 28)     /**< Shifted mode RES5 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESSEL_RES6               (_DAC_OPA1MUX_RESSEL_RES6 << 28)     /**< Shifted mode RES6 for DAC_OPA1MUX */
+#define DAC_OPA1MUX_RESSEL_RES7               (_DAC_OPA1MUX_RESSEL_RES7 << 28)     /**< Shifted mode RES7 for DAC_OPA1MUX */
+
+/* Bit fields for DAC OPA2MUX */
+#define _DAC_OPA2MUX_RESETVALUE               0x00000000UL                         /**< Default value for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_MASK                     0x7440F737UL                         /**< Mask for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_POSSEL_SHIFT             0                                    /**< Shift value for DAC_POSSEL */
+#define _DAC_OPA2MUX_POSSEL_MASK              0x7UL                                /**< Bit mask for DAC_POSSEL */
+#define _DAC_OPA2MUX_POSSEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_POSSEL_DISABLE           0x00000000UL                         /**< Mode DISABLE for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_POSSEL_POSPAD            0x00000002UL                         /**< Mode POSPAD for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_POSSEL_OPA1INP           0x00000003UL                         /**< Mode OPA1INP for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_POSSEL_OPATAP            0x00000004UL                         /**< Mode OPATAP for DAC_OPA2MUX */
+#define DAC_OPA2MUX_POSSEL_DEFAULT            (_DAC_OPA2MUX_POSSEL_DEFAULT << 0)   /**< Shifted mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_POSSEL_DISABLE            (_DAC_OPA2MUX_POSSEL_DISABLE << 0)   /**< Shifted mode DISABLE for DAC_OPA2MUX */
+#define DAC_OPA2MUX_POSSEL_POSPAD             (_DAC_OPA2MUX_POSSEL_POSPAD << 0)    /**< Shifted mode POSPAD for DAC_OPA2MUX */
+#define DAC_OPA2MUX_POSSEL_OPA1INP            (_DAC_OPA2MUX_POSSEL_OPA1INP << 0)   /**< Shifted mode OPA1INP for DAC_OPA2MUX */
+#define DAC_OPA2MUX_POSSEL_OPATAP             (_DAC_OPA2MUX_POSSEL_OPATAP << 0)    /**< Shifted mode OPATAP for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_NEGSEL_SHIFT             4                                    /**< Shift value for DAC_NEGSEL */
+#define _DAC_OPA2MUX_NEGSEL_MASK              0x30UL                               /**< Bit mask for DAC_NEGSEL */
+#define _DAC_OPA2MUX_NEGSEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_NEGSEL_DISABLE           0x00000000UL                         /**< Mode DISABLE for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_NEGSEL_UG                0x00000001UL                         /**< Mode UG for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_NEGSEL_OPATAP            0x00000002UL                         /**< Mode OPATAP for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_NEGSEL_NEGPAD            0x00000003UL                         /**< Mode NEGPAD for DAC_OPA2MUX */
+#define DAC_OPA2MUX_NEGSEL_DEFAULT            (_DAC_OPA2MUX_NEGSEL_DEFAULT << 4)   /**< Shifted mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_NEGSEL_DISABLE            (_DAC_OPA2MUX_NEGSEL_DISABLE << 4)   /**< Shifted mode DISABLE for DAC_OPA2MUX */
+#define DAC_OPA2MUX_NEGSEL_UG                 (_DAC_OPA2MUX_NEGSEL_UG << 4)        /**< Shifted mode UG for DAC_OPA2MUX */
+#define DAC_OPA2MUX_NEGSEL_OPATAP             (_DAC_OPA2MUX_NEGSEL_OPATAP << 4)    /**< Shifted mode OPATAP for DAC_OPA2MUX */
+#define DAC_OPA2MUX_NEGSEL_NEGPAD             (_DAC_OPA2MUX_NEGSEL_NEGPAD << 4)    /**< Shifted mode NEGPAD for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESINMUX_SHIFT           8                                    /**< Shift value for DAC_RESINMUX */
+#define _DAC_OPA2MUX_RESINMUX_MASK            0x700UL                              /**< Bit mask for DAC_RESINMUX */
+#define _DAC_OPA2MUX_RESINMUX_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESINMUX_DISABLE         0x00000000UL                         /**< Mode DISABLE for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESINMUX_OPA1INP         0x00000001UL                         /**< Mode OPA1INP for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESINMUX_NEGPAD          0x00000002UL                         /**< Mode NEGPAD for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESINMUX_POSPAD          0x00000003UL                         /**< Mode POSPAD for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESINMUX_VSS             0x00000004UL                         /**< Mode VSS for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESINMUX_DEFAULT          (_DAC_OPA2MUX_RESINMUX_DEFAULT << 8) /**< Shifted mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESINMUX_DISABLE          (_DAC_OPA2MUX_RESINMUX_DISABLE << 8) /**< Shifted mode DISABLE for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESINMUX_OPA1INP          (_DAC_OPA2MUX_RESINMUX_OPA1INP << 8) /**< Shifted mode OPA1INP for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESINMUX_NEGPAD           (_DAC_OPA2MUX_RESINMUX_NEGPAD << 8)  /**< Shifted mode NEGPAD for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESINMUX_POSPAD           (_DAC_OPA2MUX_RESINMUX_POSPAD << 8)  /**< Shifted mode POSPAD for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESINMUX_VSS              (_DAC_OPA2MUX_RESINMUX_VSS << 8)     /**< Shifted mode VSS for DAC_OPA2MUX */
+#define DAC_OPA2MUX_PPEN                      (0x1UL << 12)                        /**< OPA2 Positive Pad Input Enable */
+#define _DAC_OPA2MUX_PPEN_SHIFT               12                                   /**< Shift value for DAC_PPEN */
+#define _DAC_OPA2MUX_PPEN_MASK                0x1000UL                             /**< Bit mask for DAC_PPEN */
+#define _DAC_OPA2MUX_PPEN_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_PPEN_DEFAULT              (_DAC_OPA2MUX_PPEN_DEFAULT << 12)    /**< Shifted mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_NPEN                      (0x1UL << 13)                        /**< OPA2 Negative Pad Input Enable */
+#define _DAC_OPA2MUX_NPEN_SHIFT               13                                   /**< Shift value for DAC_NPEN */
+#define _DAC_OPA2MUX_NPEN_MASK                0x2000UL                             /**< Bit mask for DAC_NPEN */
+#define _DAC_OPA2MUX_NPEN_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_NPEN_DEFAULT              (_DAC_OPA2MUX_NPEN_DEFAULT << 13)    /**< Shifted mode DEFAULT for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_OUTPEN_SHIFT             14                                   /**< Shift value for DAC_OUTPEN */
+#define _DAC_OPA2MUX_OUTPEN_MASK              0xC000UL                             /**< Bit mask for DAC_OUTPEN */
+#define _DAC_OPA2MUX_OUTPEN_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_OUTPEN_OUT0              0x00000001UL                         /**< Mode OUT0 for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_OUTPEN_OUT1              0x00000002UL                         /**< Mode OUT1 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_OUTPEN_DEFAULT            (_DAC_OPA2MUX_OUTPEN_DEFAULT << 14)  /**< Shifted mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_OUTPEN_OUT0               (_DAC_OPA2MUX_OUTPEN_OUT0 << 14)     /**< Shifted mode OUT0 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_OUTPEN_OUT1               (_DAC_OPA2MUX_OUTPEN_OUT1 << 14)     /**< Shifted mode OUT1 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_OUTMODE                   (0x1UL << 22)                        /**< Output Select */
+#define _DAC_OPA2MUX_OUTMODE_SHIFT            22                                   /**< Shift value for DAC_OUTMODE */
+#define _DAC_OPA2MUX_OUTMODE_MASK             0x400000UL                           /**< Bit mask for DAC_OUTMODE */
+#define _DAC_OPA2MUX_OUTMODE_DEFAULT          0x00000000UL                         /**< Mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_OUTMODE_DEFAULT           (_DAC_OPA2MUX_OUTMODE_DEFAULT << 22) /**< Shifted mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_NEXTOUT                   (0x1UL << 26)                        /**< OPA2 Next Enable */
+#define _DAC_OPA2MUX_NEXTOUT_SHIFT            26                                   /**< Shift value for DAC_NEXTOUT */
+#define _DAC_OPA2MUX_NEXTOUT_MASK             0x4000000UL                          /**< Bit mask for DAC_NEXTOUT */
+#define _DAC_OPA2MUX_NEXTOUT_DEFAULT          0x00000000UL                         /**< Mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_NEXTOUT_DEFAULT           (_DAC_OPA2MUX_NEXTOUT_DEFAULT << 26) /**< Shifted mode DEFAULT for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESSEL_SHIFT             28                                   /**< Shift value for DAC_RESSEL */
+#define _DAC_OPA2MUX_RESSEL_MASK              0x70000000UL                         /**< Bit mask for DAC_RESSEL */
+#define _DAC_OPA2MUX_RESSEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESSEL_RES0              0x00000000UL                         /**< Mode RES0 for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESSEL_RES1              0x00000001UL                         /**< Mode RES1 for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESSEL_RES2              0x00000002UL                         /**< Mode RES2 for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESSEL_RES3              0x00000003UL                         /**< Mode RES3 for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESSEL_RES4              0x00000004UL                         /**< Mode RES4 for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESSEL_RES5              0x00000005UL                         /**< Mode RES5 for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESSEL_RES6              0x00000006UL                         /**< Mode RES6 for DAC_OPA2MUX */
+#define _DAC_OPA2MUX_RESSEL_RES7              0x00000007UL                         /**< Mode RES7 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESSEL_DEFAULT            (_DAC_OPA2MUX_RESSEL_DEFAULT << 28)  /**< Shifted mode DEFAULT for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESSEL_RES0               (_DAC_OPA2MUX_RESSEL_RES0 << 28)     /**< Shifted mode RES0 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESSEL_RES1               (_DAC_OPA2MUX_RESSEL_RES1 << 28)     /**< Shifted mode RES1 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESSEL_RES2               (_DAC_OPA2MUX_RESSEL_RES2 << 28)     /**< Shifted mode RES2 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESSEL_RES3               (_DAC_OPA2MUX_RESSEL_RES3 << 28)     /**< Shifted mode RES3 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESSEL_RES4               (_DAC_OPA2MUX_RESSEL_RES4 << 28)     /**< Shifted mode RES4 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESSEL_RES5               (_DAC_OPA2MUX_RESSEL_RES5 << 28)     /**< Shifted mode RES5 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESSEL_RES6               (_DAC_OPA2MUX_RESSEL_RES6 << 28)     /**< Shifted mode RES6 for DAC_OPA2MUX */
+#define DAC_OPA2MUX_RESSEL_RES7               (_DAC_OPA2MUX_RESSEL_RES7 << 28)     /**< Shifted mode RES7 for DAC_OPA2MUX */
+
+/** @} End of group EFM32TG_DAC */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_devinfo.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_devinfo.h
@@ -1,0 +1,174 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_DEVINFO register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_DEVINFO
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IM uint32_t CAL;           /**< Calibration temperature and checksum */
+  __IM uint32_t ADC0CAL0;      /**< ADC0 Calibration register 0 */
+  __IM uint32_t ADC0CAL1;      /**< ADC0 Calibration register 1 */
+  __IM uint32_t ADC0CAL2;      /**< ADC0 Calibration register 2 */
+  uint32_t      RESERVED0[2U]; /**< Reserved */
+  __IM uint32_t DAC0CAL0;      /**< DAC calibrartion register 0 */
+  __IM uint32_t DAC0CAL1;      /**< DAC calibrartion register 1 */
+  __IM uint32_t DAC0CAL2;      /**< DAC calibrartion register 2 */
+  __IM uint32_t AUXHFRCOCAL0;  /**< AUXHFRCO calibration register 0 */
+  __IM uint32_t AUXHFRCOCAL1;  /**< AUXHFRCO calibration register 1 */
+  __IM uint32_t HFRCOCAL0;     /**< HFRCO calibration register 0 */
+  __IM uint32_t HFRCOCAL1;     /**< HFRCO calibration register 1 */
+  __IM uint32_t MEMINFO;       /**< Memory information */
+  uint32_t      RESERVED2[2U]; /**< Reserved */
+  __IM uint32_t UNIQUEL;       /**< Low 32 bits of device unique number */
+  __IM uint32_t UNIQUEH;       /**< High 32 bits of device unique number */
+  __IM uint32_t MSIZE;         /**< Flash and SRAM Memory size in KiloBytes */
+  __IM uint32_t PART;          /**< Part description */
+} DEVINFO_TypeDef;             /** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_DEVINFO_BitFields
+ * @{
+ ******************************************************************************/
+/* Bit fields for EFM32TG_DEVINFO */
+#define _DEVINFO_CAL_CRC_MASK                      0x0000FFFFUL /**< Integrity CRC checksum mask */
+#define _DEVINFO_CAL_CRC_SHIFT                     0            /**< Integrity CRC checksum shift */
+#define _DEVINFO_CAL_TEMP_MASK                     0x00FF0000UL /**< Calibration temperature, DegC, mask */
+#define _DEVINFO_CAL_TEMP_SHIFT                    16           /**< Calibration temperature shift */
+#define _DEVINFO_ADC0CAL0_1V25_GAIN_MASK           0x00007F00UL /**< Gain for 1V25 reference, mask */
+#define _DEVINFO_ADC0CAL0_1V25_GAIN_SHIFT          8            /**< Gain for 1V25 reference, shift */
+#define _DEVINFO_ADC0CAL0_1V25_OFFSET_MASK         0x0000007FUL /**< Offset for 1V25 reference, mask */
+#define _DEVINFO_ADC0CAL0_1V25_OFFSET_SHIFT        0            /**< Offset for 1V25 reference, shift */
+#define _DEVINFO_ADC0CAL0_2V5_GAIN_MASK            0x7F000000UL /**< Gain for 2V5 reference, mask */
+#define _DEVINFO_ADC0CAL0_2V5_GAIN_SHIFT           24           /**< Gain for 2V5 reference, shift */
+#define _DEVINFO_ADC0CAL0_2V5_OFFSET_MASK          0x007F0000UL /**< Offset for 2V5 reference, mask */
+#define _DEVINFO_ADC0CAL0_2V5_OFFSET_SHIFT         16           /**< Offset for 2V5 reference, shift */
+#define _DEVINFO_ADC0CAL1_VDD_GAIN_MASK            0x00007F00UL /**< Gain for VDD reference, mask */
+#define _DEVINFO_ADC0CAL1_VDD_GAIN_SHIFT           8            /**< Gain for VDD reference, shift */
+#define _DEVINFO_ADC0CAL1_VDD_OFFSET_MASK          0x0000007FUL /**< Offset for VDD reference, mask */
+#define _DEVINFO_ADC0CAL1_VDD_OFFSET_SHIFT         0            /**< Offset for VDD reference, shift */
+#define _DEVINFO_ADC0CAL1_5VDIFF_GAIN_MASK         0x7F000000UL /**< Gain 5VDIFF for 5VDIFF reference, mask */
+#define _DEVINFO_ADC0CAL1_5VDIFF_GAIN_SHIFT        24           /**< Gain for 5VDIFF reference, mask */
+#define _DEVINFO_ADC0CAL1_5VDIFF_OFFSET_MASK       0x007F0000UL /**< Offset for 5VDIFF reference, mask */
+#define _DEVINFO_ADC0CAL1_5VDIFF_OFFSET_SHIFT      16           /**< Offset for 5VDIFF reference, shift */
+#define _DEVINFO_ADC0CAL2_2XVDDVSS_OFFSET_MASK     0x0000007FUL /**< Offset for 2XVDDVSS reference, mask */
+#define _DEVINFO_ADC0CAL2_2XVDDVSS_OFFSET_SHIFT    0            /**< Offset for 2XVDDVSS reference, shift */
+#define _DEVINFO_ADC0CAL2_TEMP1V25_MASK            0xFFF00000UL /**< Temperature reading at 1V25 reference, mask */
+#define _DEVINFO_ADC0CAL2_TEMP1V25_SHIFT           20           /**< Temperature reading at 1V25 reference, DegC */
+#define _DEVINFO_DAC0CAL0_1V25_GAIN_MASK           0x007F0000UL /**< Gain for 1V25 reference, mask */
+#define _DEVINFO_DAC0CAL0_1V25_GAIN_SHIFT          16           /**< Gain for 1V25 reference, shift */
+#define _DEVINFO_DAC0CAL0_1V25_CH1_OFFSET_MASK     0x00003F00UL /**< Channel 1 offset for 1V25 reference, mask */
+#define _DEVINFO_DAC0CAL0_1V25_CH1_OFFSET_SHIFT    8            /**< Channel 1 offset for 1V25 reference, shift */
+#define _DEVINFO_DAC0CAL0_1V25_CH0_OFFSET_MASK     0x0000003FUL /**< Channel 0 offset for 1V25 reference, mask */
+#define _DEVINFO_DAC0CAL0_1V25_CH0_OFFSET_SHIFT    0            /**< Channel 0 offset for 1V25 reference, shift */
+#define _DEVINFO_DAC0CAL1_2V5_GAIN_MASK            0x007F0000UL /**< Gain for 2V5 reference, mask */
+#define _DEVINFO_DAC0CAL1_2V5_GAIN_SHIFT           16           /**< Gain for 2V5 reference, shift */
+#define _DEVINFO_DAC0CAL1_2V5_CH1_OFFSET_MASK      0x00003F00UL /**< Channel 1 offset for 2V5 reference, mask */
+#define _DEVINFO_DAC0CAL1_2V5_CH1_OFFSET_SHIFT     8            /**< Channel 1 offset for 2V5 reference, shift */
+#define _DEVINFO_DAC0CAL1_2V5_CH0_OFFSET_MASK      0x0000003FUL /**< Channel 0 offset for 2V5 reference, mask */
+#define _DEVINFO_DAC0CAL1_2V5_CH0_OFFSET_SHIFT     0            /**< Channel 0 offset for 2V5 reference, shift */
+#define _DEVINFO_DAC0CAL2_VDD_GAIN_MASK            0x007F0000UL /**< Gain for VDD reference, mask */
+#define _DEVINFO_DAC0CAL2_VDD_GAIN_SHIFT           16           /**< Gain for VDD reference, shift */
+#define _DEVINFO_DAC0CAL2_VDD_CH1_OFFSET_MASK      0x00003F00UL /**< Channel 1 offset for VDD reference, mask */
+#define _DEVINFO_DAC0CAL2_VDD_CH1_OFFSET_SHIFT     8            /**< Channel 1 offset for VDD reference, shift */
+#define _DEVINFO_DAC0CAL2_VDD_CH0_OFFSET_MASK      0x0000003FUL /**< Channel 0 offset for VDD reference, mask */
+#define _DEVINFO_DAC0CAL2_VDD_CH0_OFFSET_SHIFT     0            /**< Channel 0 offset for VDD reference, shift*/
+#define _DEVINFO_AUXHFRCOCAL0_BAND1_MASK           0x000000FFUL /**< 1MHz tuning value for AUXHFRCO, mask */
+#define _DEVINFO_AUXHFRCOCAL0_BAND1_SHIFT          0            /**< 1MHz tuning value for AUXHFRCO, shift */
+#define _DEVINFO_AUXHFRCOCAL0_BAND7_MASK           0x0000FF00UL /**< 7MHz tuning value for AUXHFRCO, mask */
+#define _DEVINFO_AUXHFRCOCAL0_BAND7_SHIFT          8            /**< 7MHz tuning value for AUXHFRCO, shift */
+#define _DEVINFO_AUXHFRCOCAL0_BAND11_MASK          0x00FF0000UL /**< 11MHz tuning value for AUXHFRCO, mask */
+#define _DEVINFO_AUXHFRCOCAL0_BAND11_SHIFT         16           /**< 11MHz tuning value for AUXHFRCO, shift */
+#define _DEVINFO_AUXHFRCOCAL0_BAND14_MASK          0xFF000000UL /**< 14MHz tuning value for AUXHFRCO, mask */
+#define _DEVINFO_AUXHFRCOCAL0_BAND14_SHIFT         24           /**< 14MHz tuning value for AUXHFRCO, shift */
+#define _DEVINFO_AUXHFRCOCAL1_BAND21_MASK          0x000000FFUL /**< 21MHz tuning value for AUXHFRCO, mask */
+#define _DEVINFO_AUXHFRCOCAL1_BAND21_SHIFT         0            /**< 21MHz tuning value for AUXHFRCO, shift */
+#define _DEVINFO_AUXHFRCOCAL1_BAND28_MASK          0x0000FF00UL /**< 28MHz tuning value for AUXHFRCO, shift */
+#define _DEVINFO_AUXHFRCOCAL1_BAND28_SHIFT         8            /**< 28MHz tuning value for AUXHFRCO, mask */
+#define _DEVINFO_HFRCOCAL0_BAND1_MASK              0x000000FFUL /**< 1MHz tuning value for HFRCO, mask */
+#define _DEVINFO_HFRCOCAL0_BAND1_SHIFT             0            /**< 1MHz tuning value for HFRCO, shift */
+#define _DEVINFO_HFRCOCAL0_BAND7_MASK              0x0000FF00UL /**< 7MHz tuning value for HFRCO, mask */
+#define _DEVINFO_HFRCOCAL0_BAND7_SHIFT             8            /**< 7MHz tuning value for HFRCO, shift */
+#define _DEVINFO_HFRCOCAL0_BAND11_MASK             0x00FF0000UL /**< 11MHz tuning value for HFRCO, mask */
+#define _DEVINFO_HFRCOCAL0_BAND11_SHIFT            16           /**< 11MHz tuning value for HFRCO, shift */
+#define _DEVINFO_HFRCOCAL0_BAND14_MASK             0xFF000000UL /**< 14MHz tuning value for HFRCO, mask */
+#define _DEVINFO_HFRCOCAL0_BAND14_SHIFT            24           /**< 14MHz tuning value for HFRCO, shift */
+#define _DEVINFO_HFRCOCAL1_BAND21_MASK             0x000000FFUL /**< 21MHz tuning value for HFRCO, mask */
+#define _DEVINFO_HFRCOCAL1_BAND21_SHIFT            0            /**< 21MHz tuning value for HFRCO, shift */
+#define _DEVINFO_HFRCOCAL1_BAND28_MASK             0x0000FF00UL /**< 28MHz tuning value for HFRCO, shift */
+#define _DEVINFO_HFRCOCAL1_BAND28_SHIFT            8            /**< 28MHz tuning value for HFRCO, mask */
+#define _DEVINFO_MEMINFO_FLASH_PAGE_SIZE_MASK      0xFF000000UL /**< Flash page size (refer to ref.man for encoding) mask */
+#define _DEVINFO_MEMINFO_FLASH_PAGE_SIZE_SHIFT     24           /**< Flash page size shift */
+#define _DEVINFO_UNIQUEL_MASK                      0xFFFFFFFFUL /**< Lower part of  64-bit device unique number */
+#define _DEVINFO_UNIQUEL_SHIFT                     0            /**< Unique Low 32-bit shift */
+#define _DEVINFO_UNIQUEH_MASK                      0xFFFFFFFFUL /**< High part of  64-bit device unique number */
+#define _DEVINFO_UNIQUEH_SHIFT                     0            /**< Unique High 32-bit shift */
+#define _DEVINFO_MSIZE_SRAM_MASK                   0xFFFF0000UL /**< Flash size in kilobytes */
+#define _DEVINFO_MSIZE_SRAM_SHIFT                  16           /**< Bit position for flash size */
+#define _DEVINFO_MSIZE_FLASH_MASK                  0x0000FFFFUL /**< SRAM size in kilobytes */
+#define _DEVINFO_MSIZE_FLASH_SHIFT                 0            /**< Bit position for SRAM size */
+#define _DEVINFO_PART_PROD_REV_MASK                0xFF000000UL /**< Production revision */
+#define _DEVINFO_PART_PROD_REV_SHIFT               24           /**< Bit position for production revision */
+#define _DEVINFO_PART_DEVICE_FAMILY_MASK           0x00FF0000UL /**< Device Family, 0x47 for Gecko */
+#define _DEVINFO_PART_DEVICE_FAMILY_SHIFT          16           /**< Bit position for device family */
+/* Legacy family #defines */
+#define _DEVINFO_PART_DEVICE_FAMILY_G              71           /**< Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_GG             72           /**< Giant Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_TG             73           /**< Tiny Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_LG             74           /**< Leopard Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_WG             75           /**< Wonder Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_ZG             76           /**< Zero Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_HG             77           /**< Happy Gecko Device Family */
+/* New style family #defines */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32G         71           /**< Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG        72           /**< Giant Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32TG        73           /**< Tiny Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32LG        74           /**< Leopard Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32WG        75           /**< Wonder Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32ZG        76           /**< Zero Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_EFM32HG        77           /**< Happy Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_EZR32WG        120          /**< EZR Wonder Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_EZR32LG        121          /**< EZR Leopard Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_FAMILY_EZR32HG        122          /**< EZR Happy Gecko Device Family */
+#define _DEVINFO_PART_DEVICE_NUMBER_MASK           0x0000FFFFUL /**< Device number */
+#define _DEVINFO_PART_DEVICE_NUMBER_SHIFT          0            /**< Bit position for device number */
+
+/** @} End of group EFM32TG_DEVINFO */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dma.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dma.h
@@ -1,0 +1,1074 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_DMA register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_DMA
+ * @brief EFM32TG_DMA Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IM uint32_t  STATUS;          /**< DMA Status Registers  */
+  __OM uint32_t  CONFIG;          /**< DMA Configuration Register  */
+  __IOM uint32_t CTRLBASE;        /**< Channel Control Data Base Pointer Register  */
+  __IM uint32_t  ALTCTRLBASE;     /**< Channel Alternate Control Data Base Pointer Register  */
+  __IM uint32_t  CHWAITSTATUS;    /**< Channel Wait on Request Status Register  */
+  __OM uint32_t  CHSWREQ;         /**< Channel Software Request Register  */
+  __IOM uint32_t CHUSEBURSTS;     /**< Channel Useburst Set Register  */
+  __OM uint32_t  CHUSEBURSTC;     /**< Channel Useburst Clear Register  */
+  __IOM uint32_t CHREQMASKS;      /**< Channel Request Mask Set Register  */
+  __OM uint32_t  CHREQMASKC;      /**< Channel Request Mask Clear Register  */
+  __IOM uint32_t CHENS;           /**< Channel Enable Set Register  */
+  __OM uint32_t  CHENC;           /**< Channel Enable Clear Register  */
+  __IOM uint32_t CHALTS;          /**< Channel Alternate Set Register  */
+  __OM uint32_t  CHALTC;          /**< Channel Alternate Clear Register  */
+  __IOM uint32_t CHPRIS;          /**< Channel Priority Set Register  */
+  __OM uint32_t  CHPRIC;          /**< Channel Priority Clear Register  */
+  uint32_t       RESERVED0[3U];   /**< Reserved for future use **/
+  __IOM uint32_t ERRORC;          /**< Bus Error Clear Register  */
+  uint32_t       RESERVED1[880U]; /**< Reserved for future use **/
+  __IM uint32_t  CHREQSTATUS;     /**< Channel Request Status  */
+  uint32_t       RESERVED2[1U];   /**< Reserved for future use **/
+  __IM uint32_t  CHSREQSTATUS;    /**< Channel Single Request Status  */
+
+  uint32_t       RESERVED3[121U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;             /**< Interrupt Enable register  */
+
+  uint32_t       RESERVED4[60U];  /**< Reserved registers */
+  DMA_CH_TypeDef CH[8U];          /**< Channel registers */
+} DMA_TypeDef;                    /**< DMA Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_DMA_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for DMA STATUS */
+#define _DMA_STATUS_RESETVALUE                          0x10070000UL                          /**< Default value for DMA_STATUS */
+#define _DMA_STATUS_MASK                                0x001F00F1UL                          /**< Mask for DMA_STATUS */
+#define DMA_STATUS_EN                                   (0x1UL << 0)                          /**< DMA Enable Status */
+#define _DMA_STATUS_EN_SHIFT                            0                                     /**< Shift value for DMA_EN */
+#define _DMA_STATUS_EN_MASK                             0x1UL                                 /**< Bit mask for DMA_EN */
+#define _DMA_STATUS_EN_DEFAULT                          0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_EN_DEFAULT                           (_DMA_STATUS_EN_DEFAULT << 0)         /**< Shifted mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_SHIFT                         4                                     /**< Shift value for DMA_STATE */
+#define _DMA_STATUS_STATE_MASK                          0xF0UL                                /**< Bit mask for DMA_STATE */
+#define _DMA_STATUS_STATE_DEFAULT                       0x00000000UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define _DMA_STATUS_STATE_IDLE                          0x00000000UL                          /**< Mode IDLE for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDCHCTRLDATA                  0x00000001UL                          /**< Mode RDCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCENDPTR                   0x00000002UL                          /**< Mode RDSRCENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDDSTENDPTR                   0x00000003UL                          /**< Mode RDDSTENDPTR for DMA_STATUS */
+#define _DMA_STATUS_STATE_RDSRCDATA                     0x00000004UL                          /**< Mode RDSRCDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRDSTDATA                     0x00000005UL                          /**< Mode WRDSTDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_WAITREQCLR                    0x00000006UL                          /**< Mode WAITREQCLR for DMA_STATUS */
+#define _DMA_STATUS_STATE_WRCHCTRLDATA                  0x00000007UL                          /**< Mode WRCHCTRLDATA for DMA_STATUS */
+#define _DMA_STATUS_STATE_STALLED                       0x00000008UL                          /**< Mode STALLED for DMA_STATUS */
+#define _DMA_STATUS_STATE_DONE                          0x00000009UL                          /**< Mode DONE for DMA_STATUS */
+#define _DMA_STATUS_STATE_PERSCATTRANS                  0x0000000AUL                          /**< Mode PERSCATTRANS for DMA_STATUS */
+#define DMA_STATUS_STATE_DEFAULT                        (_DMA_STATUS_STATE_DEFAULT << 4)      /**< Shifted mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_STATE_IDLE                           (_DMA_STATUS_STATE_IDLE << 4)         /**< Shifted mode IDLE for DMA_STATUS */
+#define DMA_STATUS_STATE_RDCHCTRLDATA                   (_DMA_STATUS_STATE_RDCHCTRLDATA << 4) /**< Shifted mode RDCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCENDPTR                    (_DMA_STATUS_STATE_RDSRCENDPTR << 4)  /**< Shifted mode RDSRCENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDDSTENDPTR                    (_DMA_STATUS_STATE_RDDSTENDPTR << 4)  /**< Shifted mode RDDSTENDPTR for DMA_STATUS */
+#define DMA_STATUS_STATE_RDSRCDATA                      (_DMA_STATUS_STATE_RDSRCDATA << 4)    /**< Shifted mode RDSRCDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WRDSTDATA                      (_DMA_STATUS_STATE_WRDSTDATA << 4)    /**< Shifted mode WRDSTDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_WAITREQCLR                     (_DMA_STATUS_STATE_WAITREQCLR << 4)   /**< Shifted mode WAITREQCLR for DMA_STATUS */
+#define DMA_STATUS_STATE_WRCHCTRLDATA                   (_DMA_STATUS_STATE_WRCHCTRLDATA << 4) /**< Shifted mode WRCHCTRLDATA for DMA_STATUS */
+#define DMA_STATUS_STATE_STALLED                        (_DMA_STATUS_STATE_STALLED << 4)      /**< Shifted mode STALLED for DMA_STATUS */
+#define DMA_STATUS_STATE_DONE                           (_DMA_STATUS_STATE_DONE << 4)         /**< Shifted mode DONE for DMA_STATUS */
+#define DMA_STATUS_STATE_PERSCATTRANS                   (_DMA_STATUS_STATE_PERSCATTRANS << 4) /**< Shifted mode PERSCATTRANS for DMA_STATUS */
+#define _DMA_STATUS_CHNUM_SHIFT                         16                                    /**< Shift value for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_MASK                          0x1F0000UL                            /**< Bit mask for DMA_CHNUM */
+#define _DMA_STATUS_CHNUM_DEFAULT                       0x00000007UL                          /**< Mode DEFAULT for DMA_STATUS */
+#define DMA_STATUS_CHNUM_DEFAULT                        (_DMA_STATUS_CHNUM_DEFAULT << 16)     /**< Shifted mode DEFAULT for DMA_STATUS */
+
+/* Bit fields for DMA CONFIG */
+#define _DMA_CONFIG_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_CONFIG */
+#define _DMA_CONFIG_MASK                                0x00000021UL                      /**< Mask for DMA_CONFIG */
+#define DMA_CONFIG_EN                                   (0x1UL << 0)                      /**< Enable DMA */
+#define _DMA_CONFIG_EN_SHIFT                            0                                 /**< Shift value for DMA_EN */
+#define _DMA_CONFIG_EN_MASK                             0x1UL                             /**< Bit mask for DMA_EN */
+#define _DMA_CONFIG_EN_DEFAULT                          0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_EN_DEFAULT                           (_DMA_CONFIG_EN_DEFAULT << 0)     /**< Shifted mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT                               (0x1UL << 5)                      /**< Channel Protection Control */
+#define _DMA_CONFIG_CHPROT_SHIFT                        5                                 /**< Shift value for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_MASK                         0x20UL                            /**< Bit mask for DMA_CHPROT */
+#define _DMA_CONFIG_CHPROT_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_CONFIG */
+#define DMA_CONFIG_CHPROT_DEFAULT                       (_DMA_CONFIG_CHPROT_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CONFIG */
+
+/* Bit fields for DMA CTRLBASE */
+#define _DMA_CTRLBASE_RESETVALUE                        0x00000000UL                          /**< Default value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_MASK                              0xFFFFFFFFUL                          /**< Mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_SHIFT                    0                                     /**< Shift value for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_MASK                     0xFFFFFFFFUL                          /**< Bit mask for DMA_CTRLBASE */
+#define _DMA_CTRLBASE_CTRLBASE_DEFAULT                  0x00000000UL                          /**< Mode DEFAULT for DMA_CTRLBASE */
+#define DMA_CTRLBASE_CTRLBASE_DEFAULT                   (_DMA_CTRLBASE_CTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CTRLBASE */
+
+/* Bit fields for DMA ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_RESETVALUE                     0x00000080UL                                /**< Default value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_MASK                           0xFFFFFFFFUL                                /**< Mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_SHIFT              0                                           /**< Shift value for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_MASK               0xFFFFFFFFUL                                /**< Bit mask for DMA_ALTCTRLBASE */
+#define _DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT            0x00000080UL                                /**< Mode DEFAULT for DMA_ALTCTRLBASE */
+#define DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT             (_DMA_ALTCTRLBASE_ALTCTRLBASE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ALTCTRLBASE */
+
+/* Bit fields for DMA CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_RESETVALUE                    0x000000FFUL                                   /**< Default value for DMA_CHWAITSTATUS */
+#define _DMA_CHWAITSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH0WAITSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH1WAITSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH2WAITSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH3WAITSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH4WAITSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH5WAITSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH6WAITSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Wait on Request Status */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7WAITSTATUS */
+#define _DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT         0x00000001UL                                   /**< Mode DEFAULT for DMA_CHWAITSTATUS */
+#define DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT          (_DMA_CHWAITSTATUS_CH7WAITSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHWAITSTATUS */
+
+/* Bit fields for DMA CHSWREQ */
+#define _DMA_CHSWREQ_RESETVALUE                         0x00000000UL                         /**< Default value for DMA_CHSWREQ */
+#define _DMA_CHSWREQ_MASK                               0x000000FFUL                         /**< Mask for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ                            (0x1UL << 0)                         /**< Channel 0 Software Request */
+#define _DMA_CHSWREQ_CH0SWREQ_SHIFT                     0                                    /**< Shift value for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_MASK                      0x1UL                                /**< Bit mask for DMA_CH0SWREQ */
+#define _DMA_CHSWREQ_CH0SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH0SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH0SWREQ_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ                            (0x1UL << 1)                         /**< Channel 1 Software Request */
+#define _DMA_CHSWREQ_CH1SWREQ_SHIFT                     1                                    /**< Shift value for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_MASK                      0x2UL                                /**< Bit mask for DMA_CH1SWREQ */
+#define _DMA_CHSWREQ_CH1SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH1SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH1SWREQ_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ                            (0x1UL << 2)                         /**< Channel 2 Software Request */
+#define _DMA_CHSWREQ_CH2SWREQ_SHIFT                     2                                    /**< Shift value for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_MASK                      0x4UL                                /**< Bit mask for DMA_CH2SWREQ */
+#define _DMA_CHSWREQ_CH2SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH2SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH2SWREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ                            (0x1UL << 3)                         /**< Channel 3 Software Request */
+#define _DMA_CHSWREQ_CH3SWREQ_SHIFT                     3                                    /**< Shift value for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_MASK                      0x8UL                                /**< Bit mask for DMA_CH3SWREQ */
+#define _DMA_CHSWREQ_CH3SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH3SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH3SWREQ_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ                            (0x1UL << 4)                         /**< Channel 4 Software Request */
+#define _DMA_CHSWREQ_CH4SWREQ_SHIFT                     4                                    /**< Shift value for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_MASK                      0x10UL                               /**< Bit mask for DMA_CH4SWREQ */
+#define _DMA_CHSWREQ_CH4SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH4SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH4SWREQ_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ                            (0x1UL << 5)                         /**< Channel 5 Software Request */
+#define _DMA_CHSWREQ_CH5SWREQ_SHIFT                     5                                    /**< Shift value for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_MASK                      0x20UL                               /**< Bit mask for DMA_CH5SWREQ */
+#define _DMA_CHSWREQ_CH5SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH5SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH5SWREQ_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ                            (0x1UL << 6)                         /**< Channel 6 Software Request */
+#define _DMA_CHSWREQ_CH6SWREQ_SHIFT                     6                                    /**< Shift value for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_MASK                      0x40UL                               /**< Bit mask for DMA_CH6SWREQ */
+#define _DMA_CHSWREQ_CH6SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH6SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH6SWREQ_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ                            (0x1UL << 7)                         /**< Channel 7 Software Request */
+#define _DMA_CHSWREQ_CH7SWREQ_SHIFT                     7                                    /**< Shift value for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_MASK                      0x80UL                               /**< Bit mask for DMA_CH7SWREQ */
+#define _DMA_CHSWREQ_CH7SWREQ_DEFAULT                   0x00000000UL                         /**< Mode DEFAULT for DMA_CHSWREQ */
+#define DMA_CHSWREQ_CH7SWREQ_DEFAULT                    (_DMA_CHSWREQ_CH7SWREQ_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSWREQ */
+
+/* Bit fields for DMA CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_RESETVALUE                     0x00000000UL                                        /**< Default value for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_MASK                           0x000000FFUL                                        /**< Mask for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS                    (0x1UL << 0)                                        /**< Channel 0 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SHIFT             0                                                   /**< Shift value for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_MASK              0x1UL                                               /**< Bit mask for DMA_CH0USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST    0x00000000UL                                        /**< Mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define _DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY         0x00000001UL                                        /**< Mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH0USEBURSTS_DEFAULT << 0)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST     (_DMA_CHUSEBURSTS_CH0USEBURSTS_SINGLEANDBURST << 0) /**< Shifted mode SINGLEANDBURST for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY          (_DMA_CHUSEBURSTS_CH0USEBURSTS_BURSTONLY << 0)      /**< Shifted mode BURSTONLY for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS                    (0x1UL << 1)                                        /**< Channel 1 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_SHIFT             1                                                   /**< Shift value for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_MASK              0x2UL                                               /**< Bit mask for DMA_CH1USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH1USEBURSTS_DEFAULT << 1)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS                    (0x1UL << 2)                                        /**< Channel 2 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_SHIFT             2                                                   /**< Shift value for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_MASK              0x4UL                                               /**< Bit mask for DMA_CH2USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH2USEBURSTS_DEFAULT << 2)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS                    (0x1UL << 3)                                        /**< Channel 3 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_SHIFT             3                                                   /**< Shift value for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_MASK              0x8UL                                               /**< Bit mask for DMA_CH3USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH3USEBURSTS_DEFAULT << 3)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS                    (0x1UL << 4)                                        /**< Channel 4 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_SHIFT             4                                                   /**< Shift value for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_MASK              0x10UL                                              /**< Bit mask for DMA_CH4USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH4USEBURSTS_DEFAULT << 4)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS                    (0x1UL << 5)                                        /**< Channel 5 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_SHIFT             5                                                   /**< Shift value for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_MASK              0x20UL                                              /**< Bit mask for DMA_CH5USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH5USEBURSTS_DEFAULT << 5)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS                    (0x1UL << 6)                                        /**< Channel 6 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_SHIFT             6                                                   /**< Shift value for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_MASK              0x40UL                                              /**< Bit mask for DMA_CH6USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH6USEBURSTS_DEFAULT << 6)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS                    (0x1UL << 7)                                        /**< Channel 7 Useburst Set */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_SHIFT             7                                                   /**< Shift value for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_MASK              0x80UL                                              /**< Bit mask for DMA_CH7USEBURSTS */
+#define _DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT           0x00000000UL                                        /**< Mode DEFAULT for DMA_CHUSEBURSTS */
+#define DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT            (_DMA_CHUSEBURSTS_CH7USEBURSTS_DEFAULT << 7)        /**< Shifted mode DEFAULT for DMA_CHUSEBURSTS */
+
+/* Bit fields for DMA CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHUSEBURSTC */
+#define _DMA_CHUSEBURSTC_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC                    (0x1UL << 0)                                 /**< Channel 0 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_SHIFT             0                                            /**< Shift value for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_MASK              0x1UL                                        /**< Bit mask for DMA_CH0USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH0USEBURSTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC                    (0x1UL << 1)                                 /**< Channel 1 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_SHIFT             1                                            /**< Shift value for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_MASK              0x2UL                                        /**< Bit mask for DMA_CH1USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH1USEBURSTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC                    (0x1UL << 2)                                 /**< Channel 2 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_SHIFT             2                                            /**< Shift value for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_MASK              0x4UL                                        /**< Bit mask for DMA_CH2USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH2USEBURSTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC                    (0x1UL << 3)                                 /**< Channel 3 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_SHIFT             3                                            /**< Shift value for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_MASK              0x8UL                                        /**< Bit mask for DMA_CH3USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH3USEBURSTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC                    (0x1UL << 4)                                 /**< Channel 4 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_SHIFT             4                                            /**< Shift value for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_MASK              0x10UL                                       /**< Bit mask for DMA_CH4USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH4USEBURSTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC                    (0x1UL << 5)                                 /**< Channel 5 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_SHIFT             5                                            /**< Shift value for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_MASK              0x20UL                                       /**< Bit mask for DMA_CH5USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH5USEBURSTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC                    (0x1UL << 6)                                 /**< Channel 6 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_SHIFT             6                                            /**< Shift value for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_MASK              0x40UL                                       /**< Bit mask for DMA_CH6USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH6USEBURSTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC                    (0x1UL << 7)                                 /**< Channel 7 Useburst Clear */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_SHIFT             7                                            /**< Shift value for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_MASK              0x80UL                                       /**< Bit mask for DMA_CH7USEBURSTC */
+#define _DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHUSEBURSTC */
+#define DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT            (_DMA_CHUSEBURSTC_CH7USEBURSTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHUSEBURSTC */
+
+/* Bit fields for DMA CHREQMASKS */
+#define _DMA_CHREQMASKS_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKS */
+#define _DMA_CHREQMASKS_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS                      (0x1UL << 0)                               /**< Channel 0 Request Mask Set */
+#define _DMA_CHREQMASKS_CH0REQMASKS_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKS */
+#define _DMA_CHREQMASKS_CH0REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH0REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH0REQMASKS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS                      (0x1UL << 1)                               /**< Channel 1 Request Mask Set */
+#define _DMA_CHREQMASKS_CH1REQMASKS_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKS */
+#define _DMA_CHREQMASKS_CH1REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH1REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH1REQMASKS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS                      (0x1UL << 2)                               /**< Channel 2 Request Mask Set */
+#define _DMA_CHREQMASKS_CH2REQMASKS_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKS */
+#define _DMA_CHREQMASKS_CH2REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH2REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH2REQMASKS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS                      (0x1UL << 3)                               /**< Channel 3 Request Mask Set */
+#define _DMA_CHREQMASKS_CH3REQMASKS_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKS */
+#define _DMA_CHREQMASKS_CH3REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH3REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH3REQMASKS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS                      (0x1UL << 4)                               /**< Channel 4 Request Mask Set */
+#define _DMA_CHREQMASKS_CH4REQMASKS_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKS */
+#define _DMA_CHREQMASKS_CH4REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH4REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH4REQMASKS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS                      (0x1UL << 5)                               /**< Channel 5 Request Mask Set */
+#define _DMA_CHREQMASKS_CH5REQMASKS_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKS */
+#define _DMA_CHREQMASKS_CH5REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH5REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH5REQMASKS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS                      (0x1UL << 6)                               /**< Channel 6 Request Mask Set */
+#define _DMA_CHREQMASKS_CH6REQMASKS_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKS */
+#define _DMA_CHREQMASKS_CH6REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH6REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH6REQMASKS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS                      (0x1UL << 7)                               /**< Channel 7 Request Mask Set */
+#define _DMA_CHREQMASKS_CH7REQMASKS_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKS */
+#define _DMA_CHREQMASKS_CH7REQMASKS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKS */
+#define DMA_CHREQMASKS_CH7REQMASKS_DEFAULT              (_DMA_CHREQMASKS_CH7REQMASKS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKS */
+
+/* Bit fields for DMA CHREQMASKC */
+#define _DMA_CHREQMASKC_RESETVALUE                      0x00000000UL                               /**< Default value for DMA_CHREQMASKC */
+#define _DMA_CHREQMASKC_MASK                            0x000000FFUL                               /**< Mask for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC                      (0x1UL << 0)                               /**< Channel 0 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH0REQMASKC_SHIFT               0                                          /**< Shift value for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_MASK                0x1UL                                      /**< Bit mask for DMA_CH0REQMASKC */
+#define _DMA_CHREQMASKC_CH0REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH0REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH0REQMASKC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC                      (0x1UL << 1)                               /**< Channel 1 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH1REQMASKC_SHIFT               1                                          /**< Shift value for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_MASK                0x2UL                                      /**< Bit mask for DMA_CH1REQMASKC */
+#define _DMA_CHREQMASKC_CH1REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH1REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH1REQMASKC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC                      (0x1UL << 2)                               /**< Channel 2 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH2REQMASKC_SHIFT               2                                          /**< Shift value for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_MASK                0x4UL                                      /**< Bit mask for DMA_CH2REQMASKC */
+#define _DMA_CHREQMASKC_CH2REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH2REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH2REQMASKC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC                      (0x1UL << 3)                               /**< Channel 3 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH3REQMASKC_SHIFT               3                                          /**< Shift value for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_MASK                0x8UL                                      /**< Bit mask for DMA_CH3REQMASKC */
+#define _DMA_CHREQMASKC_CH3REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH3REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH3REQMASKC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC                      (0x1UL << 4)                               /**< Channel 4 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH4REQMASKC_SHIFT               4                                          /**< Shift value for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_MASK                0x10UL                                     /**< Bit mask for DMA_CH4REQMASKC */
+#define _DMA_CHREQMASKC_CH4REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH4REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH4REQMASKC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC                      (0x1UL << 5)                               /**< Channel 5 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH5REQMASKC_SHIFT               5                                          /**< Shift value for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_MASK                0x20UL                                     /**< Bit mask for DMA_CH5REQMASKC */
+#define _DMA_CHREQMASKC_CH5REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH5REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH5REQMASKC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC                      (0x1UL << 6)                               /**< Channel 6 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH6REQMASKC_SHIFT               6                                          /**< Shift value for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_MASK                0x40UL                                     /**< Bit mask for DMA_CH6REQMASKC */
+#define _DMA_CHREQMASKC_CH6REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH6REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH6REQMASKC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC                      (0x1UL << 7)                               /**< Channel 7 Request Mask Clear */
+#define _DMA_CHREQMASKC_CH7REQMASKC_SHIFT               7                                          /**< Shift value for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_MASK                0x80UL                                     /**< Bit mask for DMA_CH7REQMASKC */
+#define _DMA_CHREQMASKC_CH7REQMASKC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for DMA_CHREQMASKC */
+#define DMA_CHREQMASKC_CH7REQMASKC_DEFAULT              (_DMA_CHREQMASKC_CH7REQMASKC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQMASKC */
+
+/* Bit fields for DMA CHENS */
+#define _DMA_CHENS_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENS */
+#define _DMA_CHENS_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENS */
+#define DMA_CHENS_CH0ENS                                (0x1UL << 0)                     /**< Channel 0 Enable Set */
+#define _DMA_CHENS_CH0ENS_SHIFT                         0                                /**< Shift value for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENS */
+#define _DMA_CHENS_CH0ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH0ENS_DEFAULT                        (_DMA_CHENS_CH0ENS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS                                (0x1UL << 1)                     /**< Channel 1 Enable Set */
+#define _DMA_CHENS_CH1ENS_SHIFT                         1                                /**< Shift value for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENS */
+#define _DMA_CHENS_CH1ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH1ENS_DEFAULT                        (_DMA_CHENS_CH1ENS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS                                (0x1UL << 2)                     /**< Channel 2 Enable Set */
+#define _DMA_CHENS_CH2ENS_SHIFT                         2                                /**< Shift value for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENS */
+#define _DMA_CHENS_CH2ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH2ENS_DEFAULT                        (_DMA_CHENS_CH2ENS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS                                (0x1UL << 3)                     /**< Channel 3 Enable Set */
+#define _DMA_CHENS_CH3ENS_SHIFT                         3                                /**< Shift value for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENS */
+#define _DMA_CHENS_CH3ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH3ENS_DEFAULT                        (_DMA_CHENS_CH3ENS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS                                (0x1UL << 4)                     /**< Channel 4 Enable Set */
+#define _DMA_CHENS_CH4ENS_SHIFT                         4                                /**< Shift value for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENS */
+#define _DMA_CHENS_CH4ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH4ENS_DEFAULT                        (_DMA_CHENS_CH4ENS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS                                (0x1UL << 5)                     /**< Channel 5 Enable Set */
+#define _DMA_CHENS_CH5ENS_SHIFT                         5                                /**< Shift value for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENS */
+#define _DMA_CHENS_CH5ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH5ENS_DEFAULT                        (_DMA_CHENS_CH5ENS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS                                (0x1UL << 6)                     /**< Channel 6 Enable Set */
+#define _DMA_CHENS_CH6ENS_SHIFT                         6                                /**< Shift value for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENS */
+#define _DMA_CHENS_CH6ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH6ENS_DEFAULT                        (_DMA_CHENS_CH6ENS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS                                (0x1UL << 7)                     /**< Channel 7 Enable Set */
+#define _DMA_CHENS_CH7ENS_SHIFT                         7                                /**< Shift value for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENS */
+#define _DMA_CHENS_CH7ENS_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENS */
+#define DMA_CHENS_CH7ENS_DEFAULT                        (_DMA_CHENS_CH7ENS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENS */
+
+/* Bit fields for DMA CHENC */
+#define _DMA_CHENC_RESETVALUE                           0x00000000UL                     /**< Default value for DMA_CHENC */
+#define _DMA_CHENC_MASK                                 0x000000FFUL                     /**< Mask for DMA_CHENC */
+#define DMA_CHENC_CH0ENC                                (0x1UL << 0)                     /**< Channel 0 Enable Clear */
+#define _DMA_CHENC_CH0ENC_SHIFT                         0                                /**< Shift value for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_MASK                          0x1UL                            /**< Bit mask for DMA_CH0ENC */
+#define _DMA_CHENC_CH0ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH0ENC_DEFAULT                        (_DMA_CHENC_CH0ENC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC                                (0x1UL << 1)                     /**< Channel 1 Enable Clear */
+#define _DMA_CHENC_CH1ENC_SHIFT                         1                                /**< Shift value for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_MASK                          0x2UL                            /**< Bit mask for DMA_CH1ENC */
+#define _DMA_CHENC_CH1ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH1ENC_DEFAULT                        (_DMA_CHENC_CH1ENC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC                                (0x1UL << 2)                     /**< Channel 2 Enable Clear */
+#define _DMA_CHENC_CH2ENC_SHIFT                         2                                /**< Shift value for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_MASK                          0x4UL                            /**< Bit mask for DMA_CH2ENC */
+#define _DMA_CHENC_CH2ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH2ENC_DEFAULT                        (_DMA_CHENC_CH2ENC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC                                (0x1UL << 3)                     /**< Channel 3 Enable Clear */
+#define _DMA_CHENC_CH3ENC_SHIFT                         3                                /**< Shift value for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_MASK                          0x8UL                            /**< Bit mask for DMA_CH3ENC */
+#define _DMA_CHENC_CH3ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH3ENC_DEFAULT                        (_DMA_CHENC_CH3ENC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC                                (0x1UL << 4)                     /**< Channel 4 Enable Clear */
+#define _DMA_CHENC_CH4ENC_SHIFT                         4                                /**< Shift value for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_MASK                          0x10UL                           /**< Bit mask for DMA_CH4ENC */
+#define _DMA_CHENC_CH4ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH4ENC_DEFAULT                        (_DMA_CHENC_CH4ENC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC                                (0x1UL << 5)                     /**< Channel 5 Enable Clear */
+#define _DMA_CHENC_CH5ENC_SHIFT                         5                                /**< Shift value for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_MASK                          0x20UL                           /**< Bit mask for DMA_CH5ENC */
+#define _DMA_CHENC_CH5ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH5ENC_DEFAULT                        (_DMA_CHENC_CH5ENC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC                                (0x1UL << 6)                     /**< Channel 6 Enable Clear */
+#define _DMA_CHENC_CH6ENC_SHIFT                         6                                /**< Shift value for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_MASK                          0x40UL                           /**< Bit mask for DMA_CH6ENC */
+#define _DMA_CHENC_CH6ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH6ENC_DEFAULT                        (_DMA_CHENC_CH6ENC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC                                (0x1UL << 7)                     /**< Channel 7 Enable Clear */
+#define _DMA_CHENC_CH7ENC_SHIFT                         7                                /**< Shift value for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_MASK                          0x80UL                           /**< Bit mask for DMA_CH7ENC */
+#define _DMA_CHENC_CH7ENC_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for DMA_CHENC */
+#define DMA_CHENC_CH7ENC_DEFAULT                        (_DMA_CHENC_CH7ENC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHENC */
+
+/* Bit fields for DMA CHALTS */
+#define _DMA_CHALTS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTS */
+#define _DMA_CHALTS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS                              (0x1UL << 0)                       /**< Channel 0 Alternate Structure Set */
+#define _DMA_CHALTS_CH0ALTS_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTS */
+#define _DMA_CHALTS_CH0ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH0ALTS_DEFAULT                      (_DMA_CHALTS_CH0ALTS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS                              (0x1UL << 1)                       /**< Channel 1 Alternate Structure Set */
+#define _DMA_CHALTS_CH1ALTS_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTS */
+#define _DMA_CHALTS_CH1ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH1ALTS_DEFAULT                      (_DMA_CHALTS_CH1ALTS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS                              (0x1UL << 2)                       /**< Channel 2 Alternate Structure Set */
+#define _DMA_CHALTS_CH2ALTS_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTS */
+#define _DMA_CHALTS_CH2ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH2ALTS_DEFAULT                      (_DMA_CHALTS_CH2ALTS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS                              (0x1UL << 3)                       /**< Channel 3 Alternate Structure Set */
+#define _DMA_CHALTS_CH3ALTS_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTS */
+#define _DMA_CHALTS_CH3ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH3ALTS_DEFAULT                      (_DMA_CHALTS_CH3ALTS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS                              (0x1UL << 4)                       /**< Channel 4 Alternate Structure Set */
+#define _DMA_CHALTS_CH4ALTS_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTS */
+#define _DMA_CHALTS_CH4ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH4ALTS_DEFAULT                      (_DMA_CHALTS_CH4ALTS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS                              (0x1UL << 5)                       /**< Channel 5 Alternate Structure Set */
+#define _DMA_CHALTS_CH5ALTS_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTS */
+#define _DMA_CHALTS_CH5ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH5ALTS_DEFAULT                      (_DMA_CHALTS_CH5ALTS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS                              (0x1UL << 6)                       /**< Channel 6 Alternate Structure Set */
+#define _DMA_CHALTS_CH6ALTS_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTS */
+#define _DMA_CHALTS_CH6ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH6ALTS_DEFAULT                      (_DMA_CHALTS_CH6ALTS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS                              (0x1UL << 7)                       /**< Channel 7 Alternate Structure Set */
+#define _DMA_CHALTS_CH7ALTS_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTS */
+#define _DMA_CHALTS_CH7ALTS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTS */
+#define DMA_CHALTS_CH7ALTS_DEFAULT                      (_DMA_CHALTS_CH7ALTS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTS */
+
+/* Bit fields for DMA CHALTC */
+#define _DMA_CHALTC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHALTC */
+#define _DMA_CHALTC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC                              (0x1UL << 0)                       /**< Channel 0 Alternate Clear */
+#define _DMA_CHALTC_CH0ALTC_SHIFT                       0                                  /**< Shift value for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0ALTC */
+#define _DMA_CHALTC_CH0ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH0ALTC_DEFAULT                      (_DMA_CHALTC_CH0ALTC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC                              (0x1UL << 1)                       /**< Channel 1 Alternate Clear */
+#define _DMA_CHALTC_CH1ALTC_SHIFT                       1                                  /**< Shift value for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1ALTC */
+#define _DMA_CHALTC_CH1ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH1ALTC_DEFAULT                      (_DMA_CHALTC_CH1ALTC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC                              (0x1UL << 2)                       /**< Channel 2 Alternate Clear */
+#define _DMA_CHALTC_CH2ALTC_SHIFT                       2                                  /**< Shift value for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2ALTC */
+#define _DMA_CHALTC_CH2ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH2ALTC_DEFAULT                      (_DMA_CHALTC_CH2ALTC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC                              (0x1UL << 3)                       /**< Channel 3 Alternate Clear */
+#define _DMA_CHALTC_CH3ALTC_SHIFT                       3                                  /**< Shift value for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3ALTC */
+#define _DMA_CHALTC_CH3ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH3ALTC_DEFAULT                      (_DMA_CHALTC_CH3ALTC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC                              (0x1UL << 4)                       /**< Channel 4 Alternate Clear */
+#define _DMA_CHALTC_CH4ALTC_SHIFT                       4                                  /**< Shift value for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4ALTC */
+#define _DMA_CHALTC_CH4ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH4ALTC_DEFAULT                      (_DMA_CHALTC_CH4ALTC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC                              (0x1UL << 5)                       /**< Channel 5 Alternate Clear */
+#define _DMA_CHALTC_CH5ALTC_SHIFT                       5                                  /**< Shift value for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5ALTC */
+#define _DMA_CHALTC_CH5ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH5ALTC_DEFAULT                      (_DMA_CHALTC_CH5ALTC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC                              (0x1UL << 6)                       /**< Channel 6 Alternate Clear */
+#define _DMA_CHALTC_CH6ALTC_SHIFT                       6                                  /**< Shift value for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6ALTC */
+#define _DMA_CHALTC_CH6ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH6ALTC_DEFAULT                      (_DMA_CHALTC_CH6ALTC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC                              (0x1UL << 7)                       /**< Channel 7 Alternate Clear */
+#define _DMA_CHALTC_CH7ALTC_SHIFT                       7                                  /**< Shift value for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7ALTC */
+#define _DMA_CHALTC_CH7ALTC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHALTC */
+#define DMA_CHALTC_CH7ALTC_DEFAULT                      (_DMA_CHALTC_CH7ALTC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHALTC */
+
+/* Bit fields for DMA CHPRIS */
+#define _DMA_CHPRIS_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIS */
+#define _DMA_CHPRIS_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS                              (0x1UL << 0)                       /**< Channel 0 High Priority Set */
+#define _DMA_CHPRIS_CH0PRIS_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIS */
+#define _DMA_CHPRIS_CH0PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH0PRIS_DEFAULT                      (_DMA_CHPRIS_CH0PRIS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS                              (0x1UL << 1)                       /**< Channel 1 High Priority Set */
+#define _DMA_CHPRIS_CH1PRIS_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIS */
+#define _DMA_CHPRIS_CH1PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH1PRIS_DEFAULT                      (_DMA_CHPRIS_CH1PRIS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS                              (0x1UL << 2)                       /**< Channel 2 High Priority Set */
+#define _DMA_CHPRIS_CH2PRIS_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIS */
+#define _DMA_CHPRIS_CH2PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH2PRIS_DEFAULT                      (_DMA_CHPRIS_CH2PRIS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS                              (0x1UL << 3)                       /**< Channel 3 High Priority Set */
+#define _DMA_CHPRIS_CH3PRIS_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIS */
+#define _DMA_CHPRIS_CH3PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH3PRIS_DEFAULT                      (_DMA_CHPRIS_CH3PRIS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS                              (0x1UL << 4)                       /**< Channel 4 High Priority Set */
+#define _DMA_CHPRIS_CH4PRIS_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIS */
+#define _DMA_CHPRIS_CH4PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH4PRIS_DEFAULT                      (_DMA_CHPRIS_CH4PRIS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS                              (0x1UL << 5)                       /**< Channel 5 High Priority Set */
+#define _DMA_CHPRIS_CH5PRIS_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIS */
+#define _DMA_CHPRIS_CH5PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH5PRIS_DEFAULT                      (_DMA_CHPRIS_CH5PRIS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS                              (0x1UL << 6)                       /**< Channel 6 High Priority Set */
+#define _DMA_CHPRIS_CH6PRIS_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIS */
+#define _DMA_CHPRIS_CH6PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH6PRIS_DEFAULT                      (_DMA_CHPRIS_CH6PRIS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS                              (0x1UL << 7)                       /**< Channel 7 High Priority Set */
+#define _DMA_CHPRIS_CH7PRIS_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIS */
+#define _DMA_CHPRIS_CH7PRIS_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIS */
+#define DMA_CHPRIS_CH7PRIS_DEFAULT                      (_DMA_CHPRIS_CH7PRIS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIS */
+
+/* Bit fields for DMA CHPRIC */
+#define _DMA_CHPRIC_RESETVALUE                          0x00000000UL                       /**< Default value for DMA_CHPRIC */
+#define _DMA_CHPRIC_MASK                                0x000000FFUL                       /**< Mask for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC                              (0x1UL << 0)                       /**< Channel 0 High Priority Clear */
+#define _DMA_CHPRIC_CH0PRIC_SHIFT                       0                                  /**< Shift value for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_MASK                        0x1UL                              /**< Bit mask for DMA_CH0PRIC */
+#define _DMA_CHPRIC_CH0PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH0PRIC_DEFAULT                      (_DMA_CHPRIC_CH0PRIC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC                              (0x1UL << 1)                       /**< Channel 1 High Priority Clear */
+#define _DMA_CHPRIC_CH1PRIC_SHIFT                       1                                  /**< Shift value for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_MASK                        0x2UL                              /**< Bit mask for DMA_CH1PRIC */
+#define _DMA_CHPRIC_CH1PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH1PRIC_DEFAULT                      (_DMA_CHPRIC_CH1PRIC_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC                              (0x1UL << 2)                       /**< Channel 2 High Priority Clear */
+#define _DMA_CHPRIC_CH2PRIC_SHIFT                       2                                  /**< Shift value for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_MASK                        0x4UL                              /**< Bit mask for DMA_CH2PRIC */
+#define _DMA_CHPRIC_CH2PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH2PRIC_DEFAULT                      (_DMA_CHPRIC_CH2PRIC_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC                              (0x1UL << 3)                       /**< Channel 3 High Priority Clear */
+#define _DMA_CHPRIC_CH3PRIC_SHIFT                       3                                  /**< Shift value for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_MASK                        0x8UL                              /**< Bit mask for DMA_CH3PRIC */
+#define _DMA_CHPRIC_CH3PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH3PRIC_DEFAULT                      (_DMA_CHPRIC_CH3PRIC_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC                              (0x1UL << 4)                       /**< Channel 4 High Priority Clear */
+#define _DMA_CHPRIC_CH4PRIC_SHIFT                       4                                  /**< Shift value for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_MASK                        0x10UL                             /**< Bit mask for DMA_CH4PRIC */
+#define _DMA_CHPRIC_CH4PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH4PRIC_DEFAULT                      (_DMA_CHPRIC_CH4PRIC_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC                              (0x1UL << 5)                       /**< Channel 5 High Priority Clear */
+#define _DMA_CHPRIC_CH5PRIC_SHIFT                       5                                  /**< Shift value for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_MASK                        0x20UL                             /**< Bit mask for DMA_CH5PRIC */
+#define _DMA_CHPRIC_CH5PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH5PRIC_DEFAULT                      (_DMA_CHPRIC_CH5PRIC_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC                              (0x1UL << 6)                       /**< Channel 6 High Priority Clear */
+#define _DMA_CHPRIC_CH6PRIC_SHIFT                       6                                  /**< Shift value for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_MASK                        0x40UL                             /**< Bit mask for DMA_CH6PRIC */
+#define _DMA_CHPRIC_CH6PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH6PRIC_DEFAULT                      (_DMA_CHPRIC_CH6PRIC_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC                              (0x1UL << 7)                       /**< Channel 7 High Priority Clear */
+#define _DMA_CHPRIC_CH7PRIC_SHIFT                       7                                  /**< Shift value for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_MASK                        0x80UL                             /**< Bit mask for DMA_CH7PRIC */
+#define _DMA_CHPRIC_CH7PRIC_DEFAULT                     0x00000000UL                       /**< Mode DEFAULT for DMA_CHPRIC */
+#define DMA_CHPRIC_CH7PRIC_DEFAULT                      (_DMA_CHPRIC_CH7PRIC_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHPRIC */
+
+/* Bit fields for DMA ERRORC */
+#define _DMA_ERRORC_RESETVALUE                          0x00000000UL                      /**< Default value for DMA_ERRORC */
+#define _DMA_ERRORC_MASK                                0x00000001UL                      /**< Mask for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC                               (0x1UL << 0)                      /**< Bus Error Clear */
+#define _DMA_ERRORC_ERRORC_SHIFT                        0                                 /**< Shift value for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_MASK                         0x1UL                             /**< Bit mask for DMA_ERRORC */
+#define _DMA_ERRORC_ERRORC_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for DMA_ERRORC */
+#define DMA_ERRORC_ERRORC_DEFAULT                       (_DMA_ERRORC_ERRORC_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_ERRORC */
+
+/* Bit fields for DMA CHREQSTATUS */
+#define _DMA_CHREQSTATUS_RESETVALUE                     0x00000000UL                                 /**< Default value for DMA_CHREQSTATUS */
+#define _DMA_CHREQSTATUS_MASK                           0x000000FFUL                                 /**< Mask for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS                    (0x1UL << 0)                                 /**< Channel 0 Request Status */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_SHIFT             0                                            /**< Shift value for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_MASK              0x1UL                                        /**< Bit mask for DMA_CH0REQSTATUS */
+#define _DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH0REQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS                    (0x1UL << 1)                                 /**< Channel 1 Request Status */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_SHIFT             1                                            /**< Shift value for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_MASK              0x2UL                                        /**< Bit mask for DMA_CH1REQSTATUS */
+#define _DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH1REQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS                    (0x1UL << 2)                                 /**< Channel 2 Request Status */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_SHIFT             2                                            /**< Shift value for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_MASK              0x4UL                                        /**< Bit mask for DMA_CH2REQSTATUS */
+#define _DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH2REQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS                    (0x1UL << 3)                                 /**< Channel 3 Request Status */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_SHIFT             3                                            /**< Shift value for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_MASK              0x8UL                                        /**< Bit mask for DMA_CH3REQSTATUS */
+#define _DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH3REQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS                    (0x1UL << 4)                                 /**< Channel 4 Request Status */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_SHIFT             4                                            /**< Shift value for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_MASK              0x10UL                                       /**< Bit mask for DMA_CH4REQSTATUS */
+#define _DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH4REQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS                    (0x1UL << 5)                                 /**< Channel 5 Request Status */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_SHIFT             5                                            /**< Shift value for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_MASK              0x20UL                                       /**< Bit mask for DMA_CH5REQSTATUS */
+#define _DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH5REQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS                    (0x1UL << 6)                                 /**< Channel 6 Request Status */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_SHIFT             6                                            /**< Shift value for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_MASK              0x40UL                                       /**< Bit mask for DMA_CH6REQSTATUS */
+#define _DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH6REQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS                    (0x1UL << 7)                                 /**< Channel 7 Request Status */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_SHIFT             7                                            /**< Shift value for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_MASK              0x80UL                                       /**< Bit mask for DMA_CH7REQSTATUS */
+#define _DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for DMA_CHREQSTATUS */
+#define DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT            (_DMA_CHREQSTATUS_CH7REQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHREQSTATUS */
+
+/* Bit fields for DMA CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_RESETVALUE                    0x00000000UL                                   /**< Default value for DMA_CHSREQSTATUS */
+#define _DMA_CHSREQSTATUS_MASK                          0x000000FFUL                                   /**< Mask for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS                  (0x1UL << 0)                                   /**< Channel 0 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_SHIFT           0                                              /**< Shift value for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_MASK            0x1UL                                          /**< Bit mask for DMA_CH0SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH0SREQSTATUS_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS                  (0x1UL << 1)                                   /**< Channel 1 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_SHIFT           1                                              /**< Shift value for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_MASK            0x2UL                                          /**< Bit mask for DMA_CH1SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH1SREQSTATUS_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS                  (0x1UL << 2)                                   /**< Channel 2 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_SHIFT           2                                              /**< Shift value for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_MASK            0x4UL                                          /**< Bit mask for DMA_CH2SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH2SREQSTATUS_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS                  (0x1UL << 3)                                   /**< Channel 3 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_SHIFT           3                                              /**< Shift value for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_MASK            0x8UL                                          /**< Bit mask for DMA_CH3SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH3SREQSTATUS_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS                  (0x1UL << 4)                                   /**< Channel 4 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_SHIFT           4                                              /**< Shift value for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_MASK            0x10UL                                         /**< Bit mask for DMA_CH4SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH4SREQSTATUS_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS                  (0x1UL << 5)                                   /**< Channel 5 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_SHIFT           5                                              /**< Shift value for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_MASK            0x20UL                                         /**< Bit mask for DMA_CH5SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH5SREQSTATUS_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS                  (0x1UL << 6)                                   /**< Channel 6 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_SHIFT           6                                              /**< Shift value for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_MASK            0x40UL                                         /**< Bit mask for DMA_CH6SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH6SREQSTATUS_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS                  (0x1UL << 7)                                   /**< Channel 7 Single Request Status */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_SHIFT           7                                              /**< Shift value for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_MASK            0x80UL                                         /**< Bit mask for DMA_CH7SREQSTATUS */
+#define _DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT         0x00000000UL                                   /**< Mode DEFAULT for DMA_CHSREQSTATUS */
+#define DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT          (_DMA_CHSREQSTATUS_CH7SREQSTATUS_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_CHSREQSTATUS */
+
+/* Bit fields for DMA IF */
+#define _DMA_IF_RESETVALUE                              0x00000000UL                   /**< Default value for DMA_IF */
+#define _DMA_IF_MASK                                    0x800000FFUL                   /**< Mask for DMA_IF */
+#define DMA_IF_CH0DONE                                  (0x1UL << 0)                   /**< DMA Channel 0 Complete Interrupt Flag */
+#define _DMA_IF_CH0DONE_SHIFT                           0                              /**< Shift value for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_MASK                            0x1UL                          /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IF_CH0DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH0DONE_DEFAULT                          (_DMA_IF_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE                                  (0x1UL << 1)                   /**< DMA Channel 1 Complete Interrupt Flag */
+#define _DMA_IF_CH1DONE_SHIFT                           1                              /**< Shift value for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_MASK                            0x2UL                          /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IF_CH1DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH1DONE_DEFAULT                          (_DMA_IF_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE                                  (0x1UL << 2)                   /**< DMA Channel 2 Complete Interrupt Flag */
+#define _DMA_IF_CH2DONE_SHIFT                           2                              /**< Shift value for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_MASK                            0x4UL                          /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IF_CH2DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH2DONE_DEFAULT                          (_DMA_IF_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE                                  (0x1UL << 3)                   /**< DMA Channel 3 Complete Interrupt Flag */
+#define _DMA_IF_CH3DONE_SHIFT                           3                              /**< Shift value for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_MASK                            0x8UL                          /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IF_CH3DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH3DONE_DEFAULT                          (_DMA_IF_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE                                  (0x1UL << 4)                   /**< DMA Channel 4 Complete Interrupt Flag */
+#define _DMA_IF_CH4DONE_SHIFT                           4                              /**< Shift value for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_MASK                            0x10UL                         /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IF_CH4DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH4DONE_DEFAULT                          (_DMA_IF_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE                                  (0x1UL << 5)                   /**< DMA Channel 5 Complete Interrupt Flag */
+#define _DMA_IF_CH5DONE_SHIFT                           5                              /**< Shift value for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_MASK                            0x20UL                         /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IF_CH5DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH5DONE_DEFAULT                          (_DMA_IF_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE                                  (0x1UL << 6)                   /**< DMA Channel 6 Complete Interrupt Flag */
+#define _DMA_IF_CH6DONE_SHIFT                           6                              /**< Shift value for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_MASK                            0x40UL                         /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IF_CH6DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH6DONE_DEFAULT                          (_DMA_IF_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE                                  (0x1UL << 7)                   /**< DMA Channel 7 Complete Interrupt Flag */
+#define _DMA_IF_CH7DONE_SHIFT                           7                              /**< Shift value for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_MASK                            0x80UL                         /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IF_CH7DONE_DEFAULT                         0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_CH7DONE_DEFAULT                          (_DMA_IF_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR                                      (0x1UL << 31)                  /**< DMA Error Interrupt Flag */
+#define _DMA_IF_ERR_SHIFT                               31                             /**< Shift value for DMA_ERR */
+#define _DMA_IF_ERR_MASK                                0x80000000UL                   /**< Bit mask for DMA_ERR */
+#define _DMA_IF_ERR_DEFAULT                             0x00000000UL                   /**< Mode DEFAULT for DMA_IF */
+#define DMA_IF_ERR_DEFAULT                              (_DMA_IF_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IF */
+
+/* Bit fields for DMA IFS */
+#define _DMA_IFS_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFS */
+#define _DMA_IFS_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFS */
+#define DMA_IFS_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFS_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH0DONE_DEFAULT                         (_DMA_IFS_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFS_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH1DONE_DEFAULT                         (_DMA_IFS_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFS_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH2DONE_DEFAULT                         (_DMA_IFS_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFS_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH3DONE_DEFAULT                         (_DMA_IFS_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFS_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH4DONE_DEFAULT                         (_DMA_IFS_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFS_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH5DONE_DEFAULT                         (_DMA_IFS_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFS_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH6DONE_DEFAULT                         (_DMA_IFS_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Set */
+#define _DMA_IFS_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFS_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_CH7DONE_DEFAULT                         (_DMA_IFS_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Set */
+#define _DMA_IFS_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFS_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFS_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFS */
+#define DMA_IFS_ERR_DEFAULT                             (_DMA_IFS_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFS */
+
+/* Bit fields for DMA IFC */
+#define _DMA_IFC_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IFC */
+#define _DMA_IFC_MASK                                   0x800000FFUL                    /**< Mask for DMA_IFC */
+#define DMA_IFC_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IFC_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH0DONE_DEFAULT                         (_DMA_IFC_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IFC_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH1DONE_DEFAULT                         (_DMA_IFC_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IFC_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH2DONE_DEFAULT                         (_DMA_IFC_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IFC_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH3DONE_DEFAULT                         (_DMA_IFC_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IFC_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH4DONE_DEFAULT                         (_DMA_IFC_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IFC_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH5DONE_DEFAULT                         (_DMA_IFC_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IFC_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH6DONE_DEFAULT                         (_DMA_IFC_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Flag Clear */
+#define _DMA_IFC_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IFC_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_CH7DONE_DEFAULT                         (_DMA_IFC_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Clear */
+#define _DMA_IFC_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IFC_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IFC_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IFC */
+#define DMA_IFC_ERR_DEFAULT                             (_DMA_IFC_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IFC */
+
+/* Bit fields for DMA IEN */
+#define _DMA_IEN_RESETVALUE                             0x00000000UL                    /**< Default value for DMA_IEN */
+#define _DMA_IEN_MASK                                   0x800000FFUL                    /**< Mask for DMA_IEN */
+#define DMA_IEN_CH0DONE                                 (0x1UL << 0)                    /**< DMA Channel 0 Complete Interrupt Enable */
+#define _DMA_IEN_CH0DONE_SHIFT                          0                               /**< Shift value for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_MASK                           0x1UL                           /**< Bit mask for DMA_CH0DONE */
+#define _DMA_IEN_CH0DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH0DONE_DEFAULT                         (_DMA_IEN_CH0DONE_DEFAULT << 0) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE                                 (0x1UL << 1)                    /**< DMA Channel 1 Complete Interrupt Enable */
+#define _DMA_IEN_CH1DONE_SHIFT                          1                               /**< Shift value for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_MASK                           0x2UL                           /**< Bit mask for DMA_CH1DONE */
+#define _DMA_IEN_CH1DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH1DONE_DEFAULT                         (_DMA_IEN_CH1DONE_DEFAULT << 1) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE                                 (0x1UL << 2)                    /**< DMA Channel 2 Complete Interrupt Enable */
+#define _DMA_IEN_CH2DONE_SHIFT                          2                               /**< Shift value for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_MASK                           0x4UL                           /**< Bit mask for DMA_CH2DONE */
+#define _DMA_IEN_CH2DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH2DONE_DEFAULT                         (_DMA_IEN_CH2DONE_DEFAULT << 2) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE                                 (0x1UL << 3)                    /**< DMA Channel 3 Complete Interrupt Enable */
+#define _DMA_IEN_CH3DONE_SHIFT                          3                               /**< Shift value for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_MASK                           0x8UL                           /**< Bit mask for DMA_CH3DONE */
+#define _DMA_IEN_CH3DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH3DONE_DEFAULT                         (_DMA_IEN_CH3DONE_DEFAULT << 3) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE                                 (0x1UL << 4)                    /**< DMA Channel 4 Complete Interrupt Enable */
+#define _DMA_IEN_CH4DONE_SHIFT                          4                               /**< Shift value for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_MASK                           0x10UL                          /**< Bit mask for DMA_CH4DONE */
+#define _DMA_IEN_CH4DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH4DONE_DEFAULT                         (_DMA_IEN_CH4DONE_DEFAULT << 4) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE                                 (0x1UL << 5)                    /**< DMA Channel 5 Complete Interrupt Enable */
+#define _DMA_IEN_CH5DONE_SHIFT                          5                               /**< Shift value for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_MASK                           0x20UL                          /**< Bit mask for DMA_CH5DONE */
+#define _DMA_IEN_CH5DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH5DONE_DEFAULT                         (_DMA_IEN_CH5DONE_DEFAULT << 5) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE                                 (0x1UL << 6)                    /**< DMA Channel 6 Complete Interrupt Enable */
+#define _DMA_IEN_CH6DONE_SHIFT                          6                               /**< Shift value for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_MASK                           0x40UL                          /**< Bit mask for DMA_CH6DONE */
+#define _DMA_IEN_CH6DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH6DONE_DEFAULT                         (_DMA_IEN_CH6DONE_DEFAULT << 6) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE                                 (0x1UL << 7)                    /**< DMA Channel 7 Complete Interrupt Enable */
+#define _DMA_IEN_CH7DONE_SHIFT                          7                               /**< Shift value for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_MASK                           0x80UL                          /**< Bit mask for DMA_CH7DONE */
+#define _DMA_IEN_CH7DONE_DEFAULT                        0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_CH7DONE_DEFAULT                         (_DMA_IEN_CH7DONE_DEFAULT << 7) /**< Shifted mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR                                     (0x1UL << 31)                   /**< DMA Error Interrupt Flag Enable */
+#define _DMA_IEN_ERR_SHIFT                              31                              /**< Shift value for DMA_ERR */
+#define _DMA_IEN_ERR_MASK                               0x80000000UL                    /**< Bit mask for DMA_ERR */
+#define _DMA_IEN_ERR_DEFAULT                            0x00000000UL                    /**< Mode DEFAULT for DMA_IEN */
+#define DMA_IEN_ERR_DEFAULT                             (_DMA_IEN_ERR_DEFAULT << 31)    /**< Shifted mode DEFAULT for DMA_IEN */
+
+/* Bit fields for DMA CH_CTRL */
+#define _DMA_CH_CTRL_RESETVALUE                         0x00000000UL                                  /**< Default value for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_MASK                               0x003F000FUL                                  /**< Mask for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_SHIFT                       0                                             /**< Shift value for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_MASK                        0xFUL                                         /**< Bit mask for DMA_SIGSEL */
+#define _DMA_CH_CTRL_SIGSEL_ADC0SINGLE                  0x00000000UL                                  /**< Mode ADC0SINGLE for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_DAC0CH0                     0x00000000UL                                  /**< Mode DAC0CH0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART0RXDATAV               0x00000000UL                                  /**< Mode USART0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAV               0x00000000UL                                  /**< Mode USART1RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV              0x00000000UL                                  /**< Mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                 0x00000000UL                                  /**< Mode I2C0RXDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0UFOF                  0x00000000UL                                  /**< Mode TIMER0UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1UFOF                  0x00000000UL                                  /**< Mode TIMER1UFOF for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_MSCWDATA                    0x00000000UL                                  /**< Mode MSCWDATA for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_AESDATAWR                   0x00000000UL                                  /**< Mode AESDATAWR for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV             0x00000000UL                                  /**< Mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_ADC0SCAN                    0x00000001UL                                  /**< Mode ADC0SCAN for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_DAC0CH1                     0x00000001UL                                  /**< Mode DAC0CH1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART0TXBL                  0x00000001UL                                  /**< Mode USART0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBL                  0x00000001UL                                  /**< Mode USART1TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXBL                 0x00000001UL                                  /**< Mode LEUART0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_I2C0TXBL                    0x00000001UL                                  /**< Mode I2C0TXBL for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC0                   0x00000001UL                                  /**< Mode TIMER0CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC0                   0x00000001UL                                  /**< Mode TIMER1CC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_AESXORDATAWR                0x00000001UL                                  /**< Mode AESXORDATAWR for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART0TXEMPTY               0x00000002UL                                  /**< Mode USART0TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXEMPTY               0x00000002UL                                  /**< Mode USART1TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY              0x00000002UL                                  /**< Mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC1                   0x00000002UL                                  /**< Mode TIMER0CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC1                   0x00000002UL                                  /**< Mode TIMER1CC1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_AESDATARD                   0x00000002UL                                  /**< Mode AESDATARD for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT          0x00000003UL                                  /**< Mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER0CC2                   0x00000003UL                                  /**< Mode TIMER0CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_TIMER1CC2                   0x00000003UL                                  /**< Mode TIMER1CC2 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_AESKEYWR                    0x00000003UL                                  /**< Mode AESKEYWR for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT             0x00000004UL                                  /**< Mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_ADC0SINGLE                   (_DMA_CH_CTRL_SIGSEL_ADC0SINGLE << 0)         /**< Shifted mode ADC0SINGLE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_DAC0CH0                      (_DMA_CH_CTRL_SIGSEL_DAC0CH0 << 0)            /**< Shifted mode DAC0CH0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART0RXDATAV                (_DMA_CH_CTRL_SIGSEL_USART0RXDATAV << 0)      /**< Shifted mode USART0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAV                (_DMA_CH_CTRL_SIGSEL_USART1RXDATAV << 0)      /**< Shifted mode USART1RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV               (_DMA_CH_CTRL_SIGSEL_LEUART0RXDATAV << 0)     /**< Shifted mode LEUART0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0RXDATAV                  (_DMA_CH_CTRL_SIGSEL_I2C0RXDATAV << 0)        /**< Shifted mode I2C0RXDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER0UFOF << 0)         /**< Shifted mode TIMER0UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1UFOF                   (_DMA_CH_CTRL_SIGSEL_TIMER1UFOF << 0)         /**< Shifted mode TIMER1UFOF for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_MSCWDATA                     (_DMA_CH_CTRL_SIGSEL_MSCWDATA << 0)           /**< Shifted mode MSCWDATA for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_AESDATAWR                    (_DMA_CH_CTRL_SIGSEL_AESDATAWR << 0)          /**< Shifted mode AESDATAWR for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV              (_DMA_CH_CTRL_SIGSEL_LESENSEBUFDATAV << 0)    /**< Shifted mode LESENSEBUFDATAV for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_ADC0SCAN                     (_DMA_CH_CTRL_SIGSEL_ADC0SCAN << 0)           /**< Shifted mode ADC0SCAN for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_DAC0CH1                      (_DMA_CH_CTRL_SIGSEL_DAC0CH1 << 0)            /**< Shifted mode DAC0CH1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART0TXBL                   (_DMA_CH_CTRL_SIGSEL_USART0TXBL << 0)         /**< Shifted mode USART0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBL                   (_DMA_CH_CTRL_SIGSEL_USART1TXBL << 0)         /**< Shifted mode USART1TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXBL                  (_DMA_CH_CTRL_SIGSEL_LEUART0TXBL << 0)        /**< Shifted mode LEUART0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_I2C0TXBL                     (_DMA_CH_CTRL_SIGSEL_I2C0TXBL << 0)           /**< Shifted mode I2C0TXBL for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC0 << 0)          /**< Shifted mode TIMER0CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC0                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC0 << 0)          /**< Shifted mode TIMER1CC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_AESXORDATAWR                 (_DMA_CH_CTRL_SIGSEL_AESXORDATAWR << 0)       /**< Shifted mode AESXORDATAWR for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART0TXEMPTY                (_DMA_CH_CTRL_SIGSEL_USART0TXEMPTY << 0)      /**< Shifted mode USART0TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXEMPTY                (_DMA_CH_CTRL_SIGSEL_USART1TXEMPTY << 0)      /**< Shifted mode USART1TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY               (_DMA_CH_CTRL_SIGSEL_LEUART0TXEMPTY << 0)     /**< Shifted mode LEUART0TXEMPTY for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC1 << 0)          /**< Shifted mode TIMER0CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC1                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC1 << 0)          /**< Shifted mode TIMER1CC1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_AESDATARD                    (_DMA_CH_CTRL_SIGSEL_AESDATARD << 0)          /**< Shifted mode AESDATARD for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT           (_DMA_CH_CTRL_SIGSEL_USART1RXDATAVRIGHT << 0) /**< Shifted mode USART1RXDATAVRIGHT for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER0CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER0CC2 << 0)          /**< Shifted mode TIMER0CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_TIMER1CC2                    (_DMA_CH_CTRL_SIGSEL_TIMER1CC2 << 0)          /**< Shifted mode TIMER1CC2 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_AESKEYWR                     (_DMA_CH_CTRL_SIGSEL_AESKEYWR << 0)           /**< Shifted mode AESKEYWR for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT              (_DMA_CH_CTRL_SIGSEL_USART1TXBLRIGHT << 0)    /**< Shifted mode USART1TXBLRIGHT for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_SHIFT                    16                                            /**< Shift value for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_MASK                     0x3F0000UL                                    /**< Bit mask for DMA_SOURCESEL */
+#define _DMA_CH_CTRL_SOURCESEL_NONE                     0x00000000UL                                  /**< Mode NONE for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_ADC0                     0x00000008UL                                  /**< Mode ADC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_DAC0                     0x0000000AUL                                  /**< Mode DAC0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_USART0                   0x0000000CUL                                  /**< Mode USART0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_USART1                   0x0000000DUL                                  /**< Mode USART1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LEUART0                  0x00000010UL                                  /**< Mode LEUART0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_I2C0                     0x00000014UL                                  /**< Mode I2C0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER0                   0x00000018UL                                  /**< Mode TIMER0 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_TIMER1                   0x00000019UL                                  /**< Mode TIMER1 for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_MSC                      0x00000030UL                                  /**< Mode MSC for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_AES                      0x00000031UL                                  /**< Mode AES for DMA_CH_CTRL */
+#define _DMA_CH_CTRL_SOURCESEL_LESENSE                  0x00000032UL                                  /**< Mode LESENSE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_NONE                      (_DMA_CH_CTRL_SOURCESEL_NONE << 16)           /**< Shifted mode NONE for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_ADC0                      (_DMA_CH_CTRL_SOURCESEL_ADC0 << 16)           /**< Shifted mode ADC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_DAC0                      (_DMA_CH_CTRL_SOURCESEL_DAC0 << 16)           /**< Shifted mode DAC0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_USART0                    (_DMA_CH_CTRL_SOURCESEL_USART0 << 16)         /**< Shifted mode USART0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_USART1                    (_DMA_CH_CTRL_SOURCESEL_USART1 << 16)         /**< Shifted mode USART1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LEUART0                   (_DMA_CH_CTRL_SOURCESEL_LEUART0 << 16)        /**< Shifted mode LEUART0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_I2C0                      (_DMA_CH_CTRL_SOURCESEL_I2C0 << 16)           /**< Shifted mode I2C0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER0                    (_DMA_CH_CTRL_SOURCESEL_TIMER0 << 16)         /**< Shifted mode TIMER0 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_TIMER1                    (_DMA_CH_CTRL_SOURCESEL_TIMER1 << 16)         /**< Shifted mode TIMER1 for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_MSC                       (_DMA_CH_CTRL_SOURCESEL_MSC << 16)            /**< Shifted mode MSC for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_AES                       (_DMA_CH_CTRL_SOURCESEL_AES << 16)            /**< Shifted mode AES for DMA_CH_CTRL */
+#define DMA_CH_CTRL_SOURCESEL_LESENSE                   (_DMA_CH_CTRL_SOURCESEL_LESENSE << 16)        /**< Shifted mode LESENSE for DMA_CH_CTRL */
+
+/** @} End of group EFM32TG_DMA */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dma_ch.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dma_ch.h
@@ -1,0 +1,48 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_DMA_CH register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @brief DMA_CH EFM32TG DMA CH
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL; /**< Channel Control Register  */
+} DMA_CH_TypeDef;
+
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dma_descriptor.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dma_descriptor.h
@@ -1,0 +1,54 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_DMA_DESCRIPTOR register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_DMA_DESCRIPTOR
+ * @{
+ ******************************************************************************/
+typedef struct {
+  /* Note! Use of double __IOM (volatile) qualifier to ensure that both */
+  /* pointer and referenced memory are declared volatile. */
+  __IOM void * __IOM SRCEND;   /**< DMA source address end */
+  __IOM void * __IOM DSTEND;   /**< DMA destination address end */
+  __IOM uint32_t     CTRL;     /**< DMA control register */
+  __IOM uint32_t     USER;     /**< DMA padding register, available for user */
+} DMA_DESCRIPTOR_TypeDef;      /** @} */
+
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dmactrl.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dmactrl.h
@@ -1,0 +1,144 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_DMACTRL register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_DMACTRL_BitFields
+ * @{
+ ******************************************************************************/
+#define _DMA_CTRL_DST_INC_MASK                         0xC0000000UL  /**< Data increment for destination, bit mask */
+#define _DMA_CTRL_DST_INC_SHIFT                        30            /**< Data increment for destination, shift value */
+#define _DMA_CTRL_DST_INC_BYTE                         0x00          /**< Byte/8-bit increment */
+#define _DMA_CTRL_DST_INC_HALFWORD                     0x01          /**< Half word/16-bit increment */
+#define _DMA_CTRL_DST_INC_WORD                         0x02          /**< Word/32-bit increment */
+#define _DMA_CTRL_DST_INC_NONE                         0x03          /**< No increment */
+#define DMA_CTRL_DST_INC_BYTE                          0x00000000UL  /**< Byte/8-bit increment */
+#define DMA_CTRL_DST_INC_HALFWORD                      0x40000000UL  /**< Half word/16-bit increment */
+#define DMA_CTRL_DST_INC_WORD                          0x80000000UL  /**< Word/32-bit increment */
+#define DMA_CTRL_DST_INC_NONE                          0xC0000000UL  /**< No increment */
+#define _DMA_CTRL_DST_SIZE_MASK                        0x30000000UL  /**< Data size for destination - MUST be the same as source, bit mask */
+#define _DMA_CTRL_DST_SIZE_SHIFT                       28            /**< Data size for destination - MUST be the same as source, shift value */
+#define _DMA_CTRL_DST_SIZE_BYTE                        0x00          /**< Byte/8-bit data size */
+#define _DMA_CTRL_DST_SIZE_HALFWORD                    0x01          /**< Half word/16-bit data size */
+#define _DMA_CTRL_DST_SIZE_WORD                        0x02          /**< Word/32-bit data size */
+#define _DMA_CTRL_DST_SIZE_RSVD                        0x03          /**< Reserved */
+#define DMA_CTRL_DST_SIZE_BYTE                         0x00000000UL  /**< Byte/8-bit data size */
+#define DMA_CTRL_DST_SIZE_HALFWORD                     0x10000000UL  /**< Half word/16-bit data size */
+#define DMA_CTRL_DST_SIZE_WORD                         0x20000000UL  /**< Word/32-bit data size */
+#define DMA_CTRL_DST_SIZE_RSVD                         0x30000000UL  /**< Reserved - do not use */
+#define _DMA_CTRL_SRC_INC_MASK                         0x0C000000UL  /**< Data increment for source, bit mask */
+#define _DMA_CTRL_SRC_INC_SHIFT                        26            /**< Data increment for source, shift value */
+#define _DMA_CTRL_SRC_INC_BYTE                         0x00          /**< Byte/8-bit increment */
+#define _DMA_CTRL_SRC_INC_HALFWORD                     0x01          /**< Half word/16-bit increment */
+#define _DMA_CTRL_SRC_INC_WORD                         0x02          /**< Word/32-bit increment */
+#define _DMA_CTRL_SRC_INC_NONE                         0x03          /**< No increment */
+#define DMA_CTRL_SRC_INC_BYTE                          0x00000000UL  /**< Byte/8-bit increment */
+#define DMA_CTRL_SRC_INC_HALFWORD                      0x04000000UL  /**< Half word/16-bit increment */
+#define DMA_CTRL_SRC_INC_WORD                          0x08000000UL  /**< Word/32-bit increment */
+#define DMA_CTRL_SRC_INC_NONE                          0x0C000000UL  /**< No increment */
+#define _DMA_CTRL_SRC_SIZE_MASK                        0x03000000UL  /**< Data size for source - MUST be the same as destination, bit mask */
+#define _DMA_CTRL_SRC_SIZE_SHIFT                       24            /**< Data size for source - MUST be the same as destination, shift value */
+#define _DMA_CTRL_SRC_SIZE_BYTE                        0x00          /**< Byte/8-bit data size */
+#define _DMA_CTRL_SRC_SIZE_HALFWORD                    0x01          /**< Half word/16-bit data size */
+#define _DMA_CTRL_SRC_SIZE_WORD                        0x02          /**< Word/32-bit data size */
+#define _DMA_CTRL_SRC_SIZE_RSVD                        0x03          /**< Reserved */
+#define DMA_CTRL_SRC_SIZE_BYTE                         0x00000000UL  /**< Byte/8-bit data size */
+#define DMA_CTRL_SRC_SIZE_HALFWORD                     0x01000000UL  /**< Half word/16-bit data size */
+#define DMA_CTRL_SRC_SIZE_WORD                         0x02000000UL  /**< Word/32-bit data size */
+#define DMA_CTRL_SRC_SIZE_RSVD                         0x03000000UL  /**< Reserved - do not use */
+#define _DMA_CTRL_DST_PROT_CTRL_MASK                   0x00E00000UL  /**< Protection flag for destination, bit mask */
+#define _DMA_CTRL_DST_PROT_CTRL_SHIFT                  21            /**< Protection flag for destination, shift value */
+#define DMA_CTRL_DST_PROT_PRIVILEGED                   0x00200000UL  /**< Privileged mode for destination */
+#define DMA_CTRL_DST_PROT_NON_PRIVILEGED               0x00000000UL  /**< Non-privileged mode for estination */
+#define _DMA_CTRL_SRC_PROT_CTRL_MASK                   0x001C0000UL  /**< Protection flag for source, bit mask */
+#define _DMA_CTRL_SRC_PROT_CTRL_SHIFT                  18            /**< Protection flag for source, shift value */
+#define DMA_CTRL_SRC_PROT_PRIVILEGED                   0x00040000UL  /**< Privileged mode for destination */
+#define DMA_CTRL_SRC_PROT_NON_PRIVILEGED               0x00000000UL  /**< Non-privileged mode for estination */
+#define _DMA_CTRL_PROT_NON_PRIVILEGED                  0x00          /**< Protection bits to indicate non-privileged access */
+#define _DMA_CTRL_PROT_PRIVILEGED                      0x01          /**< Protection bits to indicate privileged access */
+#define _DMA_CTRL_R_POWER_MASK                         0x0003C000UL  /**< DMA arbitration mask */
+#define _DMA_CTRL_R_POWER_SHIFT                        14            /**< Number of DMA cycles before controller does new arbitration in 2^R */
+#define _DMA_CTRL_R_POWER_1                            0x00          /**< Arbitrate after each transfer */
+#define _DMA_CTRL_R_POWER_2                            0x01          /**< Arbitrate after every 2 transfers */
+#define _DMA_CTRL_R_POWER_4                            0x02          /**< Arbitrate after every 4 transfers */
+#define _DMA_CTRL_R_POWER_8                            0x03          /**< Arbitrate after every 8 transfers */
+#define _DMA_CTRL_R_POWER_16                           0x04          /**< Arbitrate after every 16 transfers */
+#define _DMA_CTRL_R_POWER_32                           0x05          /**< Arbitrate after every 32 transfers */
+#define _DMA_CTRL_R_POWER_64                           0x06          /**< Arbitrate after every 64 transfers */
+#define _DMA_CTRL_R_POWER_128                          0x07          /**< Arbitrate after every 128 transfers */
+#define _DMA_CTRL_R_POWER_256                          0x08          /**< Arbitrate after every 256 transfers */
+#define _DMA_CTRL_R_POWER_512                          0x09          /**< Arbitrate after every 512 transfers */
+#define _DMA_CTRL_R_POWER_1024                         0x0a          /**< Arbitrate after every 1024 transfers */
+#define DMA_CTRL_R_POWER_1                             0x00000000UL  /**< Arbitrate after each transfer */
+#define DMA_CTRL_R_POWER_2                             0x00004000UL  /**< Arbitrate after every 2 transfers */
+#define DMA_CTRL_R_POWER_4                             0x00008000UL  /**< Arbitrate after every 4 transfers */
+#define DMA_CTRL_R_POWER_8                             0x0000c000UL  /**< Arbitrate after every 8 transfers */
+#define DMA_CTRL_R_POWER_16                            0x00010000UL  /**< Arbitrate after every 16 transfers */
+#define DMA_CTRL_R_POWER_32                            0x00014000UL  /**< Arbitrate after every 32 transfers */
+#define DMA_CTRL_R_POWER_64                            0x00018000UL  /**< Arbitrate after every 64 transfers */
+#define DMA_CTRL_R_POWER_128                           0x0001c000UL  /**< Arbitrate after every 128 transfers */
+#define DMA_CTRL_R_POWER_256                           0x00020000UL  /**< Arbitrate after every 256 transfers */
+#define DMA_CTRL_R_POWER_512                           0x00024000UL  /**< Arbitrate after every 512 transfers */
+#define DMA_CTRL_R_POWER_1024                          0x00028000UL  /**< Arbitrate after every 1024 transfers */
+#define _DMA_CTRL_N_MINUS_1_MASK                       0x00003FF0UL  /**< Number of DMA transfers minus 1, bit mask. See PL230 documentation */
+#define _DMA_CTRL_N_MINUS_1_SHIFT                      4             /**< Number of DMA transfers minus 1, shift mask. See PL230 documentation */
+#define _DMA_CTRL_NEXT_USEBURST_MASK                   0x00000008UL  /**< DMA useburst_set[C] is 1 when using scatter-gather DMA and using alternate data */
+#define _DMA_CTRL_NEXT_USEBURST_SHIFT                  3             /**< DMA useburst shift */
+#define _DMA_CTRL_CYCLE_CTRL_MASK                      0x00000007UL  /**< DMA Cycle control bit mask - basic/auto/ping-poing/scath-gath */
+#define _DMA_CTRL_CYCLE_CTRL_SHIFT                     0             /**< DMA Cycle control bit shift */
+#define _DMA_CTRL_CYCLE_CTRL_INVALID                   0x00          /**< Invalid cycle type  */
+#define _DMA_CTRL_CYCLE_CTRL_BASIC                     0x01          /**< Basic cycle type */
+#define _DMA_CTRL_CYCLE_CTRL_AUTO                      0x02          /**< Auto cycle type */
+#define _DMA_CTRL_CYCLE_CTRL_PINGPONG                  0x03          /**< PingPong cycle type */
+#define _DMA_CTRL_CYCLE_CTRL_MEM_SCATTER_GATHER        0x04          /**< Memory scatter gather cycle type */
+#define _DMA_CTRL_CYCLE_CTRL_MEM_SCATTER_GATHER_ALT    0x05          /**< Memory scatter gather using alternate structure  */
+#define _DMA_CTRL_CYCLE_CTRL_PER_SCATTER_GATHER        0x06          /**< Peripheral scatter gather cycle type */
+#define _DMA_CTRL_CYCLE_CTRL_PER_SCATTER_GATHER_ALT    0x07          /**< Peripheral scatter gather cycle type using alternate structure */
+#define DMA_CTRL_CYCLE_CTRL_INVALID                    0x00000000UL  /**< Invalid cycle type */
+#define DMA_CTRL_CYCLE_CTRL_BASIC                      0x00000001UL  /**< Basic cycle type */
+#define DMA_CTRL_CYCLE_CTRL_AUTO                       0x00000002UL  /**< Auto cycle type */
+#define DMA_CTRL_CYCLE_CTRL_PINGPONG                   0x00000003UL  /**< PingPong cycle type */
+#define DMA_CTRL_CYCLE_CTRL_MEM_SCATTER_GATHER         0x000000004UL /**< Memory scatter gather cycle type */
+#define DMA_CTRL_CYCLE_CTRL_MEM_SCATTER_GATHER_ALT     0x000000005UL /**< Memory scatter gather using alternate structure  */
+#define DMA_CTRL_CYCLE_CTRL_PER_SCATTER_GATHER         0x000000006UL /**< Peripheral scatter gather cycle type */
+#define DMA_CTRL_CYCLE_CTRL_PER_SCATTER_GATHER_ALT     0x000000007UL /**< Peripheral scatter gather cycle type using alternate structure */
+
+/** @} End of group EFM32TG_DMA */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dmareq.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_dmareq.h
@@ -1,0 +1,79 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_DMAREQ register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_DMAREQ_BitFields
+ * @{
+ ******************************************************************************/
+#define DMAREQ_ADC0_SINGLE            ((8 << 16) + 0)  /**< DMA channel select for ADC0_SINGLE */
+#define DMAREQ_ADC0_SCAN              ((8 << 16) + 1)  /**< DMA channel select for ADC0_SCAN */
+#define DMAREQ_DAC0_CH0               ((10 << 16) + 0) /**< DMA channel select for DAC0_CH0 */
+#define DMAREQ_DAC0_CH1               ((10 << 16) + 1) /**< DMA channel select for DAC0_CH1 */
+#define DMAREQ_USART0_RXDATAV         ((12 << 16) + 0) /**< DMA channel select for USART0_RXDATAV */
+#define DMAREQ_USART0_TXBL            ((12 << 16) + 1) /**< DMA channel select for USART0_TXBL */
+#define DMAREQ_USART0_TXEMPTY         ((12 << 16) + 2) /**< DMA channel select for USART0_TXEMPTY */
+#define DMAREQ_USART1_RXDATAV         ((13 << 16) + 0) /**< DMA channel select for USART1_RXDATAV */
+#define DMAREQ_USART1_TXBL            ((13 << 16) + 1) /**< DMA channel select for USART1_TXBL */
+#define DMAREQ_USART1_TXEMPTY         ((13 << 16) + 2) /**< DMA channel select for USART1_TXEMPTY */
+#define DMAREQ_USART1_RXDATAVRIGHT    ((13 << 16) + 3) /**< DMA channel select for USART1_RXDATAVRIGHT */
+#define DMAREQ_USART1_TXBLRIGHT       ((13 << 16) + 4) /**< DMA channel select for USART1_TXBLRIGHT */
+#define DMAREQ_LEUART0_RXDATAV        ((16 << 16) + 0) /**< DMA channel select for LEUART0_RXDATAV */
+#define DMAREQ_LEUART0_TXBL           ((16 << 16) + 1) /**< DMA channel select for LEUART0_TXBL */
+#define DMAREQ_LEUART0_TXEMPTY        ((16 << 16) + 2) /**< DMA channel select for LEUART0_TXEMPTY */
+#define DMAREQ_I2C0_RXDATAV           ((20 << 16) + 0) /**< DMA channel select for I2C0_RXDATAV */
+#define DMAREQ_I2C0_TXBL              ((20 << 16) + 1) /**< DMA channel select for I2C0_TXBL */
+#define DMAREQ_TIMER0_UFOF            ((24 << 16) + 0) /**< DMA channel select for TIMER0_UFOF */
+#define DMAREQ_TIMER0_CC0             ((24 << 16) + 1) /**< DMA channel select for TIMER0_CC0 */
+#define DMAREQ_TIMER0_CC1             ((24 << 16) + 2) /**< DMA channel select for TIMER0_CC1 */
+#define DMAREQ_TIMER0_CC2             ((24 << 16) + 3) /**< DMA channel select for TIMER0_CC2 */
+#define DMAREQ_TIMER1_UFOF            ((25 << 16) + 0) /**< DMA channel select for TIMER1_UFOF */
+#define DMAREQ_TIMER1_CC0             ((25 << 16) + 1) /**< DMA channel select for TIMER1_CC0 */
+#define DMAREQ_TIMER1_CC1             ((25 << 16) + 2) /**< DMA channel select for TIMER1_CC1 */
+#define DMAREQ_TIMER1_CC2             ((25 << 16) + 3) /**< DMA channel select for TIMER1_CC2 */
+#define DMAREQ_MSC_WDATA              ((48 << 16) + 0) /**< DMA channel select for MSC_WDATA */
+#define DMAREQ_AES_DATAWR             ((49 << 16) + 0) /**< DMA channel select for AES_DATAWR */
+#define DMAREQ_AES_XORDATAWR          ((49 << 16) + 1) /**< DMA channel select for AES_XORDATAWR */
+#define DMAREQ_AES_DATARD             ((49 << 16) + 2) /**< DMA channel select for AES_DATARD */
+#define DMAREQ_AES_KEYWR              ((49 << 16) + 3) /**< DMA channel select for AES_KEYWR */
+#define DMAREQ_LESENSE_BUFDATAV       ((50 << 16) + 0) /**< DMA channel select for LESENSE_BUFDATAV */
+
+/** @} End of group EFM32TG_DMAREQ */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_emu.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_emu.h
@@ -1,0 +1,107 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_EMU register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_EMU
+ * @brief EFM32TG_EMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+  uint32_t       RESERVED1[6U]; /**< Reserved for future use **/
+  __IOM uint32_t AUXCTRL;       /**< Auxiliary Control Register  */
+} EMU_TypeDef;                  /**< EMU Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_EMU_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for EMU CTRL */
+#define _EMU_CTRL_RESETVALUE           0x00000000UL                      /**< Default value for EMU_CTRL */
+#define _EMU_CTRL_MASK                 0x0000000FUL                      /**< Mask for EMU_CTRL */
+#define EMU_CTRL_EMVREG                (0x1UL << 0)                      /**< Energy Mode Voltage Regulator Control */
+#define _EMU_CTRL_EMVREG_SHIFT         0                                 /**< Shift value for EMU_EMVREG */
+#define _EMU_CTRL_EMVREG_MASK          0x1UL                             /**< Bit mask for EMU_EMVREG */
+#define _EMU_CTRL_EMVREG_DEFAULT       0x00000000UL                      /**< Mode DEFAULT for EMU_CTRL */
+#define _EMU_CTRL_EMVREG_REDUCED       0x00000000UL                      /**< Mode REDUCED for EMU_CTRL */
+#define _EMU_CTRL_EMVREG_FULL          0x00000001UL                      /**< Mode FULL for EMU_CTRL */
+#define EMU_CTRL_EMVREG_DEFAULT        (_EMU_CTRL_EMVREG_DEFAULT << 0)   /**< Shifted mode DEFAULT for EMU_CTRL */
+#define EMU_CTRL_EMVREG_REDUCED        (_EMU_CTRL_EMVREG_REDUCED << 0)   /**< Shifted mode REDUCED for EMU_CTRL */
+#define EMU_CTRL_EMVREG_FULL           (_EMU_CTRL_EMVREG_FULL << 0)      /**< Shifted mode FULL for EMU_CTRL */
+#define EMU_CTRL_EM2BLOCK              (0x1UL << 1)                      /**< Energy Mode 2 Block */
+#define _EMU_CTRL_EM2BLOCK_SHIFT       1                                 /**< Shift value for EMU_EM2BLOCK */
+#define _EMU_CTRL_EM2BLOCK_MASK        0x2UL                             /**< Bit mask for EMU_EM2BLOCK */
+#define _EMU_CTRL_EM2BLOCK_DEFAULT     0x00000000UL                      /**< Mode DEFAULT for EMU_CTRL */
+#define EMU_CTRL_EM2BLOCK_DEFAULT      (_EMU_CTRL_EM2BLOCK_DEFAULT << 1) /**< Shifted mode DEFAULT for EMU_CTRL */
+#define _EMU_CTRL_EM4CTRL_SHIFT        2                                 /**< Shift value for EMU_EM4CTRL */
+#define _EMU_CTRL_EM4CTRL_MASK         0xCUL                             /**< Bit mask for EMU_EM4CTRL */
+#define _EMU_CTRL_EM4CTRL_DEFAULT      0x00000000UL                      /**< Mode DEFAULT for EMU_CTRL */
+#define EMU_CTRL_EM4CTRL_DEFAULT       (_EMU_CTRL_EM4CTRL_DEFAULT << 2)  /**< Shifted mode DEFAULT for EMU_CTRL */
+
+/* Bit fields for EMU LOCK */
+#define _EMU_LOCK_RESETVALUE           0x00000000UL                      /**< Default value for EMU_LOCK */
+#define _EMU_LOCK_MASK                 0x0000FFFFUL                      /**< Mask for EMU_LOCK */
+#define _EMU_LOCK_LOCKKEY_SHIFT        0                                 /**< Shift value for EMU_LOCKKEY */
+#define _EMU_LOCK_LOCKKEY_MASK         0xFFFFUL                          /**< Bit mask for EMU_LOCKKEY */
+#define _EMU_LOCK_LOCKKEY_DEFAULT      0x00000000UL                      /**< Mode DEFAULT for EMU_LOCK */
+#define _EMU_LOCK_LOCKKEY_UNLOCKED     0x00000000UL                      /**< Mode UNLOCKED for EMU_LOCK */
+#define _EMU_LOCK_LOCKKEY_LOCK         0x00000000UL                      /**< Mode LOCK for EMU_LOCK */
+#define _EMU_LOCK_LOCKKEY_LOCKED       0x00000001UL                      /**< Mode LOCKED for EMU_LOCK */
+#define _EMU_LOCK_LOCKKEY_UNLOCK       0x0000ADE8UL                      /**< Mode UNLOCK for EMU_LOCK */
+#define EMU_LOCK_LOCKKEY_DEFAULT       (_EMU_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for EMU_LOCK */
+#define EMU_LOCK_LOCKKEY_UNLOCKED      (_EMU_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for EMU_LOCK */
+#define EMU_LOCK_LOCKKEY_LOCK          (_EMU_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for EMU_LOCK */
+#define EMU_LOCK_LOCKKEY_LOCKED        (_EMU_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for EMU_LOCK */
+#define EMU_LOCK_LOCKKEY_UNLOCK        (_EMU_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for EMU_LOCK */
+
+/* Bit fields for EMU AUXCTRL */
+#define _EMU_AUXCTRL_RESETVALUE        0x00000000UL                       /**< Default value for EMU_AUXCTRL */
+#define _EMU_AUXCTRL_MASK              0x00000001UL                       /**< Mask for EMU_AUXCTRL */
+#define EMU_AUXCTRL_HRCCLR             (0x1UL << 0)                       /**< Hard Reset Cause Clear */
+#define _EMU_AUXCTRL_HRCCLR_SHIFT      0                                  /**< Shift value for EMU_HRCCLR */
+#define _EMU_AUXCTRL_HRCCLR_MASK       0x1UL                              /**< Bit mask for EMU_HRCCLR */
+#define _EMU_AUXCTRL_HRCCLR_DEFAULT    0x00000000UL                       /**< Mode DEFAULT for EMU_AUXCTRL */
+#define EMU_AUXCTRL_HRCCLR_DEFAULT     (_EMU_AUXCTRL_HRCCLR_DEFAULT << 0) /**< Shifted mode DEFAULT for EMU_AUXCTRL */
+
+/** @} End of group EFM32TG_EMU */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_gpio.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_gpio.h
@@ -1,0 +1,1170 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_GPIO register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_GPIO
+ * @brief EFM32TG_GPIO Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  GPIO_P_TypeDef P[6U];          /**< Port configuration bits */
+
+  uint32_t       RESERVED0[10U]; /**< Reserved for future use **/
+  __IOM uint32_t EXTIPSELL;      /**< External Interrupt Port Select Low Register  */
+  __IOM uint32_t EXTIPSELH;      /**< External Interrupt Port Select High Register  */
+  __IOM uint32_t EXTIRISE;       /**< External Interrupt Rising Edge Trigger Register  */
+  __IOM uint32_t EXTIFALL;       /**< External Interrupt Falling Edge Trigger Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
+
+  __IOM uint32_t ROUTE;          /**< I/O Routing Register  */
+  __IOM uint32_t INSENSE;        /**< Input Sense Register  */
+  __IOM uint32_t LOCK;           /**< Configuration Lock Register  */
+  __IOM uint32_t CTRL;           /**< GPIO Control Register  */
+  __IOM uint32_t CMD;            /**< GPIO Command Register  */
+  __IOM uint32_t EM4WUEN;        /**< EM4 Wake-up Enable Register  */
+  __IOM uint32_t EM4WUPOL;       /**< EM4 Wake-up Polarity Register  */
+  __IM uint32_t  EM4WUCAUSE;     /**< EM4 Wake-up Cause Register  */
+} GPIO_TypeDef;                  /**< GPIO Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_GPIO_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for GPIO P_CTRL */
+#define _GPIO_P_CTRL_RESETVALUE                           0x00000000UL                           /**< Default value for GPIO_P_CTRL */
+#define _GPIO_P_CTRL_MASK                                 0x00000003UL                           /**< Mask for GPIO_P_CTRL */
+#define _GPIO_P_CTRL_DRIVEMODE_SHIFT                      0                                      /**< Shift value for GPIO_DRIVEMODE */
+#define _GPIO_P_CTRL_DRIVEMODE_MASK                       0x3UL                                  /**< Bit mask for GPIO_DRIVEMODE */
+#define _GPIO_P_CTRL_DRIVEMODE_DEFAULT                    0x00000000UL                           /**< Mode DEFAULT for GPIO_P_CTRL */
+#define _GPIO_P_CTRL_DRIVEMODE_STANDARD                   0x00000000UL                           /**< Mode STANDARD for GPIO_P_CTRL */
+#define _GPIO_P_CTRL_DRIVEMODE_LOWEST                     0x00000001UL                           /**< Mode LOWEST for GPIO_P_CTRL */
+#define _GPIO_P_CTRL_DRIVEMODE_HIGH                       0x00000002UL                           /**< Mode HIGH for GPIO_P_CTRL */
+#define _GPIO_P_CTRL_DRIVEMODE_LOW                        0x00000003UL                           /**< Mode LOW for GPIO_P_CTRL */
+#define GPIO_P_CTRL_DRIVEMODE_DEFAULT                     (_GPIO_P_CTRL_DRIVEMODE_DEFAULT << 0)  /**< Shifted mode DEFAULT for GPIO_P_CTRL */
+#define GPIO_P_CTRL_DRIVEMODE_STANDARD                    (_GPIO_P_CTRL_DRIVEMODE_STANDARD << 0) /**< Shifted mode STANDARD for GPIO_P_CTRL */
+#define GPIO_P_CTRL_DRIVEMODE_LOWEST                      (_GPIO_P_CTRL_DRIVEMODE_LOWEST << 0)   /**< Shifted mode LOWEST for GPIO_P_CTRL */
+#define GPIO_P_CTRL_DRIVEMODE_HIGH                        (_GPIO_P_CTRL_DRIVEMODE_HIGH << 0)     /**< Shifted mode HIGH for GPIO_P_CTRL */
+#define GPIO_P_CTRL_DRIVEMODE_LOW                         (_GPIO_P_CTRL_DRIVEMODE_LOW << 0)      /**< Shifted mode LOW for GPIO_P_CTRL */
+
+/* Bit fields for GPIO P_MODEL */
+#define _GPIO_P_MODEL_RESETVALUE                          0x00000000UL                                          /**< Default value for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MASK                                0xFFFFFFFFUL                                          /**< Mask for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_SHIFT                         0                                                     /**< Shift value for GPIO_MODE0 */
+#define _GPIO_P_MODEL_MODE0_MASK                          0xFUL                                                 /**< Bit mask for GPIO_MODE0 */
+#define _GPIO_P_MODEL_MODE0_DEFAULT                       0x00000000UL                                          /**< Mode DEFAULT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_DISABLED                      0x00000000UL                                          /**< Mode DISABLED for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_INPUT                         0x00000001UL                                          /**< Mode INPUT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_INPUTPULL                     0x00000002UL                                          /**< Mode INPUTPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_INPUTPULLFILTER               0x00000003UL                                          /**< Mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_PUSHPULL                      0x00000004UL                                          /**< Mode PUSHPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_PUSHPULLDRIVE                 0x00000005UL                                          /**< Mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDOR                       0x00000006UL                                          /**< Mode WIREDOR for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDORPULLDOWN               0x00000007UL                                          /**< Mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDAND                      0x00000008UL                                          /**< Mode WIREDAND for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDANDFILTER                0x00000009UL                                          /**< Mode WIREDANDFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDANDPULLUP                0x0000000AUL                                          /**< Mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDANDPULLUPFILTER          0x0000000BUL                                          /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDANDDRIVE                 0x0000000CUL                                          /**< Mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDANDDRIVEFILTER           0x0000000DUL                                          /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDANDDRIVEPULLUP           0x0000000EUL                                          /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE0_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                          /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_DEFAULT                        (_GPIO_P_MODEL_MODE0_DEFAULT << 0)                    /**< Shifted mode DEFAULT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_DISABLED                       (_GPIO_P_MODEL_MODE0_DISABLED << 0)                   /**< Shifted mode DISABLED for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_INPUT                          (_GPIO_P_MODEL_MODE0_INPUT << 0)                      /**< Shifted mode INPUT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_INPUTPULL                      (_GPIO_P_MODEL_MODE0_INPUTPULL << 0)                  /**< Shifted mode INPUTPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_INPUTPULLFILTER                (_GPIO_P_MODEL_MODE0_INPUTPULLFILTER << 0)            /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_PUSHPULL                       (_GPIO_P_MODEL_MODE0_PUSHPULL << 0)                   /**< Shifted mode PUSHPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_PUSHPULLDRIVE                  (_GPIO_P_MODEL_MODE0_PUSHPULLDRIVE << 0)              /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDOR                        (_GPIO_P_MODEL_MODE0_WIREDOR << 0)                    /**< Shifted mode WIREDOR for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDORPULLDOWN                (_GPIO_P_MODEL_MODE0_WIREDORPULLDOWN << 0)            /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDAND                       (_GPIO_P_MODEL_MODE0_WIREDAND << 0)                   /**< Shifted mode WIREDAND for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDANDFILTER                 (_GPIO_P_MODEL_MODE0_WIREDANDFILTER << 0)             /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDANDPULLUP                 (_GPIO_P_MODEL_MODE0_WIREDANDPULLUP << 0)             /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDANDPULLUPFILTER           (_GPIO_P_MODEL_MODE0_WIREDANDPULLUPFILTER << 0)       /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDANDDRIVE                  (_GPIO_P_MODEL_MODE0_WIREDANDDRIVE << 0)              /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDANDDRIVEFILTER            (_GPIO_P_MODEL_MODE0_WIREDANDDRIVEFILTER << 0)        /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEL_MODE0_WIREDANDDRIVEPULLUP << 0)        /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE0_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEL_MODE0_WIREDANDDRIVEPULLUPFILTER << 0)  /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_SHIFT                         4                                                     /**< Shift value for GPIO_MODE1 */
+#define _GPIO_P_MODEL_MODE1_MASK                          0xF0UL                                                /**< Bit mask for GPIO_MODE1 */
+#define _GPIO_P_MODEL_MODE1_DEFAULT                       0x00000000UL                                          /**< Mode DEFAULT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_DISABLED                      0x00000000UL                                          /**< Mode DISABLED for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_INPUT                         0x00000001UL                                          /**< Mode INPUT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_INPUTPULL                     0x00000002UL                                          /**< Mode INPUTPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_INPUTPULLFILTER               0x00000003UL                                          /**< Mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_PUSHPULL                      0x00000004UL                                          /**< Mode PUSHPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_PUSHPULLDRIVE                 0x00000005UL                                          /**< Mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDOR                       0x00000006UL                                          /**< Mode WIREDOR for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDORPULLDOWN               0x00000007UL                                          /**< Mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDAND                      0x00000008UL                                          /**< Mode WIREDAND for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDANDFILTER                0x00000009UL                                          /**< Mode WIREDANDFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDANDPULLUP                0x0000000AUL                                          /**< Mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDANDPULLUPFILTER          0x0000000BUL                                          /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDANDDRIVE                 0x0000000CUL                                          /**< Mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDANDDRIVEFILTER           0x0000000DUL                                          /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDANDDRIVEPULLUP           0x0000000EUL                                          /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE1_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                          /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_DEFAULT                        (_GPIO_P_MODEL_MODE1_DEFAULT << 4)                    /**< Shifted mode DEFAULT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_DISABLED                       (_GPIO_P_MODEL_MODE1_DISABLED << 4)                   /**< Shifted mode DISABLED for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_INPUT                          (_GPIO_P_MODEL_MODE1_INPUT << 4)                      /**< Shifted mode INPUT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_INPUTPULL                      (_GPIO_P_MODEL_MODE1_INPUTPULL << 4)                  /**< Shifted mode INPUTPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_INPUTPULLFILTER                (_GPIO_P_MODEL_MODE1_INPUTPULLFILTER << 4)            /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_PUSHPULL                       (_GPIO_P_MODEL_MODE1_PUSHPULL << 4)                   /**< Shifted mode PUSHPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_PUSHPULLDRIVE                  (_GPIO_P_MODEL_MODE1_PUSHPULLDRIVE << 4)              /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDOR                        (_GPIO_P_MODEL_MODE1_WIREDOR << 4)                    /**< Shifted mode WIREDOR for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDORPULLDOWN                (_GPIO_P_MODEL_MODE1_WIREDORPULLDOWN << 4)            /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDAND                       (_GPIO_P_MODEL_MODE1_WIREDAND << 4)                   /**< Shifted mode WIREDAND for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDANDFILTER                 (_GPIO_P_MODEL_MODE1_WIREDANDFILTER << 4)             /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDANDPULLUP                 (_GPIO_P_MODEL_MODE1_WIREDANDPULLUP << 4)             /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDANDPULLUPFILTER           (_GPIO_P_MODEL_MODE1_WIREDANDPULLUPFILTER << 4)       /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDANDDRIVE                  (_GPIO_P_MODEL_MODE1_WIREDANDDRIVE << 4)              /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDANDDRIVEFILTER            (_GPIO_P_MODEL_MODE1_WIREDANDDRIVEFILTER << 4)        /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEL_MODE1_WIREDANDDRIVEPULLUP << 4)        /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE1_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEL_MODE1_WIREDANDDRIVEPULLUPFILTER << 4)  /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_SHIFT                         8                                                     /**< Shift value for GPIO_MODE2 */
+#define _GPIO_P_MODEL_MODE2_MASK                          0xF00UL                                               /**< Bit mask for GPIO_MODE2 */
+#define _GPIO_P_MODEL_MODE2_DEFAULT                       0x00000000UL                                          /**< Mode DEFAULT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_DISABLED                      0x00000000UL                                          /**< Mode DISABLED for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_INPUT                         0x00000001UL                                          /**< Mode INPUT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_INPUTPULL                     0x00000002UL                                          /**< Mode INPUTPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_INPUTPULLFILTER               0x00000003UL                                          /**< Mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_PUSHPULL                      0x00000004UL                                          /**< Mode PUSHPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_PUSHPULLDRIVE                 0x00000005UL                                          /**< Mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDOR                       0x00000006UL                                          /**< Mode WIREDOR for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDORPULLDOWN               0x00000007UL                                          /**< Mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDAND                      0x00000008UL                                          /**< Mode WIREDAND for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDANDFILTER                0x00000009UL                                          /**< Mode WIREDANDFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDANDPULLUP                0x0000000AUL                                          /**< Mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDANDPULLUPFILTER          0x0000000BUL                                          /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDANDDRIVE                 0x0000000CUL                                          /**< Mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDANDDRIVEFILTER           0x0000000DUL                                          /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDANDDRIVEPULLUP           0x0000000EUL                                          /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE2_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                          /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_DEFAULT                        (_GPIO_P_MODEL_MODE2_DEFAULT << 8)                    /**< Shifted mode DEFAULT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_DISABLED                       (_GPIO_P_MODEL_MODE2_DISABLED << 8)                   /**< Shifted mode DISABLED for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_INPUT                          (_GPIO_P_MODEL_MODE2_INPUT << 8)                      /**< Shifted mode INPUT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_INPUTPULL                      (_GPIO_P_MODEL_MODE2_INPUTPULL << 8)                  /**< Shifted mode INPUTPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_INPUTPULLFILTER                (_GPIO_P_MODEL_MODE2_INPUTPULLFILTER << 8)            /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_PUSHPULL                       (_GPIO_P_MODEL_MODE2_PUSHPULL << 8)                   /**< Shifted mode PUSHPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_PUSHPULLDRIVE                  (_GPIO_P_MODEL_MODE2_PUSHPULLDRIVE << 8)              /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDOR                        (_GPIO_P_MODEL_MODE2_WIREDOR << 8)                    /**< Shifted mode WIREDOR for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDORPULLDOWN                (_GPIO_P_MODEL_MODE2_WIREDORPULLDOWN << 8)            /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDAND                       (_GPIO_P_MODEL_MODE2_WIREDAND << 8)                   /**< Shifted mode WIREDAND for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDANDFILTER                 (_GPIO_P_MODEL_MODE2_WIREDANDFILTER << 8)             /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDANDPULLUP                 (_GPIO_P_MODEL_MODE2_WIREDANDPULLUP << 8)             /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDANDPULLUPFILTER           (_GPIO_P_MODEL_MODE2_WIREDANDPULLUPFILTER << 8)       /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDANDDRIVE                  (_GPIO_P_MODEL_MODE2_WIREDANDDRIVE << 8)              /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDANDDRIVEFILTER            (_GPIO_P_MODEL_MODE2_WIREDANDDRIVEFILTER << 8)        /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEL_MODE2_WIREDANDDRIVEPULLUP << 8)        /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE2_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEL_MODE2_WIREDANDDRIVEPULLUPFILTER << 8)  /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_SHIFT                         12                                                    /**< Shift value for GPIO_MODE3 */
+#define _GPIO_P_MODEL_MODE3_MASK                          0xF000UL                                              /**< Bit mask for GPIO_MODE3 */
+#define _GPIO_P_MODEL_MODE3_DEFAULT                       0x00000000UL                                          /**< Mode DEFAULT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_DISABLED                      0x00000000UL                                          /**< Mode DISABLED for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_INPUT                         0x00000001UL                                          /**< Mode INPUT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_INPUTPULL                     0x00000002UL                                          /**< Mode INPUTPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_INPUTPULLFILTER               0x00000003UL                                          /**< Mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_PUSHPULL                      0x00000004UL                                          /**< Mode PUSHPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_PUSHPULLDRIVE                 0x00000005UL                                          /**< Mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDOR                       0x00000006UL                                          /**< Mode WIREDOR for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDORPULLDOWN               0x00000007UL                                          /**< Mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDAND                      0x00000008UL                                          /**< Mode WIREDAND for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDANDFILTER                0x00000009UL                                          /**< Mode WIREDANDFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDANDPULLUP                0x0000000AUL                                          /**< Mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDANDPULLUPFILTER          0x0000000BUL                                          /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDANDDRIVE                 0x0000000CUL                                          /**< Mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDANDDRIVEFILTER           0x0000000DUL                                          /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDANDDRIVEPULLUP           0x0000000EUL                                          /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE3_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                          /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_DEFAULT                        (_GPIO_P_MODEL_MODE3_DEFAULT << 12)                   /**< Shifted mode DEFAULT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_DISABLED                       (_GPIO_P_MODEL_MODE3_DISABLED << 12)                  /**< Shifted mode DISABLED for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_INPUT                          (_GPIO_P_MODEL_MODE3_INPUT << 12)                     /**< Shifted mode INPUT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_INPUTPULL                      (_GPIO_P_MODEL_MODE3_INPUTPULL << 12)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_INPUTPULLFILTER                (_GPIO_P_MODEL_MODE3_INPUTPULLFILTER << 12)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_PUSHPULL                       (_GPIO_P_MODEL_MODE3_PUSHPULL << 12)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_PUSHPULLDRIVE                  (_GPIO_P_MODEL_MODE3_PUSHPULLDRIVE << 12)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDOR                        (_GPIO_P_MODEL_MODE3_WIREDOR << 12)                   /**< Shifted mode WIREDOR for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDORPULLDOWN                (_GPIO_P_MODEL_MODE3_WIREDORPULLDOWN << 12)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDAND                       (_GPIO_P_MODEL_MODE3_WIREDAND << 12)                  /**< Shifted mode WIREDAND for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDANDFILTER                 (_GPIO_P_MODEL_MODE3_WIREDANDFILTER << 12)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDANDPULLUP                 (_GPIO_P_MODEL_MODE3_WIREDANDPULLUP << 12)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDANDPULLUPFILTER           (_GPIO_P_MODEL_MODE3_WIREDANDPULLUPFILTER << 12)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDANDDRIVE                  (_GPIO_P_MODEL_MODE3_WIREDANDDRIVE << 12)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDANDDRIVEFILTER            (_GPIO_P_MODEL_MODE3_WIREDANDDRIVEFILTER << 12)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEL_MODE3_WIREDANDDRIVEPULLUP << 12)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE3_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEL_MODE3_WIREDANDDRIVEPULLUPFILTER << 12) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_SHIFT                         16                                                    /**< Shift value for GPIO_MODE4 */
+#define _GPIO_P_MODEL_MODE4_MASK                          0xF0000UL                                             /**< Bit mask for GPIO_MODE4 */
+#define _GPIO_P_MODEL_MODE4_DEFAULT                       0x00000000UL                                          /**< Mode DEFAULT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_DISABLED                      0x00000000UL                                          /**< Mode DISABLED for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_INPUT                         0x00000001UL                                          /**< Mode INPUT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_INPUTPULL                     0x00000002UL                                          /**< Mode INPUTPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_INPUTPULLFILTER               0x00000003UL                                          /**< Mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_PUSHPULL                      0x00000004UL                                          /**< Mode PUSHPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_PUSHPULLDRIVE                 0x00000005UL                                          /**< Mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDOR                       0x00000006UL                                          /**< Mode WIREDOR for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDORPULLDOWN               0x00000007UL                                          /**< Mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDAND                      0x00000008UL                                          /**< Mode WIREDAND for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDANDFILTER                0x00000009UL                                          /**< Mode WIREDANDFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDANDPULLUP                0x0000000AUL                                          /**< Mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDANDPULLUPFILTER          0x0000000BUL                                          /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDANDDRIVE                 0x0000000CUL                                          /**< Mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDANDDRIVEFILTER           0x0000000DUL                                          /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDANDDRIVEPULLUP           0x0000000EUL                                          /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE4_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                          /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_DEFAULT                        (_GPIO_P_MODEL_MODE4_DEFAULT << 16)                   /**< Shifted mode DEFAULT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_DISABLED                       (_GPIO_P_MODEL_MODE4_DISABLED << 16)                  /**< Shifted mode DISABLED for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_INPUT                          (_GPIO_P_MODEL_MODE4_INPUT << 16)                     /**< Shifted mode INPUT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_INPUTPULL                      (_GPIO_P_MODEL_MODE4_INPUTPULL << 16)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_INPUTPULLFILTER                (_GPIO_P_MODEL_MODE4_INPUTPULLFILTER << 16)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_PUSHPULL                       (_GPIO_P_MODEL_MODE4_PUSHPULL << 16)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_PUSHPULLDRIVE                  (_GPIO_P_MODEL_MODE4_PUSHPULLDRIVE << 16)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDOR                        (_GPIO_P_MODEL_MODE4_WIREDOR << 16)                   /**< Shifted mode WIREDOR for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDORPULLDOWN                (_GPIO_P_MODEL_MODE4_WIREDORPULLDOWN << 16)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDAND                       (_GPIO_P_MODEL_MODE4_WIREDAND << 16)                  /**< Shifted mode WIREDAND for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDANDFILTER                 (_GPIO_P_MODEL_MODE4_WIREDANDFILTER << 16)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDANDPULLUP                 (_GPIO_P_MODEL_MODE4_WIREDANDPULLUP << 16)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDANDPULLUPFILTER           (_GPIO_P_MODEL_MODE4_WIREDANDPULLUPFILTER << 16)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDANDDRIVE                  (_GPIO_P_MODEL_MODE4_WIREDANDDRIVE << 16)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDANDDRIVEFILTER            (_GPIO_P_MODEL_MODE4_WIREDANDDRIVEFILTER << 16)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEL_MODE4_WIREDANDDRIVEPULLUP << 16)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE4_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEL_MODE4_WIREDANDDRIVEPULLUPFILTER << 16) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_SHIFT                         20                                                    /**< Shift value for GPIO_MODE5 */
+#define _GPIO_P_MODEL_MODE5_MASK                          0xF00000UL                                            /**< Bit mask for GPIO_MODE5 */
+#define _GPIO_P_MODEL_MODE5_DEFAULT                       0x00000000UL                                          /**< Mode DEFAULT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_DISABLED                      0x00000000UL                                          /**< Mode DISABLED for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_INPUT                         0x00000001UL                                          /**< Mode INPUT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_INPUTPULL                     0x00000002UL                                          /**< Mode INPUTPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_INPUTPULLFILTER               0x00000003UL                                          /**< Mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_PUSHPULL                      0x00000004UL                                          /**< Mode PUSHPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_PUSHPULLDRIVE                 0x00000005UL                                          /**< Mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDOR                       0x00000006UL                                          /**< Mode WIREDOR for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDORPULLDOWN               0x00000007UL                                          /**< Mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDAND                      0x00000008UL                                          /**< Mode WIREDAND for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDANDFILTER                0x00000009UL                                          /**< Mode WIREDANDFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDANDPULLUP                0x0000000AUL                                          /**< Mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDANDPULLUPFILTER          0x0000000BUL                                          /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDANDDRIVE                 0x0000000CUL                                          /**< Mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDANDDRIVEFILTER           0x0000000DUL                                          /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDANDDRIVEPULLUP           0x0000000EUL                                          /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE5_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                          /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_DEFAULT                        (_GPIO_P_MODEL_MODE5_DEFAULT << 20)                   /**< Shifted mode DEFAULT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_DISABLED                       (_GPIO_P_MODEL_MODE5_DISABLED << 20)                  /**< Shifted mode DISABLED for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_INPUT                          (_GPIO_P_MODEL_MODE5_INPUT << 20)                     /**< Shifted mode INPUT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_INPUTPULL                      (_GPIO_P_MODEL_MODE5_INPUTPULL << 20)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_INPUTPULLFILTER                (_GPIO_P_MODEL_MODE5_INPUTPULLFILTER << 20)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_PUSHPULL                       (_GPIO_P_MODEL_MODE5_PUSHPULL << 20)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_PUSHPULLDRIVE                  (_GPIO_P_MODEL_MODE5_PUSHPULLDRIVE << 20)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDOR                        (_GPIO_P_MODEL_MODE5_WIREDOR << 20)                   /**< Shifted mode WIREDOR for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDORPULLDOWN                (_GPIO_P_MODEL_MODE5_WIREDORPULLDOWN << 20)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDAND                       (_GPIO_P_MODEL_MODE5_WIREDAND << 20)                  /**< Shifted mode WIREDAND for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDANDFILTER                 (_GPIO_P_MODEL_MODE5_WIREDANDFILTER << 20)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDANDPULLUP                 (_GPIO_P_MODEL_MODE5_WIREDANDPULLUP << 20)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDANDPULLUPFILTER           (_GPIO_P_MODEL_MODE5_WIREDANDPULLUPFILTER << 20)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDANDDRIVE                  (_GPIO_P_MODEL_MODE5_WIREDANDDRIVE << 20)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDANDDRIVEFILTER            (_GPIO_P_MODEL_MODE5_WIREDANDDRIVEFILTER << 20)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEL_MODE5_WIREDANDDRIVEPULLUP << 20)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE5_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEL_MODE5_WIREDANDDRIVEPULLUPFILTER << 20) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_SHIFT                         24                                                    /**< Shift value for GPIO_MODE6 */
+#define _GPIO_P_MODEL_MODE6_MASK                          0xF000000UL                                           /**< Bit mask for GPIO_MODE6 */
+#define _GPIO_P_MODEL_MODE6_DEFAULT                       0x00000000UL                                          /**< Mode DEFAULT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_DISABLED                      0x00000000UL                                          /**< Mode DISABLED for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_INPUT                         0x00000001UL                                          /**< Mode INPUT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_INPUTPULL                     0x00000002UL                                          /**< Mode INPUTPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_INPUTPULLFILTER               0x00000003UL                                          /**< Mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_PUSHPULL                      0x00000004UL                                          /**< Mode PUSHPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_PUSHPULLDRIVE                 0x00000005UL                                          /**< Mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDOR                       0x00000006UL                                          /**< Mode WIREDOR for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDORPULLDOWN               0x00000007UL                                          /**< Mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDAND                      0x00000008UL                                          /**< Mode WIREDAND for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDANDFILTER                0x00000009UL                                          /**< Mode WIREDANDFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDANDPULLUP                0x0000000AUL                                          /**< Mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDANDPULLUPFILTER          0x0000000BUL                                          /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDANDDRIVE                 0x0000000CUL                                          /**< Mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDANDDRIVEFILTER           0x0000000DUL                                          /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDANDDRIVEPULLUP           0x0000000EUL                                          /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE6_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                          /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_DEFAULT                        (_GPIO_P_MODEL_MODE6_DEFAULT << 24)                   /**< Shifted mode DEFAULT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_DISABLED                       (_GPIO_P_MODEL_MODE6_DISABLED << 24)                  /**< Shifted mode DISABLED for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_INPUT                          (_GPIO_P_MODEL_MODE6_INPUT << 24)                     /**< Shifted mode INPUT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_INPUTPULL                      (_GPIO_P_MODEL_MODE6_INPUTPULL << 24)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_INPUTPULLFILTER                (_GPIO_P_MODEL_MODE6_INPUTPULLFILTER << 24)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_PUSHPULL                       (_GPIO_P_MODEL_MODE6_PUSHPULL << 24)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_PUSHPULLDRIVE                  (_GPIO_P_MODEL_MODE6_PUSHPULLDRIVE << 24)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDOR                        (_GPIO_P_MODEL_MODE6_WIREDOR << 24)                   /**< Shifted mode WIREDOR for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDORPULLDOWN                (_GPIO_P_MODEL_MODE6_WIREDORPULLDOWN << 24)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDAND                       (_GPIO_P_MODEL_MODE6_WIREDAND << 24)                  /**< Shifted mode WIREDAND for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDANDFILTER                 (_GPIO_P_MODEL_MODE6_WIREDANDFILTER << 24)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDANDPULLUP                 (_GPIO_P_MODEL_MODE6_WIREDANDPULLUP << 24)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDANDPULLUPFILTER           (_GPIO_P_MODEL_MODE6_WIREDANDPULLUPFILTER << 24)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDANDDRIVE                  (_GPIO_P_MODEL_MODE6_WIREDANDDRIVE << 24)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDANDDRIVEFILTER            (_GPIO_P_MODEL_MODE6_WIREDANDDRIVEFILTER << 24)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEL_MODE6_WIREDANDDRIVEPULLUP << 24)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE6_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEL_MODE6_WIREDANDDRIVEPULLUPFILTER << 24) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_SHIFT                         28                                                    /**< Shift value for GPIO_MODE7 */
+#define _GPIO_P_MODEL_MODE7_MASK                          0xF0000000UL                                          /**< Bit mask for GPIO_MODE7 */
+#define _GPIO_P_MODEL_MODE7_DEFAULT                       0x00000000UL                                          /**< Mode DEFAULT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_DISABLED                      0x00000000UL                                          /**< Mode DISABLED for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_INPUT                         0x00000001UL                                          /**< Mode INPUT for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_INPUTPULL                     0x00000002UL                                          /**< Mode INPUTPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_INPUTPULLFILTER               0x00000003UL                                          /**< Mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_PUSHPULL                      0x00000004UL                                          /**< Mode PUSHPULL for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_PUSHPULLDRIVE                 0x00000005UL                                          /**< Mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDOR                       0x00000006UL                                          /**< Mode WIREDOR for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDORPULLDOWN               0x00000007UL                                          /**< Mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDAND                      0x00000008UL                                          /**< Mode WIREDAND for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDANDFILTER                0x00000009UL                                          /**< Mode WIREDANDFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDANDPULLUP                0x0000000AUL                                          /**< Mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDANDPULLUPFILTER          0x0000000BUL                                          /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDANDDRIVE                 0x0000000CUL                                          /**< Mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDANDDRIVEFILTER           0x0000000DUL                                          /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDANDDRIVEPULLUP           0x0000000EUL                                          /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define _GPIO_P_MODEL_MODE7_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                          /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_DEFAULT                        (_GPIO_P_MODEL_MODE7_DEFAULT << 28)                   /**< Shifted mode DEFAULT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_DISABLED                       (_GPIO_P_MODEL_MODE7_DISABLED << 28)                  /**< Shifted mode DISABLED for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_INPUT                          (_GPIO_P_MODEL_MODE7_INPUT << 28)                     /**< Shifted mode INPUT for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_INPUTPULL                      (_GPIO_P_MODEL_MODE7_INPUTPULL << 28)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_INPUTPULLFILTER                (_GPIO_P_MODEL_MODE7_INPUTPULLFILTER << 28)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_PUSHPULL                       (_GPIO_P_MODEL_MODE7_PUSHPULL << 28)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_PUSHPULLDRIVE                  (_GPIO_P_MODEL_MODE7_PUSHPULLDRIVE << 28)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDOR                        (_GPIO_P_MODEL_MODE7_WIREDOR << 28)                   /**< Shifted mode WIREDOR for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDORPULLDOWN                (_GPIO_P_MODEL_MODE7_WIREDORPULLDOWN << 28)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDAND                       (_GPIO_P_MODEL_MODE7_WIREDAND << 28)                  /**< Shifted mode WIREDAND for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDANDFILTER                 (_GPIO_P_MODEL_MODE7_WIREDANDFILTER << 28)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDANDPULLUP                 (_GPIO_P_MODEL_MODE7_WIREDANDPULLUP << 28)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDANDPULLUPFILTER           (_GPIO_P_MODEL_MODE7_WIREDANDPULLUPFILTER << 28)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDANDDRIVE                  (_GPIO_P_MODEL_MODE7_WIREDANDDRIVE << 28)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDANDDRIVEFILTER            (_GPIO_P_MODEL_MODE7_WIREDANDDRIVEFILTER << 28)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEL_MODE7_WIREDANDDRIVEPULLUP << 28)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEL */
+#define GPIO_P_MODEL_MODE7_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEL_MODE7_WIREDANDDRIVEPULLUPFILTER << 28) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEL */
+
+/* Bit fields for GPIO P_MODEH */
+#define _GPIO_P_MODEH_RESETVALUE                          0x00000000UL                                           /**< Default value for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MASK                                0xFFFFFFFFUL                                           /**< Mask for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_SHIFT                         0                                                      /**< Shift value for GPIO_MODE8 */
+#define _GPIO_P_MODEH_MODE8_MASK                          0xFUL                                                  /**< Bit mask for GPIO_MODE8 */
+#define _GPIO_P_MODEH_MODE8_DEFAULT                       0x00000000UL                                           /**< Mode DEFAULT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_DISABLED                      0x00000000UL                                           /**< Mode DISABLED for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_INPUT                         0x00000001UL                                           /**< Mode INPUT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_INPUTPULL                     0x00000002UL                                           /**< Mode INPUTPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_INPUTPULLFILTER               0x00000003UL                                           /**< Mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_PUSHPULL                      0x00000004UL                                           /**< Mode PUSHPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_PUSHPULLDRIVE                 0x00000005UL                                           /**< Mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDOR                       0x00000006UL                                           /**< Mode WIREDOR for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDORPULLDOWN               0x00000007UL                                           /**< Mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDAND                      0x00000008UL                                           /**< Mode WIREDAND for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDANDFILTER                0x00000009UL                                           /**< Mode WIREDANDFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDANDPULLUP                0x0000000AUL                                           /**< Mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDANDPULLUPFILTER          0x0000000BUL                                           /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDANDDRIVE                 0x0000000CUL                                           /**< Mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDANDDRIVEFILTER           0x0000000DUL                                           /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDANDDRIVEPULLUP           0x0000000EUL                                           /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE8_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                           /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_DEFAULT                        (_GPIO_P_MODEH_MODE8_DEFAULT << 0)                     /**< Shifted mode DEFAULT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_DISABLED                       (_GPIO_P_MODEH_MODE8_DISABLED << 0)                    /**< Shifted mode DISABLED for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_INPUT                          (_GPIO_P_MODEH_MODE8_INPUT << 0)                       /**< Shifted mode INPUT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_INPUTPULL                      (_GPIO_P_MODEH_MODE8_INPUTPULL << 0)                   /**< Shifted mode INPUTPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_INPUTPULLFILTER                (_GPIO_P_MODEH_MODE8_INPUTPULLFILTER << 0)             /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_PUSHPULL                       (_GPIO_P_MODEH_MODE8_PUSHPULL << 0)                    /**< Shifted mode PUSHPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_PUSHPULLDRIVE                  (_GPIO_P_MODEH_MODE8_PUSHPULLDRIVE << 0)               /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDOR                        (_GPIO_P_MODEH_MODE8_WIREDOR << 0)                     /**< Shifted mode WIREDOR for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDORPULLDOWN                (_GPIO_P_MODEH_MODE8_WIREDORPULLDOWN << 0)             /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDAND                       (_GPIO_P_MODEH_MODE8_WIREDAND << 0)                    /**< Shifted mode WIREDAND for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDANDFILTER                 (_GPIO_P_MODEH_MODE8_WIREDANDFILTER << 0)              /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDANDPULLUP                 (_GPIO_P_MODEH_MODE8_WIREDANDPULLUP << 0)              /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDANDPULLUPFILTER           (_GPIO_P_MODEH_MODE8_WIREDANDPULLUPFILTER << 0)        /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDANDDRIVE                  (_GPIO_P_MODEH_MODE8_WIREDANDDRIVE << 0)               /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDANDDRIVEFILTER            (_GPIO_P_MODEH_MODE8_WIREDANDDRIVEFILTER << 0)         /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEH_MODE8_WIREDANDDRIVEPULLUP << 0)         /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE8_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEH_MODE8_WIREDANDDRIVEPULLUPFILTER << 0)   /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_SHIFT                         4                                                      /**< Shift value for GPIO_MODE9 */
+#define _GPIO_P_MODEH_MODE9_MASK                          0xF0UL                                                 /**< Bit mask for GPIO_MODE9 */
+#define _GPIO_P_MODEH_MODE9_DEFAULT                       0x00000000UL                                           /**< Mode DEFAULT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_DISABLED                      0x00000000UL                                           /**< Mode DISABLED for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_INPUT                         0x00000001UL                                           /**< Mode INPUT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_INPUTPULL                     0x00000002UL                                           /**< Mode INPUTPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_INPUTPULLFILTER               0x00000003UL                                           /**< Mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_PUSHPULL                      0x00000004UL                                           /**< Mode PUSHPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_PUSHPULLDRIVE                 0x00000005UL                                           /**< Mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDOR                       0x00000006UL                                           /**< Mode WIREDOR for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDORPULLDOWN               0x00000007UL                                           /**< Mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDAND                      0x00000008UL                                           /**< Mode WIREDAND for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDANDFILTER                0x00000009UL                                           /**< Mode WIREDANDFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDANDPULLUP                0x0000000AUL                                           /**< Mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDANDPULLUPFILTER          0x0000000BUL                                           /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDANDDRIVE                 0x0000000CUL                                           /**< Mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDANDDRIVEFILTER           0x0000000DUL                                           /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDANDDRIVEPULLUP           0x0000000EUL                                           /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE9_WIREDANDDRIVEPULLUPFILTER     0x0000000FUL                                           /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_DEFAULT                        (_GPIO_P_MODEH_MODE9_DEFAULT << 4)                     /**< Shifted mode DEFAULT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_DISABLED                       (_GPIO_P_MODEH_MODE9_DISABLED << 4)                    /**< Shifted mode DISABLED for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_INPUT                          (_GPIO_P_MODEH_MODE9_INPUT << 4)                       /**< Shifted mode INPUT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_INPUTPULL                      (_GPIO_P_MODEH_MODE9_INPUTPULL << 4)                   /**< Shifted mode INPUTPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_INPUTPULLFILTER                (_GPIO_P_MODEH_MODE9_INPUTPULLFILTER << 4)             /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_PUSHPULL                       (_GPIO_P_MODEH_MODE9_PUSHPULL << 4)                    /**< Shifted mode PUSHPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_PUSHPULLDRIVE                  (_GPIO_P_MODEH_MODE9_PUSHPULLDRIVE << 4)               /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDOR                        (_GPIO_P_MODEH_MODE9_WIREDOR << 4)                     /**< Shifted mode WIREDOR for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDORPULLDOWN                (_GPIO_P_MODEH_MODE9_WIREDORPULLDOWN << 4)             /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDAND                       (_GPIO_P_MODEH_MODE9_WIREDAND << 4)                    /**< Shifted mode WIREDAND for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDANDFILTER                 (_GPIO_P_MODEH_MODE9_WIREDANDFILTER << 4)              /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDANDPULLUP                 (_GPIO_P_MODEH_MODE9_WIREDANDPULLUP << 4)              /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDANDPULLUPFILTER           (_GPIO_P_MODEH_MODE9_WIREDANDPULLUPFILTER << 4)        /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDANDDRIVE                  (_GPIO_P_MODEH_MODE9_WIREDANDDRIVE << 4)               /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDANDDRIVEFILTER            (_GPIO_P_MODEH_MODE9_WIREDANDDRIVEFILTER << 4)         /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDANDDRIVEPULLUP            (_GPIO_P_MODEH_MODE9_WIREDANDDRIVEPULLUP << 4)         /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE9_WIREDANDDRIVEPULLUPFILTER      (_GPIO_P_MODEH_MODE9_WIREDANDDRIVEPULLUPFILTER << 4)   /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_SHIFT                        8                                                      /**< Shift value for GPIO_MODE10 */
+#define _GPIO_P_MODEH_MODE10_MASK                         0xF00UL                                                /**< Bit mask for GPIO_MODE10 */
+#define _GPIO_P_MODEH_MODE10_DEFAULT                      0x00000000UL                                           /**< Mode DEFAULT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_DISABLED                     0x00000000UL                                           /**< Mode DISABLED for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_INPUT                        0x00000001UL                                           /**< Mode INPUT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_INPUTPULL                    0x00000002UL                                           /**< Mode INPUTPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_INPUTPULLFILTER              0x00000003UL                                           /**< Mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_PUSHPULL                     0x00000004UL                                           /**< Mode PUSHPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_PUSHPULLDRIVE                0x00000005UL                                           /**< Mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDOR                      0x00000006UL                                           /**< Mode WIREDOR for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDORPULLDOWN              0x00000007UL                                           /**< Mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDAND                     0x00000008UL                                           /**< Mode WIREDAND for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDANDFILTER               0x00000009UL                                           /**< Mode WIREDANDFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDANDPULLUP               0x0000000AUL                                           /**< Mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDANDPULLUPFILTER         0x0000000BUL                                           /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDANDDRIVE                0x0000000CUL                                           /**< Mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDANDDRIVEFILTER          0x0000000DUL                                           /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDANDDRIVEPULLUP          0x0000000EUL                                           /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE10_WIREDANDDRIVEPULLUPFILTER    0x0000000FUL                                           /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_DEFAULT                       (_GPIO_P_MODEH_MODE10_DEFAULT << 8)                    /**< Shifted mode DEFAULT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_DISABLED                      (_GPIO_P_MODEH_MODE10_DISABLED << 8)                   /**< Shifted mode DISABLED for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_INPUT                         (_GPIO_P_MODEH_MODE10_INPUT << 8)                      /**< Shifted mode INPUT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_INPUTPULL                     (_GPIO_P_MODEH_MODE10_INPUTPULL << 8)                  /**< Shifted mode INPUTPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_INPUTPULLFILTER               (_GPIO_P_MODEH_MODE10_INPUTPULLFILTER << 8)            /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_PUSHPULL                      (_GPIO_P_MODEH_MODE10_PUSHPULL << 8)                   /**< Shifted mode PUSHPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_PUSHPULLDRIVE                 (_GPIO_P_MODEH_MODE10_PUSHPULLDRIVE << 8)              /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDOR                       (_GPIO_P_MODEH_MODE10_WIREDOR << 8)                    /**< Shifted mode WIREDOR for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDORPULLDOWN               (_GPIO_P_MODEH_MODE10_WIREDORPULLDOWN << 8)            /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDAND                      (_GPIO_P_MODEH_MODE10_WIREDAND << 8)                   /**< Shifted mode WIREDAND for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDANDFILTER                (_GPIO_P_MODEH_MODE10_WIREDANDFILTER << 8)             /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDANDPULLUP                (_GPIO_P_MODEH_MODE10_WIREDANDPULLUP << 8)             /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDANDPULLUPFILTER          (_GPIO_P_MODEH_MODE10_WIREDANDPULLUPFILTER << 8)       /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDANDDRIVE                 (_GPIO_P_MODEH_MODE10_WIREDANDDRIVE << 8)              /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDANDDRIVEFILTER           (_GPIO_P_MODEH_MODE10_WIREDANDDRIVEFILTER << 8)        /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDANDDRIVEPULLUP           (_GPIO_P_MODEH_MODE10_WIREDANDDRIVEPULLUP << 8)        /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE10_WIREDANDDRIVEPULLUPFILTER     (_GPIO_P_MODEH_MODE10_WIREDANDDRIVEPULLUPFILTER << 8)  /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_SHIFT                        12                                                     /**< Shift value for GPIO_MODE11 */
+#define _GPIO_P_MODEH_MODE11_MASK                         0xF000UL                                               /**< Bit mask for GPIO_MODE11 */
+#define _GPIO_P_MODEH_MODE11_DEFAULT                      0x00000000UL                                           /**< Mode DEFAULT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_DISABLED                     0x00000000UL                                           /**< Mode DISABLED for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_INPUT                        0x00000001UL                                           /**< Mode INPUT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_INPUTPULL                    0x00000002UL                                           /**< Mode INPUTPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_INPUTPULLFILTER              0x00000003UL                                           /**< Mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_PUSHPULL                     0x00000004UL                                           /**< Mode PUSHPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_PUSHPULLDRIVE                0x00000005UL                                           /**< Mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDOR                      0x00000006UL                                           /**< Mode WIREDOR for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDORPULLDOWN              0x00000007UL                                           /**< Mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDAND                     0x00000008UL                                           /**< Mode WIREDAND for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDANDFILTER               0x00000009UL                                           /**< Mode WIREDANDFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDANDPULLUP               0x0000000AUL                                           /**< Mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDANDPULLUPFILTER         0x0000000BUL                                           /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDANDDRIVE                0x0000000CUL                                           /**< Mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDANDDRIVEFILTER          0x0000000DUL                                           /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDANDDRIVEPULLUP          0x0000000EUL                                           /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE11_WIREDANDDRIVEPULLUPFILTER    0x0000000FUL                                           /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_DEFAULT                       (_GPIO_P_MODEH_MODE11_DEFAULT << 12)                   /**< Shifted mode DEFAULT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_DISABLED                      (_GPIO_P_MODEH_MODE11_DISABLED << 12)                  /**< Shifted mode DISABLED for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_INPUT                         (_GPIO_P_MODEH_MODE11_INPUT << 12)                     /**< Shifted mode INPUT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_INPUTPULL                     (_GPIO_P_MODEH_MODE11_INPUTPULL << 12)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_INPUTPULLFILTER               (_GPIO_P_MODEH_MODE11_INPUTPULLFILTER << 12)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_PUSHPULL                      (_GPIO_P_MODEH_MODE11_PUSHPULL << 12)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_PUSHPULLDRIVE                 (_GPIO_P_MODEH_MODE11_PUSHPULLDRIVE << 12)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDOR                       (_GPIO_P_MODEH_MODE11_WIREDOR << 12)                   /**< Shifted mode WIREDOR for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDORPULLDOWN               (_GPIO_P_MODEH_MODE11_WIREDORPULLDOWN << 12)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDAND                      (_GPIO_P_MODEH_MODE11_WIREDAND << 12)                  /**< Shifted mode WIREDAND for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDANDFILTER                (_GPIO_P_MODEH_MODE11_WIREDANDFILTER << 12)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDANDPULLUP                (_GPIO_P_MODEH_MODE11_WIREDANDPULLUP << 12)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDANDPULLUPFILTER          (_GPIO_P_MODEH_MODE11_WIREDANDPULLUPFILTER << 12)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDANDDRIVE                 (_GPIO_P_MODEH_MODE11_WIREDANDDRIVE << 12)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDANDDRIVEFILTER           (_GPIO_P_MODEH_MODE11_WIREDANDDRIVEFILTER << 12)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDANDDRIVEPULLUP           (_GPIO_P_MODEH_MODE11_WIREDANDDRIVEPULLUP << 12)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE11_WIREDANDDRIVEPULLUPFILTER     (_GPIO_P_MODEH_MODE11_WIREDANDDRIVEPULLUPFILTER << 12) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_SHIFT                        16                                                     /**< Shift value for GPIO_MODE12 */
+#define _GPIO_P_MODEH_MODE12_MASK                         0xF0000UL                                              /**< Bit mask for GPIO_MODE12 */
+#define _GPIO_P_MODEH_MODE12_DEFAULT                      0x00000000UL                                           /**< Mode DEFAULT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_DISABLED                     0x00000000UL                                           /**< Mode DISABLED for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_INPUT                        0x00000001UL                                           /**< Mode INPUT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_INPUTPULL                    0x00000002UL                                           /**< Mode INPUTPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_INPUTPULLFILTER              0x00000003UL                                           /**< Mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_PUSHPULL                     0x00000004UL                                           /**< Mode PUSHPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_PUSHPULLDRIVE                0x00000005UL                                           /**< Mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDOR                      0x00000006UL                                           /**< Mode WIREDOR for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDORPULLDOWN              0x00000007UL                                           /**< Mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDAND                     0x00000008UL                                           /**< Mode WIREDAND for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDANDFILTER               0x00000009UL                                           /**< Mode WIREDANDFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDANDPULLUP               0x0000000AUL                                           /**< Mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDANDPULLUPFILTER         0x0000000BUL                                           /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDANDDRIVE                0x0000000CUL                                           /**< Mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDANDDRIVEFILTER          0x0000000DUL                                           /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDANDDRIVEPULLUP          0x0000000EUL                                           /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE12_WIREDANDDRIVEPULLUPFILTER    0x0000000FUL                                           /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_DEFAULT                       (_GPIO_P_MODEH_MODE12_DEFAULT << 16)                   /**< Shifted mode DEFAULT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_DISABLED                      (_GPIO_P_MODEH_MODE12_DISABLED << 16)                  /**< Shifted mode DISABLED for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_INPUT                         (_GPIO_P_MODEH_MODE12_INPUT << 16)                     /**< Shifted mode INPUT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_INPUTPULL                     (_GPIO_P_MODEH_MODE12_INPUTPULL << 16)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_INPUTPULLFILTER               (_GPIO_P_MODEH_MODE12_INPUTPULLFILTER << 16)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_PUSHPULL                      (_GPIO_P_MODEH_MODE12_PUSHPULL << 16)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_PUSHPULLDRIVE                 (_GPIO_P_MODEH_MODE12_PUSHPULLDRIVE << 16)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDOR                       (_GPIO_P_MODEH_MODE12_WIREDOR << 16)                   /**< Shifted mode WIREDOR for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDORPULLDOWN               (_GPIO_P_MODEH_MODE12_WIREDORPULLDOWN << 16)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDAND                      (_GPIO_P_MODEH_MODE12_WIREDAND << 16)                  /**< Shifted mode WIREDAND for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDANDFILTER                (_GPIO_P_MODEH_MODE12_WIREDANDFILTER << 16)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDANDPULLUP                (_GPIO_P_MODEH_MODE12_WIREDANDPULLUP << 16)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDANDPULLUPFILTER          (_GPIO_P_MODEH_MODE12_WIREDANDPULLUPFILTER << 16)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDANDDRIVE                 (_GPIO_P_MODEH_MODE12_WIREDANDDRIVE << 16)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDANDDRIVEFILTER           (_GPIO_P_MODEH_MODE12_WIREDANDDRIVEFILTER << 16)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDANDDRIVEPULLUP           (_GPIO_P_MODEH_MODE12_WIREDANDDRIVEPULLUP << 16)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE12_WIREDANDDRIVEPULLUPFILTER     (_GPIO_P_MODEH_MODE12_WIREDANDDRIVEPULLUPFILTER << 16) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_SHIFT                        20                                                     /**< Shift value for GPIO_MODE13 */
+#define _GPIO_P_MODEH_MODE13_MASK                         0xF00000UL                                             /**< Bit mask for GPIO_MODE13 */
+#define _GPIO_P_MODEH_MODE13_DEFAULT                      0x00000000UL                                           /**< Mode DEFAULT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_DISABLED                     0x00000000UL                                           /**< Mode DISABLED for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_INPUT                        0x00000001UL                                           /**< Mode INPUT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_INPUTPULL                    0x00000002UL                                           /**< Mode INPUTPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_INPUTPULLFILTER              0x00000003UL                                           /**< Mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_PUSHPULL                     0x00000004UL                                           /**< Mode PUSHPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_PUSHPULLDRIVE                0x00000005UL                                           /**< Mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDOR                      0x00000006UL                                           /**< Mode WIREDOR for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDORPULLDOWN              0x00000007UL                                           /**< Mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDAND                     0x00000008UL                                           /**< Mode WIREDAND for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDANDFILTER               0x00000009UL                                           /**< Mode WIREDANDFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDANDPULLUP               0x0000000AUL                                           /**< Mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDANDPULLUPFILTER         0x0000000BUL                                           /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDANDDRIVE                0x0000000CUL                                           /**< Mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDANDDRIVEFILTER          0x0000000DUL                                           /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDANDDRIVEPULLUP          0x0000000EUL                                           /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE13_WIREDANDDRIVEPULLUPFILTER    0x0000000FUL                                           /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_DEFAULT                       (_GPIO_P_MODEH_MODE13_DEFAULT << 20)                   /**< Shifted mode DEFAULT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_DISABLED                      (_GPIO_P_MODEH_MODE13_DISABLED << 20)                  /**< Shifted mode DISABLED for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_INPUT                         (_GPIO_P_MODEH_MODE13_INPUT << 20)                     /**< Shifted mode INPUT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_INPUTPULL                     (_GPIO_P_MODEH_MODE13_INPUTPULL << 20)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_INPUTPULLFILTER               (_GPIO_P_MODEH_MODE13_INPUTPULLFILTER << 20)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_PUSHPULL                      (_GPIO_P_MODEH_MODE13_PUSHPULL << 20)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_PUSHPULLDRIVE                 (_GPIO_P_MODEH_MODE13_PUSHPULLDRIVE << 20)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDOR                       (_GPIO_P_MODEH_MODE13_WIREDOR << 20)                   /**< Shifted mode WIREDOR for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDORPULLDOWN               (_GPIO_P_MODEH_MODE13_WIREDORPULLDOWN << 20)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDAND                      (_GPIO_P_MODEH_MODE13_WIREDAND << 20)                  /**< Shifted mode WIREDAND for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDANDFILTER                (_GPIO_P_MODEH_MODE13_WIREDANDFILTER << 20)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDANDPULLUP                (_GPIO_P_MODEH_MODE13_WIREDANDPULLUP << 20)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDANDPULLUPFILTER          (_GPIO_P_MODEH_MODE13_WIREDANDPULLUPFILTER << 20)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDANDDRIVE                 (_GPIO_P_MODEH_MODE13_WIREDANDDRIVE << 20)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDANDDRIVEFILTER           (_GPIO_P_MODEH_MODE13_WIREDANDDRIVEFILTER << 20)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDANDDRIVEPULLUP           (_GPIO_P_MODEH_MODE13_WIREDANDDRIVEPULLUP << 20)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE13_WIREDANDDRIVEPULLUPFILTER     (_GPIO_P_MODEH_MODE13_WIREDANDDRIVEPULLUPFILTER << 20) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_SHIFT                        24                                                     /**< Shift value for GPIO_MODE14 */
+#define _GPIO_P_MODEH_MODE14_MASK                         0xF000000UL                                            /**< Bit mask for GPIO_MODE14 */
+#define _GPIO_P_MODEH_MODE14_DEFAULT                      0x00000000UL                                           /**< Mode DEFAULT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_DISABLED                     0x00000000UL                                           /**< Mode DISABLED for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_INPUT                        0x00000001UL                                           /**< Mode INPUT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_INPUTPULL                    0x00000002UL                                           /**< Mode INPUTPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_INPUTPULLFILTER              0x00000003UL                                           /**< Mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_PUSHPULL                     0x00000004UL                                           /**< Mode PUSHPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_PUSHPULLDRIVE                0x00000005UL                                           /**< Mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDOR                      0x00000006UL                                           /**< Mode WIREDOR for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDORPULLDOWN              0x00000007UL                                           /**< Mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDAND                     0x00000008UL                                           /**< Mode WIREDAND for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDANDFILTER               0x00000009UL                                           /**< Mode WIREDANDFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDANDPULLUP               0x0000000AUL                                           /**< Mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDANDPULLUPFILTER         0x0000000BUL                                           /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDANDDRIVE                0x0000000CUL                                           /**< Mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDANDDRIVEFILTER          0x0000000DUL                                           /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDANDDRIVEPULLUP          0x0000000EUL                                           /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE14_WIREDANDDRIVEPULLUPFILTER    0x0000000FUL                                           /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_DEFAULT                       (_GPIO_P_MODEH_MODE14_DEFAULT << 24)                   /**< Shifted mode DEFAULT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_DISABLED                      (_GPIO_P_MODEH_MODE14_DISABLED << 24)                  /**< Shifted mode DISABLED for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_INPUT                         (_GPIO_P_MODEH_MODE14_INPUT << 24)                     /**< Shifted mode INPUT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_INPUTPULL                     (_GPIO_P_MODEH_MODE14_INPUTPULL << 24)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_INPUTPULLFILTER               (_GPIO_P_MODEH_MODE14_INPUTPULLFILTER << 24)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_PUSHPULL                      (_GPIO_P_MODEH_MODE14_PUSHPULL << 24)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_PUSHPULLDRIVE                 (_GPIO_P_MODEH_MODE14_PUSHPULLDRIVE << 24)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDOR                       (_GPIO_P_MODEH_MODE14_WIREDOR << 24)                   /**< Shifted mode WIREDOR for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDORPULLDOWN               (_GPIO_P_MODEH_MODE14_WIREDORPULLDOWN << 24)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDAND                      (_GPIO_P_MODEH_MODE14_WIREDAND << 24)                  /**< Shifted mode WIREDAND for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDANDFILTER                (_GPIO_P_MODEH_MODE14_WIREDANDFILTER << 24)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDANDPULLUP                (_GPIO_P_MODEH_MODE14_WIREDANDPULLUP << 24)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDANDPULLUPFILTER          (_GPIO_P_MODEH_MODE14_WIREDANDPULLUPFILTER << 24)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDANDDRIVE                 (_GPIO_P_MODEH_MODE14_WIREDANDDRIVE << 24)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDANDDRIVEFILTER           (_GPIO_P_MODEH_MODE14_WIREDANDDRIVEFILTER << 24)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDANDDRIVEPULLUP           (_GPIO_P_MODEH_MODE14_WIREDANDDRIVEPULLUP << 24)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE14_WIREDANDDRIVEPULLUPFILTER     (_GPIO_P_MODEH_MODE14_WIREDANDDRIVEPULLUPFILTER << 24) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_SHIFT                        28                                                     /**< Shift value for GPIO_MODE15 */
+#define _GPIO_P_MODEH_MODE15_MASK                         0xF0000000UL                                           /**< Bit mask for GPIO_MODE15 */
+#define _GPIO_P_MODEH_MODE15_DEFAULT                      0x00000000UL                                           /**< Mode DEFAULT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_DISABLED                     0x00000000UL                                           /**< Mode DISABLED for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_INPUT                        0x00000001UL                                           /**< Mode INPUT for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_INPUTPULL                    0x00000002UL                                           /**< Mode INPUTPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_INPUTPULLFILTER              0x00000003UL                                           /**< Mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_PUSHPULL                     0x00000004UL                                           /**< Mode PUSHPULL for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_PUSHPULLDRIVE                0x00000005UL                                           /**< Mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDOR                      0x00000006UL                                           /**< Mode WIREDOR for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDORPULLDOWN              0x00000007UL                                           /**< Mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDAND                     0x00000008UL                                           /**< Mode WIREDAND for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDANDFILTER               0x00000009UL                                           /**< Mode WIREDANDFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDANDPULLUP               0x0000000AUL                                           /**< Mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDANDPULLUPFILTER         0x0000000BUL                                           /**< Mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDANDDRIVE                0x0000000CUL                                           /**< Mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDANDDRIVEFILTER          0x0000000DUL                                           /**< Mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDANDDRIVEPULLUP          0x0000000EUL                                           /**< Mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define _GPIO_P_MODEH_MODE15_WIREDANDDRIVEPULLUPFILTER    0x0000000FUL                                           /**< Mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_DEFAULT                       (_GPIO_P_MODEH_MODE15_DEFAULT << 28)                   /**< Shifted mode DEFAULT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_DISABLED                      (_GPIO_P_MODEH_MODE15_DISABLED << 28)                  /**< Shifted mode DISABLED for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_INPUT                         (_GPIO_P_MODEH_MODE15_INPUT << 28)                     /**< Shifted mode INPUT for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_INPUTPULL                     (_GPIO_P_MODEH_MODE15_INPUTPULL << 28)                 /**< Shifted mode INPUTPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_INPUTPULLFILTER               (_GPIO_P_MODEH_MODE15_INPUTPULLFILTER << 28)           /**< Shifted mode INPUTPULLFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_PUSHPULL                      (_GPIO_P_MODEH_MODE15_PUSHPULL << 28)                  /**< Shifted mode PUSHPULL for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_PUSHPULLDRIVE                 (_GPIO_P_MODEH_MODE15_PUSHPULLDRIVE << 28)             /**< Shifted mode PUSHPULLDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDOR                       (_GPIO_P_MODEH_MODE15_WIREDOR << 28)                   /**< Shifted mode WIREDOR for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDORPULLDOWN               (_GPIO_P_MODEH_MODE15_WIREDORPULLDOWN << 28)           /**< Shifted mode WIREDORPULLDOWN for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDAND                      (_GPIO_P_MODEH_MODE15_WIREDAND << 28)                  /**< Shifted mode WIREDAND for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDANDFILTER                (_GPIO_P_MODEH_MODE15_WIREDANDFILTER << 28)            /**< Shifted mode WIREDANDFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDANDPULLUP                (_GPIO_P_MODEH_MODE15_WIREDANDPULLUP << 28)            /**< Shifted mode WIREDANDPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDANDPULLUPFILTER          (_GPIO_P_MODEH_MODE15_WIREDANDPULLUPFILTER << 28)      /**< Shifted mode WIREDANDPULLUPFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDANDDRIVE                 (_GPIO_P_MODEH_MODE15_WIREDANDDRIVE << 28)             /**< Shifted mode WIREDANDDRIVE for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDANDDRIVEFILTER           (_GPIO_P_MODEH_MODE15_WIREDANDDRIVEFILTER << 28)       /**< Shifted mode WIREDANDDRIVEFILTER for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDANDDRIVEPULLUP           (_GPIO_P_MODEH_MODE15_WIREDANDDRIVEPULLUP << 28)       /**< Shifted mode WIREDANDDRIVEPULLUP for GPIO_P_MODEH */
+#define GPIO_P_MODEH_MODE15_WIREDANDDRIVEPULLUPFILTER     (_GPIO_P_MODEH_MODE15_WIREDANDDRIVEPULLUPFILTER << 28) /**< Shifted mode WIREDANDDRIVEPULLUPFILTER for GPIO_P_MODEH */
+
+/* Bit fields for GPIO P_DOUT */
+#define _GPIO_P_DOUT_RESETVALUE                           0x00000000UL                     /**< Default value for GPIO_P_DOUT */
+#define _GPIO_P_DOUT_MASK                                 0x0000FFFFUL                     /**< Mask for GPIO_P_DOUT */
+#define _GPIO_P_DOUT_DOUT_SHIFT                           0                                /**< Shift value for GPIO_DOUT */
+#define _GPIO_P_DOUT_DOUT_MASK                            0xFFFFUL                         /**< Bit mask for GPIO_DOUT */
+#define _GPIO_P_DOUT_DOUT_DEFAULT                         0x00000000UL                     /**< Mode DEFAULT for GPIO_P_DOUT */
+#define GPIO_P_DOUT_DOUT_DEFAULT                          (_GPIO_P_DOUT_DOUT_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_P_DOUT */
+
+/* Bit fields for GPIO P_DOUTSET */
+#define _GPIO_P_DOUTSET_RESETVALUE                        0x00000000UL                           /**< Default value for GPIO_P_DOUTSET */
+#define _GPIO_P_DOUTSET_MASK                              0x0000FFFFUL                           /**< Mask for GPIO_P_DOUTSET */
+#define _GPIO_P_DOUTSET_DOUTSET_SHIFT                     0                                      /**< Shift value for GPIO_DOUTSET */
+#define _GPIO_P_DOUTSET_DOUTSET_MASK                      0xFFFFUL                               /**< Bit mask for GPIO_DOUTSET */
+#define _GPIO_P_DOUTSET_DOUTSET_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for GPIO_P_DOUTSET */
+#define GPIO_P_DOUTSET_DOUTSET_DEFAULT                    (_GPIO_P_DOUTSET_DOUTSET_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_P_DOUTSET */
+
+/* Bit fields for GPIO P_DOUTCLR */
+#define _GPIO_P_DOUTCLR_RESETVALUE                        0x00000000UL                           /**< Default value for GPIO_P_DOUTCLR */
+#define _GPIO_P_DOUTCLR_MASK                              0x0000FFFFUL                           /**< Mask for GPIO_P_DOUTCLR */
+#define _GPIO_P_DOUTCLR_DOUTCLR_SHIFT                     0                                      /**< Shift value for GPIO_DOUTCLR */
+#define _GPIO_P_DOUTCLR_DOUTCLR_MASK                      0xFFFFUL                               /**< Bit mask for GPIO_DOUTCLR */
+#define _GPIO_P_DOUTCLR_DOUTCLR_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for GPIO_P_DOUTCLR */
+#define GPIO_P_DOUTCLR_DOUTCLR_DEFAULT                    (_GPIO_P_DOUTCLR_DOUTCLR_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_P_DOUTCLR */
+
+/* Bit fields for GPIO P_DOUTTGL */
+#define _GPIO_P_DOUTTGL_RESETVALUE                        0x00000000UL                           /**< Default value for GPIO_P_DOUTTGL */
+#define _GPIO_P_DOUTTGL_MASK                              0x0000FFFFUL                           /**< Mask for GPIO_P_DOUTTGL */
+#define _GPIO_P_DOUTTGL_DOUTTGL_SHIFT                     0                                      /**< Shift value for GPIO_DOUTTGL */
+#define _GPIO_P_DOUTTGL_DOUTTGL_MASK                      0xFFFFUL                               /**< Bit mask for GPIO_DOUTTGL */
+#define _GPIO_P_DOUTTGL_DOUTTGL_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for GPIO_P_DOUTTGL */
+#define GPIO_P_DOUTTGL_DOUTTGL_DEFAULT                    (_GPIO_P_DOUTTGL_DOUTTGL_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_P_DOUTTGL */
+
+/* Bit fields for GPIO P_DIN */
+#define _GPIO_P_DIN_RESETVALUE                            0x00000000UL                   /**< Default value for GPIO_P_DIN */
+#define _GPIO_P_DIN_MASK                                  0x0000FFFFUL                   /**< Mask for GPIO_P_DIN */
+#define _GPIO_P_DIN_DIN_SHIFT                             0                              /**< Shift value for GPIO_DIN */
+#define _GPIO_P_DIN_DIN_MASK                              0xFFFFUL                       /**< Bit mask for GPIO_DIN */
+#define _GPIO_P_DIN_DIN_DEFAULT                           0x00000000UL                   /**< Mode DEFAULT for GPIO_P_DIN */
+#define GPIO_P_DIN_DIN_DEFAULT                            (_GPIO_P_DIN_DIN_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_P_DIN */
+
+/* Bit fields for GPIO P_PINLOCKN */
+#define _GPIO_P_PINLOCKN_RESETVALUE                       0x0000FFFFUL                             /**< Default value for GPIO_P_PINLOCKN */
+#define _GPIO_P_PINLOCKN_MASK                             0x0000FFFFUL                             /**< Mask for GPIO_P_PINLOCKN */
+#define _GPIO_P_PINLOCKN_PINLOCKN_SHIFT                   0                                        /**< Shift value for GPIO_PINLOCKN */
+#define _GPIO_P_PINLOCKN_PINLOCKN_MASK                    0xFFFFUL                                 /**< Bit mask for GPIO_PINLOCKN */
+#define _GPIO_P_PINLOCKN_PINLOCKN_DEFAULT                 0x0000FFFFUL                             /**< Mode DEFAULT for GPIO_P_PINLOCKN */
+#define GPIO_P_PINLOCKN_PINLOCKN_DEFAULT                  (_GPIO_P_PINLOCKN_PINLOCKN_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_P_PINLOCKN */
+
+/* Bit fields for GPIO EXTIPSELL */
+#define _GPIO_EXTIPSELL_RESETVALUE                        0x00000000UL                              /**< Default value for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_MASK                              0x77777777UL                              /**< Mask for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL0_SHIFT                   0                                         /**< Shift value for GPIO_EXTIPSEL0 */
+#define _GPIO_EXTIPSELL_EXTIPSEL0_MASK                    0x7UL                                     /**< Bit mask for GPIO_EXTIPSEL0 */
+#define _GPIO_EXTIPSELL_EXTIPSEL0_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL0_PORTA                   0x00000000UL                              /**< Mode PORTA for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL0_PORTB                   0x00000001UL                              /**< Mode PORTB for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL0_PORTC                   0x00000002UL                              /**< Mode PORTC for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL0_PORTD                   0x00000003UL                              /**< Mode PORTD for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL0_PORTE                   0x00000004UL                              /**< Mode PORTE for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL0_PORTF                   0x00000005UL                              /**< Mode PORTF for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL0_DEFAULT                  (_GPIO_EXTIPSELL_EXTIPSEL0_DEFAULT << 0)  /**< Shifted mode DEFAULT for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL0_PORTA                    (_GPIO_EXTIPSELL_EXTIPSEL0_PORTA << 0)    /**< Shifted mode PORTA for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL0_PORTB                    (_GPIO_EXTIPSELL_EXTIPSEL0_PORTB << 0)    /**< Shifted mode PORTB for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL0_PORTC                    (_GPIO_EXTIPSELL_EXTIPSEL0_PORTC << 0)    /**< Shifted mode PORTC for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL0_PORTD                    (_GPIO_EXTIPSELL_EXTIPSEL0_PORTD << 0)    /**< Shifted mode PORTD for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL0_PORTE                    (_GPIO_EXTIPSELL_EXTIPSEL0_PORTE << 0)    /**< Shifted mode PORTE for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL0_PORTF                    (_GPIO_EXTIPSELL_EXTIPSEL0_PORTF << 0)    /**< Shifted mode PORTF for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL1_SHIFT                   4                                         /**< Shift value for GPIO_EXTIPSEL1 */
+#define _GPIO_EXTIPSELL_EXTIPSEL1_MASK                    0x70UL                                    /**< Bit mask for GPIO_EXTIPSEL1 */
+#define _GPIO_EXTIPSELL_EXTIPSEL1_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL1_PORTA                   0x00000000UL                              /**< Mode PORTA for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL1_PORTB                   0x00000001UL                              /**< Mode PORTB for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL1_PORTC                   0x00000002UL                              /**< Mode PORTC for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL1_PORTD                   0x00000003UL                              /**< Mode PORTD for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL1_PORTE                   0x00000004UL                              /**< Mode PORTE for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL1_PORTF                   0x00000005UL                              /**< Mode PORTF for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL1_DEFAULT                  (_GPIO_EXTIPSELL_EXTIPSEL1_DEFAULT << 4)  /**< Shifted mode DEFAULT for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL1_PORTA                    (_GPIO_EXTIPSELL_EXTIPSEL1_PORTA << 4)    /**< Shifted mode PORTA for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL1_PORTB                    (_GPIO_EXTIPSELL_EXTIPSEL1_PORTB << 4)    /**< Shifted mode PORTB for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL1_PORTC                    (_GPIO_EXTIPSELL_EXTIPSEL1_PORTC << 4)    /**< Shifted mode PORTC for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL1_PORTD                    (_GPIO_EXTIPSELL_EXTIPSEL1_PORTD << 4)    /**< Shifted mode PORTD for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL1_PORTE                    (_GPIO_EXTIPSELL_EXTIPSEL1_PORTE << 4)    /**< Shifted mode PORTE for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL1_PORTF                    (_GPIO_EXTIPSELL_EXTIPSEL1_PORTF << 4)    /**< Shifted mode PORTF for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL2_SHIFT                   8                                         /**< Shift value for GPIO_EXTIPSEL2 */
+#define _GPIO_EXTIPSELL_EXTIPSEL2_MASK                    0x700UL                                   /**< Bit mask for GPIO_EXTIPSEL2 */
+#define _GPIO_EXTIPSELL_EXTIPSEL2_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL2_PORTA                   0x00000000UL                              /**< Mode PORTA for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL2_PORTB                   0x00000001UL                              /**< Mode PORTB for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL2_PORTC                   0x00000002UL                              /**< Mode PORTC for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL2_PORTD                   0x00000003UL                              /**< Mode PORTD for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL2_PORTE                   0x00000004UL                              /**< Mode PORTE for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL2_PORTF                   0x00000005UL                              /**< Mode PORTF for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL2_DEFAULT                  (_GPIO_EXTIPSELL_EXTIPSEL2_DEFAULT << 8)  /**< Shifted mode DEFAULT for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL2_PORTA                    (_GPIO_EXTIPSELL_EXTIPSEL2_PORTA << 8)    /**< Shifted mode PORTA for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL2_PORTB                    (_GPIO_EXTIPSELL_EXTIPSEL2_PORTB << 8)    /**< Shifted mode PORTB for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL2_PORTC                    (_GPIO_EXTIPSELL_EXTIPSEL2_PORTC << 8)    /**< Shifted mode PORTC for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL2_PORTD                    (_GPIO_EXTIPSELL_EXTIPSEL2_PORTD << 8)    /**< Shifted mode PORTD for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL2_PORTE                    (_GPIO_EXTIPSELL_EXTIPSEL2_PORTE << 8)    /**< Shifted mode PORTE for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL2_PORTF                    (_GPIO_EXTIPSELL_EXTIPSEL2_PORTF << 8)    /**< Shifted mode PORTF for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL3_SHIFT                   12                                        /**< Shift value for GPIO_EXTIPSEL3 */
+#define _GPIO_EXTIPSELL_EXTIPSEL3_MASK                    0x7000UL                                  /**< Bit mask for GPIO_EXTIPSEL3 */
+#define _GPIO_EXTIPSELL_EXTIPSEL3_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL3_PORTA                   0x00000000UL                              /**< Mode PORTA for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL3_PORTB                   0x00000001UL                              /**< Mode PORTB for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL3_PORTC                   0x00000002UL                              /**< Mode PORTC for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL3_PORTD                   0x00000003UL                              /**< Mode PORTD for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL3_PORTE                   0x00000004UL                              /**< Mode PORTE for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL3_PORTF                   0x00000005UL                              /**< Mode PORTF for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL3_DEFAULT                  (_GPIO_EXTIPSELL_EXTIPSEL3_DEFAULT << 12) /**< Shifted mode DEFAULT for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL3_PORTA                    (_GPIO_EXTIPSELL_EXTIPSEL3_PORTA << 12)   /**< Shifted mode PORTA for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL3_PORTB                    (_GPIO_EXTIPSELL_EXTIPSEL3_PORTB << 12)   /**< Shifted mode PORTB for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL3_PORTC                    (_GPIO_EXTIPSELL_EXTIPSEL3_PORTC << 12)   /**< Shifted mode PORTC for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL3_PORTD                    (_GPIO_EXTIPSELL_EXTIPSEL3_PORTD << 12)   /**< Shifted mode PORTD for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL3_PORTE                    (_GPIO_EXTIPSELL_EXTIPSEL3_PORTE << 12)   /**< Shifted mode PORTE for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL3_PORTF                    (_GPIO_EXTIPSELL_EXTIPSEL3_PORTF << 12)   /**< Shifted mode PORTF for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL4_SHIFT                   16                                        /**< Shift value for GPIO_EXTIPSEL4 */
+#define _GPIO_EXTIPSELL_EXTIPSEL4_MASK                    0x70000UL                                 /**< Bit mask for GPIO_EXTIPSEL4 */
+#define _GPIO_EXTIPSELL_EXTIPSEL4_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL4_PORTA                   0x00000000UL                              /**< Mode PORTA for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL4_PORTB                   0x00000001UL                              /**< Mode PORTB for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL4_PORTC                   0x00000002UL                              /**< Mode PORTC for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL4_PORTD                   0x00000003UL                              /**< Mode PORTD for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL4_PORTE                   0x00000004UL                              /**< Mode PORTE for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL4_PORTF                   0x00000005UL                              /**< Mode PORTF for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL4_DEFAULT                  (_GPIO_EXTIPSELL_EXTIPSEL4_DEFAULT << 16) /**< Shifted mode DEFAULT for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL4_PORTA                    (_GPIO_EXTIPSELL_EXTIPSEL4_PORTA << 16)   /**< Shifted mode PORTA for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL4_PORTB                    (_GPIO_EXTIPSELL_EXTIPSEL4_PORTB << 16)   /**< Shifted mode PORTB for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL4_PORTC                    (_GPIO_EXTIPSELL_EXTIPSEL4_PORTC << 16)   /**< Shifted mode PORTC for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL4_PORTD                    (_GPIO_EXTIPSELL_EXTIPSEL4_PORTD << 16)   /**< Shifted mode PORTD for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL4_PORTE                    (_GPIO_EXTIPSELL_EXTIPSEL4_PORTE << 16)   /**< Shifted mode PORTE for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL4_PORTF                    (_GPIO_EXTIPSELL_EXTIPSEL4_PORTF << 16)   /**< Shifted mode PORTF for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL5_SHIFT                   20                                        /**< Shift value for GPIO_EXTIPSEL5 */
+#define _GPIO_EXTIPSELL_EXTIPSEL5_MASK                    0x700000UL                                /**< Bit mask for GPIO_EXTIPSEL5 */
+#define _GPIO_EXTIPSELL_EXTIPSEL5_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL5_PORTA                   0x00000000UL                              /**< Mode PORTA for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL5_PORTB                   0x00000001UL                              /**< Mode PORTB for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL5_PORTC                   0x00000002UL                              /**< Mode PORTC for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL5_PORTD                   0x00000003UL                              /**< Mode PORTD for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL5_PORTE                   0x00000004UL                              /**< Mode PORTE for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL5_PORTF                   0x00000005UL                              /**< Mode PORTF for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL5_DEFAULT                  (_GPIO_EXTIPSELL_EXTIPSEL5_DEFAULT << 20) /**< Shifted mode DEFAULT for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL5_PORTA                    (_GPIO_EXTIPSELL_EXTIPSEL5_PORTA << 20)   /**< Shifted mode PORTA for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL5_PORTB                    (_GPIO_EXTIPSELL_EXTIPSEL5_PORTB << 20)   /**< Shifted mode PORTB for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL5_PORTC                    (_GPIO_EXTIPSELL_EXTIPSEL5_PORTC << 20)   /**< Shifted mode PORTC for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL5_PORTD                    (_GPIO_EXTIPSELL_EXTIPSEL5_PORTD << 20)   /**< Shifted mode PORTD for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL5_PORTE                    (_GPIO_EXTIPSELL_EXTIPSEL5_PORTE << 20)   /**< Shifted mode PORTE for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL5_PORTF                    (_GPIO_EXTIPSELL_EXTIPSEL5_PORTF << 20)   /**< Shifted mode PORTF for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL6_SHIFT                   24                                        /**< Shift value for GPIO_EXTIPSEL6 */
+#define _GPIO_EXTIPSELL_EXTIPSEL6_MASK                    0x7000000UL                               /**< Bit mask for GPIO_EXTIPSEL6 */
+#define _GPIO_EXTIPSELL_EXTIPSEL6_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL6_PORTA                   0x00000000UL                              /**< Mode PORTA for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL6_PORTB                   0x00000001UL                              /**< Mode PORTB for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL6_PORTC                   0x00000002UL                              /**< Mode PORTC for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL6_PORTD                   0x00000003UL                              /**< Mode PORTD for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL6_PORTE                   0x00000004UL                              /**< Mode PORTE for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL6_PORTF                   0x00000005UL                              /**< Mode PORTF for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL6_DEFAULT                  (_GPIO_EXTIPSELL_EXTIPSEL6_DEFAULT << 24) /**< Shifted mode DEFAULT for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL6_PORTA                    (_GPIO_EXTIPSELL_EXTIPSEL6_PORTA << 24)   /**< Shifted mode PORTA for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL6_PORTB                    (_GPIO_EXTIPSELL_EXTIPSEL6_PORTB << 24)   /**< Shifted mode PORTB for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL6_PORTC                    (_GPIO_EXTIPSELL_EXTIPSEL6_PORTC << 24)   /**< Shifted mode PORTC for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL6_PORTD                    (_GPIO_EXTIPSELL_EXTIPSEL6_PORTD << 24)   /**< Shifted mode PORTD for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL6_PORTE                    (_GPIO_EXTIPSELL_EXTIPSEL6_PORTE << 24)   /**< Shifted mode PORTE for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL6_PORTF                    (_GPIO_EXTIPSELL_EXTIPSEL6_PORTF << 24)   /**< Shifted mode PORTF for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL7_SHIFT                   28                                        /**< Shift value for GPIO_EXTIPSEL7 */
+#define _GPIO_EXTIPSELL_EXTIPSEL7_MASK                    0x70000000UL                              /**< Bit mask for GPIO_EXTIPSEL7 */
+#define _GPIO_EXTIPSELL_EXTIPSEL7_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL7_PORTA                   0x00000000UL                              /**< Mode PORTA for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL7_PORTB                   0x00000001UL                              /**< Mode PORTB for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL7_PORTC                   0x00000002UL                              /**< Mode PORTC for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL7_PORTD                   0x00000003UL                              /**< Mode PORTD for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL7_PORTE                   0x00000004UL                              /**< Mode PORTE for GPIO_EXTIPSELL */
+#define _GPIO_EXTIPSELL_EXTIPSEL7_PORTF                   0x00000005UL                              /**< Mode PORTF for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL7_DEFAULT                  (_GPIO_EXTIPSELL_EXTIPSEL7_DEFAULT << 28) /**< Shifted mode DEFAULT for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL7_PORTA                    (_GPIO_EXTIPSELL_EXTIPSEL7_PORTA << 28)   /**< Shifted mode PORTA for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL7_PORTB                    (_GPIO_EXTIPSELL_EXTIPSEL7_PORTB << 28)   /**< Shifted mode PORTB for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL7_PORTC                    (_GPIO_EXTIPSELL_EXTIPSEL7_PORTC << 28)   /**< Shifted mode PORTC for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL7_PORTD                    (_GPIO_EXTIPSELL_EXTIPSEL7_PORTD << 28)   /**< Shifted mode PORTD for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL7_PORTE                    (_GPIO_EXTIPSELL_EXTIPSEL7_PORTE << 28)   /**< Shifted mode PORTE for GPIO_EXTIPSELL */
+#define GPIO_EXTIPSELL_EXTIPSEL7_PORTF                    (_GPIO_EXTIPSELL_EXTIPSEL7_PORTF << 28)   /**< Shifted mode PORTF for GPIO_EXTIPSELL */
+
+/* Bit fields for GPIO EXTIPSELH */
+#define _GPIO_EXTIPSELH_RESETVALUE                        0x00000000UL                               /**< Default value for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_MASK                              0x77777777UL                               /**< Mask for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL8_SHIFT                   0                                          /**< Shift value for GPIO_EXTIPSEL8 */
+#define _GPIO_EXTIPSELH_EXTIPSEL8_MASK                    0x7UL                                      /**< Bit mask for GPIO_EXTIPSEL8 */
+#define _GPIO_EXTIPSELH_EXTIPSEL8_DEFAULT                 0x00000000UL                               /**< Mode DEFAULT for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL8_PORTA                   0x00000000UL                               /**< Mode PORTA for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL8_PORTB                   0x00000001UL                               /**< Mode PORTB for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL8_PORTC                   0x00000002UL                               /**< Mode PORTC for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL8_PORTD                   0x00000003UL                               /**< Mode PORTD for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL8_PORTE                   0x00000004UL                               /**< Mode PORTE for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL8_PORTF                   0x00000005UL                               /**< Mode PORTF for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL8_DEFAULT                  (_GPIO_EXTIPSELH_EXTIPSEL8_DEFAULT << 0)   /**< Shifted mode DEFAULT for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL8_PORTA                    (_GPIO_EXTIPSELH_EXTIPSEL8_PORTA << 0)     /**< Shifted mode PORTA for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL8_PORTB                    (_GPIO_EXTIPSELH_EXTIPSEL8_PORTB << 0)     /**< Shifted mode PORTB for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL8_PORTC                    (_GPIO_EXTIPSELH_EXTIPSEL8_PORTC << 0)     /**< Shifted mode PORTC for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL8_PORTD                    (_GPIO_EXTIPSELH_EXTIPSEL8_PORTD << 0)     /**< Shifted mode PORTD for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL8_PORTE                    (_GPIO_EXTIPSELH_EXTIPSEL8_PORTE << 0)     /**< Shifted mode PORTE for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL8_PORTF                    (_GPIO_EXTIPSELH_EXTIPSEL8_PORTF << 0)     /**< Shifted mode PORTF for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL9_SHIFT                   4                                          /**< Shift value for GPIO_EXTIPSEL9 */
+#define _GPIO_EXTIPSELH_EXTIPSEL9_MASK                    0x70UL                                     /**< Bit mask for GPIO_EXTIPSEL9 */
+#define _GPIO_EXTIPSELH_EXTIPSEL9_DEFAULT                 0x00000000UL                               /**< Mode DEFAULT for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL9_PORTA                   0x00000000UL                               /**< Mode PORTA for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL9_PORTB                   0x00000001UL                               /**< Mode PORTB for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL9_PORTC                   0x00000002UL                               /**< Mode PORTC for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL9_PORTD                   0x00000003UL                               /**< Mode PORTD for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL9_PORTE                   0x00000004UL                               /**< Mode PORTE for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL9_PORTF                   0x00000005UL                               /**< Mode PORTF for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL9_DEFAULT                  (_GPIO_EXTIPSELH_EXTIPSEL9_DEFAULT << 4)   /**< Shifted mode DEFAULT for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL9_PORTA                    (_GPIO_EXTIPSELH_EXTIPSEL9_PORTA << 4)     /**< Shifted mode PORTA for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL9_PORTB                    (_GPIO_EXTIPSELH_EXTIPSEL9_PORTB << 4)     /**< Shifted mode PORTB for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL9_PORTC                    (_GPIO_EXTIPSELH_EXTIPSEL9_PORTC << 4)     /**< Shifted mode PORTC for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL9_PORTD                    (_GPIO_EXTIPSELH_EXTIPSEL9_PORTD << 4)     /**< Shifted mode PORTD for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL9_PORTE                    (_GPIO_EXTIPSELH_EXTIPSEL9_PORTE << 4)     /**< Shifted mode PORTE for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL9_PORTF                    (_GPIO_EXTIPSELH_EXTIPSEL9_PORTF << 4)     /**< Shifted mode PORTF for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL10_SHIFT                  8                                          /**< Shift value for GPIO_EXTIPSEL10 */
+#define _GPIO_EXTIPSELH_EXTIPSEL10_MASK                   0x700UL                                    /**< Bit mask for GPIO_EXTIPSEL10 */
+#define _GPIO_EXTIPSELH_EXTIPSEL10_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL10_PORTA                  0x00000000UL                               /**< Mode PORTA for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL10_PORTB                  0x00000001UL                               /**< Mode PORTB for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL10_PORTC                  0x00000002UL                               /**< Mode PORTC for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL10_PORTD                  0x00000003UL                               /**< Mode PORTD for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL10_PORTE                  0x00000004UL                               /**< Mode PORTE for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL10_PORTF                  0x00000005UL                               /**< Mode PORTF for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL10_DEFAULT                 (_GPIO_EXTIPSELH_EXTIPSEL10_DEFAULT << 8)  /**< Shifted mode DEFAULT for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL10_PORTA                   (_GPIO_EXTIPSELH_EXTIPSEL10_PORTA << 8)    /**< Shifted mode PORTA for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL10_PORTB                   (_GPIO_EXTIPSELH_EXTIPSEL10_PORTB << 8)    /**< Shifted mode PORTB for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL10_PORTC                   (_GPIO_EXTIPSELH_EXTIPSEL10_PORTC << 8)    /**< Shifted mode PORTC for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL10_PORTD                   (_GPIO_EXTIPSELH_EXTIPSEL10_PORTD << 8)    /**< Shifted mode PORTD for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL10_PORTE                   (_GPIO_EXTIPSELH_EXTIPSEL10_PORTE << 8)    /**< Shifted mode PORTE for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL10_PORTF                   (_GPIO_EXTIPSELH_EXTIPSEL10_PORTF << 8)    /**< Shifted mode PORTF for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL11_SHIFT                  12                                         /**< Shift value for GPIO_EXTIPSEL11 */
+#define _GPIO_EXTIPSELH_EXTIPSEL11_MASK                   0x7000UL                                   /**< Bit mask for GPIO_EXTIPSEL11 */
+#define _GPIO_EXTIPSELH_EXTIPSEL11_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL11_PORTA                  0x00000000UL                               /**< Mode PORTA for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL11_PORTB                  0x00000001UL                               /**< Mode PORTB for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL11_PORTC                  0x00000002UL                               /**< Mode PORTC for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL11_PORTD                  0x00000003UL                               /**< Mode PORTD for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL11_PORTE                  0x00000004UL                               /**< Mode PORTE for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL11_PORTF                  0x00000005UL                               /**< Mode PORTF for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL11_DEFAULT                 (_GPIO_EXTIPSELH_EXTIPSEL11_DEFAULT << 12) /**< Shifted mode DEFAULT for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL11_PORTA                   (_GPIO_EXTIPSELH_EXTIPSEL11_PORTA << 12)   /**< Shifted mode PORTA for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL11_PORTB                   (_GPIO_EXTIPSELH_EXTIPSEL11_PORTB << 12)   /**< Shifted mode PORTB for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL11_PORTC                   (_GPIO_EXTIPSELH_EXTIPSEL11_PORTC << 12)   /**< Shifted mode PORTC for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL11_PORTD                   (_GPIO_EXTIPSELH_EXTIPSEL11_PORTD << 12)   /**< Shifted mode PORTD for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL11_PORTE                   (_GPIO_EXTIPSELH_EXTIPSEL11_PORTE << 12)   /**< Shifted mode PORTE for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL11_PORTF                   (_GPIO_EXTIPSELH_EXTIPSEL11_PORTF << 12)   /**< Shifted mode PORTF for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL12_SHIFT                  16                                         /**< Shift value for GPIO_EXTIPSEL12 */
+#define _GPIO_EXTIPSELH_EXTIPSEL12_MASK                   0x70000UL                                  /**< Bit mask for GPIO_EXTIPSEL12 */
+#define _GPIO_EXTIPSELH_EXTIPSEL12_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL12_PORTA                  0x00000000UL                               /**< Mode PORTA for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL12_PORTB                  0x00000001UL                               /**< Mode PORTB for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL12_PORTC                  0x00000002UL                               /**< Mode PORTC for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL12_PORTD                  0x00000003UL                               /**< Mode PORTD for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL12_PORTE                  0x00000004UL                               /**< Mode PORTE for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL12_PORTF                  0x00000005UL                               /**< Mode PORTF for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL12_DEFAULT                 (_GPIO_EXTIPSELH_EXTIPSEL12_DEFAULT << 16) /**< Shifted mode DEFAULT for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL12_PORTA                   (_GPIO_EXTIPSELH_EXTIPSEL12_PORTA << 16)   /**< Shifted mode PORTA for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL12_PORTB                   (_GPIO_EXTIPSELH_EXTIPSEL12_PORTB << 16)   /**< Shifted mode PORTB for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL12_PORTC                   (_GPIO_EXTIPSELH_EXTIPSEL12_PORTC << 16)   /**< Shifted mode PORTC for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL12_PORTD                   (_GPIO_EXTIPSELH_EXTIPSEL12_PORTD << 16)   /**< Shifted mode PORTD for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL12_PORTE                   (_GPIO_EXTIPSELH_EXTIPSEL12_PORTE << 16)   /**< Shifted mode PORTE for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL12_PORTF                   (_GPIO_EXTIPSELH_EXTIPSEL12_PORTF << 16)   /**< Shifted mode PORTF for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL13_SHIFT                  20                                         /**< Shift value for GPIO_EXTIPSEL13 */
+#define _GPIO_EXTIPSELH_EXTIPSEL13_MASK                   0x700000UL                                 /**< Bit mask for GPIO_EXTIPSEL13 */
+#define _GPIO_EXTIPSELH_EXTIPSEL13_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL13_PORTA                  0x00000000UL                               /**< Mode PORTA for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL13_PORTB                  0x00000001UL                               /**< Mode PORTB for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL13_PORTC                  0x00000002UL                               /**< Mode PORTC for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL13_PORTD                  0x00000003UL                               /**< Mode PORTD for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL13_PORTE                  0x00000004UL                               /**< Mode PORTE for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL13_PORTF                  0x00000005UL                               /**< Mode PORTF for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL13_DEFAULT                 (_GPIO_EXTIPSELH_EXTIPSEL13_DEFAULT << 20) /**< Shifted mode DEFAULT for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL13_PORTA                   (_GPIO_EXTIPSELH_EXTIPSEL13_PORTA << 20)   /**< Shifted mode PORTA for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL13_PORTB                   (_GPIO_EXTIPSELH_EXTIPSEL13_PORTB << 20)   /**< Shifted mode PORTB for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL13_PORTC                   (_GPIO_EXTIPSELH_EXTIPSEL13_PORTC << 20)   /**< Shifted mode PORTC for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL13_PORTD                   (_GPIO_EXTIPSELH_EXTIPSEL13_PORTD << 20)   /**< Shifted mode PORTD for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL13_PORTE                   (_GPIO_EXTIPSELH_EXTIPSEL13_PORTE << 20)   /**< Shifted mode PORTE for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL13_PORTF                   (_GPIO_EXTIPSELH_EXTIPSEL13_PORTF << 20)   /**< Shifted mode PORTF for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL14_SHIFT                  24                                         /**< Shift value for GPIO_EXTIPSEL14 */
+#define _GPIO_EXTIPSELH_EXTIPSEL14_MASK                   0x7000000UL                                /**< Bit mask for GPIO_EXTIPSEL14 */
+#define _GPIO_EXTIPSELH_EXTIPSEL14_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL14_PORTA                  0x00000000UL                               /**< Mode PORTA for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL14_PORTB                  0x00000001UL                               /**< Mode PORTB for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL14_PORTC                  0x00000002UL                               /**< Mode PORTC for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL14_PORTD                  0x00000003UL                               /**< Mode PORTD for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL14_PORTE                  0x00000004UL                               /**< Mode PORTE for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL14_PORTF                  0x00000005UL                               /**< Mode PORTF for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL14_DEFAULT                 (_GPIO_EXTIPSELH_EXTIPSEL14_DEFAULT << 24) /**< Shifted mode DEFAULT for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL14_PORTA                   (_GPIO_EXTIPSELH_EXTIPSEL14_PORTA << 24)   /**< Shifted mode PORTA for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL14_PORTB                   (_GPIO_EXTIPSELH_EXTIPSEL14_PORTB << 24)   /**< Shifted mode PORTB for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL14_PORTC                   (_GPIO_EXTIPSELH_EXTIPSEL14_PORTC << 24)   /**< Shifted mode PORTC for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL14_PORTD                   (_GPIO_EXTIPSELH_EXTIPSEL14_PORTD << 24)   /**< Shifted mode PORTD for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL14_PORTE                   (_GPIO_EXTIPSELH_EXTIPSEL14_PORTE << 24)   /**< Shifted mode PORTE for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL14_PORTF                   (_GPIO_EXTIPSELH_EXTIPSEL14_PORTF << 24)   /**< Shifted mode PORTF for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL15_SHIFT                  28                                         /**< Shift value for GPIO_EXTIPSEL15 */
+#define _GPIO_EXTIPSELH_EXTIPSEL15_MASK                   0x70000000UL                               /**< Bit mask for GPIO_EXTIPSEL15 */
+#define _GPIO_EXTIPSELH_EXTIPSEL15_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL15_PORTA                  0x00000000UL                               /**< Mode PORTA for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL15_PORTB                  0x00000001UL                               /**< Mode PORTB for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL15_PORTC                  0x00000002UL                               /**< Mode PORTC for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL15_PORTD                  0x00000003UL                               /**< Mode PORTD for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL15_PORTE                  0x00000004UL                               /**< Mode PORTE for GPIO_EXTIPSELH */
+#define _GPIO_EXTIPSELH_EXTIPSEL15_PORTF                  0x00000005UL                               /**< Mode PORTF for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL15_DEFAULT                 (_GPIO_EXTIPSELH_EXTIPSEL15_DEFAULT << 28) /**< Shifted mode DEFAULT for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL15_PORTA                   (_GPIO_EXTIPSELH_EXTIPSEL15_PORTA << 28)   /**< Shifted mode PORTA for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL15_PORTB                   (_GPIO_EXTIPSELH_EXTIPSEL15_PORTB << 28)   /**< Shifted mode PORTB for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL15_PORTC                   (_GPIO_EXTIPSELH_EXTIPSEL15_PORTC << 28)   /**< Shifted mode PORTC for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL15_PORTD                   (_GPIO_EXTIPSELH_EXTIPSEL15_PORTD << 28)   /**< Shifted mode PORTD for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL15_PORTE                   (_GPIO_EXTIPSELH_EXTIPSEL15_PORTE << 28)   /**< Shifted mode PORTE for GPIO_EXTIPSELH */
+#define GPIO_EXTIPSELH_EXTIPSEL15_PORTF                   (_GPIO_EXTIPSELH_EXTIPSEL15_PORTF << 28)   /**< Shifted mode PORTF for GPIO_EXTIPSELH */
+
+/* Bit fields for GPIO EXTIRISE */
+#define _GPIO_EXTIRISE_RESETVALUE                         0x00000000UL                           /**< Default value for GPIO_EXTIRISE */
+#define _GPIO_EXTIRISE_MASK                               0x0000FFFFUL                           /**< Mask for GPIO_EXTIRISE */
+#define _GPIO_EXTIRISE_EXTIRISE_SHIFT                     0                                      /**< Shift value for GPIO_EXTIRISE */
+#define _GPIO_EXTIRISE_EXTIRISE_MASK                      0xFFFFUL                               /**< Bit mask for GPIO_EXTIRISE */
+#define _GPIO_EXTIRISE_EXTIRISE_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for GPIO_EXTIRISE */
+#define GPIO_EXTIRISE_EXTIRISE_DEFAULT                    (_GPIO_EXTIRISE_EXTIRISE_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_EXTIRISE */
+
+/* Bit fields for GPIO EXTIFALL */
+#define _GPIO_EXTIFALL_RESETVALUE                         0x00000000UL                           /**< Default value for GPIO_EXTIFALL */
+#define _GPIO_EXTIFALL_MASK                               0x0000FFFFUL                           /**< Mask for GPIO_EXTIFALL */
+#define _GPIO_EXTIFALL_EXTIFALL_SHIFT                     0                                      /**< Shift value for GPIO_EXTIFALL */
+#define _GPIO_EXTIFALL_EXTIFALL_MASK                      0xFFFFUL                               /**< Bit mask for GPIO_EXTIFALL */
+#define _GPIO_EXTIFALL_EXTIFALL_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for GPIO_EXTIFALL */
+#define GPIO_EXTIFALL_EXTIFALL_DEFAULT                    (_GPIO_EXTIFALL_EXTIFALL_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_EXTIFALL */
+
+/* Bit fields for GPIO IEN */
+#define _GPIO_IEN_RESETVALUE                              0x00000000UL                 /**< Default value for GPIO_IEN */
+#define _GPIO_IEN_MASK                                    0x0000FFFFUL                 /**< Mask for GPIO_IEN */
+#define _GPIO_IEN_EXT_SHIFT                               0                            /**< Shift value for GPIO_EXT */
+#define _GPIO_IEN_EXT_MASK                                0xFFFFUL                     /**< Bit mask for GPIO_EXT */
+#define _GPIO_IEN_EXT_DEFAULT                             0x00000000UL                 /**< Mode DEFAULT for GPIO_IEN */
+#define GPIO_IEN_EXT_DEFAULT                              (_GPIO_IEN_EXT_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_IEN */
+
+/* Bit fields for GPIO IF */
+#define _GPIO_IF_RESETVALUE                               0x00000000UL                /**< Default value for GPIO_IF */
+#define _GPIO_IF_MASK                                     0x0000FFFFUL                /**< Mask for GPIO_IF */
+#define _GPIO_IF_EXT_SHIFT                                0                           /**< Shift value for GPIO_EXT */
+#define _GPIO_IF_EXT_MASK                                 0xFFFFUL                    /**< Bit mask for GPIO_EXT */
+#define _GPIO_IF_EXT_DEFAULT                              0x00000000UL                /**< Mode DEFAULT for GPIO_IF */
+#define GPIO_IF_EXT_DEFAULT                               (_GPIO_IF_EXT_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_IF */
+
+/* Bit fields for GPIO IFS */
+#define _GPIO_IFS_RESETVALUE                              0x00000000UL                 /**< Default value for GPIO_IFS */
+#define _GPIO_IFS_MASK                                    0x0000FFFFUL                 /**< Mask for GPIO_IFS */
+#define _GPIO_IFS_EXT_SHIFT                               0                            /**< Shift value for GPIO_EXT */
+#define _GPIO_IFS_EXT_MASK                                0xFFFFUL                     /**< Bit mask for GPIO_EXT */
+#define _GPIO_IFS_EXT_DEFAULT                             0x00000000UL                 /**< Mode DEFAULT for GPIO_IFS */
+#define GPIO_IFS_EXT_DEFAULT                              (_GPIO_IFS_EXT_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_IFS */
+
+/* Bit fields for GPIO IFC */
+#define _GPIO_IFC_RESETVALUE                              0x00000000UL                 /**< Default value for GPIO_IFC */
+#define _GPIO_IFC_MASK                                    0x0000FFFFUL                 /**< Mask for GPIO_IFC */
+#define _GPIO_IFC_EXT_SHIFT                               0                            /**< Shift value for GPIO_EXT */
+#define _GPIO_IFC_EXT_MASK                                0xFFFFUL                     /**< Bit mask for GPIO_EXT */
+#define _GPIO_IFC_EXT_DEFAULT                             0x00000000UL                 /**< Mode DEFAULT for GPIO_IFC */
+#define GPIO_IFC_EXT_DEFAULT                              (_GPIO_IFC_EXT_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_IFC */
+
+/* Bit fields for GPIO ROUTE */
+#define _GPIO_ROUTE_RESETVALUE                            0x00000003UL                          /**< Default value for GPIO_ROUTE */
+#define _GPIO_ROUTE_MASK                                  0x00000307UL                          /**< Mask for GPIO_ROUTE */
+#define GPIO_ROUTE_SWCLKPEN                               (0x1UL << 0)                          /**< Serial Wire Clock Pin Enable */
+#define _GPIO_ROUTE_SWCLKPEN_SHIFT                        0                                     /**< Shift value for GPIO_SWCLKPEN */
+#define _GPIO_ROUTE_SWCLKPEN_MASK                         0x1UL                                 /**< Bit mask for GPIO_SWCLKPEN */
+#define _GPIO_ROUTE_SWCLKPEN_DEFAULT                      0x00000001UL                          /**< Mode DEFAULT for GPIO_ROUTE */
+#define GPIO_ROUTE_SWCLKPEN_DEFAULT                       (_GPIO_ROUTE_SWCLKPEN_DEFAULT << 0)   /**< Shifted mode DEFAULT for GPIO_ROUTE */
+#define GPIO_ROUTE_SWDIOPEN                               (0x1UL << 1)                          /**< Serial Wire Data Pin Enable */
+#define _GPIO_ROUTE_SWDIOPEN_SHIFT                        1                                     /**< Shift value for GPIO_SWDIOPEN */
+#define _GPIO_ROUTE_SWDIOPEN_MASK                         0x2UL                                 /**< Bit mask for GPIO_SWDIOPEN */
+#define _GPIO_ROUTE_SWDIOPEN_DEFAULT                      0x00000001UL                          /**< Mode DEFAULT for GPIO_ROUTE */
+#define GPIO_ROUTE_SWDIOPEN_DEFAULT                       (_GPIO_ROUTE_SWDIOPEN_DEFAULT << 1)   /**< Shifted mode DEFAULT for GPIO_ROUTE */
+#define GPIO_ROUTE_SWOPEN                                 (0x1UL << 2)                          /**< Serial Wire Viewer Output Pin Enable */
+#define _GPIO_ROUTE_SWOPEN_SHIFT                          2                                     /**< Shift value for GPIO_SWOPEN */
+#define _GPIO_ROUTE_SWOPEN_MASK                           0x4UL                                 /**< Bit mask for GPIO_SWOPEN */
+#define _GPIO_ROUTE_SWOPEN_DEFAULT                        0x00000000UL                          /**< Mode DEFAULT for GPIO_ROUTE */
+#define GPIO_ROUTE_SWOPEN_DEFAULT                         (_GPIO_ROUTE_SWOPEN_DEFAULT << 2)     /**< Shifted mode DEFAULT for GPIO_ROUTE */
+#define _GPIO_ROUTE_SWLOCATION_SHIFT                      8                                     /**< Shift value for GPIO_SWLOCATION */
+#define _GPIO_ROUTE_SWLOCATION_MASK                       0x300UL                               /**< Bit mask for GPIO_SWLOCATION */
+#define _GPIO_ROUTE_SWLOCATION_LOC0                       0x00000000UL                          /**< Mode LOC0 for GPIO_ROUTE */
+#define _GPIO_ROUTE_SWLOCATION_DEFAULT                    0x00000000UL                          /**< Mode DEFAULT for GPIO_ROUTE */
+#define _GPIO_ROUTE_SWLOCATION_LOC1                       0x00000001UL                          /**< Mode LOC1 for GPIO_ROUTE */
+#define GPIO_ROUTE_SWLOCATION_LOC0                        (_GPIO_ROUTE_SWLOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for GPIO_ROUTE */
+#define GPIO_ROUTE_SWLOCATION_DEFAULT                     (_GPIO_ROUTE_SWLOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for GPIO_ROUTE */
+#define GPIO_ROUTE_SWLOCATION_LOC1                        (_GPIO_ROUTE_SWLOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for GPIO_ROUTE */
+
+/* Bit fields for GPIO INSENSE */
+#define _GPIO_INSENSE_RESETVALUE                          0x00000003UL                     /**< Default value for GPIO_INSENSE */
+#define _GPIO_INSENSE_MASK                                0x00000003UL                     /**< Mask for GPIO_INSENSE */
+#define GPIO_INSENSE_INT                                  (0x1UL << 0)                     /**< Interrupt Sense Enable */
+#define _GPIO_INSENSE_INT_SHIFT                           0                                /**< Shift value for GPIO_INT */
+#define _GPIO_INSENSE_INT_MASK                            0x1UL                            /**< Bit mask for GPIO_INT */
+#define _GPIO_INSENSE_INT_DEFAULT                         0x00000001UL                     /**< Mode DEFAULT for GPIO_INSENSE */
+#define GPIO_INSENSE_INT_DEFAULT                          (_GPIO_INSENSE_INT_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_INSENSE */
+#define GPIO_INSENSE_PRS                                  (0x1UL << 1)                     /**< PRS Sense Enable */
+#define _GPIO_INSENSE_PRS_SHIFT                           1                                /**< Shift value for GPIO_PRS */
+#define _GPIO_INSENSE_PRS_MASK                            0x2UL                            /**< Bit mask for GPIO_PRS */
+#define _GPIO_INSENSE_PRS_DEFAULT                         0x00000001UL                     /**< Mode DEFAULT for GPIO_INSENSE */
+#define GPIO_INSENSE_PRS_DEFAULT                          (_GPIO_INSENSE_PRS_DEFAULT << 1) /**< Shifted mode DEFAULT for GPIO_INSENSE */
+
+/* Bit fields for GPIO LOCK */
+#define _GPIO_LOCK_RESETVALUE                             0x00000000UL                       /**< Default value for GPIO_LOCK */
+#define _GPIO_LOCK_MASK                                   0x0000FFFFUL                       /**< Mask for GPIO_LOCK */
+#define _GPIO_LOCK_LOCKKEY_SHIFT                          0                                  /**< Shift value for GPIO_LOCKKEY */
+#define _GPIO_LOCK_LOCKKEY_MASK                           0xFFFFUL                           /**< Bit mask for GPIO_LOCKKEY */
+#define _GPIO_LOCK_LOCKKEY_DEFAULT                        0x00000000UL                       /**< Mode DEFAULT for GPIO_LOCK */
+#define _GPIO_LOCK_LOCKKEY_UNLOCKED                       0x00000000UL                       /**< Mode UNLOCKED for GPIO_LOCK */
+#define _GPIO_LOCK_LOCKKEY_LOCK                           0x00000000UL                       /**< Mode LOCK for GPIO_LOCK */
+#define _GPIO_LOCK_LOCKKEY_LOCKED                         0x00000001UL                       /**< Mode LOCKED for GPIO_LOCK */
+#define _GPIO_LOCK_LOCKKEY_UNLOCK                         0x0000A534UL                       /**< Mode UNLOCK for GPIO_LOCK */
+#define GPIO_LOCK_LOCKKEY_DEFAULT                         (_GPIO_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for GPIO_LOCK */
+#define GPIO_LOCK_LOCKKEY_UNLOCKED                        (_GPIO_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for GPIO_LOCK */
+#define GPIO_LOCK_LOCKKEY_LOCK                            (_GPIO_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for GPIO_LOCK */
+#define GPIO_LOCK_LOCKKEY_LOCKED                          (_GPIO_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for GPIO_LOCK */
+#define GPIO_LOCK_LOCKKEY_UNLOCK                          (_GPIO_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for GPIO_LOCK */
+
+/* Bit fields for GPIO CTRL */
+#define _GPIO_CTRL_RESETVALUE                             0x00000000UL                     /**< Default value for GPIO_CTRL */
+#define _GPIO_CTRL_MASK                                   0x00000001UL                     /**< Mask for GPIO_CTRL */
+#define GPIO_CTRL_EM4RET                                  (0x1UL << 0)                     /**< Enable EM4 retention */
+#define _GPIO_CTRL_EM4RET_SHIFT                           0                                /**< Shift value for GPIO_EM4RET */
+#define _GPIO_CTRL_EM4RET_MASK                            0x1UL                            /**< Bit mask for GPIO_EM4RET */
+#define _GPIO_CTRL_EM4RET_DEFAULT                         0x00000000UL                     /**< Mode DEFAULT for GPIO_CTRL */
+#define GPIO_CTRL_EM4RET_DEFAULT                          (_GPIO_CTRL_EM4RET_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_CTRL */
+
+/* Bit fields for GPIO CMD */
+#define _GPIO_CMD_RESETVALUE                              0x00000000UL                      /**< Default value for GPIO_CMD */
+#define _GPIO_CMD_MASK                                    0x00000001UL                      /**< Mask for GPIO_CMD */
+#define GPIO_CMD_EM4WUCLR                                 (0x1UL << 0)                      /**< EM4 Wake-up clear */
+#define _GPIO_CMD_EM4WUCLR_SHIFT                          0                                 /**< Shift value for GPIO_EM4WUCLR */
+#define _GPIO_CMD_EM4WUCLR_MASK                           0x1UL                             /**< Bit mask for GPIO_EM4WUCLR */
+#define _GPIO_CMD_EM4WUCLR_DEFAULT                        0x00000000UL                      /**< Mode DEFAULT for GPIO_CMD */
+#define GPIO_CMD_EM4WUCLR_DEFAULT                         (_GPIO_CMD_EM4WUCLR_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_CMD */
+
+/* Bit fields for GPIO EM4WUEN */
+#define _GPIO_EM4WUEN_RESETVALUE                          0x00000000UL                         /**< Default value for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_MASK                                0x0000003FUL                         /**< Mask for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_EM4WUEN_SHIFT                       0                                    /**< Shift value for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_EM4WUEN_MASK                        0x3FUL                               /**< Bit mask for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_EM4WUEN_DEFAULT                     0x00000000UL                         /**< Mode DEFAULT for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_EM4WUEN_A0                          0x00000001UL                         /**< Mode A0 for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_EM4WUEN_A6                          0x00000002UL                         /**< Mode A6 for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_EM4WUEN_C9                          0x00000004UL                         /**< Mode C9 for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_EM4WUEN_F1                          0x00000008UL                         /**< Mode F1 for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_EM4WUEN_F2                          0x00000010UL                         /**< Mode F2 for GPIO_EM4WUEN */
+#define _GPIO_EM4WUEN_EM4WUEN_E13                         0x00000020UL                         /**< Mode E13 for GPIO_EM4WUEN */
+#define GPIO_EM4WUEN_EM4WUEN_DEFAULT                      (_GPIO_EM4WUEN_EM4WUEN_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_EM4WUEN */
+#define GPIO_EM4WUEN_EM4WUEN_A0                           (_GPIO_EM4WUEN_EM4WUEN_A0 << 0)      /**< Shifted mode A0 for GPIO_EM4WUEN */
+#define GPIO_EM4WUEN_EM4WUEN_A6                           (_GPIO_EM4WUEN_EM4WUEN_A6 << 0)      /**< Shifted mode A6 for GPIO_EM4WUEN */
+#define GPIO_EM4WUEN_EM4WUEN_C9                           (_GPIO_EM4WUEN_EM4WUEN_C9 << 0)      /**< Shifted mode C9 for GPIO_EM4WUEN */
+#define GPIO_EM4WUEN_EM4WUEN_F1                           (_GPIO_EM4WUEN_EM4WUEN_F1 << 0)      /**< Shifted mode F1 for GPIO_EM4WUEN */
+#define GPIO_EM4WUEN_EM4WUEN_F2                           (_GPIO_EM4WUEN_EM4WUEN_F2 << 0)      /**< Shifted mode F2 for GPIO_EM4WUEN */
+#define GPIO_EM4WUEN_EM4WUEN_E13                          (_GPIO_EM4WUEN_EM4WUEN_E13 << 0)     /**< Shifted mode E13 for GPIO_EM4WUEN */
+
+/* Bit fields for GPIO EM4WUPOL */
+#define _GPIO_EM4WUPOL_RESETVALUE                         0x00000000UL                           /**< Default value for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_MASK                               0x0000003FUL                           /**< Mask for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_EM4WUPOL_SHIFT                     0                                      /**< Shift value for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_EM4WUPOL_MASK                      0x3FUL                                 /**< Bit mask for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_EM4WUPOL_DEFAULT                   0x00000000UL                           /**< Mode DEFAULT for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_EM4WUPOL_A0                        0x00000001UL                           /**< Mode A0 for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_EM4WUPOL_A6                        0x00000002UL                           /**< Mode A6 for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_EM4WUPOL_C9                        0x00000004UL                           /**< Mode C9 for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_EM4WUPOL_F1                        0x00000008UL                           /**< Mode F1 for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_EM4WUPOL_F2                        0x00000010UL                           /**< Mode F2 for GPIO_EM4WUPOL */
+#define _GPIO_EM4WUPOL_EM4WUPOL_E13                       0x00000020UL                           /**< Mode E13 for GPIO_EM4WUPOL */
+#define GPIO_EM4WUPOL_EM4WUPOL_DEFAULT                    (_GPIO_EM4WUPOL_EM4WUPOL_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_EM4WUPOL */
+#define GPIO_EM4WUPOL_EM4WUPOL_A0                         (_GPIO_EM4WUPOL_EM4WUPOL_A0 << 0)      /**< Shifted mode A0 for GPIO_EM4WUPOL */
+#define GPIO_EM4WUPOL_EM4WUPOL_A6                         (_GPIO_EM4WUPOL_EM4WUPOL_A6 << 0)      /**< Shifted mode A6 for GPIO_EM4WUPOL */
+#define GPIO_EM4WUPOL_EM4WUPOL_C9                         (_GPIO_EM4WUPOL_EM4WUPOL_C9 << 0)      /**< Shifted mode C9 for GPIO_EM4WUPOL */
+#define GPIO_EM4WUPOL_EM4WUPOL_F1                         (_GPIO_EM4WUPOL_EM4WUPOL_F1 << 0)      /**< Shifted mode F1 for GPIO_EM4WUPOL */
+#define GPIO_EM4WUPOL_EM4WUPOL_F2                         (_GPIO_EM4WUPOL_EM4WUPOL_F2 << 0)      /**< Shifted mode F2 for GPIO_EM4WUPOL */
+#define GPIO_EM4WUPOL_EM4WUPOL_E13                        (_GPIO_EM4WUPOL_EM4WUPOL_E13 << 0)     /**< Shifted mode E13 for GPIO_EM4WUPOL */
+
+/* Bit fields for GPIO EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_RESETVALUE                       0x00000000UL                               /**< Default value for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_MASK                             0x0000003FUL                               /**< Mask for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_EM4WUCAUSE_SHIFT                 0                                          /**< Shift value for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_EM4WUCAUSE_MASK                  0x3FUL                                     /**< Bit mask for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_EM4WUCAUSE_DEFAULT               0x00000000UL                               /**< Mode DEFAULT for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_EM4WUCAUSE_A0                    0x00000001UL                               /**< Mode A0 for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_EM4WUCAUSE_A6                    0x00000002UL                               /**< Mode A6 for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_EM4WUCAUSE_C9                    0x00000004UL                               /**< Mode C9 for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_EM4WUCAUSE_F1                    0x00000008UL                               /**< Mode F1 for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_EM4WUCAUSE_F2                    0x00000010UL                               /**< Mode F2 for GPIO_EM4WUCAUSE */
+#define _GPIO_EM4WUCAUSE_EM4WUCAUSE_E13                   0x00000020UL                               /**< Mode E13 for GPIO_EM4WUCAUSE */
+#define GPIO_EM4WUCAUSE_EM4WUCAUSE_DEFAULT                (_GPIO_EM4WUCAUSE_EM4WUCAUSE_DEFAULT << 0) /**< Shifted mode DEFAULT for GPIO_EM4WUCAUSE */
+#define GPIO_EM4WUCAUSE_EM4WUCAUSE_A0                     (_GPIO_EM4WUCAUSE_EM4WUCAUSE_A0 << 0)      /**< Shifted mode A0 for GPIO_EM4WUCAUSE */
+#define GPIO_EM4WUCAUSE_EM4WUCAUSE_A6                     (_GPIO_EM4WUCAUSE_EM4WUCAUSE_A6 << 0)      /**< Shifted mode A6 for GPIO_EM4WUCAUSE */
+#define GPIO_EM4WUCAUSE_EM4WUCAUSE_C9                     (_GPIO_EM4WUCAUSE_EM4WUCAUSE_C9 << 0)      /**< Shifted mode C9 for GPIO_EM4WUCAUSE */
+#define GPIO_EM4WUCAUSE_EM4WUCAUSE_F1                     (_GPIO_EM4WUCAUSE_EM4WUCAUSE_F1 << 0)      /**< Shifted mode F1 for GPIO_EM4WUCAUSE */
+#define GPIO_EM4WUCAUSE_EM4WUCAUSE_F2                     (_GPIO_EM4WUCAUSE_EM4WUCAUSE_F2 << 0)      /**< Shifted mode F2 for GPIO_EM4WUCAUSE */
+#define GPIO_EM4WUCAUSE_EM4WUCAUSE_E13                    (_GPIO_EM4WUCAUSE_EM4WUCAUSE_E13 << 0)     /**< Shifted mode E13 for GPIO_EM4WUCAUSE */
+
+/** @} End of group EFM32TG_GPIO */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_gpio_p.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_gpio_p.h
@@ -1,0 +1,56 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_GPIO_P register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @brief GPIO_P EFM32TG GPIO P
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;     /**< Port Control Register  */
+  __IOM uint32_t MODEL;    /**< Port Pin Mode Low Register  */
+  __IOM uint32_t MODEH;    /**< Port Pin Mode High Register  */
+  __IOM uint32_t DOUT;     /**< Port Data Out Register  */
+  __OM uint32_t  DOUTSET;  /**< Port Data Out Set Register  */
+  __OM uint32_t  DOUTCLR;  /**< Port Data Out Clear Register  */
+  __OM uint32_t  DOUTTGL;  /**< Port Data Out Toggle Register  */
+  __IM uint32_t  DIN;      /**< Port Data In Register  */
+  __IOM uint32_t PINLOCKN; /**< Port Unlocked Pins Register  */
+} GPIO_P_TypeDef;
+
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_i2c.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_i2c.h
@@ -1,0 +1,708 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_I2C register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_I2C
+ * @brief EFM32TG_I2C Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;      /**< Control Register  */
+  __IOM uint32_t CMD;       /**< Command Register  */
+  __IM uint32_t  STATE;     /**< State Register  */
+  __IM uint32_t  STATUS;    /**< Status Register  */
+  __IOM uint32_t CLKDIV;    /**< Clock Division Register  */
+  __IOM uint32_t SADDR;     /**< Slave Address Register  */
+  __IOM uint32_t SADDRMASK; /**< Slave Address Mask Register  */
+  __IM uint32_t  RXDATA;    /**< Receive Buffer Data Register  */
+  __IM uint32_t  RXDATAP;   /**< Receive Buffer Data Peek Register  */
+  __IOM uint32_t TXDATA;    /**< Transmit Buffer Data Register  */
+  __IM uint32_t  IF;        /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;       /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;       /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;       /**< Interrupt Enable Register  */
+  __IOM uint32_t ROUTE;     /**< I/O Routing Register  */
+} I2C_TypeDef;              /**< I2C Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_I2C_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for I2C CTRL */
+#define _I2C_CTRL_RESETVALUE              0x00000000UL                     /**< Default value for I2C_CTRL */
+#define _I2C_CTRL_MASK                    0x0007B37FUL                     /**< Mask for I2C_CTRL */
+#define I2C_CTRL_EN                       (0x1UL << 0)                     /**< I2C Enable */
+#define _I2C_CTRL_EN_SHIFT                0                                /**< Shift value for I2C_EN */
+#define _I2C_CTRL_EN_MASK                 0x1UL                            /**< Bit mask for I2C_EN */
+#define _I2C_CTRL_EN_DEFAULT              0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_EN_DEFAULT               (_I2C_CTRL_EN_DEFAULT << 0)      /**< Shifted mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_SLAVE                    (0x1UL << 1)                     /**< Addressable as Slave */
+#define _I2C_CTRL_SLAVE_SHIFT             1                                /**< Shift value for I2C_SLAVE */
+#define _I2C_CTRL_SLAVE_MASK              0x2UL                            /**< Bit mask for I2C_SLAVE */
+#define _I2C_CTRL_SLAVE_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_SLAVE_DEFAULT            (_I2C_CTRL_SLAVE_DEFAULT << 1)   /**< Shifted mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_AUTOACK                  (0x1UL << 2)                     /**< Automatic Acknowledge */
+#define _I2C_CTRL_AUTOACK_SHIFT           2                                /**< Shift value for I2C_AUTOACK */
+#define _I2C_CTRL_AUTOACK_MASK            0x4UL                            /**< Bit mask for I2C_AUTOACK */
+#define _I2C_CTRL_AUTOACK_DEFAULT         0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_AUTOACK_DEFAULT          (_I2C_CTRL_AUTOACK_DEFAULT << 2) /**< Shifted mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_AUTOSE                   (0x1UL << 3)                     /**< Automatic STOP when Empty */
+#define _I2C_CTRL_AUTOSE_SHIFT            3                                /**< Shift value for I2C_AUTOSE */
+#define _I2C_CTRL_AUTOSE_MASK             0x8UL                            /**< Bit mask for I2C_AUTOSE */
+#define _I2C_CTRL_AUTOSE_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_AUTOSE_DEFAULT           (_I2C_CTRL_AUTOSE_DEFAULT << 3)  /**< Shifted mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_AUTOSN                   (0x1UL << 4)                     /**< Automatic STOP on NACK */
+#define _I2C_CTRL_AUTOSN_SHIFT            4                                /**< Shift value for I2C_AUTOSN */
+#define _I2C_CTRL_AUTOSN_MASK             0x10UL                           /**< Bit mask for I2C_AUTOSN */
+#define _I2C_CTRL_AUTOSN_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_AUTOSN_DEFAULT           (_I2C_CTRL_AUTOSN_DEFAULT << 4)  /**< Shifted mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_ARBDIS                   (0x1UL << 5)                     /**< Arbitration Disable */
+#define _I2C_CTRL_ARBDIS_SHIFT            5                                /**< Shift value for I2C_ARBDIS */
+#define _I2C_CTRL_ARBDIS_MASK             0x20UL                           /**< Bit mask for I2C_ARBDIS */
+#define _I2C_CTRL_ARBDIS_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_ARBDIS_DEFAULT           (_I2C_CTRL_ARBDIS_DEFAULT << 5)  /**< Shifted mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_GCAMEN                   (0x1UL << 6)                     /**< General Call Address Match Enable */
+#define _I2C_CTRL_GCAMEN_SHIFT            6                                /**< Shift value for I2C_GCAMEN */
+#define _I2C_CTRL_GCAMEN_MASK             0x40UL                           /**< Bit mask for I2C_GCAMEN */
+#define _I2C_CTRL_GCAMEN_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_GCAMEN_DEFAULT           (_I2C_CTRL_GCAMEN_DEFAULT << 6)  /**< Shifted mode DEFAULT for I2C_CTRL */
+#define _I2C_CTRL_CLHR_SHIFT              8                                /**< Shift value for I2C_CLHR */
+#define _I2C_CTRL_CLHR_MASK               0x300UL                          /**< Bit mask for I2C_CLHR */
+#define _I2C_CTRL_CLHR_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define _I2C_CTRL_CLHR_STANDARD           0x00000000UL                     /**< Mode STANDARD for I2C_CTRL */
+#define _I2C_CTRL_CLHR_ASYMMETRIC         0x00000001UL                     /**< Mode ASYMMETRIC for I2C_CTRL */
+#define _I2C_CTRL_CLHR_FAST               0x00000002UL                     /**< Mode FAST for I2C_CTRL */
+#define I2C_CTRL_CLHR_DEFAULT             (_I2C_CTRL_CLHR_DEFAULT << 8)    /**< Shifted mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_CLHR_STANDARD            (_I2C_CTRL_CLHR_STANDARD << 8)   /**< Shifted mode STANDARD for I2C_CTRL */
+#define I2C_CTRL_CLHR_ASYMMETRIC          (_I2C_CTRL_CLHR_ASYMMETRIC << 8) /**< Shifted mode ASYMMETRIC for I2C_CTRL */
+#define I2C_CTRL_CLHR_FAST                (_I2C_CTRL_CLHR_FAST << 8)       /**< Shifted mode FAST for I2C_CTRL */
+#define _I2C_CTRL_BITO_SHIFT              12                               /**< Shift value for I2C_BITO */
+#define _I2C_CTRL_BITO_MASK               0x3000UL                         /**< Bit mask for I2C_BITO */
+#define _I2C_CTRL_BITO_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define _I2C_CTRL_BITO_OFF                0x00000000UL                     /**< Mode OFF for I2C_CTRL */
+#define _I2C_CTRL_BITO_40PCC              0x00000001UL                     /**< Mode 40PCC for I2C_CTRL */
+#define _I2C_CTRL_BITO_80PCC              0x00000002UL                     /**< Mode 80PCC for I2C_CTRL */
+#define _I2C_CTRL_BITO_160PCC             0x00000003UL                     /**< Mode 160PCC for I2C_CTRL */
+#define I2C_CTRL_BITO_DEFAULT             (_I2C_CTRL_BITO_DEFAULT << 12)   /**< Shifted mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_BITO_OFF                 (_I2C_CTRL_BITO_OFF << 12)       /**< Shifted mode OFF for I2C_CTRL */
+#define I2C_CTRL_BITO_40PCC               (_I2C_CTRL_BITO_40PCC << 12)     /**< Shifted mode 40PCC for I2C_CTRL */
+#define I2C_CTRL_BITO_80PCC               (_I2C_CTRL_BITO_80PCC << 12)     /**< Shifted mode 80PCC for I2C_CTRL */
+#define I2C_CTRL_BITO_160PCC              (_I2C_CTRL_BITO_160PCC << 12)    /**< Shifted mode 160PCC for I2C_CTRL */
+#define I2C_CTRL_GIBITO                   (0x1UL << 15)                    /**< Go Idle on Bus Idle Timeout  */
+#define _I2C_CTRL_GIBITO_SHIFT            15                               /**< Shift value for I2C_GIBITO */
+#define _I2C_CTRL_GIBITO_MASK             0x8000UL                         /**< Bit mask for I2C_GIBITO */
+#define _I2C_CTRL_GIBITO_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_GIBITO_DEFAULT           (_I2C_CTRL_GIBITO_DEFAULT << 15) /**< Shifted mode DEFAULT for I2C_CTRL */
+#define _I2C_CTRL_CLTO_SHIFT              16                               /**< Shift value for I2C_CLTO */
+#define _I2C_CTRL_CLTO_MASK               0x70000UL                        /**< Bit mask for I2C_CLTO */
+#define _I2C_CTRL_CLTO_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
+#define _I2C_CTRL_CLTO_OFF                0x00000000UL                     /**< Mode OFF for I2C_CTRL */
+#define _I2C_CTRL_CLTO_40PCC              0x00000001UL                     /**< Mode 40PCC for I2C_CTRL */
+#define _I2C_CTRL_CLTO_80PCC              0x00000002UL                     /**< Mode 80PCC for I2C_CTRL */
+#define _I2C_CTRL_CLTO_160PCC             0x00000003UL                     /**< Mode 160PCC for I2C_CTRL */
+#define _I2C_CTRL_CLTO_320PPC             0x00000004UL                     /**< Mode 320PPC for I2C_CTRL */
+#define _I2C_CTRL_CLTO_1024PPC            0x00000005UL                     /**< Mode 1024PPC for I2C_CTRL */
+#define I2C_CTRL_CLTO_DEFAULT             (_I2C_CTRL_CLTO_DEFAULT << 16)   /**< Shifted mode DEFAULT for I2C_CTRL */
+#define I2C_CTRL_CLTO_OFF                 (_I2C_CTRL_CLTO_OFF << 16)       /**< Shifted mode OFF for I2C_CTRL */
+#define I2C_CTRL_CLTO_40PCC               (_I2C_CTRL_CLTO_40PCC << 16)     /**< Shifted mode 40PCC for I2C_CTRL */
+#define I2C_CTRL_CLTO_80PCC               (_I2C_CTRL_CLTO_80PCC << 16)     /**< Shifted mode 80PCC for I2C_CTRL */
+#define I2C_CTRL_CLTO_160PCC              (_I2C_CTRL_CLTO_160PCC << 16)    /**< Shifted mode 160PCC for I2C_CTRL */
+#define I2C_CTRL_CLTO_320PPC              (_I2C_CTRL_CLTO_320PPC << 16)    /**< Shifted mode 320PPC for I2C_CTRL */
+#define I2C_CTRL_CLTO_1024PPC             (_I2C_CTRL_CLTO_1024PPC << 16)   /**< Shifted mode 1024PPC for I2C_CTRL */
+
+/* Bit fields for I2C CMD */
+#define _I2C_CMD_RESETVALUE               0x00000000UL                    /**< Default value for I2C_CMD */
+#define _I2C_CMD_MASK                     0x000000FFUL                    /**< Mask for I2C_CMD */
+#define I2C_CMD_START                     (0x1UL << 0)                    /**< Send start condition */
+#define _I2C_CMD_START_SHIFT              0                               /**< Shift value for I2C_START */
+#define _I2C_CMD_START_MASK               0x1UL                           /**< Bit mask for I2C_START */
+#define _I2C_CMD_START_DEFAULT            0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
+#define I2C_CMD_START_DEFAULT             (_I2C_CMD_START_DEFAULT << 0)   /**< Shifted mode DEFAULT for I2C_CMD */
+#define I2C_CMD_STOP                      (0x1UL << 1)                    /**< Send stop condition */
+#define _I2C_CMD_STOP_SHIFT               1                               /**< Shift value for I2C_STOP */
+#define _I2C_CMD_STOP_MASK                0x2UL                           /**< Bit mask for I2C_STOP */
+#define _I2C_CMD_STOP_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
+#define I2C_CMD_STOP_DEFAULT              (_I2C_CMD_STOP_DEFAULT << 1)    /**< Shifted mode DEFAULT for I2C_CMD */
+#define I2C_CMD_ACK                       (0x1UL << 2)                    /**< Send ACK */
+#define _I2C_CMD_ACK_SHIFT                2                               /**< Shift value for I2C_ACK */
+#define _I2C_CMD_ACK_MASK                 0x4UL                           /**< Bit mask for I2C_ACK */
+#define _I2C_CMD_ACK_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
+#define I2C_CMD_ACK_DEFAULT               (_I2C_CMD_ACK_DEFAULT << 2)     /**< Shifted mode DEFAULT for I2C_CMD */
+#define I2C_CMD_NACK                      (0x1UL << 3)                    /**< Send NACK */
+#define _I2C_CMD_NACK_SHIFT               3                               /**< Shift value for I2C_NACK */
+#define _I2C_CMD_NACK_MASK                0x8UL                           /**< Bit mask for I2C_NACK */
+#define _I2C_CMD_NACK_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
+#define I2C_CMD_NACK_DEFAULT              (_I2C_CMD_NACK_DEFAULT << 3)    /**< Shifted mode DEFAULT for I2C_CMD */
+#define I2C_CMD_CONT                      (0x1UL << 4)                    /**< Continue transmission */
+#define _I2C_CMD_CONT_SHIFT               4                               /**< Shift value for I2C_CONT */
+#define _I2C_CMD_CONT_MASK                0x10UL                          /**< Bit mask for I2C_CONT */
+#define _I2C_CMD_CONT_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
+#define I2C_CMD_CONT_DEFAULT              (_I2C_CMD_CONT_DEFAULT << 4)    /**< Shifted mode DEFAULT for I2C_CMD */
+#define I2C_CMD_ABORT                     (0x1UL << 5)                    /**< Abort transmission */
+#define _I2C_CMD_ABORT_SHIFT              5                               /**< Shift value for I2C_ABORT */
+#define _I2C_CMD_ABORT_MASK               0x20UL                          /**< Bit mask for I2C_ABORT */
+#define _I2C_CMD_ABORT_DEFAULT            0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
+#define I2C_CMD_ABORT_DEFAULT             (_I2C_CMD_ABORT_DEFAULT << 5)   /**< Shifted mode DEFAULT for I2C_CMD */
+#define I2C_CMD_CLEARTX                   (0x1UL << 6)                    /**< Clear TX */
+#define _I2C_CMD_CLEARTX_SHIFT            6                               /**< Shift value for I2C_CLEARTX */
+#define _I2C_CMD_CLEARTX_MASK             0x40UL                          /**< Bit mask for I2C_CLEARTX */
+#define _I2C_CMD_CLEARTX_DEFAULT          0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
+#define I2C_CMD_CLEARTX_DEFAULT           (_I2C_CMD_CLEARTX_DEFAULT << 6) /**< Shifted mode DEFAULT for I2C_CMD */
+#define I2C_CMD_CLEARPC                   (0x1UL << 7)                    /**< Clear Pending Commands */
+#define _I2C_CMD_CLEARPC_SHIFT            7                               /**< Shift value for I2C_CLEARPC */
+#define _I2C_CMD_CLEARPC_MASK             0x80UL                          /**< Bit mask for I2C_CLEARPC */
+#define _I2C_CMD_CLEARPC_DEFAULT          0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
+#define I2C_CMD_CLEARPC_DEFAULT           (_I2C_CMD_CLEARPC_DEFAULT << 7) /**< Shifted mode DEFAULT for I2C_CMD */
+
+/* Bit fields for I2C STATE */
+#define _I2C_STATE_RESETVALUE             0x00000001UL                          /**< Default value for I2C_STATE */
+#define _I2C_STATE_MASK                   0x000000FFUL                          /**< Mask for I2C_STATE */
+#define I2C_STATE_BUSY                    (0x1UL << 0)                          /**< Bus Busy */
+#define _I2C_STATE_BUSY_SHIFT             0                                     /**< Shift value for I2C_BUSY */
+#define _I2C_STATE_BUSY_MASK              0x1UL                                 /**< Bit mask for I2C_BUSY */
+#define _I2C_STATE_BUSY_DEFAULT           0x00000001UL                          /**< Mode DEFAULT for I2C_STATE */
+#define I2C_STATE_BUSY_DEFAULT            (_I2C_STATE_BUSY_DEFAULT << 0)        /**< Shifted mode DEFAULT for I2C_STATE */
+#define I2C_STATE_MASTER                  (0x1UL << 1)                          /**< Master */
+#define _I2C_STATE_MASTER_SHIFT           1                                     /**< Shift value for I2C_MASTER */
+#define _I2C_STATE_MASTER_MASK            0x2UL                                 /**< Bit mask for I2C_MASTER */
+#define _I2C_STATE_MASTER_DEFAULT         0x00000000UL                          /**< Mode DEFAULT for I2C_STATE */
+#define I2C_STATE_MASTER_DEFAULT          (_I2C_STATE_MASTER_DEFAULT << 1)      /**< Shifted mode DEFAULT for I2C_STATE */
+#define I2C_STATE_TRANSMITTER             (0x1UL << 2)                          /**< Transmitter */
+#define _I2C_STATE_TRANSMITTER_SHIFT      2                                     /**< Shift value for I2C_TRANSMITTER */
+#define _I2C_STATE_TRANSMITTER_MASK       0x4UL                                 /**< Bit mask for I2C_TRANSMITTER */
+#define _I2C_STATE_TRANSMITTER_DEFAULT    0x00000000UL                          /**< Mode DEFAULT for I2C_STATE */
+#define I2C_STATE_TRANSMITTER_DEFAULT     (_I2C_STATE_TRANSMITTER_DEFAULT << 2) /**< Shifted mode DEFAULT for I2C_STATE */
+#define I2C_STATE_NACKED                  (0x1UL << 3)                          /**< Nack Received */
+#define _I2C_STATE_NACKED_SHIFT           3                                     /**< Shift value for I2C_NACKED */
+#define _I2C_STATE_NACKED_MASK            0x8UL                                 /**< Bit mask for I2C_NACKED */
+#define _I2C_STATE_NACKED_DEFAULT         0x00000000UL                          /**< Mode DEFAULT for I2C_STATE */
+#define I2C_STATE_NACKED_DEFAULT          (_I2C_STATE_NACKED_DEFAULT << 3)      /**< Shifted mode DEFAULT for I2C_STATE */
+#define I2C_STATE_BUSHOLD                 (0x1UL << 4)                          /**< Bus Held */
+#define _I2C_STATE_BUSHOLD_SHIFT          4                                     /**< Shift value for I2C_BUSHOLD */
+#define _I2C_STATE_BUSHOLD_MASK           0x10UL                                /**< Bit mask for I2C_BUSHOLD */
+#define _I2C_STATE_BUSHOLD_DEFAULT        0x00000000UL                          /**< Mode DEFAULT for I2C_STATE */
+#define I2C_STATE_BUSHOLD_DEFAULT         (_I2C_STATE_BUSHOLD_DEFAULT << 4)     /**< Shifted mode DEFAULT for I2C_STATE */
+#define _I2C_STATE_STATE_SHIFT            5                                     /**< Shift value for I2C_STATE */
+#define _I2C_STATE_STATE_MASK             0xE0UL                                /**< Bit mask for I2C_STATE */
+#define _I2C_STATE_STATE_DEFAULT          0x00000000UL                          /**< Mode DEFAULT for I2C_STATE */
+#define _I2C_STATE_STATE_IDLE             0x00000000UL                          /**< Mode IDLE for I2C_STATE */
+#define _I2C_STATE_STATE_WAIT             0x00000001UL                          /**< Mode WAIT for I2C_STATE */
+#define _I2C_STATE_STATE_START            0x00000002UL                          /**< Mode START for I2C_STATE */
+#define _I2C_STATE_STATE_ADDR             0x00000003UL                          /**< Mode ADDR for I2C_STATE */
+#define _I2C_STATE_STATE_ADDRACK          0x00000004UL                          /**< Mode ADDRACK for I2C_STATE */
+#define _I2C_STATE_STATE_DATA             0x00000005UL                          /**< Mode DATA for I2C_STATE */
+#define _I2C_STATE_STATE_DATAACK          0x00000006UL                          /**< Mode DATAACK for I2C_STATE */
+#define I2C_STATE_STATE_DEFAULT           (_I2C_STATE_STATE_DEFAULT << 5)       /**< Shifted mode DEFAULT for I2C_STATE */
+#define I2C_STATE_STATE_IDLE              (_I2C_STATE_STATE_IDLE << 5)          /**< Shifted mode IDLE for I2C_STATE */
+#define I2C_STATE_STATE_WAIT              (_I2C_STATE_STATE_WAIT << 5)          /**< Shifted mode WAIT for I2C_STATE */
+#define I2C_STATE_STATE_START             (_I2C_STATE_STATE_START << 5)         /**< Shifted mode START for I2C_STATE */
+#define I2C_STATE_STATE_ADDR              (_I2C_STATE_STATE_ADDR << 5)          /**< Shifted mode ADDR for I2C_STATE */
+#define I2C_STATE_STATE_ADDRACK           (_I2C_STATE_STATE_ADDRACK << 5)       /**< Shifted mode ADDRACK for I2C_STATE */
+#define I2C_STATE_STATE_DATA              (_I2C_STATE_STATE_DATA << 5)          /**< Shifted mode DATA for I2C_STATE */
+#define I2C_STATE_STATE_DATAACK           (_I2C_STATE_STATE_DATAACK << 5)       /**< Shifted mode DATAACK for I2C_STATE */
+
+/* Bit fields for I2C STATUS */
+#define _I2C_STATUS_RESETVALUE            0x00000080UL                       /**< Default value for I2C_STATUS */
+#define _I2C_STATUS_MASK                  0x000001FFUL                       /**< Mask for I2C_STATUS */
+#define I2C_STATUS_PSTART                 (0x1UL << 0)                       /**< Pending START */
+#define _I2C_STATUS_PSTART_SHIFT          0                                  /**< Shift value for I2C_PSTART */
+#define _I2C_STATUS_PSTART_MASK           0x1UL                              /**< Bit mask for I2C_PSTART */
+#define _I2C_STATUS_PSTART_DEFAULT        0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PSTART_DEFAULT         (_I2C_STATUS_PSTART_DEFAULT << 0)  /**< Shifted mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PSTOP                  (0x1UL << 1)                       /**< Pending STOP */
+#define _I2C_STATUS_PSTOP_SHIFT           1                                  /**< Shift value for I2C_PSTOP */
+#define _I2C_STATUS_PSTOP_MASK            0x2UL                              /**< Bit mask for I2C_PSTOP */
+#define _I2C_STATUS_PSTOP_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PSTOP_DEFAULT          (_I2C_STATUS_PSTOP_DEFAULT << 1)   /**< Shifted mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PACK                   (0x1UL << 2)                       /**< Pending ACK */
+#define _I2C_STATUS_PACK_SHIFT            2                                  /**< Shift value for I2C_PACK */
+#define _I2C_STATUS_PACK_MASK             0x4UL                              /**< Bit mask for I2C_PACK */
+#define _I2C_STATUS_PACK_DEFAULT          0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PACK_DEFAULT           (_I2C_STATUS_PACK_DEFAULT << 2)    /**< Shifted mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PNACK                  (0x1UL << 3)                       /**< Pending NACK */
+#define _I2C_STATUS_PNACK_SHIFT           3                                  /**< Shift value for I2C_PNACK */
+#define _I2C_STATUS_PNACK_MASK            0x8UL                              /**< Bit mask for I2C_PNACK */
+#define _I2C_STATUS_PNACK_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PNACK_DEFAULT          (_I2C_STATUS_PNACK_DEFAULT << 3)   /**< Shifted mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PCONT                  (0x1UL << 4)                       /**< Pending continue */
+#define _I2C_STATUS_PCONT_SHIFT           4                                  /**< Shift value for I2C_PCONT */
+#define _I2C_STATUS_PCONT_MASK            0x10UL                             /**< Bit mask for I2C_PCONT */
+#define _I2C_STATUS_PCONT_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PCONT_DEFAULT          (_I2C_STATUS_PCONT_DEFAULT << 4)   /**< Shifted mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PABORT                 (0x1UL << 5)                       /**< Pending abort */
+#define _I2C_STATUS_PABORT_SHIFT          5                                  /**< Shift value for I2C_PABORT */
+#define _I2C_STATUS_PABORT_MASK           0x20UL                             /**< Bit mask for I2C_PABORT */
+#define _I2C_STATUS_PABORT_DEFAULT        0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_PABORT_DEFAULT         (_I2C_STATUS_PABORT_DEFAULT << 5)  /**< Shifted mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_TXC                    (0x1UL << 6)                       /**< TX Complete */
+#define _I2C_STATUS_TXC_SHIFT             6                                  /**< Shift value for I2C_TXC */
+#define _I2C_STATUS_TXC_MASK              0x40UL                             /**< Bit mask for I2C_TXC */
+#define _I2C_STATUS_TXC_DEFAULT           0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_TXC_DEFAULT            (_I2C_STATUS_TXC_DEFAULT << 6)     /**< Shifted mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_TXBL                   (0x1UL << 7)                       /**< TX Buffer Level */
+#define _I2C_STATUS_TXBL_SHIFT            7                                  /**< Shift value for I2C_TXBL */
+#define _I2C_STATUS_TXBL_MASK             0x80UL                             /**< Bit mask for I2C_TXBL */
+#define _I2C_STATUS_TXBL_DEFAULT          0x00000001UL                       /**< Mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_TXBL_DEFAULT           (_I2C_STATUS_TXBL_DEFAULT << 7)    /**< Shifted mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_RXDATAV                (0x1UL << 8)                       /**< RX Data Valid */
+#define _I2C_STATUS_RXDATAV_SHIFT         8                                  /**< Shift value for I2C_RXDATAV */
+#define _I2C_STATUS_RXDATAV_MASK          0x100UL                            /**< Bit mask for I2C_RXDATAV */
+#define _I2C_STATUS_RXDATAV_DEFAULT       0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
+#define I2C_STATUS_RXDATAV_DEFAULT        (_I2C_STATUS_RXDATAV_DEFAULT << 8) /**< Shifted mode DEFAULT for I2C_STATUS */
+
+/* Bit fields for I2C CLKDIV */
+#define _I2C_CLKDIV_RESETVALUE            0x00000000UL                   /**< Default value for I2C_CLKDIV */
+#define _I2C_CLKDIV_MASK                  0x000001FFUL                   /**< Mask for I2C_CLKDIV */
+#define _I2C_CLKDIV_DIV_SHIFT             0                              /**< Shift value for I2C_DIV */
+#define _I2C_CLKDIV_DIV_MASK              0x1FFUL                        /**< Bit mask for I2C_DIV */
+#define _I2C_CLKDIV_DIV_DEFAULT           0x00000000UL                   /**< Mode DEFAULT for I2C_CLKDIV */
+#define I2C_CLKDIV_DIV_DEFAULT            (_I2C_CLKDIV_DIV_DEFAULT << 0) /**< Shifted mode DEFAULT for I2C_CLKDIV */
+
+/* Bit fields for I2C SADDR */
+#define _I2C_SADDR_RESETVALUE             0x00000000UL                   /**< Default value for I2C_SADDR */
+#define _I2C_SADDR_MASK                   0x000000FEUL                   /**< Mask for I2C_SADDR */
+#define _I2C_SADDR_ADDR_SHIFT             1                              /**< Shift value for I2C_ADDR */
+#define _I2C_SADDR_ADDR_MASK              0xFEUL                         /**< Bit mask for I2C_ADDR */
+#define _I2C_SADDR_ADDR_DEFAULT           0x00000000UL                   /**< Mode DEFAULT for I2C_SADDR */
+#define I2C_SADDR_ADDR_DEFAULT            (_I2C_SADDR_ADDR_DEFAULT << 1) /**< Shifted mode DEFAULT for I2C_SADDR */
+
+/* Bit fields for I2C SADDRMASK */
+#define _I2C_SADDRMASK_RESETVALUE         0x00000000UL                       /**< Default value for I2C_SADDRMASK */
+#define _I2C_SADDRMASK_MASK               0x000000FEUL                       /**< Mask for I2C_SADDRMASK */
+#define _I2C_SADDRMASK_MASK_SHIFT         1                                  /**< Shift value for I2C_MASK */
+#define _I2C_SADDRMASK_MASK_MASK          0xFEUL                             /**< Bit mask for I2C_MASK */
+#define _I2C_SADDRMASK_MASK_DEFAULT       0x00000000UL                       /**< Mode DEFAULT for I2C_SADDRMASK */
+#define I2C_SADDRMASK_MASK_DEFAULT        (_I2C_SADDRMASK_MASK_DEFAULT << 1) /**< Shifted mode DEFAULT for I2C_SADDRMASK */
+
+/* Bit fields for I2C RXDATA */
+#define _I2C_RXDATA_RESETVALUE            0x00000000UL                      /**< Default value for I2C_RXDATA */
+#define _I2C_RXDATA_MASK                  0x000000FFUL                      /**< Mask for I2C_RXDATA */
+#define _I2C_RXDATA_RXDATA_SHIFT          0                                 /**< Shift value for I2C_RXDATA */
+#define _I2C_RXDATA_RXDATA_MASK           0xFFUL                            /**< Bit mask for I2C_RXDATA */
+#define _I2C_RXDATA_RXDATA_DEFAULT        0x00000000UL                      /**< Mode DEFAULT for I2C_RXDATA */
+#define I2C_RXDATA_RXDATA_DEFAULT         (_I2C_RXDATA_RXDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for I2C_RXDATA */
+
+/* Bit fields for I2C RXDATAP */
+#define _I2C_RXDATAP_RESETVALUE           0x00000000UL                        /**< Default value for I2C_RXDATAP */
+#define _I2C_RXDATAP_MASK                 0x000000FFUL                        /**< Mask for I2C_RXDATAP */
+#define _I2C_RXDATAP_RXDATAP_SHIFT        0                                   /**< Shift value for I2C_RXDATAP */
+#define _I2C_RXDATAP_RXDATAP_MASK         0xFFUL                              /**< Bit mask for I2C_RXDATAP */
+#define _I2C_RXDATAP_RXDATAP_DEFAULT      0x00000000UL                        /**< Mode DEFAULT for I2C_RXDATAP */
+#define I2C_RXDATAP_RXDATAP_DEFAULT       (_I2C_RXDATAP_RXDATAP_DEFAULT << 0) /**< Shifted mode DEFAULT for I2C_RXDATAP */
+
+/* Bit fields for I2C TXDATA */
+#define _I2C_TXDATA_RESETVALUE            0x00000000UL                      /**< Default value for I2C_TXDATA */
+#define _I2C_TXDATA_MASK                  0x000000FFUL                      /**< Mask for I2C_TXDATA */
+#define _I2C_TXDATA_TXDATA_SHIFT          0                                 /**< Shift value for I2C_TXDATA */
+#define _I2C_TXDATA_TXDATA_MASK           0xFFUL                            /**< Bit mask for I2C_TXDATA */
+#define _I2C_TXDATA_TXDATA_DEFAULT        0x00000000UL                      /**< Mode DEFAULT for I2C_TXDATA */
+#define I2C_TXDATA_TXDATA_DEFAULT         (_I2C_TXDATA_TXDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for I2C_TXDATA */
+
+/* Bit fields for I2C IF */
+#define _I2C_IF_RESETVALUE                0x00000010UL                    /**< Default value for I2C_IF */
+#define _I2C_IF_MASK                      0x0001FFFFUL                    /**< Mask for I2C_IF */
+#define I2C_IF_START                      (0x1UL << 0)                    /**< START condition Interrupt Flag */
+#define _I2C_IF_START_SHIFT               0                               /**< Shift value for I2C_START */
+#define _I2C_IF_START_MASK                0x1UL                           /**< Bit mask for I2C_START */
+#define _I2C_IF_START_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_START_DEFAULT              (_I2C_IF_START_DEFAULT << 0)    /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_RSTART                     (0x1UL << 1)                    /**< Repeated START condition Interrupt Flag */
+#define _I2C_IF_RSTART_SHIFT              1                               /**< Shift value for I2C_RSTART */
+#define _I2C_IF_RSTART_MASK               0x2UL                           /**< Bit mask for I2C_RSTART */
+#define _I2C_IF_RSTART_DEFAULT            0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_RSTART_DEFAULT             (_I2C_IF_RSTART_DEFAULT << 1)   /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_ADDR                       (0x1UL << 2)                    /**< Address Interrupt Flag */
+#define _I2C_IF_ADDR_SHIFT                2                               /**< Shift value for I2C_ADDR */
+#define _I2C_IF_ADDR_MASK                 0x4UL                           /**< Bit mask for I2C_ADDR */
+#define _I2C_IF_ADDR_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_ADDR_DEFAULT               (_I2C_IF_ADDR_DEFAULT << 2)     /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_TXC                        (0x1UL << 3)                    /**< Transfer Completed Interrupt Flag */
+#define _I2C_IF_TXC_SHIFT                 3                               /**< Shift value for I2C_TXC */
+#define _I2C_IF_TXC_MASK                  0x8UL                           /**< Bit mask for I2C_TXC */
+#define _I2C_IF_TXC_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_TXC_DEFAULT                (_I2C_IF_TXC_DEFAULT << 3)      /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_TXBL                       (0x1UL << 4)                    /**< Transmit Buffer Level Interrupt Flag */
+#define _I2C_IF_TXBL_SHIFT                4                               /**< Shift value for I2C_TXBL */
+#define _I2C_IF_TXBL_MASK                 0x10UL                          /**< Bit mask for I2C_TXBL */
+#define _I2C_IF_TXBL_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_TXBL_DEFAULT               (_I2C_IF_TXBL_DEFAULT << 4)     /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_RXDATAV                    (0x1UL << 5)                    /**< Receive Data Valid Interrupt Flag */
+#define _I2C_IF_RXDATAV_SHIFT             5                               /**< Shift value for I2C_RXDATAV */
+#define _I2C_IF_RXDATAV_MASK              0x20UL                          /**< Bit mask for I2C_RXDATAV */
+#define _I2C_IF_RXDATAV_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_RXDATAV_DEFAULT            (_I2C_IF_RXDATAV_DEFAULT << 5)  /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_ACK                        (0x1UL << 6)                    /**< Acknowledge Received Interrupt Flag */
+#define _I2C_IF_ACK_SHIFT                 6                               /**< Shift value for I2C_ACK */
+#define _I2C_IF_ACK_MASK                  0x40UL                          /**< Bit mask for I2C_ACK */
+#define _I2C_IF_ACK_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_ACK_DEFAULT                (_I2C_IF_ACK_DEFAULT << 6)      /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_NACK                       (0x1UL << 7)                    /**< Not Acknowledge Received Interrupt Flag */
+#define _I2C_IF_NACK_SHIFT                7                               /**< Shift value for I2C_NACK */
+#define _I2C_IF_NACK_MASK                 0x80UL                          /**< Bit mask for I2C_NACK */
+#define _I2C_IF_NACK_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_NACK_DEFAULT               (_I2C_IF_NACK_DEFAULT << 7)     /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_MSTOP                      (0x1UL << 8)                    /**< Master STOP Condition Interrupt Flag */
+#define _I2C_IF_MSTOP_SHIFT               8                               /**< Shift value for I2C_MSTOP */
+#define _I2C_IF_MSTOP_MASK                0x100UL                         /**< Bit mask for I2C_MSTOP */
+#define _I2C_IF_MSTOP_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_MSTOP_DEFAULT              (_I2C_IF_MSTOP_DEFAULT << 8)    /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_ARBLOST                    (0x1UL << 9)                    /**< Arbitration Lost Interrupt Flag */
+#define _I2C_IF_ARBLOST_SHIFT             9                               /**< Shift value for I2C_ARBLOST */
+#define _I2C_IF_ARBLOST_MASK              0x200UL                         /**< Bit mask for I2C_ARBLOST */
+#define _I2C_IF_ARBLOST_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_ARBLOST_DEFAULT            (_I2C_IF_ARBLOST_DEFAULT << 9)  /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_BUSERR                     (0x1UL << 10)                   /**< Bus Error Interrupt Flag */
+#define _I2C_IF_BUSERR_SHIFT              10                              /**< Shift value for I2C_BUSERR */
+#define _I2C_IF_BUSERR_MASK               0x400UL                         /**< Bit mask for I2C_BUSERR */
+#define _I2C_IF_BUSERR_DEFAULT            0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_BUSERR_DEFAULT             (_I2C_IF_BUSERR_DEFAULT << 10)  /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_BUSHOLD                    (0x1UL << 11)                   /**< Bus Held Interrupt Flag */
+#define _I2C_IF_BUSHOLD_SHIFT             11                              /**< Shift value for I2C_BUSHOLD */
+#define _I2C_IF_BUSHOLD_MASK              0x800UL                         /**< Bit mask for I2C_BUSHOLD */
+#define _I2C_IF_BUSHOLD_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_BUSHOLD_DEFAULT            (_I2C_IF_BUSHOLD_DEFAULT << 11) /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_TXOF                       (0x1UL << 12)                   /**< Transmit Buffer Overflow Interrupt Flag */
+#define _I2C_IF_TXOF_SHIFT                12                              /**< Shift value for I2C_TXOF */
+#define _I2C_IF_TXOF_MASK                 0x1000UL                        /**< Bit mask for I2C_TXOF */
+#define _I2C_IF_TXOF_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_TXOF_DEFAULT               (_I2C_IF_TXOF_DEFAULT << 12)    /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_RXUF                       (0x1UL << 13)                   /**< Receive Buffer Underflow Interrupt Flag */
+#define _I2C_IF_RXUF_SHIFT                13                              /**< Shift value for I2C_RXUF */
+#define _I2C_IF_RXUF_MASK                 0x2000UL                        /**< Bit mask for I2C_RXUF */
+#define _I2C_IF_RXUF_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_RXUF_DEFAULT               (_I2C_IF_RXUF_DEFAULT << 13)    /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_BITO                       (0x1UL << 14)                   /**< Bus Idle Timeout Interrupt Flag */
+#define _I2C_IF_BITO_SHIFT                14                              /**< Shift value for I2C_BITO */
+#define _I2C_IF_BITO_MASK                 0x4000UL                        /**< Bit mask for I2C_BITO */
+#define _I2C_IF_BITO_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_BITO_DEFAULT               (_I2C_IF_BITO_DEFAULT << 14)    /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_CLTO                       (0x1UL << 15)                   /**< Clock Low Timeout Interrupt Flag */
+#define _I2C_IF_CLTO_SHIFT                15                              /**< Shift value for I2C_CLTO */
+#define _I2C_IF_CLTO_MASK                 0x8000UL                        /**< Bit mask for I2C_CLTO */
+#define _I2C_IF_CLTO_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_CLTO_DEFAULT               (_I2C_IF_CLTO_DEFAULT << 15)    /**< Shifted mode DEFAULT for I2C_IF */
+#define I2C_IF_SSTOP                      (0x1UL << 16)                   /**< Slave STOP condition Interrupt Flag */
+#define _I2C_IF_SSTOP_SHIFT               16                              /**< Shift value for I2C_SSTOP */
+#define _I2C_IF_SSTOP_MASK                0x10000UL                       /**< Bit mask for I2C_SSTOP */
+#define _I2C_IF_SSTOP_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
+#define I2C_IF_SSTOP_DEFAULT              (_I2C_IF_SSTOP_DEFAULT << 16)   /**< Shifted mode DEFAULT for I2C_IF */
+
+/* Bit fields for I2C IFS */
+#define _I2C_IFS_RESETVALUE               0x00000000UL                     /**< Default value for I2C_IFS */
+#define _I2C_IFS_MASK                     0x0001FFCFUL                     /**< Mask for I2C_IFS */
+#define I2C_IFS_START                     (0x1UL << 0)                     /**< Set START Interrupt Flag */
+#define _I2C_IFS_START_SHIFT              0                                /**< Shift value for I2C_START */
+#define _I2C_IFS_START_MASK               0x1UL                            /**< Bit mask for I2C_START */
+#define _I2C_IFS_START_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_START_DEFAULT             (_I2C_IFS_START_DEFAULT << 0)    /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_RSTART                    (0x1UL << 1)                     /**< Set Repeated START Interrupt Flag */
+#define _I2C_IFS_RSTART_SHIFT             1                                /**< Shift value for I2C_RSTART */
+#define _I2C_IFS_RSTART_MASK              0x2UL                            /**< Bit mask for I2C_RSTART */
+#define _I2C_IFS_RSTART_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_RSTART_DEFAULT            (_I2C_IFS_RSTART_DEFAULT << 1)   /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_ADDR                      (0x1UL << 2)                     /**< Set Address Interrupt Flag */
+#define _I2C_IFS_ADDR_SHIFT               2                                /**< Shift value for I2C_ADDR */
+#define _I2C_IFS_ADDR_MASK                0x4UL                            /**< Bit mask for I2C_ADDR */
+#define _I2C_IFS_ADDR_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_ADDR_DEFAULT              (_I2C_IFS_ADDR_DEFAULT << 2)     /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_TXC                       (0x1UL << 3)                     /**< Set Transfer Completed Interrupt Flag */
+#define _I2C_IFS_TXC_SHIFT                3                                /**< Shift value for I2C_TXC */
+#define _I2C_IFS_TXC_MASK                 0x8UL                            /**< Bit mask for I2C_TXC */
+#define _I2C_IFS_TXC_DEFAULT              0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_TXC_DEFAULT               (_I2C_IFS_TXC_DEFAULT << 3)      /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_ACK                       (0x1UL << 6)                     /**< Set Acknowledge Received Interrupt Flag */
+#define _I2C_IFS_ACK_SHIFT                6                                /**< Shift value for I2C_ACK */
+#define _I2C_IFS_ACK_MASK                 0x40UL                           /**< Bit mask for I2C_ACK */
+#define _I2C_IFS_ACK_DEFAULT              0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_ACK_DEFAULT               (_I2C_IFS_ACK_DEFAULT << 6)      /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_NACK                      (0x1UL << 7)                     /**< Set Not Acknowledge Received Interrupt Flag */
+#define _I2C_IFS_NACK_SHIFT               7                                /**< Shift value for I2C_NACK */
+#define _I2C_IFS_NACK_MASK                0x80UL                           /**< Bit mask for I2C_NACK */
+#define _I2C_IFS_NACK_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_NACK_DEFAULT              (_I2C_IFS_NACK_DEFAULT << 7)     /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_MSTOP                     (0x1UL << 8)                     /**< Set MSTOP Interrupt Flag */
+#define _I2C_IFS_MSTOP_SHIFT              8                                /**< Shift value for I2C_MSTOP */
+#define _I2C_IFS_MSTOP_MASK               0x100UL                          /**< Bit mask for I2C_MSTOP */
+#define _I2C_IFS_MSTOP_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_MSTOP_DEFAULT             (_I2C_IFS_MSTOP_DEFAULT << 8)    /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_ARBLOST                   (0x1UL << 9)                     /**< Set Arbitration Lost Interrupt Flag */
+#define _I2C_IFS_ARBLOST_SHIFT            9                                /**< Shift value for I2C_ARBLOST */
+#define _I2C_IFS_ARBLOST_MASK             0x200UL                          /**< Bit mask for I2C_ARBLOST */
+#define _I2C_IFS_ARBLOST_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_ARBLOST_DEFAULT           (_I2C_IFS_ARBLOST_DEFAULT << 9)  /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_BUSERR                    (0x1UL << 10)                    /**< Set Bus Error Interrupt Flag */
+#define _I2C_IFS_BUSERR_SHIFT             10                               /**< Shift value for I2C_BUSERR */
+#define _I2C_IFS_BUSERR_MASK              0x400UL                          /**< Bit mask for I2C_BUSERR */
+#define _I2C_IFS_BUSERR_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_BUSERR_DEFAULT            (_I2C_IFS_BUSERR_DEFAULT << 10)  /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_BUSHOLD                   (0x1UL << 11)                    /**< Set Bus Held Interrupt Flag */
+#define _I2C_IFS_BUSHOLD_SHIFT            11                               /**< Shift value for I2C_BUSHOLD */
+#define _I2C_IFS_BUSHOLD_MASK             0x800UL                          /**< Bit mask for I2C_BUSHOLD */
+#define _I2C_IFS_BUSHOLD_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_BUSHOLD_DEFAULT           (_I2C_IFS_BUSHOLD_DEFAULT << 11) /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_TXOF                      (0x1UL << 12)                    /**< Set Transmit Buffer Overflow Interrupt Flag */
+#define _I2C_IFS_TXOF_SHIFT               12                               /**< Shift value for I2C_TXOF */
+#define _I2C_IFS_TXOF_MASK                0x1000UL                         /**< Bit mask for I2C_TXOF */
+#define _I2C_IFS_TXOF_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_TXOF_DEFAULT              (_I2C_IFS_TXOF_DEFAULT << 12)    /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_RXUF                      (0x1UL << 13)                    /**< Set Receive Buffer Underflow Interrupt Flag */
+#define _I2C_IFS_RXUF_SHIFT               13                               /**< Shift value for I2C_RXUF */
+#define _I2C_IFS_RXUF_MASK                0x2000UL                         /**< Bit mask for I2C_RXUF */
+#define _I2C_IFS_RXUF_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_RXUF_DEFAULT              (_I2C_IFS_RXUF_DEFAULT << 13)    /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_BITO                      (0x1UL << 14)                    /**< Set Bus Idle Timeout Interrupt Flag */
+#define _I2C_IFS_BITO_SHIFT               14                               /**< Shift value for I2C_BITO */
+#define _I2C_IFS_BITO_MASK                0x4000UL                         /**< Bit mask for I2C_BITO */
+#define _I2C_IFS_BITO_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_BITO_DEFAULT              (_I2C_IFS_BITO_DEFAULT << 14)    /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_CLTO                      (0x1UL << 15)                    /**< Set Clock Low Interrupt Flag */
+#define _I2C_IFS_CLTO_SHIFT               15                               /**< Shift value for I2C_CLTO */
+#define _I2C_IFS_CLTO_MASK                0x8000UL                         /**< Bit mask for I2C_CLTO */
+#define _I2C_IFS_CLTO_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_CLTO_DEFAULT              (_I2C_IFS_CLTO_DEFAULT << 15)    /**< Shifted mode DEFAULT for I2C_IFS */
+#define I2C_IFS_SSTOP                     (0x1UL << 16)                    /**< Set SSTOP Interrupt Flag */
+#define _I2C_IFS_SSTOP_SHIFT              16                               /**< Shift value for I2C_SSTOP */
+#define _I2C_IFS_SSTOP_MASK               0x10000UL                        /**< Bit mask for I2C_SSTOP */
+#define _I2C_IFS_SSTOP_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_IFS */
+#define I2C_IFS_SSTOP_DEFAULT             (_I2C_IFS_SSTOP_DEFAULT << 16)   /**< Shifted mode DEFAULT for I2C_IFS */
+
+/* Bit fields for I2C IFC */
+#define _I2C_IFC_RESETVALUE               0x00000000UL                     /**< Default value for I2C_IFC */
+#define _I2C_IFC_MASK                     0x0001FFCFUL                     /**< Mask for I2C_IFC */
+#define I2C_IFC_START                     (0x1UL << 0)                     /**< Clear START Interrupt Flag */
+#define _I2C_IFC_START_SHIFT              0                                /**< Shift value for I2C_START */
+#define _I2C_IFC_START_MASK               0x1UL                            /**< Bit mask for I2C_START */
+#define _I2C_IFC_START_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_START_DEFAULT             (_I2C_IFC_START_DEFAULT << 0)    /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_RSTART                    (0x1UL << 1)                     /**< Clear Repeated START Interrupt Flag */
+#define _I2C_IFC_RSTART_SHIFT             1                                /**< Shift value for I2C_RSTART */
+#define _I2C_IFC_RSTART_MASK              0x2UL                            /**< Bit mask for I2C_RSTART */
+#define _I2C_IFC_RSTART_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_RSTART_DEFAULT            (_I2C_IFC_RSTART_DEFAULT << 1)   /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_ADDR                      (0x1UL << 2)                     /**< Clear Address Interrupt Flag */
+#define _I2C_IFC_ADDR_SHIFT               2                                /**< Shift value for I2C_ADDR */
+#define _I2C_IFC_ADDR_MASK                0x4UL                            /**< Bit mask for I2C_ADDR */
+#define _I2C_IFC_ADDR_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_ADDR_DEFAULT              (_I2C_IFC_ADDR_DEFAULT << 2)     /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_TXC                       (0x1UL << 3)                     /**< Clear Transfer Completed Interrupt Flag */
+#define _I2C_IFC_TXC_SHIFT                3                                /**< Shift value for I2C_TXC */
+#define _I2C_IFC_TXC_MASK                 0x8UL                            /**< Bit mask for I2C_TXC */
+#define _I2C_IFC_TXC_DEFAULT              0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_TXC_DEFAULT               (_I2C_IFC_TXC_DEFAULT << 3)      /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_ACK                       (0x1UL << 6)                     /**< Clear Acknowledge Received Interrupt Flag */
+#define _I2C_IFC_ACK_SHIFT                6                                /**< Shift value for I2C_ACK */
+#define _I2C_IFC_ACK_MASK                 0x40UL                           /**< Bit mask for I2C_ACK */
+#define _I2C_IFC_ACK_DEFAULT              0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_ACK_DEFAULT               (_I2C_IFC_ACK_DEFAULT << 6)      /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_NACK                      (0x1UL << 7)                     /**< Clear Not Acknowledge Received Interrupt Flag */
+#define _I2C_IFC_NACK_SHIFT               7                                /**< Shift value for I2C_NACK */
+#define _I2C_IFC_NACK_MASK                0x80UL                           /**< Bit mask for I2C_NACK */
+#define _I2C_IFC_NACK_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_NACK_DEFAULT              (_I2C_IFC_NACK_DEFAULT << 7)     /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_MSTOP                     (0x1UL << 8)                     /**< Clear MSTOP Interrupt Flag */
+#define _I2C_IFC_MSTOP_SHIFT              8                                /**< Shift value for I2C_MSTOP */
+#define _I2C_IFC_MSTOP_MASK               0x100UL                          /**< Bit mask for I2C_MSTOP */
+#define _I2C_IFC_MSTOP_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_MSTOP_DEFAULT             (_I2C_IFC_MSTOP_DEFAULT << 8)    /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_ARBLOST                   (0x1UL << 9)                     /**< Clear Arbitration Lost Interrupt Flag */
+#define _I2C_IFC_ARBLOST_SHIFT            9                                /**< Shift value for I2C_ARBLOST */
+#define _I2C_IFC_ARBLOST_MASK             0x200UL                          /**< Bit mask for I2C_ARBLOST */
+#define _I2C_IFC_ARBLOST_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_ARBLOST_DEFAULT           (_I2C_IFC_ARBLOST_DEFAULT << 9)  /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_BUSERR                    (0x1UL << 10)                    /**< Clear Bus Error Interrupt Flag */
+#define _I2C_IFC_BUSERR_SHIFT             10                               /**< Shift value for I2C_BUSERR */
+#define _I2C_IFC_BUSERR_MASK              0x400UL                          /**< Bit mask for I2C_BUSERR */
+#define _I2C_IFC_BUSERR_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_BUSERR_DEFAULT            (_I2C_IFC_BUSERR_DEFAULT << 10)  /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_BUSHOLD                   (0x1UL << 11)                    /**< Clear Bus Held Interrupt Flag */
+#define _I2C_IFC_BUSHOLD_SHIFT            11                               /**< Shift value for I2C_BUSHOLD */
+#define _I2C_IFC_BUSHOLD_MASK             0x800UL                          /**< Bit mask for I2C_BUSHOLD */
+#define _I2C_IFC_BUSHOLD_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_BUSHOLD_DEFAULT           (_I2C_IFC_BUSHOLD_DEFAULT << 11) /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_TXOF                      (0x1UL << 12)                    /**< Clear Transmit Buffer Overflow Interrupt Flag */
+#define _I2C_IFC_TXOF_SHIFT               12                               /**< Shift value for I2C_TXOF */
+#define _I2C_IFC_TXOF_MASK                0x1000UL                         /**< Bit mask for I2C_TXOF */
+#define _I2C_IFC_TXOF_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_TXOF_DEFAULT              (_I2C_IFC_TXOF_DEFAULT << 12)    /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_RXUF                      (0x1UL << 13)                    /**< Clear Receive Buffer Underflow Interrupt Flag */
+#define _I2C_IFC_RXUF_SHIFT               13                               /**< Shift value for I2C_RXUF */
+#define _I2C_IFC_RXUF_MASK                0x2000UL                         /**< Bit mask for I2C_RXUF */
+#define _I2C_IFC_RXUF_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_RXUF_DEFAULT              (_I2C_IFC_RXUF_DEFAULT << 13)    /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_BITO                      (0x1UL << 14)                    /**< Clear Bus Idle Timeout Interrupt Flag */
+#define _I2C_IFC_BITO_SHIFT               14                               /**< Shift value for I2C_BITO */
+#define _I2C_IFC_BITO_MASK                0x4000UL                         /**< Bit mask for I2C_BITO */
+#define _I2C_IFC_BITO_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_BITO_DEFAULT              (_I2C_IFC_BITO_DEFAULT << 14)    /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_CLTO                      (0x1UL << 15)                    /**< Clear Clock Low Interrupt Flag */
+#define _I2C_IFC_CLTO_SHIFT               15                               /**< Shift value for I2C_CLTO */
+#define _I2C_IFC_CLTO_MASK                0x8000UL                         /**< Bit mask for I2C_CLTO */
+#define _I2C_IFC_CLTO_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_CLTO_DEFAULT              (_I2C_IFC_CLTO_DEFAULT << 15)    /**< Shifted mode DEFAULT for I2C_IFC */
+#define I2C_IFC_SSTOP                     (0x1UL << 16)                    /**< Clear SSTOP Interrupt Flag */
+#define _I2C_IFC_SSTOP_SHIFT              16                               /**< Shift value for I2C_SSTOP */
+#define _I2C_IFC_SSTOP_MASK               0x10000UL                        /**< Bit mask for I2C_SSTOP */
+#define _I2C_IFC_SSTOP_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_IFC */
+#define I2C_IFC_SSTOP_DEFAULT             (_I2C_IFC_SSTOP_DEFAULT << 16)   /**< Shifted mode DEFAULT for I2C_IFC */
+
+/* Bit fields for I2C IEN */
+#define _I2C_IEN_RESETVALUE               0x00000000UL                     /**< Default value for I2C_IEN */
+#define _I2C_IEN_MASK                     0x0001FFFFUL                     /**< Mask for I2C_IEN */
+#define I2C_IEN_START                     (0x1UL << 0)                     /**< START Condition Interrupt Enable */
+#define _I2C_IEN_START_SHIFT              0                                /**< Shift value for I2C_START */
+#define _I2C_IEN_START_MASK               0x1UL                            /**< Bit mask for I2C_START */
+#define _I2C_IEN_START_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_START_DEFAULT             (_I2C_IEN_START_DEFAULT << 0)    /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_RSTART                    (0x1UL << 1)                     /**< Repeated START condition Interrupt Enable */
+#define _I2C_IEN_RSTART_SHIFT             1                                /**< Shift value for I2C_RSTART */
+#define _I2C_IEN_RSTART_MASK              0x2UL                            /**< Bit mask for I2C_RSTART */
+#define _I2C_IEN_RSTART_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_RSTART_DEFAULT            (_I2C_IEN_RSTART_DEFAULT << 1)   /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_ADDR                      (0x1UL << 2)                     /**< Address Interrupt Enable */
+#define _I2C_IEN_ADDR_SHIFT               2                                /**< Shift value for I2C_ADDR */
+#define _I2C_IEN_ADDR_MASK                0x4UL                            /**< Bit mask for I2C_ADDR */
+#define _I2C_IEN_ADDR_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_ADDR_DEFAULT              (_I2C_IEN_ADDR_DEFAULT << 2)     /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_TXC                       (0x1UL << 3)                     /**< Transfer Completed Interrupt Enable */
+#define _I2C_IEN_TXC_SHIFT                3                                /**< Shift value for I2C_TXC */
+#define _I2C_IEN_TXC_MASK                 0x8UL                            /**< Bit mask for I2C_TXC */
+#define _I2C_IEN_TXC_DEFAULT              0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_TXC_DEFAULT               (_I2C_IEN_TXC_DEFAULT << 3)      /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_TXBL                      (0x1UL << 4)                     /**< Transmit Buffer level Interrupt Enable */
+#define _I2C_IEN_TXBL_SHIFT               4                                /**< Shift value for I2C_TXBL */
+#define _I2C_IEN_TXBL_MASK                0x10UL                           /**< Bit mask for I2C_TXBL */
+#define _I2C_IEN_TXBL_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_TXBL_DEFAULT              (_I2C_IEN_TXBL_DEFAULT << 4)     /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_RXDATAV                   (0x1UL << 5)                     /**< Receive Data Valid Interrupt Enable */
+#define _I2C_IEN_RXDATAV_SHIFT            5                                /**< Shift value for I2C_RXDATAV */
+#define _I2C_IEN_RXDATAV_MASK             0x20UL                           /**< Bit mask for I2C_RXDATAV */
+#define _I2C_IEN_RXDATAV_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_RXDATAV_DEFAULT           (_I2C_IEN_RXDATAV_DEFAULT << 5)  /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_ACK                       (0x1UL << 6)                     /**< Acknowledge Received Interrupt Enable */
+#define _I2C_IEN_ACK_SHIFT                6                                /**< Shift value for I2C_ACK */
+#define _I2C_IEN_ACK_MASK                 0x40UL                           /**< Bit mask for I2C_ACK */
+#define _I2C_IEN_ACK_DEFAULT              0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_ACK_DEFAULT               (_I2C_IEN_ACK_DEFAULT << 6)      /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_NACK                      (0x1UL << 7)                     /**< Not Acknowledge Received Interrupt Enable */
+#define _I2C_IEN_NACK_SHIFT               7                                /**< Shift value for I2C_NACK */
+#define _I2C_IEN_NACK_MASK                0x80UL                           /**< Bit mask for I2C_NACK */
+#define _I2C_IEN_NACK_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_NACK_DEFAULT              (_I2C_IEN_NACK_DEFAULT << 7)     /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_MSTOP                     (0x1UL << 8)                     /**< MSTOP Interrupt Enable */
+#define _I2C_IEN_MSTOP_SHIFT              8                                /**< Shift value for I2C_MSTOP */
+#define _I2C_IEN_MSTOP_MASK               0x100UL                          /**< Bit mask for I2C_MSTOP */
+#define _I2C_IEN_MSTOP_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_MSTOP_DEFAULT             (_I2C_IEN_MSTOP_DEFAULT << 8)    /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_ARBLOST                   (0x1UL << 9)                     /**< Arbitration Lost Interrupt Enable */
+#define _I2C_IEN_ARBLOST_SHIFT            9                                /**< Shift value for I2C_ARBLOST */
+#define _I2C_IEN_ARBLOST_MASK             0x200UL                          /**< Bit mask for I2C_ARBLOST */
+#define _I2C_IEN_ARBLOST_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_ARBLOST_DEFAULT           (_I2C_IEN_ARBLOST_DEFAULT << 9)  /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_BUSERR                    (0x1UL << 10)                    /**< Bus Error Interrupt Enable */
+#define _I2C_IEN_BUSERR_SHIFT             10                               /**< Shift value for I2C_BUSERR */
+#define _I2C_IEN_BUSERR_MASK              0x400UL                          /**< Bit mask for I2C_BUSERR */
+#define _I2C_IEN_BUSERR_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_BUSERR_DEFAULT            (_I2C_IEN_BUSERR_DEFAULT << 10)  /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_BUSHOLD                   (0x1UL << 11)                    /**< Bus Held Interrupt Enable */
+#define _I2C_IEN_BUSHOLD_SHIFT            11                               /**< Shift value for I2C_BUSHOLD */
+#define _I2C_IEN_BUSHOLD_MASK             0x800UL                          /**< Bit mask for I2C_BUSHOLD */
+#define _I2C_IEN_BUSHOLD_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_BUSHOLD_DEFAULT           (_I2C_IEN_BUSHOLD_DEFAULT << 11) /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_TXOF                      (0x1UL << 12)                    /**< Transmit Buffer Overflow Interrupt Enable */
+#define _I2C_IEN_TXOF_SHIFT               12                               /**< Shift value for I2C_TXOF */
+#define _I2C_IEN_TXOF_MASK                0x1000UL                         /**< Bit mask for I2C_TXOF */
+#define _I2C_IEN_TXOF_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_TXOF_DEFAULT              (_I2C_IEN_TXOF_DEFAULT << 12)    /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_RXUF                      (0x1UL << 13)                    /**< Receive Buffer Underflow Interrupt Enable */
+#define _I2C_IEN_RXUF_SHIFT               13                               /**< Shift value for I2C_RXUF */
+#define _I2C_IEN_RXUF_MASK                0x2000UL                         /**< Bit mask for I2C_RXUF */
+#define _I2C_IEN_RXUF_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_RXUF_DEFAULT              (_I2C_IEN_RXUF_DEFAULT << 13)    /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_BITO                      (0x1UL << 14)                    /**< Bus Idle Timeout Interrupt Enable */
+#define _I2C_IEN_BITO_SHIFT               14                               /**< Shift value for I2C_BITO */
+#define _I2C_IEN_BITO_MASK                0x4000UL                         /**< Bit mask for I2C_BITO */
+#define _I2C_IEN_BITO_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_BITO_DEFAULT              (_I2C_IEN_BITO_DEFAULT << 14)    /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_CLTO                      (0x1UL << 15)                    /**< Clock Low Interrupt Enable */
+#define _I2C_IEN_CLTO_SHIFT               15                               /**< Shift value for I2C_CLTO */
+#define _I2C_IEN_CLTO_MASK                0x8000UL                         /**< Bit mask for I2C_CLTO */
+#define _I2C_IEN_CLTO_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_CLTO_DEFAULT              (_I2C_IEN_CLTO_DEFAULT << 15)    /**< Shifted mode DEFAULT for I2C_IEN */
+#define I2C_IEN_SSTOP                     (0x1UL << 16)                    /**< SSTOP Interrupt Enable */
+#define _I2C_IEN_SSTOP_SHIFT              16                               /**< Shift value for I2C_SSTOP */
+#define _I2C_IEN_SSTOP_MASK               0x10000UL                        /**< Bit mask for I2C_SSTOP */
+#define _I2C_IEN_SSTOP_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for I2C_IEN */
+#define I2C_IEN_SSTOP_DEFAULT             (_I2C_IEN_SSTOP_DEFAULT << 16)   /**< Shifted mode DEFAULT for I2C_IEN */
+
+/* Bit fields for I2C ROUTE */
+#define _I2C_ROUTE_RESETVALUE             0x00000000UL                       /**< Default value for I2C_ROUTE */
+#define _I2C_ROUTE_MASK                   0x00000703UL                       /**< Mask for I2C_ROUTE */
+#define I2C_ROUTE_SDAPEN                  (0x1UL << 0)                       /**< SDA Pin Enable */
+#define _I2C_ROUTE_SDAPEN_SHIFT           0                                  /**< Shift value for I2C_SDAPEN */
+#define _I2C_ROUTE_SDAPEN_MASK            0x1UL                              /**< Bit mask for I2C_SDAPEN */
+#define _I2C_ROUTE_SDAPEN_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for I2C_ROUTE */
+#define I2C_ROUTE_SDAPEN_DEFAULT          (_I2C_ROUTE_SDAPEN_DEFAULT << 0)   /**< Shifted mode DEFAULT for I2C_ROUTE */
+#define I2C_ROUTE_SCLPEN                  (0x1UL << 1)                       /**< SCL Pin Enable */
+#define _I2C_ROUTE_SCLPEN_SHIFT           1                                  /**< Shift value for I2C_SCLPEN */
+#define _I2C_ROUTE_SCLPEN_MASK            0x2UL                              /**< Bit mask for I2C_SCLPEN */
+#define _I2C_ROUTE_SCLPEN_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for I2C_ROUTE */
+#define I2C_ROUTE_SCLPEN_DEFAULT          (_I2C_ROUTE_SCLPEN_DEFAULT << 1)   /**< Shifted mode DEFAULT for I2C_ROUTE */
+#define _I2C_ROUTE_LOCATION_SHIFT         8                                  /**< Shift value for I2C_LOCATION */
+#define _I2C_ROUTE_LOCATION_MASK          0x700UL                            /**< Bit mask for I2C_LOCATION */
+#define _I2C_ROUTE_LOCATION_LOC0          0x00000000UL                       /**< Mode LOC0 for I2C_ROUTE */
+#define _I2C_ROUTE_LOCATION_DEFAULT       0x00000000UL                       /**< Mode DEFAULT for I2C_ROUTE */
+#define _I2C_ROUTE_LOCATION_LOC1          0x00000001UL                       /**< Mode LOC1 for I2C_ROUTE */
+#define _I2C_ROUTE_LOCATION_LOC2          0x00000002UL                       /**< Mode LOC2 for I2C_ROUTE */
+#define _I2C_ROUTE_LOCATION_LOC3          0x00000003UL                       /**< Mode LOC3 for I2C_ROUTE */
+#define _I2C_ROUTE_LOCATION_LOC4          0x00000004UL                       /**< Mode LOC4 for I2C_ROUTE */
+#define _I2C_ROUTE_LOCATION_LOC5          0x00000005UL                       /**< Mode LOC5 for I2C_ROUTE */
+#define _I2C_ROUTE_LOCATION_LOC6          0x00000006UL                       /**< Mode LOC6 for I2C_ROUTE */
+#define I2C_ROUTE_LOCATION_LOC0           (_I2C_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for I2C_ROUTE */
+#define I2C_ROUTE_LOCATION_DEFAULT        (_I2C_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for I2C_ROUTE */
+#define I2C_ROUTE_LOCATION_LOC1           (_I2C_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for I2C_ROUTE */
+#define I2C_ROUTE_LOCATION_LOC2           (_I2C_ROUTE_LOCATION_LOC2 << 8)    /**< Shifted mode LOC2 for I2C_ROUTE */
+#define I2C_ROUTE_LOCATION_LOC3           (_I2C_ROUTE_LOCATION_LOC3 << 8)    /**< Shifted mode LOC3 for I2C_ROUTE */
+#define I2C_ROUTE_LOCATION_LOC4           (_I2C_ROUTE_LOCATION_LOC4 << 8)    /**< Shifted mode LOC4 for I2C_ROUTE */
+#define I2C_ROUTE_LOCATION_LOC5           (_I2C_ROUTE_LOCATION_LOC5 << 8)    /**< Shifted mode LOC5 for I2C_ROUTE */
+#define I2C_ROUTE_LOCATION_LOC6           (_I2C_ROUTE_LOCATION_LOC6 << 8)    /**< Shifted mode LOC6 for I2C_ROUTE */
+
+/** @} End of group EFM32TG_I2C */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lcd.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lcd.h
@@ -1,0 +1,480 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_LCD register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_LCD
+ * @brief EFM32TG_LCD Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;           /**< Control Register  */
+  __IOM uint32_t DISPCTRL;       /**< Display Control Register  */
+  __IOM uint32_t SEGEN;          /**< Segment Enable Register  */
+  __IOM uint32_t BACTRL;         /**< Blink and Animation Control Register  */
+  __IM uint32_t  STATUS;         /**< Status Register  */
+  __IOM uint32_t AREGA;          /**< Animation Register A  */
+  __IOM uint32_t AREGB;          /**< Animation Register B  */
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
+  uint32_t       RESERVED0[5U];  /**< Reserved for future use **/
+  __IOM uint32_t SEGD0L;         /**< Segment Data Low Register 0  */
+  __IOM uint32_t SEGD1L;         /**< Segment Data Low Register 1  */
+  __IOM uint32_t SEGD2L;         /**< Segment Data Low Register 2  */
+  __IOM uint32_t SEGD3L;         /**< Segment Data Low Register 3  */
+
+  uint32_t       RESERVED1[4U];  /**< Reserved for future use **/
+  __IOM uint32_t FREEZE;         /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;       /**< Synchronization Busy Register  */
+
+  uint32_t       RESERVED2[25U]; /**< Reserved for future use **/
+  __IOM uint32_t SEGD4L;         /**< Segment Data Low Register 4  */
+  __IOM uint32_t SEGD5L;         /**< Segment Data Low Register 5  */
+  __IOM uint32_t SEGD6L;         /**< Segment Data Low Register 6  */
+  __IOM uint32_t SEGD7L;         /**< Segment Data Low Register 7  */
+} LCD_TypeDef;                   /**< LCD Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_LCD_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for LCD CTRL */
+#define _LCD_CTRL_RESETVALUE               0x00000000UL                       /**< Default value for LCD_CTRL */
+#define _LCD_CTRL_MASK                     0x00800007UL                       /**< Mask for LCD_CTRL */
+#define LCD_CTRL_EN                        (0x1UL << 0)                       /**< LCD Enable */
+#define _LCD_CTRL_EN_SHIFT                 0                                  /**< Shift value for LCD_EN */
+#define _LCD_CTRL_EN_MASK                  0x1UL                              /**< Bit mask for LCD_EN */
+#define _LCD_CTRL_EN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for LCD_CTRL */
+#define LCD_CTRL_EN_DEFAULT                (_LCD_CTRL_EN_DEFAULT << 0)        /**< Shifted mode DEFAULT for LCD_CTRL */
+#define _LCD_CTRL_UDCTRL_SHIFT             1                                  /**< Shift value for LCD_UDCTRL */
+#define _LCD_CTRL_UDCTRL_MASK              0x6UL                              /**< Bit mask for LCD_UDCTRL */
+#define _LCD_CTRL_UDCTRL_DEFAULT           0x00000000UL                       /**< Mode DEFAULT for LCD_CTRL */
+#define _LCD_CTRL_UDCTRL_REGULAR           0x00000000UL                       /**< Mode REGULAR for LCD_CTRL */
+#define _LCD_CTRL_UDCTRL_FCEVENT           0x00000001UL                       /**< Mode FCEVENT for LCD_CTRL */
+#define _LCD_CTRL_UDCTRL_FRAMESTART        0x00000002UL                       /**< Mode FRAMESTART for LCD_CTRL */
+#define LCD_CTRL_UDCTRL_DEFAULT            (_LCD_CTRL_UDCTRL_DEFAULT << 1)    /**< Shifted mode DEFAULT for LCD_CTRL */
+#define LCD_CTRL_UDCTRL_REGULAR            (_LCD_CTRL_UDCTRL_REGULAR << 1)    /**< Shifted mode REGULAR for LCD_CTRL */
+#define LCD_CTRL_UDCTRL_FCEVENT            (_LCD_CTRL_UDCTRL_FCEVENT << 1)    /**< Shifted mode FCEVENT for LCD_CTRL */
+#define LCD_CTRL_UDCTRL_FRAMESTART         (_LCD_CTRL_UDCTRL_FRAMESTART << 1) /**< Shifted mode FRAMESTART for LCD_CTRL */
+#define LCD_CTRL_DSC                       (0x1UL << 23)                      /**< Direct Segment Control */
+#define _LCD_CTRL_DSC_SHIFT                23                                 /**< Shift value for LCD_DSC */
+#define _LCD_CTRL_DSC_MASK                 0x800000UL                         /**< Bit mask for LCD_DSC */
+#define _LCD_CTRL_DSC_DEFAULT              0x00000000UL                       /**< Mode DEFAULT for LCD_CTRL */
+#define LCD_CTRL_DSC_DEFAULT               (_LCD_CTRL_DSC_DEFAULT << 23)      /**< Shifted mode DEFAULT for LCD_CTRL */
+
+/* Bit fields for LCD DISPCTRL */
+#define _LCD_DISPCTRL_RESETVALUE           0x000C1F00UL                            /**< Default value for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_MASK                 0x005D9F1FUL                            /**< Mask for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_MUX_SHIFT            0                                       /**< Shift value for LCD_MUX */
+#define _LCD_DISPCTRL_MUX_MASK             0x3UL                                   /**< Bit mask for LCD_MUX */
+#define _LCD_DISPCTRL_MUX_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_MUX_STATIC           0x00000000UL                            /**< Mode STATIC for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_MUX_DUPLEX           0x00000001UL                            /**< Mode DUPLEX for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_MUX_TRIPLEX          0x00000002UL                            /**< Mode TRIPLEX for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_MUX_QUADRUPLEX       0x00000003UL                            /**< Mode QUADRUPLEX for LCD_DISPCTRL */
+#define LCD_DISPCTRL_MUX_DEFAULT           (_LCD_DISPCTRL_MUX_DEFAULT << 0)        /**< Shifted mode DEFAULT for LCD_DISPCTRL */
+#define LCD_DISPCTRL_MUX_STATIC            (_LCD_DISPCTRL_MUX_STATIC << 0)         /**< Shifted mode STATIC for LCD_DISPCTRL */
+#define LCD_DISPCTRL_MUX_DUPLEX            (_LCD_DISPCTRL_MUX_DUPLEX << 0)         /**< Shifted mode DUPLEX for LCD_DISPCTRL */
+#define LCD_DISPCTRL_MUX_TRIPLEX           (_LCD_DISPCTRL_MUX_TRIPLEX << 0)        /**< Shifted mode TRIPLEX for LCD_DISPCTRL */
+#define LCD_DISPCTRL_MUX_QUADRUPLEX        (_LCD_DISPCTRL_MUX_QUADRUPLEX << 0)     /**< Shifted mode QUADRUPLEX for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_BIAS_SHIFT           2                                       /**< Shift value for LCD_BIAS */
+#define _LCD_DISPCTRL_BIAS_MASK            0xCUL                                   /**< Bit mask for LCD_BIAS */
+#define _LCD_DISPCTRL_BIAS_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_BIAS_STATIC          0x00000000UL                            /**< Mode STATIC for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_BIAS_ONEHALF         0x00000001UL                            /**< Mode ONEHALF for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_BIAS_ONETHIRD        0x00000002UL                            /**< Mode ONETHIRD for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_BIAS_ONEFOURTH       0x00000003UL                            /**< Mode ONEFOURTH for LCD_DISPCTRL */
+#define LCD_DISPCTRL_BIAS_DEFAULT          (_LCD_DISPCTRL_BIAS_DEFAULT << 2)       /**< Shifted mode DEFAULT for LCD_DISPCTRL */
+#define LCD_DISPCTRL_BIAS_STATIC           (_LCD_DISPCTRL_BIAS_STATIC << 2)        /**< Shifted mode STATIC for LCD_DISPCTRL */
+#define LCD_DISPCTRL_BIAS_ONEHALF          (_LCD_DISPCTRL_BIAS_ONEHALF << 2)       /**< Shifted mode ONEHALF for LCD_DISPCTRL */
+#define LCD_DISPCTRL_BIAS_ONETHIRD         (_LCD_DISPCTRL_BIAS_ONETHIRD << 2)      /**< Shifted mode ONETHIRD for LCD_DISPCTRL */
+#define LCD_DISPCTRL_BIAS_ONEFOURTH        (_LCD_DISPCTRL_BIAS_ONEFOURTH << 2)     /**< Shifted mode ONEFOURTH for LCD_DISPCTRL */
+#define LCD_DISPCTRL_WAVE                  (0x1UL << 4)                            /**< Waveform Selection */
+#define _LCD_DISPCTRL_WAVE_SHIFT           4                                       /**< Shift value for LCD_WAVE */
+#define _LCD_DISPCTRL_WAVE_MASK            0x10UL                                  /**< Bit mask for LCD_WAVE */
+#define _LCD_DISPCTRL_WAVE_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_WAVE_LOWPOWER        0x00000000UL                            /**< Mode LOWPOWER for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_WAVE_NORMAL          0x00000001UL                            /**< Mode NORMAL for LCD_DISPCTRL */
+#define LCD_DISPCTRL_WAVE_DEFAULT          (_LCD_DISPCTRL_WAVE_DEFAULT << 4)       /**< Shifted mode DEFAULT for LCD_DISPCTRL */
+#define LCD_DISPCTRL_WAVE_LOWPOWER         (_LCD_DISPCTRL_WAVE_LOWPOWER << 4)      /**< Shifted mode LOWPOWER for LCD_DISPCTRL */
+#define LCD_DISPCTRL_WAVE_NORMAL           (_LCD_DISPCTRL_WAVE_NORMAL << 4)        /**< Shifted mode NORMAL for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_CONLEV_SHIFT         8                                       /**< Shift value for LCD_CONLEV */
+#define _LCD_DISPCTRL_CONLEV_MASK          0x1F00UL                                /**< Bit mask for LCD_CONLEV */
+#define _LCD_DISPCTRL_CONLEV_MIN           0x00000000UL                            /**< Mode MIN for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_CONLEV_DEFAULT       0x0000001FUL                            /**< Mode DEFAULT for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_CONLEV_MAX           0x0000001FUL                            /**< Mode MAX for LCD_DISPCTRL */
+#define LCD_DISPCTRL_CONLEV_MIN            (_LCD_DISPCTRL_CONLEV_MIN << 8)         /**< Shifted mode MIN for LCD_DISPCTRL */
+#define LCD_DISPCTRL_CONLEV_DEFAULT        (_LCD_DISPCTRL_CONLEV_DEFAULT << 8)     /**< Shifted mode DEFAULT for LCD_DISPCTRL */
+#define LCD_DISPCTRL_CONLEV_MAX            (_LCD_DISPCTRL_CONLEV_MAX << 8)         /**< Shifted mode MAX for LCD_DISPCTRL */
+#define LCD_DISPCTRL_CONCONF               (0x1UL << 15)                           /**< Contrast Configuration */
+#define _LCD_DISPCTRL_CONCONF_SHIFT        15                                      /**< Shift value for LCD_CONCONF */
+#define _LCD_DISPCTRL_CONCONF_MASK         0x8000UL                                /**< Bit mask for LCD_CONCONF */
+#define _LCD_DISPCTRL_CONCONF_DEFAULT      0x00000000UL                            /**< Mode DEFAULT for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_CONCONF_VLCD         0x00000000UL                            /**< Mode VLCD for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_CONCONF_GND          0x00000001UL                            /**< Mode GND for LCD_DISPCTRL */
+#define LCD_DISPCTRL_CONCONF_DEFAULT       (_LCD_DISPCTRL_CONCONF_DEFAULT << 15)   /**< Shifted mode DEFAULT for LCD_DISPCTRL */
+#define LCD_DISPCTRL_CONCONF_VLCD          (_LCD_DISPCTRL_CONCONF_VLCD << 15)      /**< Shifted mode VLCD for LCD_DISPCTRL */
+#define LCD_DISPCTRL_CONCONF_GND           (_LCD_DISPCTRL_CONCONF_GND << 15)       /**< Shifted mode GND for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VLCDSEL               (0x1UL << 16)                           /**< VLCD Selection */
+#define _LCD_DISPCTRL_VLCDSEL_SHIFT        16                                      /**< Shift value for LCD_VLCDSEL */
+#define _LCD_DISPCTRL_VLCDSEL_MASK         0x10000UL                               /**< Bit mask for LCD_VLCDSEL */
+#define _LCD_DISPCTRL_VLCDSEL_DEFAULT      0x00000000UL                            /**< Mode DEFAULT for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VLCDSEL_VDD          0x00000000UL                            /**< Mode VDD for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VLCDSEL_VEXTBOOST    0x00000001UL                            /**< Mode VEXTBOOST for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VLCDSEL_DEFAULT       (_LCD_DISPCTRL_VLCDSEL_DEFAULT << 16)   /**< Shifted mode DEFAULT for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VLCDSEL_VDD           (_LCD_DISPCTRL_VLCDSEL_VDD << 16)       /**< Shifted mode VDD for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VLCDSEL_VEXTBOOST     (_LCD_DISPCTRL_VLCDSEL_VEXTBOOST << 16) /**< Shifted mode VEXTBOOST for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VBLEV_SHIFT          18                                      /**< Shift value for LCD_VBLEV */
+#define _LCD_DISPCTRL_VBLEV_MASK           0x1C0000UL                              /**< Bit mask for LCD_VBLEV */
+#define _LCD_DISPCTRL_VBLEV_LEVEL0         0x00000000UL                            /**< Mode LEVEL0 for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VBLEV_LEVEL1         0x00000001UL                            /**< Mode LEVEL1 for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VBLEV_LEVEL2         0x00000002UL                            /**< Mode LEVEL2 for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VBLEV_DEFAULT        0x00000003UL                            /**< Mode DEFAULT for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VBLEV_LEVEL3         0x00000003UL                            /**< Mode LEVEL3 for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VBLEV_LEVEL4         0x00000004UL                            /**< Mode LEVEL4 for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VBLEV_LEVEL5         0x00000005UL                            /**< Mode LEVEL5 for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VBLEV_LEVEL6         0x00000006UL                            /**< Mode LEVEL6 for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_VBLEV_LEVEL7         0x00000007UL                            /**< Mode LEVEL7 for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VBLEV_LEVEL0          (_LCD_DISPCTRL_VBLEV_LEVEL0 << 18)      /**< Shifted mode LEVEL0 for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VBLEV_LEVEL1          (_LCD_DISPCTRL_VBLEV_LEVEL1 << 18)      /**< Shifted mode LEVEL1 for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VBLEV_LEVEL2          (_LCD_DISPCTRL_VBLEV_LEVEL2 << 18)      /**< Shifted mode LEVEL2 for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VBLEV_DEFAULT         (_LCD_DISPCTRL_VBLEV_DEFAULT << 18)     /**< Shifted mode DEFAULT for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VBLEV_LEVEL3          (_LCD_DISPCTRL_VBLEV_LEVEL3 << 18)      /**< Shifted mode LEVEL3 for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VBLEV_LEVEL4          (_LCD_DISPCTRL_VBLEV_LEVEL4 << 18)      /**< Shifted mode LEVEL4 for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VBLEV_LEVEL5          (_LCD_DISPCTRL_VBLEV_LEVEL5 << 18)      /**< Shifted mode LEVEL5 for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VBLEV_LEVEL6          (_LCD_DISPCTRL_VBLEV_LEVEL6 << 18)      /**< Shifted mode LEVEL6 for LCD_DISPCTRL */
+#define LCD_DISPCTRL_VBLEV_LEVEL7          (_LCD_DISPCTRL_VBLEV_LEVEL7 << 18)      /**< Shifted mode LEVEL7 for LCD_DISPCTRL */
+#define LCD_DISPCTRL_MUXE                  (0x1UL << 22)                           /**< Extended Mux Configuration */
+#define _LCD_DISPCTRL_MUXE_SHIFT           22                                      /**< Shift value for LCD_MUXE */
+#define _LCD_DISPCTRL_MUXE_MASK            0x400000UL                              /**< Bit mask for LCD_MUXE */
+#define _LCD_DISPCTRL_MUXE_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_MUXE_MUX             0x00000000UL                            /**< Mode MUX for LCD_DISPCTRL */
+#define _LCD_DISPCTRL_MUXE_MUXE            0x00000001UL                            /**< Mode MUXE for LCD_DISPCTRL */
+#define LCD_DISPCTRL_MUXE_DEFAULT          (_LCD_DISPCTRL_MUXE_DEFAULT << 22)      /**< Shifted mode DEFAULT for LCD_DISPCTRL */
+#define LCD_DISPCTRL_MUXE_MUX              (_LCD_DISPCTRL_MUXE_MUX << 22)          /**< Shifted mode MUX for LCD_DISPCTRL */
+#define LCD_DISPCTRL_MUXE_MUXE             (_LCD_DISPCTRL_MUXE_MUXE << 22)         /**< Shifted mode MUXE for LCD_DISPCTRL */
+
+/* Bit fields for LCD SEGEN */
+#define _LCD_SEGEN_RESETVALUE              0x00000000UL                    /**< Default value for LCD_SEGEN */
+#define _LCD_SEGEN_MASK                    0x000003FFUL                    /**< Mask for LCD_SEGEN */
+#define _LCD_SEGEN_SEGEN_SHIFT             0                               /**< Shift value for LCD_SEGEN */
+#define _LCD_SEGEN_SEGEN_MASK              0x3FFUL                         /**< Bit mask for LCD_SEGEN */
+#define _LCD_SEGEN_SEGEN_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for LCD_SEGEN */
+#define LCD_SEGEN_SEGEN_DEFAULT            (_LCD_SEGEN_SEGEN_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_SEGEN */
+
+/* Bit fields for LCD BACTRL */
+#define _LCD_BACTRL_RESETVALUE             0x00000000UL                          /**< Default value for LCD_BACTRL */
+#define _LCD_BACTRL_MASK                   0x00FF01FFUL                          /**< Mask for LCD_BACTRL */
+#define LCD_BACTRL_BLINKEN                 (0x1UL << 0)                          /**< Blink Enable */
+#define _LCD_BACTRL_BLINKEN_SHIFT          0                                     /**< Shift value for LCD_BLINKEN */
+#define _LCD_BACTRL_BLINKEN_MASK           0x1UL                                 /**< Bit mask for LCD_BLINKEN */
+#define _LCD_BACTRL_BLINKEN_DEFAULT        0x00000000UL                          /**< Mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_BLINKEN_DEFAULT         (_LCD_BACTRL_BLINKEN_DEFAULT << 0)    /**< Shifted mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_BLANK                   (0x1UL << 1)                          /**< Blank Display */
+#define _LCD_BACTRL_BLANK_SHIFT            1                                     /**< Shift value for LCD_BLANK */
+#define _LCD_BACTRL_BLANK_MASK             0x2UL                                 /**< Bit mask for LCD_BLANK */
+#define _LCD_BACTRL_BLANK_DEFAULT          0x00000000UL                          /**< Mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_BLANK_DEFAULT           (_LCD_BACTRL_BLANK_DEFAULT << 1)      /**< Shifted mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_AEN                     (0x1UL << 2)                          /**< Animation Enable */
+#define _LCD_BACTRL_AEN_SHIFT              2                                     /**< Shift value for LCD_AEN */
+#define _LCD_BACTRL_AEN_MASK               0x4UL                                 /**< Bit mask for LCD_AEN */
+#define _LCD_BACTRL_AEN_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_AEN_DEFAULT             (_LCD_BACTRL_AEN_DEFAULT << 2)        /**< Shifted mode DEFAULT for LCD_BACTRL */
+#define _LCD_BACTRL_AREGASC_SHIFT          3                                     /**< Shift value for LCD_AREGASC */
+#define _LCD_BACTRL_AREGASC_MASK           0x18UL                                /**< Bit mask for LCD_AREGASC */
+#define _LCD_BACTRL_AREGASC_DEFAULT        0x00000000UL                          /**< Mode DEFAULT for LCD_BACTRL */
+#define _LCD_BACTRL_AREGASC_NOSHIFT        0x00000000UL                          /**< Mode NOSHIFT for LCD_BACTRL */
+#define _LCD_BACTRL_AREGASC_SHIFTLEFT      0x00000001UL                          /**< Mode SHIFTLEFT for LCD_BACTRL */
+#define _LCD_BACTRL_AREGASC_SHIFTRIGHT     0x00000002UL                          /**< Mode SHIFTRIGHT for LCD_BACTRL */
+#define LCD_BACTRL_AREGASC_DEFAULT         (_LCD_BACTRL_AREGASC_DEFAULT << 3)    /**< Shifted mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_AREGASC_NOSHIFT         (_LCD_BACTRL_AREGASC_NOSHIFT << 3)    /**< Shifted mode NOSHIFT for LCD_BACTRL */
+#define LCD_BACTRL_AREGASC_SHIFTLEFT       (_LCD_BACTRL_AREGASC_SHIFTLEFT << 3)  /**< Shifted mode SHIFTLEFT for LCD_BACTRL */
+#define LCD_BACTRL_AREGASC_SHIFTRIGHT      (_LCD_BACTRL_AREGASC_SHIFTRIGHT << 3) /**< Shifted mode SHIFTRIGHT for LCD_BACTRL */
+#define _LCD_BACTRL_AREGBSC_SHIFT          5                                     /**< Shift value for LCD_AREGBSC */
+#define _LCD_BACTRL_AREGBSC_MASK           0x60UL                                /**< Bit mask for LCD_AREGBSC */
+#define _LCD_BACTRL_AREGBSC_DEFAULT        0x00000000UL                          /**< Mode DEFAULT for LCD_BACTRL */
+#define _LCD_BACTRL_AREGBSC_NOSHIFT        0x00000000UL                          /**< Mode NOSHIFT for LCD_BACTRL */
+#define _LCD_BACTRL_AREGBSC_SHIFTLEFT      0x00000001UL                          /**< Mode SHIFTLEFT for LCD_BACTRL */
+#define _LCD_BACTRL_AREGBSC_SHIFTRIGHT     0x00000002UL                          /**< Mode SHIFTRIGHT for LCD_BACTRL */
+#define LCD_BACTRL_AREGBSC_DEFAULT         (_LCD_BACTRL_AREGBSC_DEFAULT << 5)    /**< Shifted mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_AREGBSC_NOSHIFT         (_LCD_BACTRL_AREGBSC_NOSHIFT << 5)    /**< Shifted mode NOSHIFT for LCD_BACTRL */
+#define LCD_BACTRL_AREGBSC_SHIFTLEFT       (_LCD_BACTRL_AREGBSC_SHIFTLEFT << 5)  /**< Shifted mode SHIFTLEFT for LCD_BACTRL */
+#define LCD_BACTRL_AREGBSC_SHIFTRIGHT      (_LCD_BACTRL_AREGBSC_SHIFTRIGHT << 5) /**< Shifted mode SHIFTRIGHT for LCD_BACTRL */
+#define LCD_BACTRL_ALOGSEL                 (0x1UL << 7)                          /**< Animate Logic Function Select */
+#define _LCD_BACTRL_ALOGSEL_SHIFT          7                                     /**< Shift value for LCD_ALOGSEL */
+#define _LCD_BACTRL_ALOGSEL_MASK           0x80UL                                /**< Bit mask for LCD_ALOGSEL */
+#define _LCD_BACTRL_ALOGSEL_DEFAULT        0x00000000UL                          /**< Mode DEFAULT for LCD_BACTRL */
+#define _LCD_BACTRL_ALOGSEL_AND            0x00000000UL                          /**< Mode AND for LCD_BACTRL */
+#define _LCD_BACTRL_ALOGSEL_OR             0x00000001UL                          /**< Mode OR for LCD_BACTRL */
+#define LCD_BACTRL_ALOGSEL_DEFAULT         (_LCD_BACTRL_ALOGSEL_DEFAULT << 7)    /**< Shifted mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_ALOGSEL_AND             (_LCD_BACTRL_ALOGSEL_AND << 7)        /**< Shifted mode AND for LCD_BACTRL */
+#define LCD_BACTRL_ALOGSEL_OR              (_LCD_BACTRL_ALOGSEL_OR << 7)         /**< Shifted mode OR for LCD_BACTRL */
+#define LCD_BACTRL_FCEN                    (0x1UL << 8)                          /**< Frame Counter Enable */
+#define _LCD_BACTRL_FCEN_SHIFT             8                                     /**< Shift value for LCD_FCEN */
+#define _LCD_BACTRL_FCEN_MASK              0x100UL                               /**< Bit mask for LCD_FCEN */
+#define _LCD_BACTRL_FCEN_DEFAULT           0x00000000UL                          /**< Mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_FCEN_DEFAULT            (_LCD_BACTRL_FCEN_DEFAULT << 8)       /**< Shifted mode DEFAULT for LCD_BACTRL */
+#define _LCD_BACTRL_FCPRESC_SHIFT          16                                    /**< Shift value for LCD_FCPRESC */
+#define _LCD_BACTRL_FCPRESC_MASK           0x30000UL                             /**< Bit mask for LCD_FCPRESC */
+#define _LCD_BACTRL_FCPRESC_DEFAULT        0x00000000UL                          /**< Mode DEFAULT for LCD_BACTRL */
+#define _LCD_BACTRL_FCPRESC_DIV1           0x00000000UL                          /**< Mode DIV1 for LCD_BACTRL */
+#define _LCD_BACTRL_FCPRESC_DIV2           0x00000001UL                          /**< Mode DIV2 for LCD_BACTRL */
+#define _LCD_BACTRL_FCPRESC_DIV4           0x00000002UL                          /**< Mode DIV4 for LCD_BACTRL */
+#define _LCD_BACTRL_FCPRESC_DIV8           0x00000003UL                          /**< Mode DIV8 for LCD_BACTRL */
+#define LCD_BACTRL_FCPRESC_DEFAULT         (_LCD_BACTRL_FCPRESC_DEFAULT << 16)   /**< Shifted mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_FCPRESC_DIV1            (_LCD_BACTRL_FCPRESC_DIV1 << 16)      /**< Shifted mode DIV1 for LCD_BACTRL */
+#define LCD_BACTRL_FCPRESC_DIV2            (_LCD_BACTRL_FCPRESC_DIV2 << 16)      /**< Shifted mode DIV2 for LCD_BACTRL */
+#define LCD_BACTRL_FCPRESC_DIV4            (_LCD_BACTRL_FCPRESC_DIV4 << 16)      /**< Shifted mode DIV4 for LCD_BACTRL */
+#define LCD_BACTRL_FCPRESC_DIV8            (_LCD_BACTRL_FCPRESC_DIV8 << 16)      /**< Shifted mode DIV8 for LCD_BACTRL */
+#define _LCD_BACTRL_FCTOP_SHIFT            18                                    /**< Shift value for LCD_FCTOP */
+#define _LCD_BACTRL_FCTOP_MASK             0xFC0000UL                            /**< Bit mask for LCD_FCTOP */
+#define _LCD_BACTRL_FCTOP_DEFAULT          0x00000000UL                          /**< Mode DEFAULT for LCD_BACTRL */
+#define LCD_BACTRL_FCTOP_DEFAULT           (_LCD_BACTRL_FCTOP_DEFAULT << 18)     /**< Shifted mode DEFAULT for LCD_BACTRL */
+
+/* Bit fields for LCD STATUS */
+#define _LCD_STATUS_RESETVALUE             0x00000000UL                      /**< Default value for LCD_STATUS */
+#define _LCD_STATUS_MASK                   0x0000010FUL                      /**< Mask for LCD_STATUS */
+#define _LCD_STATUS_ASTATE_SHIFT           0                                 /**< Shift value for LCD_ASTATE */
+#define _LCD_STATUS_ASTATE_MASK            0xFUL                             /**< Bit mask for LCD_ASTATE */
+#define _LCD_STATUS_ASTATE_DEFAULT         0x00000000UL                      /**< Mode DEFAULT for LCD_STATUS */
+#define LCD_STATUS_ASTATE_DEFAULT          (_LCD_STATUS_ASTATE_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_STATUS */
+#define LCD_STATUS_BLINK                   (0x1UL << 8)                      /**< Blink State */
+#define _LCD_STATUS_BLINK_SHIFT            8                                 /**< Shift value for LCD_BLINK */
+#define _LCD_STATUS_BLINK_MASK             0x100UL                           /**< Bit mask for LCD_BLINK */
+#define _LCD_STATUS_BLINK_DEFAULT          0x00000000UL                      /**< Mode DEFAULT for LCD_STATUS */
+#define LCD_STATUS_BLINK_DEFAULT           (_LCD_STATUS_BLINK_DEFAULT << 8)  /**< Shifted mode DEFAULT for LCD_STATUS */
+
+/* Bit fields for LCD AREGA */
+#define _LCD_AREGA_RESETVALUE              0x00000000UL                    /**< Default value for LCD_AREGA */
+#define _LCD_AREGA_MASK                    0x000000FFUL                    /**< Mask for LCD_AREGA */
+#define _LCD_AREGA_AREGA_SHIFT             0                               /**< Shift value for LCD_AREGA */
+#define _LCD_AREGA_AREGA_MASK              0xFFUL                          /**< Bit mask for LCD_AREGA */
+#define _LCD_AREGA_AREGA_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for LCD_AREGA */
+#define LCD_AREGA_AREGA_DEFAULT            (_LCD_AREGA_AREGA_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_AREGA */
+
+/* Bit fields for LCD AREGB */
+#define _LCD_AREGB_RESETVALUE              0x00000000UL                    /**< Default value for LCD_AREGB */
+#define _LCD_AREGB_MASK                    0x000000FFUL                    /**< Mask for LCD_AREGB */
+#define _LCD_AREGB_AREGB_SHIFT             0                               /**< Shift value for LCD_AREGB */
+#define _LCD_AREGB_AREGB_MASK              0xFFUL                          /**< Bit mask for LCD_AREGB */
+#define _LCD_AREGB_AREGB_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for LCD_AREGB */
+#define LCD_AREGB_AREGB_DEFAULT            (_LCD_AREGB_AREGB_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_AREGB */
+
+/* Bit fields for LCD IF */
+#define _LCD_IF_RESETVALUE                 0x00000000UL              /**< Default value for LCD_IF */
+#define _LCD_IF_MASK                       0x00000001UL              /**< Mask for LCD_IF */
+#define LCD_IF_FC                          (0x1UL << 0)              /**< Frame Counter Interrupt Flag */
+#define _LCD_IF_FC_SHIFT                   0                         /**< Shift value for LCD_FC */
+#define _LCD_IF_FC_MASK                    0x1UL                     /**< Bit mask for LCD_FC */
+#define _LCD_IF_FC_DEFAULT                 0x00000000UL              /**< Mode DEFAULT for LCD_IF */
+#define LCD_IF_FC_DEFAULT                  (_LCD_IF_FC_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_IF */
+
+/* Bit fields for LCD IFS */
+#define _LCD_IFS_RESETVALUE                0x00000000UL               /**< Default value for LCD_IFS */
+#define _LCD_IFS_MASK                      0x00000001UL               /**< Mask for LCD_IFS */
+#define LCD_IFS_FC                         (0x1UL << 0)               /**< Frame Counter Interrupt Flag Set */
+#define _LCD_IFS_FC_SHIFT                  0                          /**< Shift value for LCD_FC */
+#define _LCD_IFS_FC_MASK                   0x1UL                      /**< Bit mask for LCD_FC */
+#define _LCD_IFS_FC_DEFAULT                0x00000000UL               /**< Mode DEFAULT for LCD_IFS */
+#define LCD_IFS_FC_DEFAULT                 (_LCD_IFS_FC_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_IFS */
+
+/* Bit fields for LCD IFC */
+#define _LCD_IFC_RESETVALUE                0x00000000UL               /**< Default value for LCD_IFC */
+#define _LCD_IFC_MASK                      0x00000001UL               /**< Mask for LCD_IFC */
+#define LCD_IFC_FC                         (0x1UL << 0)               /**< Frame Counter Interrupt Flag Clear */
+#define _LCD_IFC_FC_SHIFT                  0                          /**< Shift value for LCD_FC */
+#define _LCD_IFC_FC_MASK                   0x1UL                      /**< Bit mask for LCD_FC */
+#define _LCD_IFC_FC_DEFAULT                0x00000000UL               /**< Mode DEFAULT for LCD_IFC */
+#define LCD_IFC_FC_DEFAULT                 (_LCD_IFC_FC_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_IFC */
+
+/* Bit fields for LCD IEN */
+#define _LCD_IEN_RESETVALUE                0x00000000UL               /**< Default value for LCD_IEN */
+#define _LCD_IEN_MASK                      0x00000001UL               /**< Mask for LCD_IEN */
+#define LCD_IEN_FC                         (0x1UL << 0)               /**< Frame Counter Interrupt Enable */
+#define _LCD_IEN_FC_SHIFT                  0                          /**< Shift value for LCD_FC */
+#define _LCD_IEN_FC_MASK                   0x1UL                      /**< Bit mask for LCD_FC */
+#define _LCD_IEN_FC_DEFAULT                0x00000000UL               /**< Mode DEFAULT for LCD_IEN */
+#define LCD_IEN_FC_DEFAULT                 (_LCD_IEN_FC_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_IEN */
+
+/* Bit fields for LCD SEGD0L */
+#define _LCD_SEGD0L_RESETVALUE             0x00000000UL                      /**< Default value for LCD_SEGD0L */
+#define _LCD_SEGD0L_MASK                   0x00FFFFFFUL                      /**< Mask for LCD_SEGD0L */
+#define _LCD_SEGD0L_SEGD0L_SHIFT           0                                 /**< Shift value for LCD_SEGD0L */
+#define _LCD_SEGD0L_SEGD0L_MASK            0xFFFFFFUL                        /**< Bit mask for LCD_SEGD0L */
+#define _LCD_SEGD0L_SEGD0L_DEFAULT         0x00000000UL                      /**< Mode DEFAULT for LCD_SEGD0L */
+#define LCD_SEGD0L_SEGD0L_DEFAULT          (_LCD_SEGD0L_SEGD0L_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_SEGD0L */
+
+/* Bit fields for LCD SEGD1L */
+#define _LCD_SEGD1L_RESETVALUE             0x00000000UL                      /**< Default value for LCD_SEGD1L */
+#define _LCD_SEGD1L_MASK                   0x00FFFFFFUL                      /**< Mask for LCD_SEGD1L */
+#define _LCD_SEGD1L_SEGD1L_SHIFT           0                                 /**< Shift value for LCD_SEGD1L */
+#define _LCD_SEGD1L_SEGD1L_MASK            0xFFFFFFUL                        /**< Bit mask for LCD_SEGD1L */
+#define _LCD_SEGD1L_SEGD1L_DEFAULT         0x00000000UL                      /**< Mode DEFAULT for LCD_SEGD1L */
+#define LCD_SEGD1L_SEGD1L_DEFAULT          (_LCD_SEGD1L_SEGD1L_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_SEGD1L */
+
+/* Bit fields for LCD SEGD2L */
+#define _LCD_SEGD2L_RESETVALUE             0x00000000UL                      /**< Default value for LCD_SEGD2L */
+#define _LCD_SEGD2L_MASK                   0x00FFFFFFUL                      /**< Mask for LCD_SEGD2L */
+#define _LCD_SEGD2L_SEGD2L_SHIFT           0                                 /**< Shift value for LCD_SEGD2L */
+#define _LCD_SEGD2L_SEGD2L_MASK            0xFFFFFFUL                        /**< Bit mask for LCD_SEGD2L */
+#define _LCD_SEGD2L_SEGD2L_DEFAULT         0x00000000UL                      /**< Mode DEFAULT for LCD_SEGD2L */
+#define LCD_SEGD2L_SEGD2L_DEFAULT          (_LCD_SEGD2L_SEGD2L_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_SEGD2L */
+
+/* Bit fields for LCD SEGD3L */
+#define _LCD_SEGD3L_RESETVALUE             0x00000000UL                      /**< Default value for LCD_SEGD3L */
+#define _LCD_SEGD3L_MASK                   0x00FFFFFFUL                      /**< Mask for LCD_SEGD3L */
+#define _LCD_SEGD3L_SEGD3L_SHIFT           0                                 /**< Shift value for LCD_SEGD3L */
+#define _LCD_SEGD3L_SEGD3L_MASK            0xFFFFFFUL                        /**< Bit mask for LCD_SEGD3L */
+#define _LCD_SEGD3L_SEGD3L_DEFAULT         0x00000000UL                      /**< Mode DEFAULT for LCD_SEGD3L */
+#define LCD_SEGD3L_SEGD3L_DEFAULT          (_LCD_SEGD3L_SEGD3L_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_SEGD3L */
+
+/* Bit fields for LCD FREEZE */
+#define _LCD_FREEZE_RESETVALUE             0x00000000UL                         /**< Default value for LCD_FREEZE */
+#define _LCD_FREEZE_MASK                   0x00000001UL                         /**< Mask for LCD_FREEZE */
+#define LCD_FREEZE_REGFREEZE               (0x1UL << 0)                         /**< Register Update Freeze */
+#define _LCD_FREEZE_REGFREEZE_SHIFT        0                                    /**< Shift value for LCD_REGFREEZE */
+#define _LCD_FREEZE_REGFREEZE_MASK         0x1UL                                /**< Bit mask for LCD_REGFREEZE */
+#define _LCD_FREEZE_REGFREEZE_DEFAULT      0x00000000UL                         /**< Mode DEFAULT for LCD_FREEZE */
+#define _LCD_FREEZE_REGFREEZE_UPDATE       0x00000000UL                         /**< Mode UPDATE for LCD_FREEZE */
+#define _LCD_FREEZE_REGFREEZE_FREEZE       0x00000001UL                         /**< Mode FREEZE for LCD_FREEZE */
+#define LCD_FREEZE_REGFREEZE_DEFAULT       (_LCD_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_FREEZE */
+#define LCD_FREEZE_REGFREEZE_UPDATE        (_LCD_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for LCD_FREEZE */
+#define LCD_FREEZE_REGFREEZE_FREEZE        (_LCD_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for LCD_FREEZE */
+
+/* Bit fields for LCD SYNCBUSY */
+#define _LCD_SYNCBUSY_RESETVALUE           0x00000000UL                         /**< Default value for LCD_SYNCBUSY */
+#define _LCD_SYNCBUSY_MASK                 0x000F00FFUL                         /**< Mask for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_CTRL                  (0x1UL << 0)                         /**< CTRL Register Busy */
+#define _LCD_SYNCBUSY_CTRL_SHIFT           0                                    /**< Shift value for LCD_CTRL */
+#define _LCD_SYNCBUSY_CTRL_MASK            0x1UL                                /**< Bit mask for LCD_CTRL */
+#define _LCD_SYNCBUSY_CTRL_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_CTRL_DEFAULT          (_LCD_SYNCBUSY_CTRL_DEFAULT << 0)    /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_BACTRL                (0x1UL << 1)                         /**< BACTRL Register Busy */
+#define _LCD_SYNCBUSY_BACTRL_SHIFT         1                                    /**< Shift value for LCD_BACTRL */
+#define _LCD_SYNCBUSY_BACTRL_MASK          0x2UL                                /**< Bit mask for LCD_BACTRL */
+#define _LCD_SYNCBUSY_BACTRL_DEFAULT       0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_BACTRL_DEFAULT        (_LCD_SYNCBUSY_BACTRL_DEFAULT << 1)  /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_AREGA                 (0x1UL << 2)                         /**< AREGA Register Busy */
+#define _LCD_SYNCBUSY_AREGA_SHIFT          2                                    /**< Shift value for LCD_AREGA */
+#define _LCD_SYNCBUSY_AREGA_MASK           0x4UL                                /**< Bit mask for LCD_AREGA */
+#define _LCD_SYNCBUSY_AREGA_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_AREGA_DEFAULT         (_LCD_SYNCBUSY_AREGA_DEFAULT << 2)   /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_AREGB                 (0x1UL << 3)                         /**< AREGB Register Busy */
+#define _LCD_SYNCBUSY_AREGB_SHIFT          3                                    /**< Shift value for LCD_AREGB */
+#define _LCD_SYNCBUSY_AREGB_MASK           0x8UL                                /**< Bit mask for LCD_AREGB */
+#define _LCD_SYNCBUSY_AREGB_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_AREGB_DEFAULT         (_LCD_SYNCBUSY_AREGB_DEFAULT << 3)   /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD0L                (0x1UL << 4)                         /**< SEGD0L Register Busy */
+#define _LCD_SYNCBUSY_SEGD0L_SHIFT         4                                    /**< Shift value for LCD_SEGD0L */
+#define _LCD_SYNCBUSY_SEGD0L_MASK          0x10UL                               /**< Bit mask for LCD_SEGD0L */
+#define _LCD_SYNCBUSY_SEGD0L_DEFAULT       0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD0L_DEFAULT        (_LCD_SYNCBUSY_SEGD0L_DEFAULT << 4)  /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD1L                (0x1UL << 5)                         /**< SEGD1L Register Busy */
+#define _LCD_SYNCBUSY_SEGD1L_SHIFT         5                                    /**< Shift value for LCD_SEGD1L */
+#define _LCD_SYNCBUSY_SEGD1L_MASK          0x20UL                               /**< Bit mask for LCD_SEGD1L */
+#define _LCD_SYNCBUSY_SEGD1L_DEFAULT       0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD1L_DEFAULT        (_LCD_SYNCBUSY_SEGD1L_DEFAULT << 5)  /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD2L                (0x1UL << 6)                         /**< SEGD2L Register Busy */
+#define _LCD_SYNCBUSY_SEGD2L_SHIFT         6                                    /**< Shift value for LCD_SEGD2L */
+#define _LCD_SYNCBUSY_SEGD2L_MASK          0x40UL                               /**< Bit mask for LCD_SEGD2L */
+#define _LCD_SYNCBUSY_SEGD2L_DEFAULT       0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD2L_DEFAULT        (_LCD_SYNCBUSY_SEGD2L_DEFAULT << 6)  /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD3L                (0x1UL << 7)                         /**< SEGD3L Register Busy */
+#define _LCD_SYNCBUSY_SEGD3L_SHIFT         7                                    /**< Shift value for LCD_SEGD3L */
+#define _LCD_SYNCBUSY_SEGD3L_MASK          0x80UL                               /**< Bit mask for LCD_SEGD3L */
+#define _LCD_SYNCBUSY_SEGD3L_DEFAULT       0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD3L_DEFAULT        (_LCD_SYNCBUSY_SEGD3L_DEFAULT << 7)  /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD4L                (0x1UL << 16)                        /**< SEGD4L Register Busy */
+#define _LCD_SYNCBUSY_SEGD4L_SHIFT         16                                   /**< Shift value for LCD_SEGD4L */
+#define _LCD_SYNCBUSY_SEGD4L_MASK          0x10000UL                            /**< Bit mask for LCD_SEGD4L */
+#define _LCD_SYNCBUSY_SEGD4L_DEFAULT       0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD4L_DEFAULT        (_LCD_SYNCBUSY_SEGD4L_DEFAULT << 16) /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD5L                (0x1UL << 17)                        /**< SEGD5L Register Busy */
+#define _LCD_SYNCBUSY_SEGD5L_SHIFT         17                                   /**< Shift value for LCD_SEGD5L */
+#define _LCD_SYNCBUSY_SEGD5L_MASK          0x20000UL                            /**< Bit mask for LCD_SEGD5L */
+#define _LCD_SYNCBUSY_SEGD5L_DEFAULT       0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD5L_DEFAULT        (_LCD_SYNCBUSY_SEGD5L_DEFAULT << 17) /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD6L                (0x1UL << 18)                        /**< SEGD6L Register Busy */
+#define _LCD_SYNCBUSY_SEGD6L_SHIFT         18                                   /**< Shift value for LCD_SEGD6L */
+#define _LCD_SYNCBUSY_SEGD6L_MASK          0x40000UL                            /**< Bit mask for LCD_SEGD6L */
+#define _LCD_SYNCBUSY_SEGD6L_DEFAULT       0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD6L_DEFAULT        (_LCD_SYNCBUSY_SEGD6L_DEFAULT << 18) /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD7L                (0x1UL << 19)                        /**< SEGD7L Register Busy */
+#define _LCD_SYNCBUSY_SEGD7L_SHIFT         19                                   /**< Shift value for LCD_SEGD7L */
+#define _LCD_SYNCBUSY_SEGD7L_MASK          0x80000UL                            /**< Bit mask for LCD_SEGD7L */
+#define _LCD_SYNCBUSY_SEGD7L_DEFAULT       0x00000000UL                         /**< Mode DEFAULT for LCD_SYNCBUSY */
+#define LCD_SYNCBUSY_SEGD7L_DEFAULT        (_LCD_SYNCBUSY_SEGD7L_DEFAULT << 19) /**< Shifted mode DEFAULT for LCD_SYNCBUSY */
+
+/* Bit fields for LCD SEGD4L */
+#define _LCD_SEGD4L_RESETVALUE             0x00000000UL                      /**< Default value for LCD_SEGD4L */
+#define _LCD_SEGD4L_MASK                   0x00FFFFFFUL                      /**< Mask for LCD_SEGD4L */
+#define _LCD_SEGD4L_SEGD4L_SHIFT           0                                 /**< Shift value for LCD_SEGD4L */
+#define _LCD_SEGD4L_SEGD4L_MASK            0xFFFFFFUL                        /**< Bit mask for LCD_SEGD4L */
+#define _LCD_SEGD4L_SEGD4L_DEFAULT         0x00000000UL                      /**< Mode DEFAULT for LCD_SEGD4L */
+#define LCD_SEGD4L_SEGD4L_DEFAULT          (_LCD_SEGD4L_SEGD4L_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_SEGD4L */
+
+/* Bit fields for LCD SEGD5L */
+#define _LCD_SEGD5L_RESETVALUE             0x00000000UL                      /**< Default value for LCD_SEGD5L */
+#define _LCD_SEGD5L_MASK                   0x00FFFFFFUL                      /**< Mask for LCD_SEGD5L */
+#define _LCD_SEGD5L_SEGD5L_SHIFT           0                                 /**< Shift value for LCD_SEGD5L */
+#define _LCD_SEGD5L_SEGD5L_MASK            0xFFFFFFUL                        /**< Bit mask for LCD_SEGD5L */
+#define _LCD_SEGD5L_SEGD5L_DEFAULT         0x00000000UL                      /**< Mode DEFAULT for LCD_SEGD5L */
+#define LCD_SEGD5L_SEGD5L_DEFAULT          (_LCD_SEGD5L_SEGD5L_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_SEGD5L */
+
+/* Bit fields for LCD SEGD6L */
+#define _LCD_SEGD6L_RESETVALUE             0x00000000UL                      /**< Default value for LCD_SEGD6L */
+#define _LCD_SEGD6L_MASK                   0x00FFFFFFUL                      /**< Mask for LCD_SEGD6L */
+#define _LCD_SEGD6L_SEGD6L_SHIFT           0                                 /**< Shift value for LCD_SEGD6L */
+#define _LCD_SEGD6L_SEGD6L_MASK            0xFFFFFFUL                        /**< Bit mask for LCD_SEGD6L */
+#define _LCD_SEGD6L_SEGD6L_DEFAULT         0x00000000UL                      /**< Mode DEFAULT for LCD_SEGD6L */
+#define LCD_SEGD6L_SEGD6L_DEFAULT          (_LCD_SEGD6L_SEGD6L_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_SEGD6L */
+
+/* Bit fields for LCD SEGD7L */
+#define _LCD_SEGD7L_RESETVALUE             0x00000000UL                      /**< Default value for LCD_SEGD7L */
+#define _LCD_SEGD7L_MASK                   0x00FFFFFFUL                      /**< Mask for LCD_SEGD7L */
+#define _LCD_SEGD7L_SEGD7L_SHIFT           0                                 /**< Shift value for LCD_SEGD7L */
+#define _LCD_SEGD7L_SEGD7L_MASK            0xFFFFFFUL                        /**< Bit mask for LCD_SEGD7L */
+#define _LCD_SEGD7L_SEGD7L_DEFAULT         0x00000000UL                      /**< Mode DEFAULT for LCD_SEGD7L */
+#define LCD_SEGD7L_SEGD7L_DEFAULT          (_LCD_SEGD7L_SEGD7L_DEFAULT << 0) /**< Shifted mode DEFAULT for LCD_SEGD7L */
+
+/** @} End of group EFM32TG_LCD */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lesense.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lesense.h
@@ -1,0 +1,1893 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_LESENSE register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_LESENSE
+ * @brief EFM32TG_LESENSE Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t      CTRL;            /**< Control Register  */
+  __IOM uint32_t      TIMCTRL;         /**< Timing Control Register  */
+  __IOM uint32_t      PERCTRL;         /**< Peripheral Control Register  */
+  __IOM uint32_t      DECCTRL;         /**< Decoder control Register  */
+  __IOM uint32_t      BIASCTRL;        /**< Bias Control Register  */
+  __IOM uint32_t      CMD;             /**< Command Register  */
+  __IOM uint32_t      CHEN;            /**< Channel enable Register  */
+  __IM uint32_t       SCANRES;         /**< Scan result register  */
+  __IM uint32_t       STATUS;          /**< Status Register  */
+  __IM uint32_t       PTR;             /**< Result buffer pointers  */
+  __IM uint32_t       BUFDATA;         /**< Result buffer data register  */
+  __IM uint32_t       CURCH;           /**< Current channel index  */
+  __IOM uint32_t      DECSTATE;        /**< Current decoder state  */
+  __IOM uint32_t      SENSORSTATE;     /**< Decoder input register  */
+  __IOM uint32_t      IDLECONF;        /**< GPIO Idle phase configuration  */
+  __IOM uint32_t      ALTEXCONF;       /**< Alternative excite pin configuration  */
+  __IM uint32_t       IF;              /**< Interrupt Flag Register  */
+  __IOM uint32_t      IFC;             /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t      IFS;             /**< Interrupt Flag Set Register  */
+  __IOM uint32_t      IEN;             /**< Interrupt Enable Register  */
+  __IM uint32_t       SYNCBUSY;        /**< Synchronization Busy Register  */
+  __IOM uint32_t      ROUTE;           /**< I/O Routing Register  */
+  __IOM uint32_t      POWERDOWN;       /**< LESENSE RAM power-down register  */
+
+  uint32_t            RESERVED0[105U]; /**< Reserved registers */
+  LESENSE_ST_TypeDef  ST[16U];         /**< Decoding states */
+
+  LESENSE_BUF_TypeDef BUF[16U];        /**< Scanresult */
+
+  LESENSE_CH_TypeDef  CH[16U];         /**< Scanconfig */
+} LESENSE_TypeDef;                     /**< LESENSE Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_LESENSE_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for LESENSE CTRL */
+#define _LESENSE_CTRL_RESETVALUE                       0x00000000UL                             /**< Default value for LESENSE_CTRL */
+#define _LESENSE_CTRL_MASK                             0x00772EDFUL                             /**< Mask for LESENSE_CTRL */
+#define _LESENSE_CTRL_SCANMODE_SHIFT                   0                                        /**< Shift value for LESENSE_SCANMODE */
+#define _LESENSE_CTRL_SCANMODE_MASK                    0x3UL                                    /**< Bit mask for LESENSE_SCANMODE */
+#define _LESENSE_CTRL_SCANMODE_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define _LESENSE_CTRL_SCANMODE_PERIODIC                0x00000000UL                             /**< Mode PERIODIC for LESENSE_CTRL */
+#define _LESENSE_CTRL_SCANMODE_ONESHOT                 0x00000001UL                             /**< Mode ONESHOT for LESENSE_CTRL */
+#define _LESENSE_CTRL_SCANMODE_PRS                     0x00000002UL                             /**< Mode PRS for LESENSE_CTRL */
+#define LESENSE_CTRL_SCANMODE_DEFAULT                  (_LESENSE_CTRL_SCANMODE_DEFAULT << 0)    /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_SCANMODE_PERIODIC                 (_LESENSE_CTRL_SCANMODE_PERIODIC << 0)   /**< Shifted mode PERIODIC for LESENSE_CTRL */
+#define LESENSE_CTRL_SCANMODE_ONESHOT                  (_LESENSE_CTRL_SCANMODE_ONESHOT << 0)    /**< Shifted mode ONESHOT for LESENSE_CTRL */
+#define LESENSE_CTRL_SCANMODE_PRS                      (_LESENSE_CTRL_SCANMODE_PRS << 0)        /**< Shifted mode PRS for LESENSE_CTRL */
+#define _LESENSE_CTRL_PRSSEL_SHIFT                     2                                        /**< Shift value for LESENSE_PRSSEL */
+#define _LESENSE_CTRL_PRSSEL_MASK                      0x1CUL                                   /**< Bit mask for LESENSE_PRSSEL */
+#define _LESENSE_CTRL_PRSSEL_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define _LESENSE_CTRL_PRSSEL_PRSCH0                    0x00000000UL                             /**< Mode PRSCH0 for LESENSE_CTRL */
+#define _LESENSE_CTRL_PRSSEL_PRSCH1                    0x00000001UL                             /**< Mode PRSCH1 for LESENSE_CTRL */
+#define _LESENSE_CTRL_PRSSEL_PRSCH2                    0x00000002UL                             /**< Mode PRSCH2 for LESENSE_CTRL */
+#define _LESENSE_CTRL_PRSSEL_PRSCH3                    0x00000003UL                             /**< Mode PRSCH3 for LESENSE_CTRL */
+#define _LESENSE_CTRL_PRSSEL_PRSCH4                    0x00000004UL                             /**< Mode PRSCH4 for LESENSE_CTRL */
+#define _LESENSE_CTRL_PRSSEL_PRSCH5                    0x00000005UL                             /**< Mode PRSCH5 for LESENSE_CTRL */
+#define _LESENSE_CTRL_PRSSEL_PRSCH6                    0x00000006UL                             /**< Mode PRSCH6 for LESENSE_CTRL */
+#define _LESENSE_CTRL_PRSSEL_PRSCH7                    0x00000007UL                             /**< Mode PRSCH7 for LESENSE_CTRL */
+#define LESENSE_CTRL_PRSSEL_DEFAULT                    (_LESENSE_CTRL_PRSSEL_DEFAULT << 2)      /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_PRSSEL_PRSCH0                     (_LESENSE_CTRL_PRSSEL_PRSCH0 << 2)       /**< Shifted mode PRSCH0 for LESENSE_CTRL */
+#define LESENSE_CTRL_PRSSEL_PRSCH1                     (_LESENSE_CTRL_PRSSEL_PRSCH1 << 2)       /**< Shifted mode PRSCH1 for LESENSE_CTRL */
+#define LESENSE_CTRL_PRSSEL_PRSCH2                     (_LESENSE_CTRL_PRSSEL_PRSCH2 << 2)       /**< Shifted mode PRSCH2 for LESENSE_CTRL */
+#define LESENSE_CTRL_PRSSEL_PRSCH3                     (_LESENSE_CTRL_PRSSEL_PRSCH3 << 2)       /**< Shifted mode PRSCH3 for LESENSE_CTRL */
+#define LESENSE_CTRL_PRSSEL_PRSCH4                     (_LESENSE_CTRL_PRSSEL_PRSCH4 << 2)       /**< Shifted mode PRSCH4 for LESENSE_CTRL */
+#define LESENSE_CTRL_PRSSEL_PRSCH5                     (_LESENSE_CTRL_PRSSEL_PRSCH5 << 2)       /**< Shifted mode PRSCH5 for LESENSE_CTRL */
+#define LESENSE_CTRL_PRSSEL_PRSCH6                     (_LESENSE_CTRL_PRSSEL_PRSCH6 << 2)       /**< Shifted mode PRSCH6 for LESENSE_CTRL */
+#define LESENSE_CTRL_PRSSEL_PRSCH7                     (_LESENSE_CTRL_PRSSEL_PRSCH7 << 2)       /**< Shifted mode PRSCH7 for LESENSE_CTRL */
+#define _LESENSE_CTRL_SCANCONF_SHIFT                   6                                        /**< Shift value for LESENSE_SCANCONF */
+#define _LESENSE_CTRL_SCANCONF_MASK                    0xC0UL                                   /**< Bit mask for LESENSE_SCANCONF */
+#define _LESENSE_CTRL_SCANCONF_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define _LESENSE_CTRL_SCANCONF_DIRMAP                  0x00000000UL                             /**< Mode DIRMAP for LESENSE_CTRL */
+#define _LESENSE_CTRL_SCANCONF_INVMAP                  0x00000001UL                             /**< Mode INVMAP for LESENSE_CTRL */
+#define _LESENSE_CTRL_SCANCONF_TOGGLE                  0x00000002UL                             /**< Mode TOGGLE for LESENSE_CTRL */
+#define _LESENSE_CTRL_SCANCONF_DECDEF                  0x00000003UL                             /**< Mode DECDEF for LESENSE_CTRL */
+#define LESENSE_CTRL_SCANCONF_DEFAULT                  (_LESENSE_CTRL_SCANCONF_DEFAULT << 6)    /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_SCANCONF_DIRMAP                   (_LESENSE_CTRL_SCANCONF_DIRMAP << 6)     /**< Shifted mode DIRMAP for LESENSE_CTRL */
+#define LESENSE_CTRL_SCANCONF_INVMAP                   (_LESENSE_CTRL_SCANCONF_INVMAP << 6)     /**< Shifted mode INVMAP for LESENSE_CTRL */
+#define LESENSE_CTRL_SCANCONF_TOGGLE                   (_LESENSE_CTRL_SCANCONF_TOGGLE << 6)     /**< Shifted mode TOGGLE for LESENSE_CTRL */
+#define LESENSE_CTRL_SCANCONF_DECDEF                   (_LESENSE_CTRL_SCANCONF_DECDEF << 6)     /**< Shifted mode DECDEF for LESENSE_CTRL */
+#define LESENSE_CTRL_ACMP0INV                          (0x1UL << 9)                             /**< Invert analog comparator 0 output */
+#define _LESENSE_CTRL_ACMP0INV_SHIFT                   9                                        /**< Shift value for LESENSE_ACMP0INV */
+#define _LESENSE_CTRL_ACMP0INV_MASK                    0x200UL                                  /**< Bit mask for LESENSE_ACMP0INV */
+#define _LESENSE_CTRL_ACMP0INV_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_ACMP0INV_DEFAULT                  (_LESENSE_CTRL_ACMP0INV_DEFAULT << 9)    /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_ACMP1INV                          (0x1UL << 10)                            /**< Invert analog comparator 1 output */
+#define _LESENSE_CTRL_ACMP1INV_SHIFT                   10                                       /**< Shift value for LESENSE_ACMP1INV */
+#define _LESENSE_CTRL_ACMP1INV_MASK                    0x400UL                                  /**< Bit mask for LESENSE_ACMP1INV */
+#define _LESENSE_CTRL_ACMP1INV_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_ACMP1INV_DEFAULT                  (_LESENSE_CTRL_ACMP1INV_DEFAULT << 10)   /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_ALTEXMAP                          (0x1UL << 11)                            /**< Alternative excitation map */
+#define _LESENSE_CTRL_ALTEXMAP_SHIFT                   11                                       /**< Shift value for LESENSE_ALTEXMAP */
+#define _LESENSE_CTRL_ALTEXMAP_MASK                    0x800UL                                  /**< Bit mask for LESENSE_ALTEXMAP */
+#define _LESENSE_CTRL_ALTEXMAP_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define _LESENSE_CTRL_ALTEXMAP_ALTEX                   0x00000000UL                             /**< Mode ALTEX for LESENSE_CTRL */
+#define _LESENSE_CTRL_ALTEXMAP_ACMP                    0x00000001UL                             /**< Mode ACMP for LESENSE_CTRL */
+#define LESENSE_CTRL_ALTEXMAP_DEFAULT                  (_LESENSE_CTRL_ALTEXMAP_DEFAULT << 11)   /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_ALTEXMAP_ALTEX                    (_LESENSE_CTRL_ALTEXMAP_ALTEX << 11)     /**< Shifted mode ALTEX for LESENSE_CTRL */
+#define LESENSE_CTRL_ALTEXMAP_ACMP                     (_LESENSE_CTRL_ALTEXMAP_ACMP << 11)      /**< Shifted mode ACMP for LESENSE_CTRL */
+#define LESENSE_CTRL_DUALSAMPLE                        (0x1UL << 13)                            /**< Enable dual sample mode */
+#define _LESENSE_CTRL_DUALSAMPLE_SHIFT                 13                                       /**< Shift value for LESENSE_DUALSAMPLE */
+#define _LESENSE_CTRL_DUALSAMPLE_MASK                  0x2000UL                                 /**< Bit mask for LESENSE_DUALSAMPLE */
+#define _LESENSE_CTRL_DUALSAMPLE_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_DUALSAMPLE_DEFAULT                (_LESENSE_CTRL_DUALSAMPLE_DEFAULT << 13) /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_BUFOW                             (0x1UL << 16)                            /**< Result buffer overwrite */
+#define _LESENSE_CTRL_BUFOW_SHIFT                      16                                       /**< Shift value for LESENSE_BUFOW */
+#define _LESENSE_CTRL_BUFOW_MASK                       0x10000UL                                /**< Bit mask for LESENSE_BUFOW */
+#define _LESENSE_CTRL_BUFOW_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_BUFOW_DEFAULT                     (_LESENSE_CTRL_BUFOW_DEFAULT << 16)      /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_STRSCANRES                        (0x1UL << 17)                            /**< Enable storing of SCANRES */
+#define _LESENSE_CTRL_STRSCANRES_SHIFT                 17                                       /**< Shift value for LESENSE_STRSCANRES */
+#define _LESENSE_CTRL_STRSCANRES_MASK                  0x20000UL                                /**< Bit mask for LESENSE_STRSCANRES */
+#define _LESENSE_CTRL_STRSCANRES_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_STRSCANRES_DEFAULT                (_LESENSE_CTRL_STRSCANRES_DEFAULT << 17) /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_BUFIDL                            (0x1UL << 18)                            /**< Result buffer interrupt and DMA trigger level */
+#define _LESENSE_CTRL_BUFIDL_SHIFT                     18                                       /**< Shift value for LESENSE_BUFIDL */
+#define _LESENSE_CTRL_BUFIDL_MASK                      0x40000UL                                /**< Bit mask for LESENSE_BUFIDL */
+#define _LESENSE_CTRL_BUFIDL_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define _LESENSE_CTRL_BUFIDL_HALFFULL                  0x00000000UL                             /**< Mode HALFFULL for LESENSE_CTRL */
+#define _LESENSE_CTRL_BUFIDL_FULL                      0x00000001UL                             /**< Mode FULL for LESENSE_CTRL */
+#define LESENSE_CTRL_BUFIDL_DEFAULT                    (_LESENSE_CTRL_BUFIDL_DEFAULT << 18)     /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_BUFIDL_HALFFULL                   (_LESENSE_CTRL_BUFIDL_HALFFULL << 18)    /**< Shifted mode HALFFULL for LESENSE_CTRL */
+#define LESENSE_CTRL_BUFIDL_FULL                       (_LESENSE_CTRL_BUFIDL_FULL << 18)        /**< Shifted mode FULL for LESENSE_CTRL */
+#define _LESENSE_CTRL_DMAWU_SHIFT                      20                                       /**< Shift value for LESENSE_DMAWU */
+#define _LESENSE_CTRL_DMAWU_MASK                       0x300000UL                               /**< Bit mask for LESENSE_DMAWU */
+#define _LESENSE_CTRL_DMAWU_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define _LESENSE_CTRL_DMAWU_DISABLE                    0x00000000UL                             /**< Mode DISABLE for LESENSE_CTRL */
+#define _LESENSE_CTRL_DMAWU_BUFDATAV                   0x00000001UL                             /**< Mode BUFDATAV for LESENSE_CTRL */
+#define _LESENSE_CTRL_DMAWU_BUFLEVEL                   0x00000002UL                             /**< Mode BUFLEVEL for LESENSE_CTRL */
+#define LESENSE_CTRL_DMAWU_DEFAULT                     (_LESENSE_CTRL_DMAWU_DEFAULT << 20)      /**< Shifted mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_DMAWU_DISABLE                     (_LESENSE_CTRL_DMAWU_DISABLE << 20)      /**< Shifted mode DISABLE for LESENSE_CTRL */
+#define LESENSE_CTRL_DMAWU_BUFDATAV                    (_LESENSE_CTRL_DMAWU_BUFDATAV << 20)     /**< Shifted mode BUFDATAV for LESENSE_CTRL */
+#define LESENSE_CTRL_DMAWU_BUFLEVEL                    (_LESENSE_CTRL_DMAWU_BUFLEVEL << 20)     /**< Shifted mode BUFLEVEL for LESENSE_CTRL */
+#define LESENSE_CTRL_DEBUGRUN                          (0x1UL << 22)                            /**< Debug Mode Run Enable */
+#define _LESENSE_CTRL_DEBUGRUN_SHIFT                   22                                       /**< Shift value for LESENSE_DEBUGRUN */
+#define _LESENSE_CTRL_DEBUGRUN_MASK                    0x400000UL                               /**< Bit mask for LESENSE_DEBUGRUN */
+#define _LESENSE_CTRL_DEBUGRUN_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_CTRL */
+#define LESENSE_CTRL_DEBUGRUN_DEFAULT                  (_LESENSE_CTRL_DEBUGRUN_DEFAULT << 22)   /**< Shifted mode DEFAULT for LESENSE_CTRL */
+
+/* Bit fields for LESENSE TIMCTRL */
+#define _LESENSE_TIMCTRL_RESETVALUE                    0x00000000UL                              /**< Default value for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_MASK                          0x00CFF773UL                              /**< Mask for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_AUXPRESC_SHIFT                0                                         /**< Shift value for LESENSE_AUXPRESC */
+#define _LESENSE_TIMCTRL_AUXPRESC_MASK                 0x3UL                                     /**< Bit mask for LESENSE_AUXPRESC */
+#define _LESENSE_TIMCTRL_AUXPRESC_DEFAULT              0x00000000UL                              /**< Mode DEFAULT for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_AUXPRESC_DIV1                 0x00000000UL                              /**< Mode DIV1 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_AUXPRESC_DIV2                 0x00000001UL                              /**< Mode DIV2 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_AUXPRESC_DIV4                 0x00000002UL                              /**< Mode DIV4 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_AUXPRESC_DIV8                 0x00000003UL                              /**< Mode DIV8 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_AUXPRESC_DEFAULT               (_LESENSE_TIMCTRL_AUXPRESC_DEFAULT << 0)  /**< Shifted mode DEFAULT for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_AUXPRESC_DIV1                  (_LESENSE_TIMCTRL_AUXPRESC_DIV1 << 0)     /**< Shifted mode DIV1 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_AUXPRESC_DIV2                  (_LESENSE_TIMCTRL_AUXPRESC_DIV2 << 0)     /**< Shifted mode DIV2 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_AUXPRESC_DIV4                  (_LESENSE_TIMCTRL_AUXPRESC_DIV4 << 0)     /**< Shifted mode DIV4 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_AUXPRESC_DIV8                  (_LESENSE_TIMCTRL_AUXPRESC_DIV8 << 0)     /**< Shifted mode DIV8 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_LFPRESC_SHIFT                 4                                         /**< Shift value for LESENSE_LFPRESC */
+#define _LESENSE_TIMCTRL_LFPRESC_MASK                  0x70UL                                    /**< Bit mask for LESENSE_LFPRESC */
+#define _LESENSE_TIMCTRL_LFPRESC_DEFAULT               0x00000000UL                              /**< Mode DEFAULT for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_LFPRESC_DIV1                  0x00000000UL                              /**< Mode DIV1 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_LFPRESC_DIV2                  0x00000001UL                              /**< Mode DIV2 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_LFPRESC_DIV4                  0x00000002UL                              /**< Mode DIV4 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_LFPRESC_DIV8                  0x00000003UL                              /**< Mode DIV8 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_LFPRESC_DIV16                 0x00000004UL                              /**< Mode DIV16 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_LFPRESC_DIV32                 0x00000005UL                              /**< Mode DIV32 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_LFPRESC_DIV64                 0x00000006UL                              /**< Mode DIV64 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_LFPRESC_DIV128                0x00000007UL                              /**< Mode DIV128 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_LFPRESC_DEFAULT                (_LESENSE_TIMCTRL_LFPRESC_DEFAULT << 4)   /**< Shifted mode DEFAULT for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_LFPRESC_DIV1                   (_LESENSE_TIMCTRL_LFPRESC_DIV1 << 4)      /**< Shifted mode DIV1 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_LFPRESC_DIV2                   (_LESENSE_TIMCTRL_LFPRESC_DIV2 << 4)      /**< Shifted mode DIV2 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_LFPRESC_DIV4                   (_LESENSE_TIMCTRL_LFPRESC_DIV4 << 4)      /**< Shifted mode DIV4 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_LFPRESC_DIV8                   (_LESENSE_TIMCTRL_LFPRESC_DIV8 << 4)      /**< Shifted mode DIV8 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_LFPRESC_DIV16                  (_LESENSE_TIMCTRL_LFPRESC_DIV16 << 4)     /**< Shifted mode DIV16 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_LFPRESC_DIV32                  (_LESENSE_TIMCTRL_LFPRESC_DIV32 << 4)     /**< Shifted mode DIV32 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_LFPRESC_DIV64                  (_LESENSE_TIMCTRL_LFPRESC_DIV64 << 4)     /**< Shifted mode DIV64 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_LFPRESC_DIV128                 (_LESENSE_TIMCTRL_LFPRESC_DIV128 << 4)    /**< Shifted mode DIV128 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCPRESC_SHIFT                 8                                         /**< Shift value for LESENSE_PCPRESC */
+#define _LESENSE_TIMCTRL_PCPRESC_MASK                  0x700UL                                   /**< Bit mask for LESENSE_PCPRESC */
+#define _LESENSE_TIMCTRL_PCPRESC_DEFAULT               0x00000000UL                              /**< Mode DEFAULT for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCPRESC_DIV1                  0x00000000UL                              /**< Mode DIV1 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCPRESC_DIV2                  0x00000001UL                              /**< Mode DIV2 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCPRESC_DIV4                  0x00000002UL                              /**< Mode DIV4 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCPRESC_DIV8                  0x00000003UL                              /**< Mode DIV8 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCPRESC_DIV16                 0x00000004UL                              /**< Mode DIV16 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCPRESC_DIV32                 0x00000005UL                              /**< Mode DIV32 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCPRESC_DIV64                 0x00000006UL                              /**< Mode DIV64 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCPRESC_DIV128                0x00000007UL                              /**< Mode DIV128 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCPRESC_DEFAULT                (_LESENSE_TIMCTRL_PCPRESC_DEFAULT << 8)   /**< Shifted mode DEFAULT for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCPRESC_DIV1                   (_LESENSE_TIMCTRL_PCPRESC_DIV1 << 8)      /**< Shifted mode DIV1 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCPRESC_DIV2                   (_LESENSE_TIMCTRL_PCPRESC_DIV2 << 8)      /**< Shifted mode DIV2 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCPRESC_DIV4                   (_LESENSE_TIMCTRL_PCPRESC_DIV4 << 8)      /**< Shifted mode DIV4 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCPRESC_DIV8                   (_LESENSE_TIMCTRL_PCPRESC_DIV8 << 8)      /**< Shifted mode DIV8 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCPRESC_DIV16                  (_LESENSE_TIMCTRL_PCPRESC_DIV16 << 8)     /**< Shifted mode DIV16 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCPRESC_DIV32                  (_LESENSE_TIMCTRL_PCPRESC_DIV32 << 8)     /**< Shifted mode DIV32 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCPRESC_DIV64                  (_LESENSE_TIMCTRL_PCPRESC_DIV64 << 8)     /**< Shifted mode DIV64 for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCPRESC_DIV128                 (_LESENSE_TIMCTRL_PCPRESC_DIV128 << 8)    /**< Shifted mode DIV128 for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_PCTOP_SHIFT                   12                                        /**< Shift value for LESENSE_PCTOP */
+#define _LESENSE_TIMCTRL_PCTOP_MASK                    0xFF000UL                                 /**< Bit mask for LESENSE_PCTOP */
+#define _LESENSE_TIMCTRL_PCTOP_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_PCTOP_DEFAULT                  (_LESENSE_TIMCTRL_PCTOP_DEFAULT << 12)    /**< Shifted mode DEFAULT for LESENSE_TIMCTRL */
+#define _LESENSE_TIMCTRL_STARTDLY_SHIFT                22                                        /**< Shift value for LESENSE_STARTDLY */
+#define _LESENSE_TIMCTRL_STARTDLY_MASK                 0xC00000UL                                /**< Bit mask for LESENSE_STARTDLY */
+#define _LESENSE_TIMCTRL_STARTDLY_DEFAULT              0x00000000UL                              /**< Mode DEFAULT for LESENSE_TIMCTRL */
+#define LESENSE_TIMCTRL_STARTDLY_DEFAULT               (_LESENSE_TIMCTRL_STARTDLY_DEFAULT << 22) /**< Shifted mode DEFAULT for LESENSE_TIMCTRL */
+
+/* Bit fields for LESENSE PERCTRL */
+#define _LESENSE_PERCTRL_RESETVALUE                    0x00000000UL                                        /**< Default value for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_MASK                          0x0CF47FFFUL                                        /**< Mask for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0DATA                     (0x1UL << 0)                                        /**< DAC CH0 data selection. */
+#define _LESENSE_PERCTRL_DACCH0DATA_SHIFT              0                                                   /**< Shift value for LESENSE_DACCH0DATA */
+#define _LESENSE_PERCTRL_DACCH0DATA_MASK               0x1UL                                               /**< Bit mask for LESENSE_DACCH0DATA */
+#define _LESENSE_PERCTRL_DACCH0DATA_DEFAULT            0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0DATA_DACDATA            0x00000000UL                                        /**< Mode DACDATA for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0DATA_ACMPTHRES          0x00000001UL                                        /**< Mode ACMPTHRES for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0DATA_DEFAULT             (_LESENSE_PERCTRL_DACCH0DATA_DEFAULT << 0)          /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0DATA_DACDATA             (_LESENSE_PERCTRL_DACCH0DATA_DACDATA << 0)          /**< Shifted mode DACDATA for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0DATA_ACMPTHRES           (_LESENSE_PERCTRL_DACCH0DATA_ACMPTHRES << 0)        /**< Shifted mode ACMPTHRES for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1DATA                     (0x1UL << 1)                                        /**< DAC CH1 data selection. */
+#define _LESENSE_PERCTRL_DACCH1DATA_SHIFT              1                                                   /**< Shift value for LESENSE_DACCH1DATA */
+#define _LESENSE_PERCTRL_DACCH1DATA_MASK               0x2UL                                               /**< Bit mask for LESENSE_DACCH1DATA */
+#define _LESENSE_PERCTRL_DACCH1DATA_DEFAULT            0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1DATA_DACDATA            0x00000000UL                                        /**< Mode DACDATA for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1DATA_ACMPTHRES          0x00000001UL                                        /**< Mode ACMPTHRES for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1DATA_DEFAULT             (_LESENSE_PERCTRL_DACCH1DATA_DEFAULT << 1)          /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1DATA_DACDATA             (_LESENSE_PERCTRL_DACCH1DATA_DACDATA << 1)          /**< Shifted mode DACDATA for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1DATA_ACMPTHRES           (_LESENSE_PERCTRL_DACCH1DATA_ACMPTHRES << 1)        /**< Shifted mode ACMPTHRES for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0CONV_SHIFT              2                                                   /**< Shift value for LESENSE_DACCH0CONV */
+#define _LESENSE_PERCTRL_DACCH0CONV_MASK               0xCUL                                               /**< Bit mask for LESENSE_DACCH0CONV */
+#define _LESENSE_PERCTRL_DACCH0CONV_DEFAULT            0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0CONV_DISABLE            0x00000000UL                                        /**< Mode DISABLE for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0CONV_CONTINUOUS         0x00000001UL                                        /**< Mode CONTINUOUS for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0CONV_SAMPLEHOLD         0x00000002UL                                        /**< Mode SAMPLEHOLD for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0CONV_SAMPLEOFF          0x00000003UL                                        /**< Mode SAMPLEOFF for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0CONV_DEFAULT             (_LESENSE_PERCTRL_DACCH0CONV_DEFAULT << 2)          /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0CONV_DISABLE             (_LESENSE_PERCTRL_DACCH0CONV_DISABLE << 2)          /**< Shifted mode DISABLE for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0CONV_CONTINUOUS          (_LESENSE_PERCTRL_DACCH0CONV_CONTINUOUS << 2)       /**< Shifted mode CONTINUOUS for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0CONV_SAMPLEHOLD          (_LESENSE_PERCTRL_DACCH0CONV_SAMPLEHOLD << 2)       /**< Shifted mode SAMPLEHOLD for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0CONV_SAMPLEOFF           (_LESENSE_PERCTRL_DACCH0CONV_SAMPLEOFF << 2)        /**< Shifted mode SAMPLEOFF for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1CONV_SHIFT              4                                                   /**< Shift value for LESENSE_DACCH1CONV */
+#define _LESENSE_PERCTRL_DACCH1CONV_MASK               0x30UL                                              /**< Bit mask for LESENSE_DACCH1CONV */
+#define _LESENSE_PERCTRL_DACCH1CONV_DEFAULT            0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1CONV_DISABLE            0x00000000UL                                        /**< Mode DISABLE for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1CONV_CONTINUOUS         0x00000001UL                                        /**< Mode CONTINUOUS for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1CONV_SAMPLEHOLD         0x00000002UL                                        /**< Mode SAMPLEHOLD for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1CONV_SAMPLEOFF          0x00000003UL                                        /**< Mode SAMPLEOFF for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1CONV_DEFAULT             (_LESENSE_PERCTRL_DACCH1CONV_DEFAULT << 4)          /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1CONV_DISABLE             (_LESENSE_PERCTRL_DACCH1CONV_DISABLE << 4)          /**< Shifted mode DISABLE for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1CONV_CONTINUOUS          (_LESENSE_PERCTRL_DACCH1CONV_CONTINUOUS << 4)       /**< Shifted mode CONTINUOUS for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1CONV_SAMPLEHOLD          (_LESENSE_PERCTRL_DACCH1CONV_SAMPLEHOLD << 4)       /**< Shifted mode SAMPLEHOLD for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1CONV_SAMPLEOFF           (_LESENSE_PERCTRL_DACCH1CONV_SAMPLEOFF << 4)        /**< Shifted mode SAMPLEOFF for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0OUT_SHIFT               6                                                   /**< Shift value for LESENSE_DACCH0OUT */
+#define _LESENSE_PERCTRL_DACCH0OUT_MASK                0xC0UL                                              /**< Bit mask for LESENSE_DACCH0OUT */
+#define _LESENSE_PERCTRL_DACCH0OUT_DEFAULT             0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0OUT_DISABLE             0x00000000UL                                        /**< Mode DISABLE for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0OUT_PIN                 0x00000001UL                                        /**< Mode PIN for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0OUT_ADCACMP             0x00000002UL                                        /**< Mode ADCACMP for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH0OUT_PINADCACMP          0x00000003UL                                        /**< Mode PINADCACMP for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0OUT_DEFAULT              (_LESENSE_PERCTRL_DACCH0OUT_DEFAULT << 6)           /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0OUT_DISABLE              (_LESENSE_PERCTRL_DACCH0OUT_DISABLE << 6)           /**< Shifted mode DISABLE for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0OUT_PIN                  (_LESENSE_PERCTRL_DACCH0OUT_PIN << 6)               /**< Shifted mode PIN for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0OUT_ADCACMP              (_LESENSE_PERCTRL_DACCH0OUT_ADCACMP << 6)           /**< Shifted mode ADCACMP for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH0OUT_PINADCACMP           (_LESENSE_PERCTRL_DACCH0OUT_PINADCACMP << 6)        /**< Shifted mode PINADCACMP for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1OUT_SHIFT               8                                                   /**< Shift value for LESENSE_DACCH1OUT */
+#define _LESENSE_PERCTRL_DACCH1OUT_MASK                0x300UL                                             /**< Bit mask for LESENSE_DACCH1OUT */
+#define _LESENSE_PERCTRL_DACCH1OUT_DEFAULT             0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1OUT_DISABLE             0x00000000UL                                        /**< Mode DISABLE for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1OUT_PIN                 0x00000001UL                                        /**< Mode PIN for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1OUT_ADCACMP             0x00000002UL                                        /**< Mode ADCACMP for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACCH1OUT_PINADCACMP          0x00000003UL                                        /**< Mode PINADCACMP for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1OUT_DEFAULT              (_LESENSE_PERCTRL_DACCH1OUT_DEFAULT << 8)           /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1OUT_DISABLE              (_LESENSE_PERCTRL_DACCH1OUT_DISABLE << 8)           /**< Shifted mode DISABLE for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1OUT_PIN                  (_LESENSE_PERCTRL_DACCH1OUT_PIN << 8)               /**< Shifted mode PIN for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1OUT_ADCACMP              (_LESENSE_PERCTRL_DACCH1OUT_ADCACMP << 8)           /**< Shifted mode ADCACMP for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACCH1OUT_PINADCACMP           (_LESENSE_PERCTRL_DACCH1OUT_PINADCACMP << 8)        /**< Shifted mode PINADCACMP for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACPRESC_SHIFT                10                                                  /**< Shift value for LESENSE_DACPRESC */
+#define _LESENSE_PERCTRL_DACPRESC_MASK                 0x7C00UL                                            /**< Bit mask for LESENSE_DACPRESC */
+#define _LESENSE_PERCTRL_DACPRESC_DEFAULT              0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACPRESC_DEFAULT               (_LESENSE_PERCTRL_DACPRESC_DEFAULT << 10)           /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACREF                         (0x1UL << 18)                                       /**< DAC bandgap reference used */
+#define _LESENSE_PERCTRL_DACREF_SHIFT                  18                                                  /**< Shift value for LESENSE_DACREF */
+#define _LESENSE_PERCTRL_DACREF_MASK                   0x40000UL                                           /**< Bit mask for LESENSE_DACREF */
+#define _LESENSE_PERCTRL_DACREF_DEFAULT                0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACREF_VDD                    0x00000000UL                                        /**< Mode VDD for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_DACREF_BANDGAP                0x00000001UL                                        /**< Mode BANDGAP for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACREF_DEFAULT                 (_LESENSE_PERCTRL_DACREF_DEFAULT << 18)             /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACREF_VDD                     (_LESENSE_PERCTRL_DACREF_VDD << 18)                 /**< Shifted mode VDD for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_DACREF_BANDGAP                 (_LESENSE_PERCTRL_DACREF_BANDGAP << 18)             /**< Shifted mode BANDGAP for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_ACMP0MODE_SHIFT               20                                                  /**< Shift value for LESENSE_ACMP0MODE */
+#define _LESENSE_PERCTRL_ACMP0MODE_MASK                0x300000UL                                          /**< Bit mask for LESENSE_ACMP0MODE */
+#define _LESENSE_PERCTRL_ACMP0MODE_DEFAULT             0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_ACMP0MODE_DISABLE             0x00000000UL                                        /**< Mode DISABLE for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_ACMP0MODE_MUX                 0x00000001UL                                        /**< Mode MUX for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_ACMP0MODE_MUXTHRES            0x00000002UL                                        /**< Mode MUXTHRES for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_ACMP0MODE_DEFAULT              (_LESENSE_PERCTRL_ACMP0MODE_DEFAULT << 20)          /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_ACMP0MODE_DISABLE              (_LESENSE_PERCTRL_ACMP0MODE_DISABLE << 20)          /**< Shifted mode DISABLE for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_ACMP0MODE_MUX                  (_LESENSE_PERCTRL_ACMP0MODE_MUX << 20)              /**< Shifted mode MUX for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_ACMP0MODE_MUXTHRES             (_LESENSE_PERCTRL_ACMP0MODE_MUXTHRES << 20)         /**< Shifted mode MUXTHRES for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_ACMP1MODE_SHIFT               22                                                  /**< Shift value for LESENSE_ACMP1MODE */
+#define _LESENSE_PERCTRL_ACMP1MODE_MASK                0xC00000UL                                          /**< Bit mask for LESENSE_ACMP1MODE */
+#define _LESENSE_PERCTRL_ACMP1MODE_DEFAULT             0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_ACMP1MODE_DISABLE             0x00000000UL                                        /**< Mode DISABLE for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_ACMP1MODE_MUX                 0x00000001UL                                        /**< Mode MUX for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_ACMP1MODE_MUXTHRES            0x00000002UL                                        /**< Mode MUXTHRES for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_ACMP1MODE_DEFAULT              (_LESENSE_PERCTRL_ACMP1MODE_DEFAULT << 22)          /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_ACMP1MODE_DISABLE              (_LESENSE_PERCTRL_ACMP1MODE_DISABLE << 22)          /**< Shifted mode DISABLE for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_ACMP1MODE_MUX                  (_LESENSE_PERCTRL_ACMP1MODE_MUX << 22)              /**< Shifted mode MUX for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_ACMP1MODE_MUXTHRES             (_LESENSE_PERCTRL_ACMP1MODE_MUXTHRES << 22)         /**< Shifted mode MUXTHRES for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_WARMUPMODE_SHIFT              26                                                  /**< Shift value for LESENSE_WARMUPMODE */
+#define _LESENSE_PERCTRL_WARMUPMODE_MASK               0xC000000UL                                         /**< Bit mask for LESENSE_WARMUPMODE */
+#define _LESENSE_PERCTRL_WARMUPMODE_DEFAULT            0x00000000UL                                        /**< Mode DEFAULT for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_WARMUPMODE_NORMAL             0x00000000UL                                        /**< Mode NORMAL for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_WARMUPMODE_KEEPACMPWARM       0x00000001UL                                        /**< Mode KEEPACMPWARM for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_WARMUPMODE_KEEPDACWARM        0x00000002UL                                        /**< Mode KEEPDACWARM for LESENSE_PERCTRL */
+#define _LESENSE_PERCTRL_WARMUPMODE_KEEPACMPDACWARM    0x00000003UL                                        /**< Mode KEEPACMPDACWARM for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_WARMUPMODE_DEFAULT             (_LESENSE_PERCTRL_WARMUPMODE_DEFAULT << 26)         /**< Shifted mode DEFAULT for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_WARMUPMODE_NORMAL              (_LESENSE_PERCTRL_WARMUPMODE_NORMAL << 26)          /**< Shifted mode NORMAL for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_WARMUPMODE_KEEPACMPWARM        (_LESENSE_PERCTRL_WARMUPMODE_KEEPACMPWARM << 26)    /**< Shifted mode KEEPACMPWARM for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_WARMUPMODE_KEEPDACWARM         (_LESENSE_PERCTRL_WARMUPMODE_KEEPDACWARM << 26)     /**< Shifted mode KEEPDACWARM for LESENSE_PERCTRL */
+#define LESENSE_PERCTRL_WARMUPMODE_KEEPACMPDACWARM     (_LESENSE_PERCTRL_WARMUPMODE_KEEPACMPDACWARM << 26) /**< Shifted mode KEEPACMPDACWARM for LESENSE_PERCTRL */
+
+/* Bit fields for LESENSE DECCTRL */
+#define _LESENSE_DECCTRL_RESETVALUE                    0x00000000UL                              /**< Default value for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_MASK                          0x01DDDDFFUL                              /**< Mask for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_DISABLE                        (0x1UL << 0)                              /**< Disable the decoder */
+#define _LESENSE_DECCTRL_DISABLE_SHIFT                 0                                         /**< Shift value for LESENSE_DISABLE */
+#define _LESENSE_DECCTRL_DISABLE_MASK                  0x1UL                                     /**< Bit mask for LESENSE_DISABLE */
+#define _LESENSE_DECCTRL_DISABLE_DEFAULT               0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_DISABLE_DEFAULT                (_LESENSE_DECCTRL_DISABLE_DEFAULT << 0)   /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_ERRCHK                         (0x1UL << 1)                              /**< Enable check of current state */
+#define _LESENSE_DECCTRL_ERRCHK_SHIFT                  1                                         /**< Shift value for LESENSE_ERRCHK */
+#define _LESENSE_DECCTRL_ERRCHK_MASK                   0x2UL                                     /**< Bit mask for LESENSE_ERRCHK */
+#define _LESENSE_DECCTRL_ERRCHK_DEFAULT                0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_ERRCHK_DEFAULT                 (_LESENSE_DECCTRL_ERRCHK_DEFAULT << 1)    /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_INTMAP                         (0x1UL << 2)                              /**< Enable decoder to channel interrupt mapping */
+#define _LESENSE_DECCTRL_INTMAP_SHIFT                  2                                         /**< Shift value for LESENSE_INTMAP */
+#define _LESENSE_DECCTRL_INTMAP_MASK                   0x4UL                                     /**< Bit mask for LESENSE_INTMAP */
+#define _LESENSE_DECCTRL_INTMAP_DEFAULT                0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_INTMAP_DEFAULT                 (_LESENSE_DECCTRL_INTMAP_DEFAULT << 2)    /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_HYSTPRS0                       (0x1UL << 3)                              /**< Enable decoder hysteresis on PRS0 output */
+#define _LESENSE_DECCTRL_HYSTPRS0_SHIFT                3                                         /**< Shift value for LESENSE_HYSTPRS0 */
+#define _LESENSE_DECCTRL_HYSTPRS0_MASK                 0x8UL                                     /**< Bit mask for LESENSE_HYSTPRS0 */
+#define _LESENSE_DECCTRL_HYSTPRS0_DEFAULT              0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_HYSTPRS0_DEFAULT               (_LESENSE_DECCTRL_HYSTPRS0_DEFAULT << 3)  /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_HYSTPRS1                       (0x1UL << 4)                              /**< Enable decoder hysteresis on PRS1 output */
+#define _LESENSE_DECCTRL_HYSTPRS1_SHIFT                4                                         /**< Shift value for LESENSE_HYSTPRS1 */
+#define _LESENSE_DECCTRL_HYSTPRS1_MASK                 0x10UL                                    /**< Bit mask for LESENSE_HYSTPRS1 */
+#define _LESENSE_DECCTRL_HYSTPRS1_DEFAULT              0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_HYSTPRS1_DEFAULT               (_LESENSE_DECCTRL_HYSTPRS1_DEFAULT << 4)  /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_HYSTPRS2                       (0x1UL << 5)                              /**< Enable decoder hysteresis on PRS2 output */
+#define _LESENSE_DECCTRL_HYSTPRS2_SHIFT                5                                         /**< Shift value for LESENSE_HYSTPRS2 */
+#define _LESENSE_DECCTRL_HYSTPRS2_MASK                 0x20UL                                    /**< Bit mask for LESENSE_HYSTPRS2 */
+#define _LESENSE_DECCTRL_HYSTPRS2_DEFAULT              0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_HYSTPRS2_DEFAULT               (_LESENSE_DECCTRL_HYSTPRS2_DEFAULT << 5)  /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_HYSTIRQ                        (0x1UL << 6)                              /**< Enable decoder hysteresis on interrupt requests */
+#define _LESENSE_DECCTRL_HYSTIRQ_SHIFT                 6                                         /**< Shift value for LESENSE_HYSTIRQ */
+#define _LESENSE_DECCTRL_HYSTIRQ_MASK                  0x40UL                                    /**< Bit mask for LESENSE_HYSTIRQ */
+#define _LESENSE_DECCTRL_HYSTIRQ_DEFAULT               0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_HYSTIRQ_DEFAULT                (_LESENSE_DECCTRL_HYSTIRQ_DEFAULT << 6)   /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSCNT                         (0x1UL << 7)                              /**< Enable count mode on decoder PRS channels 0 and 1 */
+#define _LESENSE_DECCTRL_PRSCNT_SHIFT                  7                                         /**< Shift value for LESENSE_PRSCNT */
+#define _LESENSE_DECCTRL_PRSCNT_MASK                   0x80UL                                    /**< Bit mask for LESENSE_PRSCNT */
+#define _LESENSE_DECCTRL_PRSCNT_DEFAULT                0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSCNT_DEFAULT                 (_LESENSE_DECCTRL_PRSCNT_DEFAULT << 7)    /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_INPUT                          (0x1UL << 8)                              /**<  */
+#define _LESENSE_DECCTRL_INPUT_SHIFT                   8                                         /**< Shift value for LESENSE_INPUT */
+#define _LESENSE_DECCTRL_INPUT_MASK                    0x100UL                                   /**< Bit mask for LESENSE_INPUT */
+#define _LESENSE_DECCTRL_INPUT_DEFAULT                 0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_INPUT_SENSORSTATE             0x00000000UL                              /**< Mode SENSORSTATE for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_INPUT_PRS                     0x00000001UL                              /**< Mode PRS for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_INPUT_DEFAULT                  (_LESENSE_DECCTRL_INPUT_DEFAULT << 8)     /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_INPUT_SENSORSTATE              (_LESENSE_DECCTRL_INPUT_SENSORSTATE << 8) /**< Shifted mode SENSORSTATE for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_INPUT_PRS                      (_LESENSE_DECCTRL_INPUT_PRS << 8)         /**< Shifted mode PRS for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL0_SHIFT                 10                                        /**< Shift value for LESENSE_PRSSEL0 */
+#define _LESENSE_DECCTRL_PRSSEL0_MASK                  0x1C00UL                                  /**< Bit mask for LESENSE_PRSSEL0 */
+#define _LESENSE_DECCTRL_PRSSEL0_DEFAULT               0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL0_PRSCH0                0x00000000UL                              /**< Mode PRSCH0 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL0_PRSCH1                0x00000001UL                              /**< Mode PRSCH1 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL0_PRSCH2                0x00000002UL                              /**< Mode PRSCH2 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL0_PRSCH3                0x00000003UL                              /**< Mode PRSCH3 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL0_PRSCH4                0x00000004UL                              /**< Mode PRSCH4 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL0_PRSCH5                0x00000005UL                              /**< Mode PRSCH5 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL0_PRSCH6                0x00000006UL                              /**< Mode PRSCH6 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL0_PRSCH7                0x00000007UL                              /**< Mode PRSCH7 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL0_DEFAULT                (_LESENSE_DECCTRL_PRSSEL0_DEFAULT << 10)  /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL0_PRSCH0                 (_LESENSE_DECCTRL_PRSSEL0_PRSCH0 << 10)   /**< Shifted mode PRSCH0 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL0_PRSCH1                 (_LESENSE_DECCTRL_PRSSEL0_PRSCH1 << 10)   /**< Shifted mode PRSCH1 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL0_PRSCH2                 (_LESENSE_DECCTRL_PRSSEL0_PRSCH2 << 10)   /**< Shifted mode PRSCH2 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL0_PRSCH3                 (_LESENSE_DECCTRL_PRSSEL0_PRSCH3 << 10)   /**< Shifted mode PRSCH3 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL0_PRSCH4                 (_LESENSE_DECCTRL_PRSSEL0_PRSCH4 << 10)   /**< Shifted mode PRSCH4 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL0_PRSCH5                 (_LESENSE_DECCTRL_PRSSEL0_PRSCH5 << 10)   /**< Shifted mode PRSCH5 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL0_PRSCH6                 (_LESENSE_DECCTRL_PRSSEL0_PRSCH6 << 10)   /**< Shifted mode PRSCH6 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL0_PRSCH7                 (_LESENSE_DECCTRL_PRSSEL0_PRSCH7 << 10)   /**< Shifted mode PRSCH7 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL1_SHIFT                 14                                        /**< Shift value for LESENSE_PRSSEL1 */
+#define _LESENSE_DECCTRL_PRSSEL1_MASK                  0x1C000UL                                 /**< Bit mask for LESENSE_PRSSEL1 */
+#define _LESENSE_DECCTRL_PRSSEL1_DEFAULT               0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL1_PRSCH0                0x00000000UL                              /**< Mode PRSCH0 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL1_PRSCH1                0x00000001UL                              /**< Mode PRSCH1 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL1_PRSCH2                0x00000002UL                              /**< Mode PRSCH2 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL1_PRSCH3                0x00000003UL                              /**< Mode PRSCH3 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL1_PRSCH4                0x00000004UL                              /**< Mode PRSCH4 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL1_PRSCH5                0x00000005UL                              /**< Mode PRSCH5 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL1_PRSCH6                0x00000006UL                              /**< Mode PRSCH6 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL1_PRSCH7                0x00000007UL                              /**< Mode PRSCH7 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL1_DEFAULT                (_LESENSE_DECCTRL_PRSSEL1_DEFAULT << 14)  /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL1_PRSCH0                 (_LESENSE_DECCTRL_PRSSEL1_PRSCH0 << 14)   /**< Shifted mode PRSCH0 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL1_PRSCH1                 (_LESENSE_DECCTRL_PRSSEL1_PRSCH1 << 14)   /**< Shifted mode PRSCH1 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL1_PRSCH2                 (_LESENSE_DECCTRL_PRSSEL1_PRSCH2 << 14)   /**< Shifted mode PRSCH2 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL1_PRSCH3                 (_LESENSE_DECCTRL_PRSSEL1_PRSCH3 << 14)   /**< Shifted mode PRSCH3 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL1_PRSCH4                 (_LESENSE_DECCTRL_PRSSEL1_PRSCH4 << 14)   /**< Shifted mode PRSCH4 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL1_PRSCH5                 (_LESENSE_DECCTRL_PRSSEL1_PRSCH5 << 14)   /**< Shifted mode PRSCH5 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL1_PRSCH6                 (_LESENSE_DECCTRL_PRSSEL1_PRSCH6 << 14)   /**< Shifted mode PRSCH6 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL1_PRSCH7                 (_LESENSE_DECCTRL_PRSSEL1_PRSCH7 << 14)   /**< Shifted mode PRSCH7 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL2_SHIFT                 18                                        /**< Shift value for LESENSE_PRSSEL2 */
+#define _LESENSE_DECCTRL_PRSSEL2_MASK                  0x1C0000UL                                /**< Bit mask for LESENSE_PRSSEL2 */
+#define _LESENSE_DECCTRL_PRSSEL2_DEFAULT               0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL2_PRSCH0                0x00000000UL                              /**< Mode PRSCH0 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL2_PRSCH1                0x00000001UL                              /**< Mode PRSCH1 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL2_PRSCH2                0x00000002UL                              /**< Mode PRSCH2 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL2_PRSCH3                0x00000003UL                              /**< Mode PRSCH3 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL2_PRSCH4                0x00000004UL                              /**< Mode PRSCH4 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL2_PRSCH5                0x00000005UL                              /**< Mode PRSCH5 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL2_PRSCH6                0x00000006UL                              /**< Mode PRSCH6 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL2_PRSCH7                0x00000007UL                              /**< Mode PRSCH7 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL2_DEFAULT                (_LESENSE_DECCTRL_PRSSEL2_DEFAULT << 18)  /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL2_PRSCH0                 (_LESENSE_DECCTRL_PRSSEL2_PRSCH0 << 18)   /**< Shifted mode PRSCH0 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL2_PRSCH1                 (_LESENSE_DECCTRL_PRSSEL2_PRSCH1 << 18)   /**< Shifted mode PRSCH1 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL2_PRSCH2                 (_LESENSE_DECCTRL_PRSSEL2_PRSCH2 << 18)   /**< Shifted mode PRSCH2 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL2_PRSCH3                 (_LESENSE_DECCTRL_PRSSEL2_PRSCH3 << 18)   /**< Shifted mode PRSCH3 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL2_PRSCH4                 (_LESENSE_DECCTRL_PRSSEL2_PRSCH4 << 18)   /**< Shifted mode PRSCH4 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL2_PRSCH5                 (_LESENSE_DECCTRL_PRSSEL2_PRSCH5 << 18)   /**< Shifted mode PRSCH5 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL2_PRSCH6                 (_LESENSE_DECCTRL_PRSSEL2_PRSCH6 << 18)   /**< Shifted mode PRSCH6 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL2_PRSCH7                 (_LESENSE_DECCTRL_PRSSEL2_PRSCH7 << 18)   /**< Shifted mode PRSCH7 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL3_SHIFT                 22                                        /**< Shift value for LESENSE_PRSSEL3 */
+#define _LESENSE_DECCTRL_PRSSEL3_MASK                  0x1C00000UL                               /**< Bit mask for LESENSE_PRSSEL3 */
+#define _LESENSE_DECCTRL_PRSSEL3_DEFAULT               0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL3_PRSCH0                0x00000000UL                              /**< Mode PRSCH0 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL3_PRSCH1                0x00000001UL                              /**< Mode PRSCH1 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL3_PRSCH2                0x00000002UL                              /**< Mode PRSCH2 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL3_PRSCH3                0x00000003UL                              /**< Mode PRSCH3 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL3_PRSCH4                0x00000004UL                              /**< Mode PRSCH4 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL3_PRSCH5                0x00000005UL                              /**< Mode PRSCH5 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL3_PRSCH6                0x00000006UL                              /**< Mode PRSCH6 for LESENSE_DECCTRL */
+#define _LESENSE_DECCTRL_PRSSEL3_PRSCH7                0x00000007UL                              /**< Mode PRSCH7 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL3_DEFAULT                (_LESENSE_DECCTRL_PRSSEL3_DEFAULT << 22)  /**< Shifted mode DEFAULT for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL3_PRSCH0                 (_LESENSE_DECCTRL_PRSSEL3_PRSCH0 << 22)   /**< Shifted mode PRSCH0 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL3_PRSCH1                 (_LESENSE_DECCTRL_PRSSEL3_PRSCH1 << 22)   /**< Shifted mode PRSCH1 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL3_PRSCH2                 (_LESENSE_DECCTRL_PRSSEL3_PRSCH2 << 22)   /**< Shifted mode PRSCH2 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL3_PRSCH3                 (_LESENSE_DECCTRL_PRSSEL3_PRSCH3 << 22)   /**< Shifted mode PRSCH3 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL3_PRSCH4                 (_LESENSE_DECCTRL_PRSSEL3_PRSCH4 << 22)   /**< Shifted mode PRSCH4 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL3_PRSCH5                 (_LESENSE_DECCTRL_PRSSEL3_PRSCH5 << 22)   /**< Shifted mode PRSCH5 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL3_PRSCH6                 (_LESENSE_DECCTRL_PRSSEL3_PRSCH6 << 22)   /**< Shifted mode PRSCH6 for LESENSE_DECCTRL */
+#define LESENSE_DECCTRL_PRSSEL3_PRSCH7                 (_LESENSE_DECCTRL_PRSSEL3_PRSCH7 << 22)   /**< Shifted mode PRSCH7 for LESENSE_DECCTRL */
+
+/* Bit fields for LESENSE BIASCTRL */
+#define _LESENSE_BIASCTRL_RESETVALUE                   0x00000000UL                                /**< Default value for LESENSE_BIASCTRL */
+#define _LESENSE_BIASCTRL_MASK                         0x00000003UL                                /**< Mask for LESENSE_BIASCTRL */
+#define _LESENSE_BIASCTRL_BIASMODE_SHIFT               0                                           /**< Shift value for LESENSE_BIASMODE */
+#define _LESENSE_BIASCTRL_BIASMODE_MASK                0x3UL                                       /**< Bit mask for LESENSE_BIASMODE */
+#define _LESENSE_BIASCTRL_BIASMODE_DEFAULT             0x00000000UL                                /**< Mode DEFAULT for LESENSE_BIASCTRL */
+#define _LESENSE_BIASCTRL_BIASMODE_DUTYCYCLE           0x00000000UL                                /**< Mode DUTYCYCLE for LESENSE_BIASCTRL */
+#define _LESENSE_BIASCTRL_BIASMODE_HIGHACC             0x00000001UL                                /**< Mode HIGHACC for LESENSE_BIASCTRL */
+#define _LESENSE_BIASCTRL_BIASMODE_DONTTOUCH           0x00000002UL                                /**< Mode DONTTOUCH for LESENSE_BIASCTRL */
+#define LESENSE_BIASCTRL_BIASMODE_DEFAULT              (_LESENSE_BIASCTRL_BIASMODE_DEFAULT << 0)   /**< Shifted mode DEFAULT for LESENSE_BIASCTRL */
+#define LESENSE_BIASCTRL_BIASMODE_DUTYCYCLE            (_LESENSE_BIASCTRL_BIASMODE_DUTYCYCLE << 0) /**< Shifted mode DUTYCYCLE for LESENSE_BIASCTRL */
+#define LESENSE_BIASCTRL_BIASMODE_HIGHACC              (_LESENSE_BIASCTRL_BIASMODE_HIGHACC << 0)   /**< Shifted mode HIGHACC for LESENSE_BIASCTRL */
+#define LESENSE_BIASCTRL_BIASMODE_DONTTOUCH            (_LESENSE_BIASCTRL_BIASMODE_DONTTOUCH << 0) /**< Shifted mode DONTTOUCH for LESENSE_BIASCTRL */
+
+/* Bit fields for LESENSE CMD */
+#define _LESENSE_CMD_RESETVALUE                        0x00000000UL                         /**< Default value for LESENSE_CMD */
+#define _LESENSE_CMD_MASK                              0x0000000FUL                         /**< Mask for LESENSE_CMD */
+#define LESENSE_CMD_START                              (0x1UL << 0)                         /**< Start scanning of sensors. */
+#define _LESENSE_CMD_START_SHIFT                       0                                    /**< Shift value for LESENSE_START */
+#define _LESENSE_CMD_START_MASK                        0x1UL                                /**< Bit mask for LESENSE_START */
+#define _LESENSE_CMD_START_DEFAULT                     0x00000000UL                         /**< Mode DEFAULT for LESENSE_CMD */
+#define LESENSE_CMD_START_DEFAULT                      (_LESENSE_CMD_START_DEFAULT << 0)    /**< Shifted mode DEFAULT for LESENSE_CMD */
+#define LESENSE_CMD_STOP                               (0x1UL << 1)                         /**< Stop scanning of sensors */
+#define _LESENSE_CMD_STOP_SHIFT                        1                                    /**< Shift value for LESENSE_STOP */
+#define _LESENSE_CMD_STOP_MASK                         0x2UL                                /**< Bit mask for LESENSE_STOP */
+#define _LESENSE_CMD_STOP_DEFAULT                      0x00000000UL                         /**< Mode DEFAULT for LESENSE_CMD */
+#define LESENSE_CMD_STOP_DEFAULT                       (_LESENSE_CMD_STOP_DEFAULT << 1)     /**< Shifted mode DEFAULT for LESENSE_CMD */
+#define LESENSE_CMD_DECODE                             (0x1UL << 2)                         /**< Start decoder */
+#define _LESENSE_CMD_DECODE_SHIFT                      2                                    /**< Shift value for LESENSE_DECODE */
+#define _LESENSE_CMD_DECODE_MASK                       0x4UL                                /**< Bit mask for LESENSE_DECODE */
+#define _LESENSE_CMD_DECODE_DEFAULT                    0x00000000UL                         /**< Mode DEFAULT for LESENSE_CMD */
+#define LESENSE_CMD_DECODE_DEFAULT                     (_LESENSE_CMD_DECODE_DEFAULT << 2)   /**< Shifted mode DEFAULT for LESENSE_CMD */
+#define LESENSE_CMD_CLEARBUF                           (0x1UL << 3)                         /**< Clear result buffer */
+#define _LESENSE_CMD_CLEARBUF_SHIFT                    3                                    /**< Shift value for LESENSE_CLEARBUF */
+#define _LESENSE_CMD_CLEARBUF_MASK                     0x8UL                                /**< Bit mask for LESENSE_CLEARBUF */
+#define _LESENSE_CMD_CLEARBUF_DEFAULT                  0x00000000UL                         /**< Mode DEFAULT for LESENSE_CMD */
+#define LESENSE_CMD_CLEARBUF_DEFAULT                   (_LESENSE_CMD_CLEARBUF_DEFAULT << 3) /**< Shifted mode DEFAULT for LESENSE_CMD */
+
+/* Bit fields for LESENSE CHEN */
+#define _LESENSE_CHEN_RESETVALUE                       0x00000000UL                      /**< Default value for LESENSE_CHEN */
+#define _LESENSE_CHEN_MASK                             0x0000FFFFUL                      /**< Mask for LESENSE_CHEN */
+#define _LESENSE_CHEN_CHEN_SHIFT                       0                                 /**< Shift value for LESENSE_CHEN */
+#define _LESENSE_CHEN_CHEN_MASK                        0xFFFFUL                          /**< Bit mask for LESENSE_CHEN */
+#define _LESENSE_CHEN_CHEN_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for LESENSE_CHEN */
+#define LESENSE_CHEN_CHEN_DEFAULT                      (_LESENSE_CHEN_CHEN_DEFAULT << 0) /**< Shifted mode DEFAULT for LESENSE_CHEN */
+
+/* Bit fields for LESENSE SCANRES */
+#define _LESENSE_SCANRES_RESETVALUE                    0x00000000UL                            /**< Default value for LESENSE_SCANRES */
+#define _LESENSE_SCANRES_MASK                          0x0000FFFFUL                            /**< Mask for LESENSE_SCANRES */
+#define _LESENSE_SCANRES_SCANRES_SHIFT                 0                                       /**< Shift value for LESENSE_SCANRES */
+#define _LESENSE_SCANRES_SCANRES_MASK                  0xFFFFUL                                /**< Bit mask for LESENSE_SCANRES */
+#define _LESENSE_SCANRES_SCANRES_DEFAULT               0x00000000UL                            /**< Mode DEFAULT for LESENSE_SCANRES */
+#define LESENSE_SCANRES_SCANRES_DEFAULT                (_LESENSE_SCANRES_SCANRES_DEFAULT << 0) /**< Shifted mode DEFAULT for LESENSE_SCANRES */
+
+/* Bit fields for LESENSE STATUS */
+#define _LESENSE_STATUS_RESETVALUE                     0x00000000UL                               /**< Default value for LESENSE_STATUS */
+#define _LESENSE_STATUS_MASK                           0x0000003FUL                               /**< Mask for LESENSE_STATUS */
+#define LESENSE_STATUS_BUFDATAV                        (0x1UL << 0)                               /**< Result data valid */
+#define _LESENSE_STATUS_BUFDATAV_SHIFT                 0                                          /**< Shift value for LESENSE_BUFDATAV */
+#define _LESENSE_STATUS_BUFDATAV_MASK                  0x1UL                                      /**< Bit mask for LESENSE_BUFDATAV */
+#define _LESENSE_STATUS_BUFDATAV_DEFAULT               0x00000000UL                               /**< Mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_BUFDATAV_DEFAULT                (_LESENSE_STATUS_BUFDATAV_DEFAULT << 0)    /**< Shifted mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_BUFHALFFULL                     (0x1UL << 1)                               /**< Result buffer half full */
+#define _LESENSE_STATUS_BUFHALFFULL_SHIFT              1                                          /**< Shift value for LESENSE_BUFHALFFULL */
+#define _LESENSE_STATUS_BUFHALFFULL_MASK               0x2UL                                      /**< Bit mask for LESENSE_BUFHALFFULL */
+#define _LESENSE_STATUS_BUFHALFFULL_DEFAULT            0x00000000UL                               /**< Mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_BUFHALFFULL_DEFAULT             (_LESENSE_STATUS_BUFHALFFULL_DEFAULT << 1) /**< Shifted mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_BUFFULL                         (0x1UL << 2)                               /**< Result buffer full */
+#define _LESENSE_STATUS_BUFFULL_SHIFT                  2                                          /**< Shift value for LESENSE_BUFFULL */
+#define _LESENSE_STATUS_BUFFULL_MASK                   0x4UL                                      /**< Bit mask for LESENSE_BUFFULL */
+#define _LESENSE_STATUS_BUFFULL_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_BUFFULL_DEFAULT                 (_LESENSE_STATUS_BUFFULL_DEFAULT << 2)     /**< Shifted mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_RUNNING                         (0x1UL << 3)                               /**< LESENSE is active */
+#define _LESENSE_STATUS_RUNNING_SHIFT                  3                                          /**< Shift value for LESENSE_RUNNING */
+#define _LESENSE_STATUS_RUNNING_MASK                   0x8UL                                      /**< Bit mask for LESENSE_RUNNING */
+#define _LESENSE_STATUS_RUNNING_DEFAULT                0x00000000UL                               /**< Mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_RUNNING_DEFAULT                 (_LESENSE_STATUS_RUNNING_DEFAULT << 3)     /**< Shifted mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_SCANACTIVE                      (0x1UL << 4)                               /**< LESENSE is currently interfacing sensors. */
+#define _LESENSE_STATUS_SCANACTIVE_SHIFT               4                                          /**< Shift value for LESENSE_SCANACTIVE */
+#define _LESENSE_STATUS_SCANACTIVE_MASK                0x10UL                                     /**< Bit mask for LESENSE_SCANACTIVE */
+#define _LESENSE_STATUS_SCANACTIVE_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_SCANACTIVE_DEFAULT              (_LESENSE_STATUS_SCANACTIVE_DEFAULT << 4)  /**< Shifted mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_DACACTIVE                       (0x1UL << 5)                               /**< LESENSE DAC interface is active */
+#define _LESENSE_STATUS_DACACTIVE_SHIFT                5                                          /**< Shift value for LESENSE_DACACTIVE */
+#define _LESENSE_STATUS_DACACTIVE_MASK                 0x20UL                                     /**< Bit mask for LESENSE_DACACTIVE */
+#define _LESENSE_STATUS_DACACTIVE_DEFAULT              0x00000000UL                               /**< Mode DEFAULT for LESENSE_STATUS */
+#define LESENSE_STATUS_DACACTIVE_DEFAULT               (_LESENSE_STATUS_DACACTIVE_DEFAULT << 5)   /**< Shifted mode DEFAULT for LESENSE_STATUS */
+
+/* Bit fields for LESENSE PTR */
+#define _LESENSE_PTR_RESETVALUE                        0x00000000UL                   /**< Default value for LESENSE_PTR */
+#define _LESENSE_PTR_MASK                              0x000001EFUL                   /**< Mask for LESENSE_PTR */
+#define _LESENSE_PTR_RD_SHIFT                          0                              /**< Shift value for LESENSE_RD */
+#define _LESENSE_PTR_RD_MASK                           0xFUL                          /**< Bit mask for LESENSE_RD */
+#define _LESENSE_PTR_RD_DEFAULT                        0x00000000UL                   /**< Mode DEFAULT for LESENSE_PTR */
+#define LESENSE_PTR_RD_DEFAULT                         (_LESENSE_PTR_RD_DEFAULT << 0) /**< Shifted mode DEFAULT for LESENSE_PTR */
+#define _LESENSE_PTR_WR_SHIFT                          5                              /**< Shift value for LESENSE_WR */
+#define _LESENSE_PTR_WR_MASK                           0x1E0UL                        /**< Bit mask for LESENSE_WR */
+#define _LESENSE_PTR_WR_DEFAULT                        0x00000000UL                   /**< Mode DEFAULT for LESENSE_PTR */
+#define LESENSE_PTR_WR_DEFAULT                         (_LESENSE_PTR_WR_DEFAULT << 5) /**< Shifted mode DEFAULT for LESENSE_PTR */
+
+/* Bit fields for LESENSE BUFDATA */
+#define _LESENSE_BUFDATA_RESETVALUE                    0x00000000UL                            /**< Default value for LESENSE_BUFDATA */
+#define _LESENSE_BUFDATA_MASK                          0x0000FFFFUL                            /**< Mask for LESENSE_BUFDATA */
+#define _LESENSE_BUFDATA_BUFDATA_SHIFT                 0                                       /**< Shift value for LESENSE_BUFDATA */
+#define _LESENSE_BUFDATA_BUFDATA_MASK                  0xFFFFUL                                /**< Bit mask for LESENSE_BUFDATA */
+#define _LESENSE_BUFDATA_BUFDATA_DEFAULT               0x00000000UL                            /**< Mode DEFAULT for LESENSE_BUFDATA */
+#define LESENSE_BUFDATA_BUFDATA_DEFAULT                (_LESENSE_BUFDATA_BUFDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for LESENSE_BUFDATA */
+
+/* Bit fields for LESENSE CURCH */
+#define _LESENSE_CURCH_RESETVALUE                      0x00000000UL                        /**< Default value for LESENSE_CURCH */
+#define _LESENSE_CURCH_MASK                            0x0000000FUL                        /**< Mask for LESENSE_CURCH */
+#define _LESENSE_CURCH_CURCH_SHIFT                     0                                   /**< Shift value for LESENSE_CURCH */
+#define _LESENSE_CURCH_CURCH_MASK                      0xFUL                               /**< Bit mask for LESENSE_CURCH */
+#define _LESENSE_CURCH_CURCH_DEFAULT                   0x00000000UL                        /**< Mode DEFAULT for LESENSE_CURCH */
+#define LESENSE_CURCH_CURCH_DEFAULT                    (_LESENSE_CURCH_CURCH_DEFAULT << 0) /**< Shifted mode DEFAULT for LESENSE_CURCH */
+
+/* Bit fields for LESENSE DECSTATE */
+#define _LESENSE_DECSTATE_RESETVALUE                   0x00000000UL                              /**< Default value for LESENSE_DECSTATE */
+#define _LESENSE_DECSTATE_MASK                         0x0000000FUL                              /**< Mask for LESENSE_DECSTATE */
+#define _LESENSE_DECSTATE_DECSTATE_SHIFT               0                                         /**< Shift value for LESENSE_DECSTATE */
+#define _LESENSE_DECSTATE_DECSTATE_MASK                0xFUL                                     /**< Bit mask for LESENSE_DECSTATE */
+#define _LESENSE_DECSTATE_DECSTATE_DEFAULT             0x00000000UL                              /**< Mode DEFAULT for LESENSE_DECSTATE */
+#define LESENSE_DECSTATE_DECSTATE_DEFAULT              (_LESENSE_DECSTATE_DECSTATE_DEFAULT << 0) /**< Shifted mode DEFAULT for LESENSE_DECSTATE */
+
+/* Bit fields for LESENSE SENSORSTATE */
+#define _LESENSE_SENSORSTATE_RESETVALUE                0x00000000UL                                    /**< Default value for LESENSE_SENSORSTATE */
+#define _LESENSE_SENSORSTATE_MASK                      0x0000000FUL                                    /**< Mask for LESENSE_SENSORSTATE */
+#define _LESENSE_SENSORSTATE_SENSORSTATE_SHIFT         0                                               /**< Shift value for LESENSE_SENSORSTATE */
+#define _LESENSE_SENSORSTATE_SENSORSTATE_MASK          0xFUL                                           /**< Bit mask for LESENSE_SENSORSTATE */
+#define _LESENSE_SENSORSTATE_SENSORSTATE_DEFAULT       0x00000000UL                                    /**< Mode DEFAULT for LESENSE_SENSORSTATE */
+#define LESENSE_SENSORSTATE_SENSORSTATE_DEFAULT        (_LESENSE_SENSORSTATE_SENSORSTATE_DEFAULT << 0) /**< Shifted mode DEFAULT for LESENSE_SENSORSTATE */
+
+/* Bit fields for LESENSE IDLECONF */
+#define _LESENSE_IDLECONF_RESETVALUE                   0x00000000UL                           /**< Default value for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_MASK                         0xFFFFFFFFUL                           /**< Mask for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH0_SHIFT                    0                                      /**< Shift value for LESENSE_CH0 */
+#define _LESENSE_IDLECONF_CH0_MASK                     0x3UL                                  /**< Bit mask for LESENSE_CH0 */
+#define _LESENSE_IDLECONF_CH0_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH0_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH0_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH0_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH0_DACCH0                   0x00000003UL                           /**< Mode DACCH0 for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH0_DEFAULT                   (_LESENSE_IDLECONF_CH0_DEFAULT << 0)   /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH0_DISABLE                   (_LESENSE_IDLECONF_CH0_DISABLE << 0)   /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH0_HIGH                      (_LESENSE_IDLECONF_CH0_HIGH << 0)      /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH0_LOW                       (_LESENSE_IDLECONF_CH0_LOW << 0)       /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH0_DACCH0                    (_LESENSE_IDLECONF_CH0_DACCH0 << 0)    /**< Shifted mode DACCH0 for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH1_SHIFT                    2                                      /**< Shift value for LESENSE_CH1 */
+#define _LESENSE_IDLECONF_CH1_MASK                     0xCUL                                  /**< Bit mask for LESENSE_CH1 */
+#define _LESENSE_IDLECONF_CH1_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH1_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH1_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH1_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH1_DACCH0                   0x00000003UL                           /**< Mode DACCH0 for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH1_DEFAULT                   (_LESENSE_IDLECONF_CH1_DEFAULT << 2)   /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH1_DISABLE                   (_LESENSE_IDLECONF_CH1_DISABLE << 2)   /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH1_HIGH                      (_LESENSE_IDLECONF_CH1_HIGH << 2)      /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH1_LOW                       (_LESENSE_IDLECONF_CH1_LOW << 2)       /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH1_DACCH0                    (_LESENSE_IDLECONF_CH1_DACCH0 << 2)    /**< Shifted mode DACCH0 for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH2_SHIFT                    4                                      /**< Shift value for LESENSE_CH2 */
+#define _LESENSE_IDLECONF_CH2_MASK                     0x30UL                                 /**< Bit mask for LESENSE_CH2 */
+#define _LESENSE_IDLECONF_CH2_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH2_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH2_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH2_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH2_DACCH0                   0x00000003UL                           /**< Mode DACCH0 for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH2_DEFAULT                   (_LESENSE_IDLECONF_CH2_DEFAULT << 4)   /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH2_DISABLE                   (_LESENSE_IDLECONF_CH2_DISABLE << 4)   /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH2_HIGH                      (_LESENSE_IDLECONF_CH2_HIGH << 4)      /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH2_LOW                       (_LESENSE_IDLECONF_CH2_LOW << 4)       /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH2_DACCH0                    (_LESENSE_IDLECONF_CH2_DACCH0 << 4)    /**< Shifted mode DACCH0 for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH3_SHIFT                    6                                      /**< Shift value for LESENSE_CH3 */
+#define _LESENSE_IDLECONF_CH3_MASK                     0xC0UL                                 /**< Bit mask for LESENSE_CH3 */
+#define _LESENSE_IDLECONF_CH3_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH3_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH3_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH3_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH3_DACCH0                   0x00000003UL                           /**< Mode DACCH0 for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH3_DEFAULT                   (_LESENSE_IDLECONF_CH3_DEFAULT << 6)   /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH3_DISABLE                   (_LESENSE_IDLECONF_CH3_DISABLE << 6)   /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH3_HIGH                      (_LESENSE_IDLECONF_CH3_HIGH << 6)      /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH3_LOW                       (_LESENSE_IDLECONF_CH3_LOW << 6)       /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH3_DACCH0                    (_LESENSE_IDLECONF_CH3_DACCH0 << 6)    /**< Shifted mode DACCH0 for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH4_SHIFT                    8                                      /**< Shift value for LESENSE_CH4 */
+#define _LESENSE_IDLECONF_CH4_MASK                     0x300UL                                /**< Bit mask for LESENSE_CH4 */
+#define _LESENSE_IDLECONF_CH4_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH4_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH4_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH4_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH4_DEFAULT                   (_LESENSE_IDLECONF_CH4_DEFAULT << 8)   /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH4_DISABLE                   (_LESENSE_IDLECONF_CH4_DISABLE << 8)   /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH4_HIGH                      (_LESENSE_IDLECONF_CH4_HIGH << 8)      /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH4_LOW                       (_LESENSE_IDLECONF_CH4_LOW << 8)       /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH5_SHIFT                    10                                     /**< Shift value for LESENSE_CH5 */
+#define _LESENSE_IDLECONF_CH5_MASK                     0xC00UL                                /**< Bit mask for LESENSE_CH5 */
+#define _LESENSE_IDLECONF_CH5_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH5_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH5_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH5_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH5_DEFAULT                   (_LESENSE_IDLECONF_CH5_DEFAULT << 10)  /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH5_DISABLE                   (_LESENSE_IDLECONF_CH5_DISABLE << 10)  /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH5_HIGH                      (_LESENSE_IDLECONF_CH5_HIGH << 10)     /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH5_LOW                       (_LESENSE_IDLECONF_CH5_LOW << 10)      /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH6_SHIFT                    12                                     /**< Shift value for LESENSE_CH6 */
+#define _LESENSE_IDLECONF_CH6_MASK                     0x3000UL                               /**< Bit mask for LESENSE_CH6 */
+#define _LESENSE_IDLECONF_CH6_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH6_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH6_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH6_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH6_DEFAULT                   (_LESENSE_IDLECONF_CH6_DEFAULT << 12)  /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH6_DISABLE                   (_LESENSE_IDLECONF_CH6_DISABLE << 12)  /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH6_HIGH                      (_LESENSE_IDLECONF_CH6_HIGH << 12)     /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH6_LOW                       (_LESENSE_IDLECONF_CH6_LOW << 12)      /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH7_SHIFT                    14                                     /**< Shift value for LESENSE_CH7 */
+#define _LESENSE_IDLECONF_CH7_MASK                     0xC000UL                               /**< Bit mask for LESENSE_CH7 */
+#define _LESENSE_IDLECONF_CH7_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH7_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH7_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH7_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH7_DEFAULT                   (_LESENSE_IDLECONF_CH7_DEFAULT << 14)  /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH7_DISABLE                   (_LESENSE_IDLECONF_CH7_DISABLE << 14)  /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH7_HIGH                      (_LESENSE_IDLECONF_CH7_HIGH << 14)     /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH7_LOW                       (_LESENSE_IDLECONF_CH7_LOW << 14)      /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH8_SHIFT                    16                                     /**< Shift value for LESENSE_CH8 */
+#define _LESENSE_IDLECONF_CH8_MASK                     0x30000UL                              /**< Bit mask for LESENSE_CH8 */
+#define _LESENSE_IDLECONF_CH8_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH8_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH8_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH8_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH8_DEFAULT                   (_LESENSE_IDLECONF_CH8_DEFAULT << 16)  /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH8_DISABLE                   (_LESENSE_IDLECONF_CH8_DISABLE << 16)  /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH8_HIGH                      (_LESENSE_IDLECONF_CH8_HIGH << 16)     /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH8_LOW                       (_LESENSE_IDLECONF_CH8_LOW << 16)      /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH9_SHIFT                    18                                     /**< Shift value for LESENSE_CH9 */
+#define _LESENSE_IDLECONF_CH9_MASK                     0xC0000UL                              /**< Bit mask for LESENSE_CH9 */
+#define _LESENSE_IDLECONF_CH9_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH9_DISABLE                  0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH9_HIGH                     0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH9_LOW                      0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH9_DEFAULT                   (_LESENSE_IDLECONF_CH9_DEFAULT << 18)  /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH9_DISABLE                   (_LESENSE_IDLECONF_CH9_DISABLE << 18)  /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH9_HIGH                      (_LESENSE_IDLECONF_CH9_HIGH << 18)     /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH9_LOW                       (_LESENSE_IDLECONF_CH9_LOW << 18)      /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH10_SHIFT                   20                                     /**< Shift value for LESENSE_CH10 */
+#define _LESENSE_IDLECONF_CH10_MASK                    0x300000UL                             /**< Bit mask for LESENSE_CH10 */
+#define _LESENSE_IDLECONF_CH10_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH10_DISABLE                 0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH10_HIGH                    0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH10_LOW                     0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH10_DEFAULT                  (_LESENSE_IDLECONF_CH10_DEFAULT << 20) /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH10_DISABLE                  (_LESENSE_IDLECONF_CH10_DISABLE << 20) /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH10_HIGH                     (_LESENSE_IDLECONF_CH10_HIGH << 20)    /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH10_LOW                      (_LESENSE_IDLECONF_CH10_LOW << 20)     /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH11_SHIFT                   22                                     /**< Shift value for LESENSE_CH11 */
+#define _LESENSE_IDLECONF_CH11_MASK                    0xC00000UL                             /**< Bit mask for LESENSE_CH11 */
+#define _LESENSE_IDLECONF_CH11_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH11_DISABLE                 0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH11_HIGH                    0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH11_LOW                     0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH11_DEFAULT                  (_LESENSE_IDLECONF_CH11_DEFAULT << 22) /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH11_DISABLE                  (_LESENSE_IDLECONF_CH11_DISABLE << 22) /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH11_HIGH                     (_LESENSE_IDLECONF_CH11_HIGH << 22)    /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH11_LOW                      (_LESENSE_IDLECONF_CH11_LOW << 22)     /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH12_SHIFT                   24                                     /**< Shift value for LESENSE_CH12 */
+#define _LESENSE_IDLECONF_CH12_MASK                    0x3000000UL                            /**< Bit mask for LESENSE_CH12 */
+#define _LESENSE_IDLECONF_CH12_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH12_DISABLE                 0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH12_HIGH                    0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH12_LOW                     0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH12_DACCH1                  0x00000003UL                           /**< Mode DACCH1 for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH12_DEFAULT                  (_LESENSE_IDLECONF_CH12_DEFAULT << 24) /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH12_DISABLE                  (_LESENSE_IDLECONF_CH12_DISABLE << 24) /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH12_HIGH                     (_LESENSE_IDLECONF_CH12_HIGH << 24)    /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH12_LOW                      (_LESENSE_IDLECONF_CH12_LOW << 24)     /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH12_DACCH1                   (_LESENSE_IDLECONF_CH12_DACCH1 << 24)  /**< Shifted mode DACCH1 for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH13_SHIFT                   26                                     /**< Shift value for LESENSE_CH13 */
+#define _LESENSE_IDLECONF_CH13_MASK                    0xC000000UL                            /**< Bit mask for LESENSE_CH13 */
+#define _LESENSE_IDLECONF_CH13_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH13_DISABLE                 0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH13_HIGH                    0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH13_LOW                     0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH13_DACCH1                  0x00000003UL                           /**< Mode DACCH1 for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH13_DEFAULT                  (_LESENSE_IDLECONF_CH13_DEFAULT << 26) /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH13_DISABLE                  (_LESENSE_IDLECONF_CH13_DISABLE << 26) /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH13_HIGH                     (_LESENSE_IDLECONF_CH13_HIGH << 26)    /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH13_LOW                      (_LESENSE_IDLECONF_CH13_LOW << 26)     /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH13_DACCH1                   (_LESENSE_IDLECONF_CH13_DACCH1 << 26)  /**< Shifted mode DACCH1 for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH14_SHIFT                   28                                     /**< Shift value for LESENSE_CH14 */
+#define _LESENSE_IDLECONF_CH14_MASK                    0x30000000UL                           /**< Bit mask for LESENSE_CH14 */
+#define _LESENSE_IDLECONF_CH14_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH14_DISABLE                 0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH14_HIGH                    0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH14_LOW                     0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH14_DACCH1                  0x00000003UL                           /**< Mode DACCH1 for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH14_DEFAULT                  (_LESENSE_IDLECONF_CH14_DEFAULT << 28) /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH14_DISABLE                  (_LESENSE_IDLECONF_CH14_DISABLE << 28) /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH14_HIGH                     (_LESENSE_IDLECONF_CH14_HIGH << 28)    /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH14_LOW                      (_LESENSE_IDLECONF_CH14_LOW << 28)     /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH14_DACCH1                   (_LESENSE_IDLECONF_CH14_DACCH1 << 28)  /**< Shifted mode DACCH1 for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH15_SHIFT                   30                                     /**< Shift value for LESENSE_CH15 */
+#define _LESENSE_IDLECONF_CH15_MASK                    0xC0000000UL                           /**< Bit mask for LESENSE_CH15 */
+#define _LESENSE_IDLECONF_CH15_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH15_DISABLE                 0x00000000UL                           /**< Mode DISABLE for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH15_HIGH                    0x00000001UL                           /**< Mode HIGH for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH15_LOW                     0x00000002UL                           /**< Mode LOW for LESENSE_IDLECONF */
+#define _LESENSE_IDLECONF_CH15_DACCH1                  0x00000003UL                           /**< Mode DACCH1 for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH15_DEFAULT                  (_LESENSE_IDLECONF_CH15_DEFAULT << 30) /**< Shifted mode DEFAULT for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH15_DISABLE                  (_LESENSE_IDLECONF_CH15_DISABLE << 30) /**< Shifted mode DISABLE for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH15_HIGH                     (_LESENSE_IDLECONF_CH15_HIGH << 30)    /**< Shifted mode HIGH for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH15_LOW                      (_LESENSE_IDLECONF_CH15_LOW << 30)     /**< Shifted mode LOW for LESENSE_IDLECONF */
+#define LESENSE_IDLECONF_CH15_DACCH1                   (_LESENSE_IDLECONF_CH15_DACCH1 << 30)  /**< Shifted mode DACCH1 for LESENSE_IDLECONF */
+
+/* Bit fields for LESENSE ALTEXCONF */
+#define _LESENSE_ALTEXCONF_RESETVALUE                  0x00000000UL                                 /**< Default value for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_MASK                        0x00FFFFFFUL                                 /**< Mask for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF0_SHIFT             0                                            /**< Shift value for LESENSE_IDLECONF0 */
+#define _LESENSE_ALTEXCONF_IDLECONF0_MASK              0x3UL                                        /**< Bit mask for LESENSE_IDLECONF0 */
+#define _LESENSE_ALTEXCONF_IDLECONF0_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF0_DISABLE           0x00000000UL                                 /**< Mode DISABLE for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF0_HIGH              0x00000001UL                                 /**< Mode HIGH for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF0_LOW               0x00000002UL                                 /**< Mode LOW for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF0_DEFAULT            (_LESENSE_ALTEXCONF_IDLECONF0_DEFAULT << 0)  /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF0_DISABLE            (_LESENSE_ALTEXCONF_IDLECONF0_DISABLE << 0)  /**< Shifted mode DISABLE for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF0_HIGH               (_LESENSE_ALTEXCONF_IDLECONF0_HIGH << 0)     /**< Shifted mode HIGH for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF0_LOW                (_LESENSE_ALTEXCONF_IDLECONF0_LOW << 0)      /**< Shifted mode LOW for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF1_SHIFT             2                                            /**< Shift value for LESENSE_IDLECONF1 */
+#define _LESENSE_ALTEXCONF_IDLECONF1_MASK              0xCUL                                        /**< Bit mask for LESENSE_IDLECONF1 */
+#define _LESENSE_ALTEXCONF_IDLECONF1_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF1_DISABLE           0x00000000UL                                 /**< Mode DISABLE for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF1_HIGH              0x00000001UL                                 /**< Mode HIGH for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF1_LOW               0x00000002UL                                 /**< Mode LOW for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF1_DEFAULT            (_LESENSE_ALTEXCONF_IDLECONF1_DEFAULT << 2)  /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF1_DISABLE            (_LESENSE_ALTEXCONF_IDLECONF1_DISABLE << 2)  /**< Shifted mode DISABLE for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF1_HIGH               (_LESENSE_ALTEXCONF_IDLECONF1_HIGH << 2)     /**< Shifted mode HIGH for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF1_LOW                (_LESENSE_ALTEXCONF_IDLECONF1_LOW << 2)      /**< Shifted mode LOW for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF2_SHIFT             4                                            /**< Shift value for LESENSE_IDLECONF2 */
+#define _LESENSE_ALTEXCONF_IDLECONF2_MASK              0x30UL                                       /**< Bit mask for LESENSE_IDLECONF2 */
+#define _LESENSE_ALTEXCONF_IDLECONF2_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF2_DISABLE           0x00000000UL                                 /**< Mode DISABLE for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF2_HIGH              0x00000001UL                                 /**< Mode HIGH for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF2_LOW               0x00000002UL                                 /**< Mode LOW for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF2_DEFAULT            (_LESENSE_ALTEXCONF_IDLECONF2_DEFAULT << 4)  /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF2_DISABLE            (_LESENSE_ALTEXCONF_IDLECONF2_DISABLE << 4)  /**< Shifted mode DISABLE for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF2_HIGH               (_LESENSE_ALTEXCONF_IDLECONF2_HIGH << 4)     /**< Shifted mode HIGH for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF2_LOW                (_LESENSE_ALTEXCONF_IDLECONF2_LOW << 4)      /**< Shifted mode LOW for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF3_SHIFT             6                                            /**< Shift value for LESENSE_IDLECONF3 */
+#define _LESENSE_ALTEXCONF_IDLECONF3_MASK              0xC0UL                                       /**< Bit mask for LESENSE_IDLECONF3 */
+#define _LESENSE_ALTEXCONF_IDLECONF3_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF3_DISABLE           0x00000000UL                                 /**< Mode DISABLE for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF3_HIGH              0x00000001UL                                 /**< Mode HIGH for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF3_LOW               0x00000002UL                                 /**< Mode LOW for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF3_DEFAULT            (_LESENSE_ALTEXCONF_IDLECONF3_DEFAULT << 6)  /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF3_DISABLE            (_LESENSE_ALTEXCONF_IDLECONF3_DISABLE << 6)  /**< Shifted mode DISABLE for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF3_HIGH               (_LESENSE_ALTEXCONF_IDLECONF3_HIGH << 6)     /**< Shifted mode HIGH for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF3_LOW                (_LESENSE_ALTEXCONF_IDLECONF3_LOW << 6)      /**< Shifted mode LOW for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF4_SHIFT             8                                            /**< Shift value for LESENSE_IDLECONF4 */
+#define _LESENSE_ALTEXCONF_IDLECONF4_MASK              0x300UL                                      /**< Bit mask for LESENSE_IDLECONF4 */
+#define _LESENSE_ALTEXCONF_IDLECONF4_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF4_DISABLE           0x00000000UL                                 /**< Mode DISABLE for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF4_HIGH              0x00000001UL                                 /**< Mode HIGH for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF4_LOW               0x00000002UL                                 /**< Mode LOW for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF4_DEFAULT            (_LESENSE_ALTEXCONF_IDLECONF4_DEFAULT << 8)  /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF4_DISABLE            (_LESENSE_ALTEXCONF_IDLECONF4_DISABLE << 8)  /**< Shifted mode DISABLE for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF4_HIGH               (_LESENSE_ALTEXCONF_IDLECONF4_HIGH << 8)     /**< Shifted mode HIGH for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF4_LOW                (_LESENSE_ALTEXCONF_IDLECONF4_LOW << 8)      /**< Shifted mode LOW for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF5_SHIFT             10                                           /**< Shift value for LESENSE_IDLECONF5 */
+#define _LESENSE_ALTEXCONF_IDLECONF5_MASK              0xC00UL                                      /**< Bit mask for LESENSE_IDLECONF5 */
+#define _LESENSE_ALTEXCONF_IDLECONF5_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF5_DISABLE           0x00000000UL                                 /**< Mode DISABLE for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF5_HIGH              0x00000001UL                                 /**< Mode HIGH for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF5_LOW               0x00000002UL                                 /**< Mode LOW for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF5_DEFAULT            (_LESENSE_ALTEXCONF_IDLECONF5_DEFAULT << 10) /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF5_DISABLE            (_LESENSE_ALTEXCONF_IDLECONF5_DISABLE << 10) /**< Shifted mode DISABLE for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF5_HIGH               (_LESENSE_ALTEXCONF_IDLECONF5_HIGH << 10)    /**< Shifted mode HIGH for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF5_LOW                (_LESENSE_ALTEXCONF_IDLECONF5_LOW << 10)     /**< Shifted mode LOW for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF6_SHIFT             12                                           /**< Shift value for LESENSE_IDLECONF6 */
+#define _LESENSE_ALTEXCONF_IDLECONF6_MASK              0x3000UL                                     /**< Bit mask for LESENSE_IDLECONF6 */
+#define _LESENSE_ALTEXCONF_IDLECONF6_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF6_DISABLE           0x00000000UL                                 /**< Mode DISABLE for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF6_HIGH              0x00000001UL                                 /**< Mode HIGH for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF6_LOW               0x00000002UL                                 /**< Mode LOW for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF6_DEFAULT            (_LESENSE_ALTEXCONF_IDLECONF6_DEFAULT << 12) /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF6_DISABLE            (_LESENSE_ALTEXCONF_IDLECONF6_DISABLE << 12) /**< Shifted mode DISABLE for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF6_HIGH               (_LESENSE_ALTEXCONF_IDLECONF6_HIGH << 12)    /**< Shifted mode HIGH for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF6_LOW                (_LESENSE_ALTEXCONF_IDLECONF6_LOW << 12)     /**< Shifted mode LOW for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF7_SHIFT             14                                           /**< Shift value for LESENSE_IDLECONF7 */
+#define _LESENSE_ALTEXCONF_IDLECONF7_MASK              0xC000UL                                     /**< Bit mask for LESENSE_IDLECONF7 */
+#define _LESENSE_ALTEXCONF_IDLECONF7_DEFAULT           0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF7_DISABLE           0x00000000UL                                 /**< Mode DISABLE for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF7_HIGH              0x00000001UL                                 /**< Mode HIGH for LESENSE_ALTEXCONF */
+#define _LESENSE_ALTEXCONF_IDLECONF7_LOW               0x00000002UL                                 /**< Mode LOW for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF7_DEFAULT            (_LESENSE_ALTEXCONF_IDLECONF7_DEFAULT << 14) /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF7_DISABLE            (_LESENSE_ALTEXCONF_IDLECONF7_DISABLE << 14) /**< Shifted mode DISABLE for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF7_HIGH               (_LESENSE_ALTEXCONF_IDLECONF7_HIGH << 14)    /**< Shifted mode HIGH for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_IDLECONF7_LOW                (_LESENSE_ALTEXCONF_IDLECONF7_LOW << 14)     /**< Shifted mode LOW for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX0                         (0x1UL << 16)                                /**< ALTEX0 always excite enable */
+#define _LESENSE_ALTEXCONF_AEX0_SHIFT                  16                                           /**< Shift value for LESENSE_AEX0 */
+#define _LESENSE_ALTEXCONF_AEX0_MASK                   0x10000UL                                    /**< Bit mask for LESENSE_AEX0 */
+#define _LESENSE_ALTEXCONF_AEX0_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX0_DEFAULT                 (_LESENSE_ALTEXCONF_AEX0_DEFAULT << 16)      /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX1                         (0x1UL << 17)                                /**< ALTEX1 always excite enable */
+#define _LESENSE_ALTEXCONF_AEX1_SHIFT                  17                                           /**< Shift value for LESENSE_AEX1 */
+#define _LESENSE_ALTEXCONF_AEX1_MASK                   0x20000UL                                    /**< Bit mask for LESENSE_AEX1 */
+#define _LESENSE_ALTEXCONF_AEX1_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX1_DEFAULT                 (_LESENSE_ALTEXCONF_AEX1_DEFAULT << 17)      /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX2                         (0x1UL << 18)                                /**< ALTEX2 always excite enable */
+#define _LESENSE_ALTEXCONF_AEX2_SHIFT                  18                                           /**< Shift value for LESENSE_AEX2 */
+#define _LESENSE_ALTEXCONF_AEX2_MASK                   0x40000UL                                    /**< Bit mask for LESENSE_AEX2 */
+#define _LESENSE_ALTEXCONF_AEX2_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX2_DEFAULT                 (_LESENSE_ALTEXCONF_AEX2_DEFAULT << 18)      /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX3                         (0x1UL << 19)                                /**< ALTEX3 always excite enable */
+#define _LESENSE_ALTEXCONF_AEX3_SHIFT                  19                                           /**< Shift value for LESENSE_AEX3 */
+#define _LESENSE_ALTEXCONF_AEX3_MASK                   0x80000UL                                    /**< Bit mask for LESENSE_AEX3 */
+#define _LESENSE_ALTEXCONF_AEX3_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX3_DEFAULT                 (_LESENSE_ALTEXCONF_AEX3_DEFAULT << 19)      /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX4                         (0x1UL << 20)                                /**< ALTEX4 always excite enable */
+#define _LESENSE_ALTEXCONF_AEX4_SHIFT                  20                                           /**< Shift value for LESENSE_AEX4 */
+#define _LESENSE_ALTEXCONF_AEX4_MASK                   0x100000UL                                   /**< Bit mask for LESENSE_AEX4 */
+#define _LESENSE_ALTEXCONF_AEX4_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX4_DEFAULT                 (_LESENSE_ALTEXCONF_AEX4_DEFAULT << 20)      /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX5                         (0x1UL << 21)                                /**< ALTEX5 always excite enable */
+#define _LESENSE_ALTEXCONF_AEX5_SHIFT                  21                                           /**< Shift value for LESENSE_AEX5 */
+#define _LESENSE_ALTEXCONF_AEX5_MASK                   0x200000UL                                   /**< Bit mask for LESENSE_AEX5 */
+#define _LESENSE_ALTEXCONF_AEX5_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX5_DEFAULT                 (_LESENSE_ALTEXCONF_AEX5_DEFAULT << 21)      /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX6                         (0x1UL << 22)                                /**< ALTEX6 always excite enable */
+#define _LESENSE_ALTEXCONF_AEX6_SHIFT                  22                                           /**< Shift value for LESENSE_AEX6 */
+#define _LESENSE_ALTEXCONF_AEX6_MASK                   0x400000UL                                   /**< Bit mask for LESENSE_AEX6 */
+#define _LESENSE_ALTEXCONF_AEX6_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX6_DEFAULT                 (_LESENSE_ALTEXCONF_AEX6_DEFAULT << 22)      /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX7                         (0x1UL << 23)                                /**< ALTEX7 always excite enable */
+#define _LESENSE_ALTEXCONF_AEX7_SHIFT                  23                                           /**< Shift value for LESENSE_AEX7 */
+#define _LESENSE_ALTEXCONF_AEX7_MASK                   0x800000UL                                   /**< Bit mask for LESENSE_AEX7 */
+#define _LESENSE_ALTEXCONF_AEX7_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for LESENSE_ALTEXCONF */
+#define LESENSE_ALTEXCONF_AEX7_DEFAULT                 (_LESENSE_ALTEXCONF_AEX7_DEFAULT << 23)      /**< Shifted mode DEFAULT for LESENSE_ALTEXCONF */
+
+/* Bit fields for LESENSE IF */
+#define _LESENSE_IF_RESETVALUE                         0x00000000UL                             /**< Default value for LESENSE_IF */
+#define _LESENSE_IF_MASK                               0x007FFFFFUL                             /**< Mask for LESENSE_IF */
+#define LESENSE_IF_CH0                                 (0x1UL << 0)                             /**<  */
+#define _LESENSE_IF_CH0_SHIFT                          0                                        /**< Shift value for LESENSE_CH0 */
+#define _LESENSE_IF_CH0_MASK                           0x1UL                                    /**< Bit mask for LESENSE_CH0 */
+#define _LESENSE_IF_CH0_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH0_DEFAULT                         (_LESENSE_IF_CH0_DEFAULT << 0)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH1                                 (0x1UL << 1)                             /**<  */
+#define _LESENSE_IF_CH1_SHIFT                          1                                        /**< Shift value for LESENSE_CH1 */
+#define _LESENSE_IF_CH1_MASK                           0x2UL                                    /**< Bit mask for LESENSE_CH1 */
+#define _LESENSE_IF_CH1_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH1_DEFAULT                         (_LESENSE_IF_CH1_DEFAULT << 1)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH2                                 (0x1UL << 2)                             /**<  */
+#define _LESENSE_IF_CH2_SHIFT                          2                                        /**< Shift value for LESENSE_CH2 */
+#define _LESENSE_IF_CH2_MASK                           0x4UL                                    /**< Bit mask for LESENSE_CH2 */
+#define _LESENSE_IF_CH2_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH2_DEFAULT                         (_LESENSE_IF_CH2_DEFAULT << 2)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH3                                 (0x1UL << 3)                             /**<  */
+#define _LESENSE_IF_CH3_SHIFT                          3                                        /**< Shift value for LESENSE_CH3 */
+#define _LESENSE_IF_CH3_MASK                           0x8UL                                    /**< Bit mask for LESENSE_CH3 */
+#define _LESENSE_IF_CH3_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH3_DEFAULT                         (_LESENSE_IF_CH3_DEFAULT << 3)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH4                                 (0x1UL << 4)                             /**<  */
+#define _LESENSE_IF_CH4_SHIFT                          4                                        /**< Shift value for LESENSE_CH4 */
+#define _LESENSE_IF_CH4_MASK                           0x10UL                                   /**< Bit mask for LESENSE_CH4 */
+#define _LESENSE_IF_CH4_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH4_DEFAULT                         (_LESENSE_IF_CH4_DEFAULT << 4)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH5                                 (0x1UL << 5)                             /**<  */
+#define _LESENSE_IF_CH5_SHIFT                          5                                        /**< Shift value for LESENSE_CH5 */
+#define _LESENSE_IF_CH5_MASK                           0x20UL                                   /**< Bit mask for LESENSE_CH5 */
+#define _LESENSE_IF_CH5_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH5_DEFAULT                         (_LESENSE_IF_CH5_DEFAULT << 5)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH6                                 (0x1UL << 6)                             /**<  */
+#define _LESENSE_IF_CH6_SHIFT                          6                                        /**< Shift value for LESENSE_CH6 */
+#define _LESENSE_IF_CH6_MASK                           0x40UL                                   /**< Bit mask for LESENSE_CH6 */
+#define _LESENSE_IF_CH6_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH6_DEFAULT                         (_LESENSE_IF_CH6_DEFAULT << 6)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH7                                 (0x1UL << 7)                             /**<  */
+#define _LESENSE_IF_CH7_SHIFT                          7                                        /**< Shift value for LESENSE_CH7 */
+#define _LESENSE_IF_CH7_MASK                           0x80UL                                   /**< Bit mask for LESENSE_CH7 */
+#define _LESENSE_IF_CH7_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH7_DEFAULT                         (_LESENSE_IF_CH7_DEFAULT << 7)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH8                                 (0x1UL << 8)                             /**<  */
+#define _LESENSE_IF_CH8_SHIFT                          8                                        /**< Shift value for LESENSE_CH8 */
+#define _LESENSE_IF_CH8_MASK                           0x100UL                                  /**< Bit mask for LESENSE_CH8 */
+#define _LESENSE_IF_CH8_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH8_DEFAULT                         (_LESENSE_IF_CH8_DEFAULT << 8)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH9                                 (0x1UL << 9)                             /**<  */
+#define _LESENSE_IF_CH9_SHIFT                          9                                        /**< Shift value for LESENSE_CH9 */
+#define _LESENSE_IF_CH9_MASK                           0x200UL                                  /**< Bit mask for LESENSE_CH9 */
+#define _LESENSE_IF_CH9_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH9_DEFAULT                         (_LESENSE_IF_CH9_DEFAULT << 9)           /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH10                                (0x1UL << 10)                            /**<  */
+#define _LESENSE_IF_CH10_SHIFT                         10                                       /**< Shift value for LESENSE_CH10 */
+#define _LESENSE_IF_CH10_MASK                          0x400UL                                  /**< Bit mask for LESENSE_CH10 */
+#define _LESENSE_IF_CH10_DEFAULT                       0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH10_DEFAULT                        (_LESENSE_IF_CH10_DEFAULT << 10)         /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH11                                (0x1UL << 11)                            /**<  */
+#define _LESENSE_IF_CH11_SHIFT                         11                                       /**< Shift value for LESENSE_CH11 */
+#define _LESENSE_IF_CH11_MASK                          0x800UL                                  /**< Bit mask for LESENSE_CH11 */
+#define _LESENSE_IF_CH11_DEFAULT                       0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH11_DEFAULT                        (_LESENSE_IF_CH11_DEFAULT << 11)         /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH12                                (0x1UL << 12)                            /**<  */
+#define _LESENSE_IF_CH12_SHIFT                         12                                       /**< Shift value for LESENSE_CH12 */
+#define _LESENSE_IF_CH12_MASK                          0x1000UL                                 /**< Bit mask for LESENSE_CH12 */
+#define _LESENSE_IF_CH12_DEFAULT                       0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH12_DEFAULT                        (_LESENSE_IF_CH12_DEFAULT << 12)         /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH13                                (0x1UL << 13)                            /**<  */
+#define _LESENSE_IF_CH13_SHIFT                         13                                       /**< Shift value for LESENSE_CH13 */
+#define _LESENSE_IF_CH13_MASK                          0x2000UL                                 /**< Bit mask for LESENSE_CH13 */
+#define _LESENSE_IF_CH13_DEFAULT                       0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH13_DEFAULT                        (_LESENSE_IF_CH13_DEFAULT << 13)         /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH14                                (0x1UL << 14)                            /**<  */
+#define _LESENSE_IF_CH14_SHIFT                         14                                       /**< Shift value for LESENSE_CH14 */
+#define _LESENSE_IF_CH14_MASK                          0x4000UL                                 /**< Bit mask for LESENSE_CH14 */
+#define _LESENSE_IF_CH14_DEFAULT                       0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH14_DEFAULT                        (_LESENSE_IF_CH14_DEFAULT << 14)         /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH15                                (0x1UL << 15)                            /**<  */
+#define _LESENSE_IF_CH15_SHIFT                         15                                       /**< Shift value for LESENSE_CH15 */
+#define _LESENSE_IF_CH15_MASK                          0x8000UL                                 /**< Bit mask for LESENSE_CH15 */
+#define _LESENSE_IF_CH15_DEFAULT                       0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CH15_DEFAULT                        (_LESENSE_IF_CH15_DEFAULT << 15)         /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_SCANCOMPLETE                        (0x1UL << 16)                            /**<  */
+#define _LESENSE_IF_SCANCOMPLETE_SHIFT                 16                                       /**< Shift value for LESENSE_SCANCOMPLETE */
+#define _LESENSE_IF_SCANCOMPLETE_MASK                  0x10000UL                                /**< Bit mask for LESENSE_SCANCOMPLETE */
+#define _LESENSE_IF_SCANCOMPLETE_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_SCANCOMPLETE_DEFAULT                (_LESENSE_IF_SCANCOMPLETE_DEFAULT << 16) /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_DEC                                 (0x1UL << 17)                            /**<  */
+#define _LESENSE_IF_DEC_SHIFT                          17                                       /**< Shift value for LESENSE_DEC */
+#define _LESENSE_IF_DEC_MASK                           0x20000UL                                /**< Bit mask for LESENSE_DEC */
+#define _LESENSE_IF_DEC_DEFAULT                        0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_DEC_DEFAULT                         (_LESENSE_IF_DEC_DEFAULT << 17)          /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_DECERR                              (0x1UL << 18)                            /**<  */
+#define _LESENSE_IF_DECERR_SHIFT                       18                                       /**< Shift value for LESENSE_DECERR */
+#define _LESENSE_IF_DECERR_MASK                        0x40000UL                                /**< Bit mask for LESENSE_DECERR */
+#define _LESENSE_IF_DECERR_DEFAULT                     0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_DECERR_DEFAULT                      (_LESENSE_IF_DECERR_DEFAULT << 18)       /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_BUFDATAV                            (0x1UL << 19)                            /**<  */
+#define _LESENSE_IF_BUFDATAV_SHIFT                     19                                       /**< Shift value for LESENSE_BUFDATAV */
+#define _LESENSE_IF_BUFDATAV_MASK                      0x80000UL                                /**< Bit mask for LESENSE_BUFDATAV */
+#define _LESENSE_IF_BUFDATAV_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_BUFDATAV_DEFAULT                    (_LESENSE_IF_BUFDATAV_DEFAULT << 19)     /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_BUFLEVEL                            (0x1UL << 20)                            /**<  */
+#define _LESENSE_IF_BUFLEVEL_SHIFT                     20                                       /**< Shift value for LESENSE_BUFLEVEL */
+#define _LESENSE_IF_BUFLEVEL_MASK                      0x100000UL                               /**< Bit mask for LESENSE_BUFLEVEL */
+#define _LESENSE_IF_BUFLEVEL_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_BUFLEVEL_DEFAULT                    (_LESENSE_IF_BUFLEVEL_DEFAULT << 20)     /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_BUFOF                               (0x1UL << 21)                            /**<  */
+#define _LESENSE_IF_BUFOF_SHIFT                        21                                       /**< Shift value for LESENSE_BUFOF */
+#define _LESENSE_IF_BUFOF_MASK                         0x200000UL                               /**< Bit mask for LESENSE_BUFOF */
+#define _LESENSE_IF_BUFOF_DEFAULT                      0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_BUFOF_DEFAULT                       (_LESENSE_IF_BUFOF_DEFAULT << 21)        /**< Shifted mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CNTOF                               (0x1UL << 22)                            /**<  */
+#define _LESENSE_IF_CNTOF_SHIFT                        22                                       /**< Shift value for LESENSE_CNTOF */
+#define _LESENSE_IF_CNTOF_MASK                         0x400000UL                               /**< Bit mask for LESENSE_CNTOF */
+#define _LESENSE_IF_CNTOF_DEFAULT                      0x00000000UL                             /**< Mode DEFAULT for LESENSE_IF */
+#define LESENSE_IF_CNTOF_DEFAULT                       (_LESENSE_IF_CNTOF_DEFAULT << 22)        /**< Shifted mode DEFAULT for LESENSE_IF */
+
+/* Bit fields for LESENSE IFC */
+#define _LESENSE_IFC_RESETVALUE                        0x00000000UL                              /**< Default value for LESENSE_IFC */
+#define _LESENSE_IFC_MASK                              0x007FFFFFUL                              /**< Mask for LESENSE_IFC */
+#define LESENSE_IFC_CH0                                (0x1UL << 0)                              /**<  */
+#define _LESENSE_IFC_CH0_SHIFT                         0                                         /**< Shift value for LESENSE_CH0 */
+#define _LESENSE_IFC_CH0_MASK                          0x1UL                                     /**< Bit mask for LESENSE_CH0 */
+#define _LESENSE_IFC_CH0_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH0_DEFAULT                        (_LESENSE_IFC_CH0_DEFAULT << 0)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH1                                (0x1UL << 1)                              /**<  */
+#define _LESENSE_IFC_CH1_SHIFT                         1                                         /**< Shift value for LESENSE_CH1 */
+#define _LESENSE_IFC_CH1_MASK                          0x2UL                                     /**< Bit mask for LESENSE_CH1 */
+#define _LESENSE_IFC_CH1_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH1_DEFAULT                        (_LESENSE_IFC_CH1_DEFAULT << 1)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH2                                (0x1UL << 2)                              /**<  */
+#define _LESENSE_IFC_CH2_SHIFT                         2                                         /**< Shift value for LESENSE_CH2 */
+#define _LESENSE_IFC_CH2_MASK                          0x4UL                                     /**< Bit mask for LESENSE_CH2 */
+#define _LESENSE_IFC_CH2_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH2_DEFAULT                        (_LESENSE_IFC_CH2_DEFAULT << 2)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH3                                (0x1UL << 3)                              /**<  */
+#define _LESENSE_IFC_CH3_SHIFT                         3                                         /**< Shift value for LESENSE_CH3 */
+#define _LESENSE_IFC_CH3_MASK                          0x8UL                                     /**< Bit mask for LESENSE_CH3 */
+#define _LESENSE_IFC_CH3_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH3_DEFAULT                        (_LESENSE_IFC_CH3_DEFAULT << 3)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH4                                (0x1UL << 4)                              /**<  */
+#define _LESENSE_IFC_CH4_SHIFT                         4                                         /**< Shift value for LESENSE_CH4 */
+#define _LESENSE_IFC_CH4_MASK                          0x10UL                                    /**< Bit mask for LESENSE_CH4 */
+#define _LESENSE_IFC_CH4_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH4_DEFAULT                        (_LESENSE_IFC_CH4_DEFAULT << 4)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH5                                (0x1UL << 5)                              /**<  */
+#define _LESENSE_IFC_CH5_SHIFT                         5                                         /**< Shift value for LESENSE_CH5 */
+#define _LESENSE_IFC_CH5_MASK                          0x20UL                                    /**< Bit mask for LESENSE_CH5 */
+#define _LESENSE_IFC_CH5_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH5_DEFAULT                        (_LESENSE_IFC_CH5_DEFAULT << 5)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH6                                (0x1UL << 6)                              /**<  */
+#define _LESENSE_IFC_CH6_SHIFT                         6                                         /**< Shift value for LESENSE_CH6 */
+#define _LESENSE_IFC_CH6_MASK                          0x40UL                                    /**< Bit mask for LESENSE_CH6 */
+#define _LESENSE_IFC_CH6_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH6_DEFAULT                        (_LESENSE_IFC_CH6_DEFAULT << 6)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH7                                (0x1UL << 7)                              /**<  */
+#define _LESENSE_IFC_CH7_SHIFT                         7                                         /**< Shift value for LESENSE_CH7 */
+#define _LESENSE_IFC_CH7_MASK                          0x80UL                                    /**< Bit mask for LESENSE_CH7 */
+#define _LESENSE_IFC_CH7_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH7_DEFAULT                        (_LESENSE_IFC_CH7_DEFAULT << 7)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH8                                (0x1UL << 8)                              /**<  */
+#define _LESENSE_IFC_CH8_SHIFT                         8                                         /**< Shift value for LESENSE_CH8 */
+#define _LESENSE_IFC_CH8_MASK                          0x100UL                                   /**< Bit mask for LESENSE_CH8 */
+#define _LESENSE_IFC_CH8_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH8_DEFAULT                        (_LESENSE_IFC_CH8_DEFAULT << 8)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH9                                (0x1UL << 9)                              /**<  */
+#define _LESENSE_IFC_CH9_SHIFT                         9                                         /**< Shift value for LESENSE_CH9 */
+#define _LESENSE_IFC_CH9_MASK                          0x200UL                                   /**< Bit mask for LESENSE_CH9 */
+#define _LESENSE_IFC_CH9_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH9_DEFAULT                        (_LESENSE_IFC_CH9_DEFAULT << 9)           /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH10                               (0x1UL << 10)                             /**<  */
+#define _LESENSE_IFC_CH10_SHIFT                        10                                        /**< Shift value for LESENSE_CH10 */
+#define _LESENSE_IFC_CH10_MASK                         0x400UL                                   /**< Bit mask for LESENSE_CH10 */
+#define _LESENSE_IFC_CH10_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH10_DEFAULT                       (_LESENSE_IFC_CH10_DEFAULT << 10)         /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH11                               (0x1UL << 11)                             /**<  */
+#define _LESENSE_IFC_CH11_SHIFT                        11                                        /**< Shift value for LESENSE_CH11 */
+#define _LESENSE_IFC_CH11_MASK                         0x800UL                                   /**< Bit mask for LESENSE_CH11 */
+#define _LESENSE_IFC_CH11_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH11_DEFAULT                       (_LESENSE_IFC_CH11_DEFAULT << 11)         /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH12                               (0x1UL << 12)                             /**<  */
+#define _LESENSE_IFC_CH12_SHIFT                        12                                        /**< Shift value for LESENSE_CH12 */
+#define _LESENSE_IFC_CH12_MASK                         0x1000UL                                  /**< Bit mask for LESENSE_CH12 */
+#define _LESENSE_IFC_CH12_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH12_DEFAULT                       (_LESENSE_IFC_CH12_DEFAULT << 12)         /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH13                               (0x1UL << 13)                             /**<  */
+#define _LESENSE_IFC_CH13_SHIFT                        13                                        /**< Shift value for LESENSE_CH13 */
+#define _LESENSE_IFC_CH13_MASK                         0x2000UL                                  /**< Bit mask for LESENSE_CH13 */
+#define _LESENSE_IFC_CH13_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH13_DEFAULT                       (_LESENSE_IFC_CH13_DEFAULT << 13)         /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH14                               (0x1UL << 14)                             /**<  */
+#define _LESENSE_IFC_CH14_SHIFT                        14                                        /**< Shift value for LESENSE_CH14 */
+#define _LESENSE_IFC_CH14_MASK                         0x4000UL                                  /**< Bit mask for LESENSE_CH14 */
+#define _LESENSE_IFC_CH14_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH14_DEFAULT                       (_LESENSE_IFC_CH14_DEFAULT << 14)         /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH15                               (0x1UL << 15)                             /**<  */
+#define _LESENSE_IFC_CH15_SHIFT                        15                                        /**< Shift value for LESENSE_CH15 */
+#define _LESENSE_IFC_CH15_MASK                         0x8000UL                                  /**< Bit mask for LESENSE_CH15 */
+#define _LESENSE_IFC_CH15_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CH15_DEFAULT                       (_LESENSE_IFC_CH15_DEFAULT << 15)         /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_SCANCOMPLETE                       (0x1UL << 16)                             /**<  */
+#define _LESENSE_IFC_SCANCOMPLETE_SHIFT                16                                        /**< Shift value for LESENSE_SCANCOMPLETE */
+#define _LESENSE_IFC_SCANCOMPLETE_MASK                 0x10000UL                                 /**< Bit mask for LESENSE_SCANCOMPLETE */
+#define _LESENSE_IFC_SCANCOMPLETE_DEFAULT              0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_SCANCOMPLETE_DEFAULT               (_LESENSE_IFC_SCANCOMPLETE_DEFAULT << 16) /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_DEC                                (0x1UL << 17)                             /**<  */
+#define _LESENSE_IFC_DEC_SHIFT                         17                                        /**< Shift value for LESENSE_DEC */
+#define _LESENSE_IFC_DEC_MASK                          0x20000UL                                 /**< Bit mask for LESENSE_DEC */
+#define _LESENSE_IFC_DEC_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_DEC_DEFAULT                        (_LESENSE_IFC_DEC_DEFAULT << 17)          /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_DECERR                             (0x1UL << 18)                             /**<  */
+#define _LESENSE_IFC_DECERR_SHIFT                      18                                        /**< Shift value for LESENSE_DECERR */
+#define _LESENSE_IFC_DECERR_MASK                       0x40000UL                                 /**< Bit mask for LESENSE_DECERR */
+#define _LESENSE_IFC_DECERR_DEFAULT                    0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_DECERR_DEFAULT                     (_LESENSE_IFC_DECERR_DEFAULT << 18)       /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_BUFDATAV                           (0x1UL << 19)                             /**<  */
+#define _LESENSE_IFC_BUFDATAV_SHIFT                    19                                        /**< Shift value for LESENSE_BUFDATAV */
+#define _LESENSE_IFC_BUFDATAV_MASK                     0x80000UL                                 /**< Bit mask for LESENSE_BUFDATAV */
+#define _LESENSE_IFC_BUFDATAV_DEFAULT                  0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_BUFDATAV_DEFAULT                   (_LESENSE_IFC_BUFDATAV_DEFAULT << 19)     /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_BUFLEVEL                           (0x1UL << 20)                             /**<  */
+#define _LESENSE_IFC_BUFLEVEL_SHIFT                    20                                        /**< Shift value for LESENSE_BUFLEVEL */
+#define _LESENSE_IFC_BUFLEVEL_MASK                     0x100000UL                                /**< Bit mask for LESENSE_BUFLEVEL */
+#define _LESENSE_IFC_BUFLEVEL_DEFAULT                  0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_BUFLEVEL_DEFAULT                   (_LESENSE_IFC_BUFLEVEL_DEFAULT << 20)     /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_BUFOF                              (0x1UL << 21)                             /**<  */
+#define _LESENSE_IFC_BUFOF_SHIFT                       21                                        /**< Shift value for LESENSE_BUFOF */
+#define _LESENSE_IFC_BUFOF_MASK                        0x200000UL                                /**< Bit mask for LESENSE_BUFOF */
+#define _LESENSE_IFC_BUFOF_DEFAULT                     0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_BUFOF_DEFAULT                      (_LESENSE_IFC_BUFOF_DEFAULT << 21)        /**< Shifted mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CNTOF                              (0x1UL << 22)                             /**<  */
+#define _LESENSE_IFC_CNTOF_SHIFT                       22                                        /**< Shift value for LESENSE_CNTOF */
+#define _LESENSE_IFC_CNTOF_MASK                        0x400000UL                                /**< Bit mask for LESENSE_CNTOF */
+#define _LESENSE_IFC_CNTOF_DEFAULT                     0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFC */
+#define LESENSE_IFC_CNTOF_DEFAULT                      (_LESENSE_IFC_CNTOF_DEFAULT << 22)        /**< Shifted mode DEFAULT for LESENSE_IFC */
+
+/* Bit fields for LESENSE IFS */
+#define _LESENSE_IFS_RESETVALUE                        0x00000000UL                              /**< Default value for LESENSE_IFS */
+#define _LESENSE_IFS_MASK                              0x007FFFFFUL                              /**< Mask for LESENSE_IFS */
+#define LESENSE_IFS_CH0                                (0x1UL << 0)                              /**<  */
+#define _LESENSE_IFS_CH0_SHIFT                         0                                         /**< Shift value for LESENSE_CH0 */
+#define _LESENSE_IFS_CH0_MASK                          0x1UL                                     /**< Bit mask for LESENSE_CH0 */
+#define _LESENSE_IFS_CH0_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH0_DEFAULT                        (_LESENSE_IFS_CH0_DEFAULT << 0)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH1                                (0x1UL << 1)                              /**<  */
+#define _LESENSE_IFS_CH1_SHIFT                         1                                         /**< Shift value for LESENSE_CH1 */
+#define _LESENSE_IFS_CH1_MASK                          0x2UL                                     /**< Bit mask for LESENSE_CH1 */
+#define _LESENSE_IFS_CH1_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH1_DEFAULT                        (_LESENSE_IFS_CH1_DEFAULT << 1)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH2                                (0x1UL << 2)                              /**<  */
+#define _LESENSE_IFS_CH2_SHIFT                         2                                         /**< Shift value for LESENSE_CH2 */
+#define _LESENSE_IFS_CH2_MASK                          0x4UL                                     /**< Bit mask for LESENSE_CH2 */
+#define _LESENSE_IFS_CH2_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH2_DEFAULT                        (_LESENSE_IFS_CH2_DEFAULT << 2)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH3                                (0x1UL << 3)                              /**<  */
+#define _LESENSE_IFS_CH3_SHIFT                         3                                         /**< Shift value for LESENSE_CH3 */
+#define _LESENSE_IFS_CH3_MASK                          0x8UL                                     /**< Bit mask for LESENSE_CH3 */
+#define _LESENSE_IFS_CH3_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH3_DEFAULT                        (_LESENSE_IFS_CH3_DEFAULT << 3)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH4                                (0x1UL << 4)                              /**<  */
+#define _LESENSE_IFS_CH4_SHIFT                         4                                         /**< Shift value for LESENSE_CH4 */
+#define _LESENSE_IFS_CH4_MASK                          0x10UL                                    /**< Bit mask for LESENSE_CH4 */
+#define _LESENSE_IFS_CH4_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH4_DEFAULT                        (_LESENSE_IFS_CH4_DEFAULT << 4)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH5                                (0x1UL << 5)                              /**<  */
+#define _LESENSE_IFS_CH5_SHIFT                         5                                         /**< Shift value for LESENSE_CH5 */
+#define _LESENSE_IFS_CH5_MASK                          0x20UL                                    /**< Bit mask for LESENSE_CH5 */
+#define _LESENSE_IFS_CH5_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH5_DEFAULT                        (_LESENSE_IFS_CH5_DEFAULT << 5)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH6                                (0x1UL << 6)                              /**<  */
+#define _LESENSE_IFS_CH6_SHIFT                         6                                         /**< Shift value for LESENSE_CH6 */
+#define _LESENSE_IFS_CH6_MASK                          0x40UL                                    /**< Bit mask for LESENSE_CH6 */
+#define _LESENSE_IFS_CH6_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH6_DEFAULT                        (_LESENSE_IFS_CH6_DEFAULT << 6)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH7                                (0x1UL << 7)                              /**<  */
+#define _LESENSE_IFS_CH7_SHIFT                         7                                         /**< Shift value for LESENSE_CH7 */
+#define _LESENSE_IFS_CH7_MASK                          0x80UL                                    /**< Bit mask for LESENSE_CH7 */
+#define _LESENSE_IFS_CH7_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH7_DEFAULT                        (_LESENSE_IFS_CH7_DEFAULT << 7)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH8                                (0x1UL << 8)                              /**<  */
+#define _LESENSE_IFS_CH8_SHIFT                         8                                         /**< Shift value for LESENSE_CH8 */
+#define _LESENSE_IFS_CH8_MASK                          0x100UL                                   /**< Bit mask for LESENSE_CH8 */
+#define _LESENSE_IFS_CH8_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH8_DEFAULT                        (_LESENSE_IFS_CH8_DEFAULT << 8)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH9                                (0x1UL << 9)                              /**<  */
+#define _LESENSE_IFS_CH9_SHIFT                         9                                         /**< Shift value for LESENSE_CH9 */
+#define _LESENSE_IFS_CH9_MASK                          0x200UL                                   /**< Bit mask for LESENSE_CH9 */
+#define _LESENSE_IFS_CH9_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH9_DEFAULT                        (_LESENSE_IFS_CH9_DEFAULT << 9)           /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH10                               (0x1UL << 10)                             /**<  */
+#define _LESENSE_IFS_CH10_SHIFT                        10                                        /**< Shift value for LESENSE_CH10 */
+#define _LESENSE_IFS_CH10_MASK                         0x400UL                                   /**< Bit mask for LESENSE_CH10 */
+#define _LESENSE_IFS_CH10_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH10_DEFAULT                       (_LESENSE_IFS_CH10_DEFAULT << 10)         /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH11                               (0x1UL << 11)                             /**<  */
+#define _LESENSE_IFS_CH11_SHIFT                        11                                        /**< Shift value for LESENSE_CH11 */
+#define _LESENSE_IFS_CH11_MASK                         0x800UL                                   /**< Bit mask for LESENSE_CH11 */
+#define _LESENSE_IFS_CH11_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH11_DEFAULT                       (_LESENSE_IFS_CH11_DEFAULT << 11)         /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH12                               (0x1UL << 12)                             /**<  */
+#define _LESENSE_IFS_CH12_SHIFT                        12                                        /**< Shift value for LESENSE_CH12 */
+#define _LESENSE_IFS_CH12_MASK                         0x1000UL                                  /**< Bit mask for LESENSE_CH12 */
+#define _LESENSE_IFS_CH12_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH12_DEFAULT                       (_LESENSE_IFS_CH12_DEFAULT << 12)         /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH13                               (0x1UL << 13)                             /**<  */
+#define _LESENSE_IFS_CH13_SHIFT                        13                                        /**< Shift value for LESENSE_CH13 */
+#define _LESENSE_IFS_CH13_MASK                         0x2000UL                                  /**< Bit mask for LESENSE_CH13 */
+#define _LESENSE_IFS_CH13_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH13_DEFAULT                       (_LESENSE_IFS_CH13_DEFAULT << 13)         /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH14                               (0x1UL << 14)                             /**<  */
+#define _LESENSE_IFS_CH14_SHIFT                        14                                        /**< Shift value for LESENSE_CH14 */
+#define _LESENSE_IFS_CH14_MASK                         0x4000UL                                  /**< Bit mask for LESENSE_CH14 */
+#define _LESENSE_IFS_CH14_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH14_DEFAULT                       (_LESENSE_IFS_CH14_DEFAULT << 14)         /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH15                               (0x1UL << 15)                             /**<  */
+#define _LESENSE_IFS_CH15_SHIFT                        15                                        /**< Shift value for LESENSE_CH15 */
+#define _LESENSE_IFS_CH15_MASK                         0x8000UL                                  /**< Bit mask for LESENSE_CH15 */
+#define _LESENSE_IFS_CH15_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CH15_DEFAULT                       (_LESENSE_IFS_CH15_DEFAULT << 15)         /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_SCANCOMPLETE                       (0x1UL << 16)                             /**<  */
+#define _LESENSE_IFS_SCANCOMPLETE_SHIFT                16                                        /**< Shift value for LESENSE_SCANCOMPLETE */
+#define _LESENSE_IFS_SCANCOMPLETE_MASK                 0x10000UL                                 /**< Bit mask for LESENSE_SCANCOMPLETE */
+#define _LESENSE_IFS_SCANCOMPLETE_DEFAULT              0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_SCANCOMPLETE_DEFAULT               (_LESENSE_IFS_SCANCOMPLETE_DEFAULT << 16) /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_DEC                                (0x1UL << 17)                             /**<  */
+#define _LESENSE_IFS_DEC_SHIFT                         17                                        /**< Shift value for LESENSE_DEC */
+#define _LESENSE_IFS_DEC_MASK                          0x20000UL                                 /**< Bit mask for LESENSE_DEC */
+#define _LESENSE_IFS_DEC_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_DEC_DEFAULT                        (_LESENSE_IFS_DEC_DEFAULT << 17)          /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_DECERR                             (0x1UL << 18)                             /**<  */
+#define _LESENSE_IFS_DECERR_SHIFT                      18                                        /**< Shift value for LESENSE_DECERR */
+#define _LESENSE_IFS_DECERR_MASK                       0x40000UL                                 /**< Bit mask for LESENSE_DECERR */
+#define _LESENSE_IFS_DECERR_DEFAULT                    0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_DECERR_DEFAULT                     (_LESENSE_IFS_DECERR_DEFAULT << 18)       /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_BUFDATAV                           (0x1UL << 19)                             /**<  */
+#define _LESENSE_IFS_BUFDATAV_SHIFT                    19                                        /**< Shift value for LESENSE_BUFDATAV */
+#define _LESENSE_IFS_BUFDATAV_MASK                     0x80000UL                                 /**< Bit mask for LESENSE_BUFDATAV */
+#define _LESENSE_IFS_BUFDATAV_DEFAULT                  0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_BUFDATAV_DEFAULT                   (_LESENSE_IFS_BUFDATAV_DEFAULT << 19)     /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_BUFLEVEL                           (0x1UL << 20)                             /**<  */
+#define _LESENSE_IFS_BUFLEVEL_SHIFT                    20                                        /**< Shift value for LESENSE_BUFLEVEL */
+#define _LESENSE_IFS_BUFLEVEL_MASK                     0x100000UL                                /**< Bit mask for LESENSE_BUFLEVEL */
+#define _LESENSE_IFS_BUFLEVEL_DEFAULT                  0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_BUFLEVEL_DEFAULT                   (_LESENSE_IFS_BUFLEVEL_DEFAULT << 20)     /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_BUFOF                              (0x1UL << 21)                             /**<  */
+#define _LESENSE_IFS_BUFOF_SHIFT                       21                                        /**< Shift value for LESENSE_BUFOF */
+#define _LESENSE_IFS_BUFOF_MASK                        0x200000UL                                /**< Bit mask for LESENSE_BUFOF */
+#define _LESENSE_IFS_BUFOF_DEFAULT                     0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_BUFOF_DEFAULT                      (_LESENSE_IFS_BUFOF_DEFAULT << 21)        /**< Shifted mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CNTOF                              (0x1UL << 22)                             /**<  */
+#define _LESENSE_IFS_CNTOF_SHIFT                       22                                        /**< Shift value for LESENSE_CNTOF */
+#define _LESENSE_IFS_CNTOF_MASK                        0x400000UL                                /**< Bit mask for LESENSE_CNTOF */
+#define _LESENSE_IFS_CNTOF_DEFAULT                     0x00000000UL                              /**< Mode DEFAULT for LESENSE_IFS */
+#define LESENSE_IFS_CNTOF_DEFAULT                      (_LESENSE_IFS_CNTOF_DEFAULT << 22)        /**< Shifted mode DEFAULT for LESENSE_IFS */
+
+/* Bit fields for LESENSE IEN */
+#define _LESENSE_IEN_RESETVALUE                        0x00000000UL                              /**< Default value for LESENSE_IEN */
+#define _LESENSE_IEN_MASK                              0x007FFFFFUL                              /**< Mask for LESENSE_IEN */
+#define LESENSE_IEN_CH0                                (0x1UL << 0)                              /**<  */
+#define _LESENSE_IEN_CH0_SHIFT                         0                                         /**< Shift value for LESENSE_CH0 */
+#define _LESENSE_IEN_CH0_MASK                          0x1UL                                     /**< Bit mask for LESENSE_CH0 */
+#define _LESENSE_IEN_CH0_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH0_DEFAULT                        (_LESENSE_IEN_CH0_DEFAULT << 0)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH1                                (0x1UL << 1)                              /**<  */
+#define _LESENSE_IEN_CH1_SHIFT                         1                                         /**< Shift value for LESENSE_CH1 */
+#define _LESENSE_IEN_CH1_MASK                          0x2UL                                     /**< Bit mask for LESENSE_CH1 */
+#define _LESENSE_IEN_CH1_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH1_DEFAULT                        (_LESENSE_IEN_CH1_DEFAULT << 1)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH2                                (0x1UL << 2)                              /**<  */
+#define _LESENSE_IEN_CH2_SHIFT                         2                                         /**< Shift value for LESENSE_CH2 */
+#define _LESENSE_IEN_CH2_MASK                          0x4UL                                     /**< Bit mask for LESENSE_CH2 */
+#define _LESENSE_IEN_CH2_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH2_DEFAULT                        (_LESENSE_IEN_CH2_DEFAULT << 2)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH3                                (0x1UL << 3)                              /**<  */
+#define _LESENSE_IEN_CH3_SHIFT                         3                                         /**< Shift value for LESENSE_CH3 */
+#define _LESENSE_IEN_CH3_MASK                          0x8UL                                     /**< Bit mask for LESENSE_CH3 */
+#define _LESENSE_IEN_CH3_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH3_DEFAULT                        (_LESENSE_IEN_CH3_DEFAULT << 3)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH4                                (0x1UL << 4)                              /**<  */
+#define _LESENSE_IEN_CH4_SHIFT                         4                                         /**< Shift value for LESENSE_CH4 */
+#define _LESENSE_IEN_CH4_MASK                          0x10UL                                    /**< Bit mask for LESENSE_CH4 */
+#define _LESENSE_IEN_CH4_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH4_DEFAULT                        (_LESENSE_IEN_CH4_DEFAULT << 4)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH5                                (0x1UL << 5)                              /**<  */
+#define _LESENSE_IEN_CH5_SHIFT                         5                                         /**< Shift value for LESENSE_CH5 */
+#define _LESENSE_IEN_CH5_MASK                          0x20UL                                    /**< Bit mask for LESENSE_CH5 */
+#define _LESENSE_IEN_CH5_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH5_DEFAULT                        (_LESENSE_IEN_CH5_DEFAULT << 5)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH6                                (0x1UL << 6)                              /**<  */
+#define _LESENSE_IEN_CH6_SHIFT                         6                                         /**< Shift value for LESENSE_CH6 */
+#define _LESENSE_IEN_CH6_MASK                          0x40UL                                    /**< Bit mask for LESENSE_CH6 */
+#define _LESENSE_IEN_CH6_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH6_DEFAULT                        (_LESENSE_IEN_CH6_DEFAULT << 6)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH7                                (0x1UL << 7)                              /**<  */
+#define _LESENSE_IEN_CH7_SHIFT                         7                                         /**< Shift value for LESENSE_CH7 */
+#define _LESENSE_IEN_CH7_MASK                          0x80UL                                    /**< Bit mask for LESENSE_CH7 */
+#define _LESENSE_IEN_CH7_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH7_DEFAULT                        (_LESENSE_IEN_CH7_DEFAULT << 7)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH8                                (0x1UL << 8)                              /**<  */
+#define _LESENSE_IEN_CH8_SHIFT                         8                                         /**< Shift value for LESENSE_CH8 */
+#define _LESENSE_IEN_CH8_MASK                          0x100UL                                   /**< Bit mask for LESENSE_CH8 */
+#define _LESENSE_IEN_CH8_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH8_DEFAULT                        (_LESENSE_IEN_CH8_DEFAULT << 8)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH9                                (0x1UL << 9)                              /**<  */
+#define _LESENSE_IEN_CH9_SHIFT                         9                                         /**< Shift value for LESENSE_CH9 */
+#define _LESENSE_IEN_CH9_MASK                          0x200UL                                   /**< Bit mask for LESENSE_CH9 */
+#define _LESENSE_IEN_CH9_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH9_DEFAULT                        (_LESENSE_IEN_CH9_DEFAULT << 9)           /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH10                               (0x1UL << 10)                             /**<  */
+#define _LESENSE_IEN_CH10_SHIFT                        10                                        /**< Shift value for LESENSE_CH10 */
+#define _LESENSE_IEN_CH10_MASK                         0x400UL                                   /**< Bit mask for LESENSE_CH10 */
+#define _LESENSE_IEN_CH10_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH10_DEFAULT                       (_LESENSE_IEN_CH10_DEFAULT << 10)         /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH11                               (0x1UL << 11)                             /**<  */
+#define _LESENSE_IEN_CH11_SHIFT                        11                                        /**< Shift value for LESENSE_CH11 */
+#define _LESENSE_IEN_CH11_MASK                         0x800UL                                   /**< Bit mask for LESENSE_CH11 */
+#define _LESENSE_IEN_CH11_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH11_DEFAULT                       (_LESENSE_IEN_CH11_DEFAULT << 11)         /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH12                               (0x1UL << 12)                             /**<  */
+#define _LESENSE_IEN_CH12_SHIFT                        12                                        /**< Shift value for LESENSE_CH12 */
+#define _LESENSE_IEN_CH12_MASK                         0x1000UL                                  /**< Bit mask for LESENSE_CH12 */
+#define _LESENSE_IEN_CH12_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH12_DEFAULT                       (_LESENSE_IEN_CH12_DEFAULT << 12)         /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH13                               (0x1UL << 13)                             /**<  */
+#define _LESENSE_IEN_CH13_SHIFT                        13                                        /**< Shift value for LESENSE_CH13 */
+#define _LESENSE_IEN_CH13_MASK                         0x2000UL                                  /**< Bit mask for LESENSE_CH13 */
+#define _LESENSE_IEN_CH13_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH13_DEFAULT                       (_LESENSE_IEN_CH13_DEFAULT << 13)         /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH14                               (0x1UL << 14)                             /**<  */
+#define _LESENSE_IEN_CH14_SHIFT                        14                                        /**< Shift value for LESENSE_CH14 */
+#define _LESENSE_IEN_CH14_MASK                         0x4000UL                                  /**< Bit mask for LESENSE_CH14 */
+#define _LESENSE_IEN_CH14_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH14_DEFAULT                       (_LESENSE_IEN_CH14_DEFAULT << 14)         /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH15                               (0x1UL << 15)                             /**<  */
+#define _LESENSE_IEN_CH15_SHIFT                        15                                        /**< Shift value for LESENSE_CH15 */
+#define _LESENSE_IEN_CH15_MASK                         0x8000UL                                  /**< Bit mask for LESENSE_CH15 */
+#define _LESENSE_IEN_CH15_DEFAULT                      0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CH15_DEFAULT                       (_LESENSE_IEN_CH15_DEFAULT << 15)         /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_SCANCOMPLETE                       (0x1UL << 16)                             /**<  */
+#define _LESENSE_IEN_SCANCOMPLETE_SHIFT                16                                        /**< Shift value for LESENSE_SCANCOMPLETE */
+#define _LESENSE_IEN_SCANCOMPLETE_MASK                 0x10000UL                                 /**< Bit mask for LESENSE_SCANCOMPLETE */
+#define _LESENSE_IEN_SCANCOMPLETE_DEFAULT              0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_SCANCOMPLETE_DEFAULT               (_LESENSE_IEN_SCANCOMPLETE_DEFAULT << 16) /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_DEC                                (0x1UL << 17)                             /**<  */
+#define _LESENSE_IEN_DEC_SHIFT                         17                                        /**< Shift value for LESENSE_DEC */
+#define _LESENSE_IEN_DEC_MASK                          0x20000UL                                 /**< Bit mask for LESENSE_DEC */
+#define _LESENSE_IEN_DEC_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_DEC_DEFAULT                        (_LESENSE_IEN_DEC_DEFAULT << 17)          /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_DECERR                             (0x1UL << 18)                             /**<  */
+#define _LESENSE_IEN_DECERR_SHIFT                      18                                        /**< Shift value for LESENSE_DECERR */
+#define _LESENSE_IEN_DECERR_MASK                       0x40000UL                                 /**< Bit mask for LESENSE_DECERR */
+#define _LESENSE_IEN_DECERR_DEFAULT                    0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_DECERR_DEFAULT                     (_LESENSE_IEN_DECERR_DEFAULT << 18)       /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_BUFDATAV                           (0x1UL << 19)                             /**<  */
+#define _LESENSE_IEN_BUFDATAV_SHIFT                    19                                        /**< Shift value for LESENSE_BUFDATAV */
+#define _LESENSE_IEN_BUFDATAV_MASK                     0x80000UL                                 /**< Bit mask for LESENSE_BUFDATAV */
+#define _LESENSE_IEN_BUFDATAV_DEFAULT                  0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_BUFDATAV_DEFAULT                   (_LESENSE_IEN_BUFDATAV_DEFAULT << 19)     /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_BUFLEVEL                           (0x1UL << 20)                             /**<  */
+#define _LESENSE_IEN_BUFLEVEL_SHIFT                    20                                        /**< Shift value for LESENSE_BUFLEVEL */
+#define _LESENSE_IEN_BUFLEVEL_MASK                     0x100000UL                                /**< Bit mask for LESENSE_BUFLEVEL */
+#define _LESENSE_IEN_BUFLEVEL_DEFAULT                  0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_BUFLEVEL_DEFAULT                   (_LESENSE_IEN_BUFLEVEL_DEFAULT << 20)     /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_BUFOF                              (0x1UL << 21)                             /**<  */
+#define _LESENSE_IEN_BUFOF_SHIFT                       21                                        /**< Shift value for LESENSE_BUFOF */
+#define _LESENSE_IEN_BUFOF_MASK                        0x200000UL                                /**< Bit mask for LESENSE_BUFOF */
+#define _LESENSE_IEN_BUFOF_DEFAULT                     0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_BUFOF_DEFAULT                      (_LESENSE_IEN_BUFOF_DEFAULT << 21)        /**< Shifted mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CNTOF                              (0x1UL << 22)                             /**<  */
+#define _LESENSE_IEN_CNTOF_SHIFT                       22                                        /**< Shift value for LESENSE_CNTOF */
+#define _LESENSE_IEN_CNTOF_MASK                        0x400000UL                                /**< Bit mask for LESENSE_CNTOF */
+#define _LESENSE_IEN_CNTOF_DEFAULT                     0x00000000UL                              /**< Mode DEFAULT for LESENSE_IEN */
+#define LESENSE_IEN_CNTOF_DEFAULT                      (_LESENSE_IEN_CNTOF_DEFAULT << 22)        /**< Shifted mode DEFAULT for LESENSE_IEN */
+
+/* Bit fields for LESENSE SYNCBUSY */
+#define _LESENSE_SYNCBUSY_RESETVALUE                   0x00000000UL                                  /**< Default value for LESENSE_SYNCBUSY */
+#define _LESENSE_SYNCBUSY_MASK                         0x07E3FFFFUL                                  /**< Mask for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_CTRL                          (0x1UL << 0)                                  /**< LESENSE_CTRL Register Busy */
+#define _LESENSE_SYNCBUSY_CTRL_SHIFT                   0                                             /**< Shift value for LESENSE_CTRL */
+#define _LESENSE_SYNCBUSY_CTRL_MASK                    0x1UL                                         /**< Bit mask for LESENSE_CTRL */
+#define _LESENSE_SYNCBUSY_CTRL_DEFAULT                 0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_CTRL_DEFAULT                  (_LESENSE_SYNCBUSY_CTRL_DEFAULT << 0)         /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_TIMCTRL                       (0x1UL << 1)                                  /**< LESENSE_TIMCTRL Register Busy */
+#define _LESENSE_SYNCBUSY_TIMCTRL_SHIFT                1                                             /**< Shift value for LESENSE_TIMCTRL */
+#define _LESENSE_SYNCBUSY_TIMCTRL_MASK                 0x2UL                                         /**< Bit mask for LESENSE_TIMCTRL */
+#define _LESENSE_SYNCBUSY_TIMCTRL_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_TIMCTRL_DEFAULT               (_LESENSE_SYNCBUSY_TIMCTRL_DEFAULT << 1)      /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_PERCTRL                       (0x1UL << 2)                                  /**< LESENSE_PERCTRL Register Busy */
+#define _LESENSE_SYNCBUSY_PERCTRL_SHIFT                2                                             /**< Shift value for LESENSE_PERCTRL */
+#define _LESENSE_SYNCBUSY_PERCTRL_MASK                 0x4UL                                         /**< Bit mask for LESENSE_PERCTRL */
+#define _LESENSE_SYNCBUSY_PERCTRL_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_PERCTRL_DEFAULT               (_LESENSE_SYNCBUSY_PERCTRL_DEFAULT << 2)      /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_DECCTRL                       (0x1UL << 3)                                  /**< LESENSE_DECCTRL Register Busy */
+#define _LESENSE_SYNCBUSY_DECCTRL_SHIFT                3                                             /**< Shift value for LESENSE_DECCTRL */
+#define _LESENSE_SYNCBUSY_DECCTRL_MASK                 0x8UL                                         /**< Bit mask for LESENSE_DECCTRL */
+#define _LESENSE_SYNCBUSY_DECCTRL_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_DECCTRL_DEFAULT               (_LESENSE_SYNCBUSY_DECCTRL_DEFAULT << 3)      /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_BIASCTRL                      (0x1UL << 4)                                  /**< LESENSE_BIASCTRL Register Busy */
+#define _LESENSE_SYNCBUSY_BIASCTRL_SHIFT               4                                             /**< Shift value for LESENSE_BIASCTRL */
+#define _LESENSE_SYNCBUSY_BIASCTRL_MASK                0x10UL                                        /**< Bit mask for LESENSE_BIASCTRL */
+#define _LESENSE_SYNCBUSY_BIASCTRL_DEFAULT             0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_BIASCTRL_DEFAULT              (_LESENSE_SYNCBUSY_BIASCTRL_DEFAULT << 4)     /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_CMD                           (0x1UL << 5)                                  /**< LESENSE_CMD Register Busy */
+#define _LESENSE_SYNCBUSY_CMD_SHIFT                    5                                             /**< Shift value for LESENSE_CMD */
+#define _LESENSE_SYNCBUSY_CMD_MASK                     0x20UL                                        /**< Bit mask for LESENSE_CMD */
+#define _LESENSE_SYNCBUSY_CMD_DEFAULT                  0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_CMD_DEFAULT                   (_LESENSE_SYNCBUSY_CMD_DEFAULT << 5)          /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_CHEN                          (0x1UL << 6)                                  /**< LESENSE_CHEN Register Busy */
+#define _LESENSE_SYNCBUSY_CHEN_SHIFT                   6                                             /**< Shift value for LESENSE_CHEN */
+#define _LESENSE_SYNCBUSY_CHEN_MASK                    0x40UL                                        /**< Bit mask for LESENSE_CHEN */
+#define _LESENSE_SYNCBUSY_CHEN_DEFAULT                 0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_CHEN_DEFAULT                  (_LESENSE_SYNCBUSY_CHEN_DEFAULT << 6)         /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_SCANRES                       (0x1UL << 7)                                  /**< LESENSE_SCANRES Register Busy */
+#define _LESENSE_SYNCBUSY_SCANRES_SHIFT                7                                             /**< Shift value for LESENSE_SCANRES */
+#define _LESENSE_SYNCBUSY_SCANRES_MASK                 0x80UL                                        /**< Bit mask for LESENSE_SCANRES */
+#define _LESENSE_SYNCBUSY_SCANRES_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_SCANRES_DEFAULT               (_LESENSE_SYNCBUSY_SCANRES_DEFAULT << 7)      /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_STATUS                        (0x1UL << 8)                                  /**< LESENSE_STATUS Register Busy */
+#define _LESENSE_SYNCBUSY_STATUS_SHIFT                 8                                             /**< Shift value for LESENSE_STATUS */
+#define _LESENSE_SYNCBUSY_STATUS_MASK                  0x100UL                                       /**< Bit mask for LESENSE_STATUS */
+#define _LESENSE_SYNCBUSY_STATUS_DEFAULT               0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_STATUS_DEFAULT                (_LESENSE_SYNCBUSY_STATUS_DEFAULT << 8)       /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_PTR                           (0x1UL << 9)                                  /**< LESENSE_PTR Register Busy */
+#define _LESENSE_SYNCBUSY_PTR_SHIFT                    9                                             /**< Shift value for LESENSE_PTR */
+#define _LESENSE_SYNCBUSY_PTR_MASK                     0x200UL                                       /**< Bit mask for LESENSE_PTR */
+#define _LESENSE_SYNCBUSY_PTR_DEFAULT                  0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_PTR_DEFAULT                   (_LESENSE_SYNCBUSY_PTR_DEFAULT << 9)          /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_BUFDATA                       (0x1UL << 10)                                 /**< LESENSE_BUFDATA Register Busy */
+#define _LESENSE_SYNCBUSY_BUFDATA_SHIFT                10                                            /**< Shift value for LESENSE_BUFDATA */
+#define _LESENSE_SYNCBUSY_BUFDATA_MASK                 0x400UL                                       /**< Bit mask for LESENSE_BUFDATA */
+#define _LESENSE_SYNCBUSY_BUFDATA_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_BUFDATA_DEFAULT               (_LESENSE_SYNCBUSY_BUFDATA_DEFAULT << 10)     /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_CURCH                         (0x1UL << 11)                                 /**< LESENSE_CURCH Register Busy */
+#define _LESENSE_SYNCBUSY_CURCH_SHIFT                  11                                            /**< Shift value for LESENSE_CURCH */
+#define _LESENSE_SYNCBUSY_CURCH_MASK                   0x800UL                                       /**< Bit mask for LESENSE_CURCH */
+#define _LESENSE_SYNCBUSY_CURCH_DEFAULT                0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_CURCH_DEFAULT                 (_LESENSE_SYNCBUSY_CURCH_DEFAULT << 11)       /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_DECSTATE                      (0x1UL << 12)                                 /**< LESENSE_DECSTATE Register Busy */
+#define _LESENSE_SYNCBUSY_DECSTATE_SHIFT               12                                            /**< Shift value for LESENSE_DECSTATE */
+#define _LESENSE_SYNCBUSY_DECSTATE_MASK                0x1000UL                                      /**< Bit mask for LESENSE_DECSTATE */
+#define _LESENSE_SYNCBUSY_DECSTATE_DEFAULT             0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_DECSTATE_DEFAULT              (_LESENSE_SYNCBUSY_DECSTATE_DEFAULT << 12)    /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_SENSORSTATE                   (0x1UL << 13)                                 /**< LESENSE_SENSORSTATE Register Busy */
+#define _LESENSE_SYNCBUSY_SENSORSTATE_SHIFT            13                                            /**< Shift value for LESENSE_SENSORSTATE */
+#define _LESENSE_SYNCBUSY_SENSORSTATE_MASK             0x2000UL                                      /**< Bit mask for LESENSE_SENSORSTATE */
+#define _LESENSE_SYNCBUSY_SENSORSTATE_DEFAULT          0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_SENSORSTATE_DEFAULT           (_LESENSE_SYNCBUSY_SENSORSTATE_DEFAULT << 13) /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_IDLECONF                      (0x1UL << 14)                                 /**< LESENSE_IDLECONF Register Busy */
+#define _LESENSE_SYNCBUSY_IDLECONF_SHIFT               14                                            /**< Shift value for LESENSE_IDLECONF */
+#define _LESENSE_SYNCBUSY_IDLECONF_MASK                0x4000UL                                      /**< Bit mask for LESENSE_IDLECONF */
+#define _LESENSE_SYNCBUSY_IDLECONF_DEFAULT             0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_IDLECONF_DEFAULT              (_LESENSE_SYNCBUSY_IDLECONF_DEFAULT << 14)    /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_ALTEXCONF                     (0x1UL << 15)                                 /**< LESENSE_ALTEXCONF Register Busy */
+#define _LESENSE_SYNCBUSY_ALTEXCONF_SHIFT              15                                            /**< Shift value for LESENSE_ALTEXCONF */
+#define _LESENSE_SYNCBUSY_ALTEXCONF_MASK               0x8000UL                                      /**< Bit mask for LESENSE_ALTEXCONF */
+#define _LESENSE_SYNCBUSY_ALTEXCONF_DEFAULT            0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_ALTEXCONF_DEFAULT             (_LESENSE_SYNCBUSY_ALTEXCONF_DEFAULT << 15)   /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_ROUTE                         (0x1UL << 16)                                 /**< LESENSE_ROUTE Register Busy */
+#define _LESENSE_SYNCBUSY_ROUTE_SHIFT                  16                                            /**< Shift value for LESENSE_ROUTE */
+#define _LESENSE_SYNCBUSY_ROUTE_MASK                   0x10000UL                                     /**< Bit mask for LESENSE_ROUTE */
+#define _LESENSE_SYNCBUSY_ROUTE_DEFAULT                0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_ROUTE_DEFAULT                 (_LESENSE_SYNCBUSY_ROUTE_DEFAULT << 16)       /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_POWERDOWN                     (0x1UL << 17)                                 /**< LESENSE_POWERDOWN Register Busy */
+#define _LESENSE_SYNCBUSY_POWERDOWN_SHIFT              17                                            /**< Shift value for LESENSE_POWERDOWN */
+#define _LESENSE_SYNCBUSY_POWERDOWN_MASK               0x20000UL                                     /**< Bit mask for LESENSE_POWERDOWN */
+#define _LESENSE_SYNCBUSY_POWERDOWN_DEFAULT            0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_POWERDOWN_DEFAULT             (_LESENSE_SYNCBUSY_POWERDOWN_DEFAULT << 17)   /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_TCONFA                        (0x1UL << 21)                                 /**< LESENSE_STx_TCONFA Register Busy */
+#define _LESENSE_SYNCBUSY_TCONFA_SHIFT                 21                                            /**< Shift value for LESENSE_TCONFA */
+#define _LESENSE_SYNCBUSY_TCONFA_MASK                  0x200000UL                                    /**< Bit mask for LESENSE_TCONFA */
+#define _LESENSE_SYNCBUSY_TCONFA_DEFAULT               0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_TCONFA_DEFAULT                (_LESENSE_SYNCBUSY_TCONFA_DEFAULT << 21)      /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_TCONFB                        (0x1UL << 22)                                 /**< LESENSE_STx_TCONFB Register Busy */
+#define _LESENSE_SYNCBUSY_TCONFB_SHIFT                 22                                            /**< Shift value for LESENSE_TCONFB */
+#define _LESENSE_SYNCBUSY_TCONFB_MASK                  0x400000UL                                    /**< Bit mask for LESENSE_TCONFB */
+#define _LESENSE_SYNCBUSY_TCONFB_DEFAULT               0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_TCONFB_DEFAULT                (_LESENSE_SYNCBUSY_TCONFB_DEFAULT << 22)      /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_DATA                          (0x1UL << 23)                                 /**< LESENSE_BUFx_DATA Register Busy */
+#define _LESENSE_SYNCBUSY_DATA_SHIFT                   23                                            /**< Shift value for LESENSE_DATA */
+#define _LESENSE_SYNCBUSY_DATA_MASK                    0x800000UL                                    /**< Bit mask for LESENSE_DATA */
+#define _LESENSE_SYNCBUSY_DATA_DEFAULT                 0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_DATA_DEFAULT                  (_LESENSE_SYNCBUSY_DATA_DEFAULT << 23)        /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_TIMING                        (0x1UL << 24)                                 /**< LESENSE_CHx_TIMING Register Busy */
+#define _LESENSE_SYNCBUSY_TIMING_SHIFT                 24                                            /**< Shift value for LESENSE_TIMING */
+#define _LESENSE_SYNCBUSY_TIMING_MASK                  0x1000000UL                                   /**< Bit mask for LESENSE_TIMING */
+#define _LESENSE_SYNCBUSY_TIMING_DEFAULT               0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_TIMING_DEFAULT                (_LESENSE_SYNCBUSY_TIMING_DEFAULT << 24)      /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_INTERACT                      (0x1UL << 25)                                 /**< LESENSE_CHx_INTERACT Register Busy */
+#define _LESENSE_SYNCBUSY_INTERACT_SHIFT               25                                            /**< Shift value for LESENSE_INTERACT */
+#define _LESENSE_SYNCBUSY_INTERACT_MASK                0x2000000UL                                   /**< Bit mask for LESENSE_INTERACT */
+#define _LESENSE_SYNCBUSY_INTERACT_DEFAULT             0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_INTERACT_DEFAULT              (_LESENSE_SYNCBUSY_INTERACT_DEFAULT << 25)    /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_EVAL                          (0x1UL << 26)                                 /**< LESENSE_CHx_EVAL Register Busy */
+#define _LESENSE_SYNCBUSY_EVAL_SHIFT                   26                                            /**< Shift value for LESENSE_EVAL */
+#define _LESENSE_SYNCBUSY_EVAL_MASK                    0x4000000UL                                   /**< Bit mask for LESENSE_EVAL */
+#define _LESENSE_SYNCBUSY_EVAL_DEFAULT                 0x00000000UL                                  /**< Mode DEFAULT for LESENSE_SYNCBUSY */
+#define LESENSE_SYNCBUSY_EVAL_DEFAULT                  (_LESENSE_SYNCBUSY_EVAL_DEFAULT << 26)        /**< Shifted mode DEFAULT for LESENSE_SYNCBUSY */
+
+/* Bit fields for LESENSE ROUTE */
+#define _LESENSE_ROUTE_RESETVALUE                      0x00000000UL                             /**< Default value for LESENSE_ROUTE */
+#define _LESENSE_ROUTE_MASK                            0x00FFFFFFUL                             /**< Mask for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH0PEN                           (0x1UL << 0)                             /**< CH0 Pin Enable */
+#define _LESENSE_ROUTE_CH0PEN_SHIFT                    0                                        /**< Shift value for LESENSE_CH0PEN */
+#define _LESENSE_ROUTE_CH0PEN_MASK                     0x1UL                                    /**< Bit mask for LESENSE_CH0PEN */
+#define _LESENSE_ROUTE_CH0PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH0PEN_DEFAULT                   (_LESENSE_ROUTE_CH0PEN_DEFAULT << 0)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH1PEN                           (0x1UL << 1)                             /**< CH0 Pin Enable */
+#define _LESENSE_ROUTE_CH1PEN_SHIFT                    1                                        /**< Shift value for LESENSE_CH1PEN */
+#define _LESENSE_ROUTE_CH1PEN_MASK                     0x2UL                                    /**< Bit mask for LESENSE_CH1PEN */
+#define _LESENSE_ROUTE_CH1PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH1PEN_DEFAULT                   (_LESENSE_ROUTE_CH1PEN_DEFAULT << 1)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH2PEN                           (0x1UL << 2)                             /**< CH2 Pin Enable */
+#define _LESENSE_ROUTE_CH2PEN_SHIFT                    2                                        /**< Shift value for LESENSE_CH2PEN */
+#define _LESENSE_ROUTE_CH2PEN_MASK                     0x4UL                                    /**< Bit mask for LESENSE_CH2PEN */
+#define _LESENSE_ROUTE_CH2PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH2PEN_DEFAULT                   (_LESENSE_ROUTE_CH2PEN_DEFAULT << 2)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH3PEN                           (0x1UL << 3)                             /**< CH3 Pin Enable */
+#define _LESENSE_ROUTE_CH3PEN_SHIFT                    3                                        /**< Shift value for LESENSE_CH3PEN */
+#define _LESENSE_ROUTE_CH3PEN_MASK                     0x8UL                                    /**< Bit mask for LESENSE_CH3PEN */
+#define _LESENSE_ROUTE_CH3PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH3PEN_DEFAULT                   (_LESENSE_ROUTE_CH3PEN_DEFAULT << 3)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH4PEN                           (0x1UL << 4)                             /**< CH4 Pin Enable */
+#define _LESENSE_ROUTE_CH4PEN_SHIFT                    4                                        /**< Shift value for LESENSE_CH4PEN */
+#define _LESENSE_ROUTE_CH4PEN_MASK                     0x10UL                                   /**< Bit mask for LESENSE_CH4PEN */
+#define _LESENSE_ROUTE_CH4PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH4PEN_DEFAULT                   (_LESENSE_ROUTE_CH4PEN_DEFAULT << 4)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH5PEN                           (0x1UL << 5)                             /**< CH5 Pin Enable */
+#define _LESENSE_ROUTE_CH5PEN_SHIFT                    5                                        /**< Shift value for LESENSE_CH5PEN */
+#define _LESENSE_ROUTE_CH5PEN_MASK                     0x20UL                                   /**< Bit mask for LESENSE_CH5PEN */
+#define _LESENSE_ROUTE_CH5PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH5PEN_DEFAULT                   (_LESENSE_ROUTE_CH5PEN_DEFAULT << 5)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH6PEN                           (0x1UL << 6)                             /**< CH6 Pin Enable */
+#define _LESENSE_ROUTE_CH6PEN_SHIFT                    6                                        /**< Shift value for LESENSE_CH6PEN */
+#define _LESENSE_ROUTE_CH6PEN_MASK                     0x40UL                                   /**< Bit mask for LESENSE_CH6PEN */
+#define _LESENSE_ROUTE_CH6PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH6PEN_DEFAULT                   (_LESENSE_ROUTE_CH6PEN_DEFAULT << 6)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH7PEN                           (0x1UL << 7)                             /**< CH7 Pin Enable */
+#define _LESENSE_ROUTE_CH7PEN_SHIFT                    7                                        /**< Shift value for LESENSE_CH7PEN */
+#define _LESENSE_ROUTE_CH7PEN_MASK                     0x80UL                                   /**< Bit mask for LESENSE_CH7PEN */
+#define _LESENSE_ROUTE_CH7PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH7PEN_DEFAULT                   (_LESENSE_ROUTE_CH7PEN_DEFAULT << 7)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH8PEN                           (0x1UL << 8)                             /**< CH8 Pin Enable */
+#define _LESENSE_ROUTE_CH8PEN_SHIFT                    8                                        /**< Shift value for LESENSE_CH8PEN */
+#define _LESENSE_ROUTE_CH8PEN_MASK                     0x100UL                                  /**< Bit mask for LESENSE_CH8PEN */
+#define _LESENSE_ROUTE_CH8PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH8PEN_DEFAULT                   (_LESENSE_ROUTE_CH8PEN_DEFAULT << 8)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH9PEN                           (0x1UL << 9)                             /**< CH9 Pin Enable */
+#define _LESENSE_ROUTE_CH9PEN_SHIFT                    9                                        /**< Shift value for LESENSE_CH9PEN */
+#define _LESENSE_ROUTE_CH9PEN_MASK                     0x200UL                                  /**< Bit mask for LESENSE_CH9PEN */
+#define _LESENSE_ROUTE_CH9PEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH9PEN_DEFAULT                   (_LESENSE_ROUTE_CH9PEN_DEFAULT << 9)     /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH10PEN                          (0x1UL << 10)                            /**< CH10 Pin Enable */
+#define _LESENSE_ROUTE_CH10PEN_SHIFT                   10                                       /**< Shift value for LESENSE_CH10PEN */
+#define _LESENSE_ROUTE_CH10PEN_MASK                    0x400UL                                  /**< Bit mask for LESENSE_CH10PEN */
+#define _LESENSE_ROUTE_CH10PEN_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH10PEN_DEFAULT                  (_LESENSE_ROUTE_CH10PEN_DEFAULT << 10)   /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH11PEN                          (0x1UL << 11)                            /**< CH11 Pin Enable */
+#define _LESENSE_ROUTE_CH11PEN_SHIFT                   11                                       /**< Shift value for LESENSE_CH11PEN */
+#define _LESENSE_ROUTE_CH11PEN_MASK                    0x800UL                                  /**< Bit mask for LESENSE_CH11PEN */
+#define _LESENSE_ROUTE_CH11PEN_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH11PEN_DEFAULT                  (_LESENSE_ROUTE_CH11PEN_DEFAULT << 11)   /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH12PEN                          (0x1UL << 12)                            /**< CH12 Pin Enable */
+#define _LESENSE_ROUTE_CH12PEN_SHIFT                   12                                       /**< Shift value for LESENSE_CH12PEN */
+#define _LESENSE_ROUTE_CH12PEN_MASK                    0x1000UL                                 /**< Bit mask for LESENSE_CH12PEN */
+#define _LESENSE_ROUTE_CH12PEN_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH12PEN_DEFAULT                  (_LESENSE_ROUTE_CH12PEN_DEFAULT << 12)   /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH13PEN                          (0x1UL << 13)                            /**< CH13 Pin Enable */
+#define _LESENSE_ROUTE_CH13PEN_SHIFT                   13                                       /**< Shift value for LESENSE_CH13PEN */
+#define _LESENSE_ROUTE_CH13PEN_MASK                    0x2000UL                                 /**< Bit mask for LESENSE_CH13PEN */
+#define _LESENSE_ROUTE_CH13PEN_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH13PEN_DEFAULT                  (_LESENSE_ROUTE_CH13PEN_DEFAULT << 13)   /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH14PEN                          (0x1UL << 14)                            /**< CH14 Pin Enable */
+#define _LESENSE_ROUTE_CH14PEN_SHIFT                   14                                       /**< Shift value for LESENSE_CH14PEN */
+#define _LESENSE_ROUTE_CH14PEN_MASK                    0x4000UL                                 /**< Bit mask for LESENSE_CH14PEN */
+#define _LESENSE_ROUTE_CH14PEN_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH14PEN_DEFAULT                  (_LESENSE_ROUTE_CH14PEN_DEFAULT << 14)   /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH15PEN                          (0x1UL << 15)                            /**< CH15 Pin Enable */
+#define _LESENSE_ROUTE_CH15PEN_SHIFT                   15                                       /**< Shift value for LESENSE_CH15PEN */
+#define _LESENSE_ROUTE_CH15PEN_MASK                    0x8000UL                                 /**< Bit mask for LESENSE_CH15PEN */
+#define _LESENSE_ROUTE_CH15PEN_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_CH15PEN_DEFAULT                  (_LESENSE_ROUTE_CH15PEN_DEFAULT << 15)   /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX0PEN                        (0x1UL << 16)                            /**< ALTEX0 Pin Enable */
+#define _LESENSE_ROUTE_ALTEX0PEN_SHIFT                 16                                       /**< Shift value for LESENSE_ALTEX0PEN */
+#define _LESENSE_ROUTE_ALTEX0PEN_MASK                  0x10000UL                                /**< Bit mask for LESENSE_ALTEX0PEN */
+#define _LESENSE_ROUTE_ALTEX0PEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX0PEN_DEFAULT                (_LESENSE_ROUTE_ALTEX0PEN_DEFAULT << 16) /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX1PEN                        (0x1UL << 17)                            /**< ALTEX1 Pin Enable */
+#define _LESENSE_ROUTE_ALTEX1PEN_SHIFT                 17                                       /**< Shift value for LESENSE_ALTEX1PEN */
+#define _LESENSE_ROUTE_ALTEX1PEN_MASK                  0x20000UL                                /**< Bit mask for LESENSE_ALTEX1PEN */
+#define _LESENSE_ROUTE_ALTEX1PEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX1PEN_DEFAULT                (_LESENSE_ROUTE_ALTEX1PEN_DEFAULT << 17) /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX2PEN                        (0x1UL << 18)                            /**< ALTEX2 Pin Enable */
+#define _LESENSE_ROUTE_ALTEX2PEN_SHIFT                 18                                       /**< Shift value for LESENSE_ALTEX2PEN */
+#define _LESENSE_ROUTE_ALTEX2PEN_MASK                  0x40000UL                                /**< Bit mask for LESENSE_ALTEX2PEN */
+#define _LESENSE_ROUTE_ALTEX2PEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX2PEN_DEFAULT                (_LESENSE_ROUTE_ALTEX2PEN_DEFAULT << 18) /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX3PEN                        (0x1UL << 19)                            /**< ALTEX3 Pin Enable */
+#define _LESENSE_ROUTE_ALTEX3PEN_SHIFT                 19                                       /**< Shift value for LESENSE_ALTEX3PEN */
+#define _LESENSE_ROUTE_ALTEX3PEN_MASK                  0x80000UL                                /**< Bit mask for LESENSE_ALTEX3PEN */
+#define _LESENSE_ROUTE_ALTEX3PEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX3PEN_DEFAULT                (_LESENSE_ROUTE_ALTEX3PEN_DEFAULT << 19) /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX4PEN                        (0x1UL << 20)                            /**< ALTEX4 Pin Enable */
+#define _LESENSE_ROUTE_ALTEX4PEN_SHIFT                 20                                       /**< Shift value for LESENSE_ALTEX4PEN */
+#define _LESENSE_ROUTE_ALTEX4PEN_MASK                  0x100000UL                               /**< Bit mask for LESENSE_ALTEX4PEN */
+#define _LESENSE_ROUTE_ALTEX4PEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX4PEN_DEFAULT                (_LESENSE_ROUTE_ALTEX4PEN_DEFAULT << 20) /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX5PEN                        (0x1UL << 21)                            /**< ALTEX5 Pin Enable */
+#define _LESENSE_ROUTE_ALTEX5PEN_SHIFT                 21                                       /**< Shift value for LESENSE_ALTEX5PEN */
+#define _LESENSE_ROUTE_ALTEX5PEN_MASK                  0x200000UL                               /**< Bit mask for LESENSE_ALTEX5PEN */
+#define _LESENSE_ROUTE_ALTEX5PEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX5PEN_DEFAULT                (_LESENSE_ROUTE_ALTEX5PEN_DEFAULT << 21) /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX6PEN                        (0x1UL << 22)                            /**< ALTEX6 Pin Enable */
+#define _LESENSE_ROUTE_ALTEX6PEN_SHIFT                 22                                       /**< Shift value for LESENSE_ALTEX6PEN */
+#define _LESENSE_ROUTE_ALTEX6PEN_MASK                  0x400000UL                               /**< Bit mask for LESENSE_ALTEX6PEN */
+#define _LESENSE_ROUTE_ALTEX6PEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX6PEN_DEFAULT                (_LESENSE_ROUTE_ALTEX6PEN_DEFAULT << 22) /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX7PEN                        (0x1UL << 23)                            /**< ALTEX7 Pin Enable */
+#define _LESENSE_ROUTE_ALTEX7PEN_SHIFT                 23                                       /**< Shift value for LESENSE_ALTEX7PEN */
+#define _LESENSE_ROUTE_ALTEX7PEN_MASK                  0x800000UL                               /**< Bit mask for LESENSE_ALTEX7PEN */
+#define _LESENSE_ROUTE_ALTEX7PEN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for LESENSE_ROUTE */
+#define LESENSE_ROUTE_ALTEX7PEN_DEFAULT                (_LESENSE_ROUTE_ALTEX7PEN_DEFAULT << 23) /**< Shifted mode DEFAULT for LESENSE_ROUTE */
+
+/* Bit fields for LESENSE POWERDOWN */
+#define _LESENSE_POWERDOWN_RESETVALUE                  0x00000000UL                          /**< Default value for LESENSE_POWERDOWN */
+#define _LESENSE_POWERDOWN_MASK                        0x00000001UL                          /**< Mask for LESENSE_POWERDOWN */
+#define LESENSE_POWERDOWN_RAM                          (0x1UL << 0)                          /**< LESENSE RAM power-down */
+#define _LESENSE_POWERDOWN_RAM_SHIFT                   0                                     /**< Shift value for LESENSE_RAM */
+#define _LESENSE_POWERDOWN_RAM_MASK                    0x1UL                                 /**< Bit mask for LESENSE_RAM */
+#define _LESENSE_POWERDOWN_RAM_DEFAULT                 0x00000000UL                          /**< Mode DEFAULT for LESENSE_POWERDOWN */
+#define LESENSE_POWERDOWN_RAM_DEFAULT                  (_LESENSE_POWERDOWN_RAM_DEFAULT << 0) /**< Shifted mode DEFAULT for LESENSE_POWERDOWN */
+
+/* Bit fields for LESENSE ST_TCONFA */
+#define _LESENSE_ST_TCONFA_RESETVALUE                  0x00000000UL                                  /**< Default value for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_MASK                        0x00057FFFUL                                  /**< Mask for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_COMP_SHIFT                  0                                             /**< Shift value for LESENSE_COMP */
+#define _LESENSE_ST_TCONFA_COMP_MASK                   0xFUL                                         /**< Bit mask for LESENSE_COMP */
+#define _LESENSE_ST_TCONFA_COMP_DEFAULT                0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_COMP_DEFAULT                 (_LESENSE_ST_TCONFA_COMP_DEFAULT << 0)        /**< Shifted mode DEFAULT for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_MASK_SHIFT                  4                                             /**< Shift value for LESENSE_MASK */
+#define _LESENSE_ST_TCONFA_MASK_MASK                   0xF0UL                                        /**< Bit mask for LESENSE_MASK */
+#define _LESENSE_ST_TCONFA_MASK_DEFAULT                0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_MASK_DEFAULT                 (_LESENSE_ST_TCONFA_MASK_DEFAULT << 4)        /**< Shifted mode DEFAULT for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_NEXTSTATE_SHIFT             8                                             /**< Shift value for LESENSE_NEXTSTATE */
+#define _LESENSE_ST_TCONFA_NEXTSTATE_MASK              0xF00UL                                       /**< Bit mask for LESENSE_NEXTSTATE */
+#define _LESENSE_ST_TCONFA_NEXTSTATE_DEFAULT           0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_NEXTSTATE_DEFAULT            (_LESENSE_ST_TCONFA_NEXTSTATE_DEFAULT << 8)   /**< Shifted mode DEFAULT for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_SHIFT                12                                            /**< Shift value for LESENSE_PRSACT */
+#define _LESENSE_ST_TCONFA_PRSACT_MASK                 0x7000UL                                      /**< Bit mask for LESENSE_PRSACT */
+#define _LESENSE_ST_TCONFA_PRSACT_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_NONE                 0x00000000UL                                  /**< Mode NONE for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_PRS0                 0x00000001UL                                  /**< Mode PRS0 for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_UP                   0x00000001UL                                  /**< Mode UP for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_DOWN                 0x00000002UL                                  /**< Mode DOWN for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_PRS1                 0x00000002UL                                  /**< Mode PRS1 for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_PRS01                0x00000003UL                                  /**< Mode PRS01 for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_PRS2                 0x00000004UL                                  /**< Mode PRS2 for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_UPANDPRS2            0x00000005UL                                  /**< Mode UPANDPRS2 for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_PRS02                0x00000005UL                                  /**< Mode PRS02 for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_PRS12                0x00000006UL                                  /**< Mode PRS12 for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_DOWNANDPRS2          0x00000006UL                                  /**< Mode DOWNANDPRS2 for LESENSE_ST_TCONFA */
+#define _LESENSE_ST_TCONFA_PRSACT_PRS012               0x00000007UL                                  /**< Mode PRS012 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_DEFAULT               (_LESENSE_ST_TCONFA_PRSACT_DEFAULT << 12)     /**< Shifted mode DEFAULT for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_NONE                  (_LESENSE_ST_TCONFA_PRSACT_NONE << 12)        /**< Shifted mode NONE for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_PRS0                  (_LESENSE_ST_TCONFA_PRSACT_PRS0 << 12)        /**< Shifted mode PRS0 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_UP                    (_LESENSE_ST_TCONFA_PRSACT_UP << 12)          /**< Shifted mode UP for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_DOWN                  (_LESENSE_ST_TCONFA_PRSACT_DOWN << 12)        /**< Shifted mode DOWN for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_PRS1                  (_LESENSE_ST_TCONFA_PRSACT_PRS1 << 12)        /**< Shifted mode PRS1 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_PRS01                 (_LESENSE_ST_TCONFA_PRSACT_PRS01 << 12)       /**< Shifted mode PRS01 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_PRS2                  (_LESENSE_ST_TCONFA_PRSACT_PRS2 << 12)        /**< Shifted mode PRS2 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_UPANDPRS2             (_LESENSE_ST_TCONFA_PRSACT_UPANDPRS2 << 12)   /**< Shifted mode UPANDPRS2 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_PRS02                 (_LESENSE_ST_TCONFA_PRSACT_PRS02 << 12)       /**< Shifted mode PRS02 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_PRS12                 (_LESENSE_ST_TCONFA_PRSACT_PRS12 << 12)       /**< Shifted mode PRS12 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_DOWNANDPRS2           (_LESENSE_ST_TCONFA_PRSACT_DOWNANDPRS2 << 12) /**< Shifted mode DOWNANDPRS2 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_PRSACT_PRS012                (_LESENSE_ST_TCONFA_PRSACT_PRS012 << 12)      /**< Shifted mode PRS012 for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_SETIF                        (0x1UL << 16)                                 /**< Set interrupt flag enable */
+#define _LESENSE_ST_TCONFA_SETIF_SHIFT                 16                                            /**< Shift value for LESENSE_SETIF */
+#define _LESENSE_ST_TCONFA_SETIF_MASK                  0x10000UL                                     /**< Bit mask for LESENSE_SETIF */
+#define _LESENSE_ST_TCONFA_SETIF_DEFAULT               0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_SETIF_DEFAULT                (_LESENSE_ST_TCONFA_SETIF_DEFAULT << 16)      /**< Shifted mode DEFAULT for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_CHAIN                        (0x1UL << 18)                                 /**< Enable state descriptor chaining */
+#define _LESENSE_ST_TCONFA_CHAIN_SHIFT                 18                                            /**< Shift value for LESENSE_CHAIN */
+#define _LESENSE_ST_TCONFA_CHAIN_MASK                  0x40000UL                                     /**< Bit mask for LESENSE_CHAIN */
+#define _LESENSE_ST_TCONFA_CHAIN_DEFAULT               0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFA */
+#define LESENSE_ST_TCONFA_CHAIN_DEFAULT                (_LESENSE_ST_TCONFA_CHAIN_DEFAULT << 18)      /**< Shifted mode DEFAULT for LESENSE_ST_TCONFA */
+
+/* Bit fields for LESENSE ST_TCONFB */
+#define _LESENSE_ST_TCONFB_RESETVALUE                  0x00000000UL                                  /**< Default value for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_MASK                        0x00017FFFUL                                  /**< Mask for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_COMP_SHIFT                  0                                             /**< Shift value for LESENSE_COMP */
+#define _LESENSE_ST_TCONFB_COMP_MASK                   0xFUL                                         /**< Bit mask for LESENSE_COMP */
+#define _LESENSE_ST_TCONFB_COMP_DEFAULT                0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_COMP_DEFAULT                 (_LESENSE_ST_TCONFB_COMP_DEFAULT << 0)        /**< Shifted mode DEFAULT for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_MASK_SHIFT                  4                                             /**< Shift value for LESENSE_MASK */
+#define _LESENSE_ST_TCONFB_MASK_MASK                   0xF0UL                                        /**< Bit mask for LESENSE_MASK */
+#define _LESENSE_ST_TCONFB_MASK_DEFAULT                0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_MASK_DEFAULT                 (_LESENSE_ST_TCONFB_MASK_DEFAULT << 4)        /**< Shifted mode DEFAULT for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_NEXTSTATE_SHIFT             8                                             /**< Shift value for LESENSE_NEXTSTATE */
+#define _LESENSE_ST_TCONFB_NEXTSTATE_MASK              0xF00UL                                       /**< Bit mask for LESENSE_NEXTSTATE */
+#define _LESENSE_ST_TCONFB_NEXTSTATE_DEFAULT           0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_NEXTSTATE_DEFAULT            (_LESENSE_ST_TCONFB_NEXTSTATE_DEFAULT << 8)   /**< Shifted mode DEFAULT for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_SHIFT                12                                            /**< Shift value for LESENSE_PRSACT */
+#define _LESENSE_ST_TCONFB_PRSACT_MASK                 0x7000UL                                      /**< Bit mask for LESENSE_PRSACT */
+#define _LESENSE_ST_TCONFB_PRSACT_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_NONE                 0x00000000UL                                  /**< Mode NONE for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_PRS0                 0x00000001UL                                  /**< Mode PRS0 for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_UP                   0x00000001UL                                  /**< Mode UP for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_DOWN                 0x00000002UL                                  /**< Mode DOWN for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_PRS1                 0x00000002UL                                  /**< Mode PRS1 for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_PRS01                0x00000003UL                                  /**< Mode PRS01 for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_PRS2                 0x00000004UL                                  /**< Mode PRS2 for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_UPANDPRS2            0x00000005UL                                  /**< Mode UPANDPRS2 for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_PRS02                0x00000005UL                                  /**< Mode PRS02 for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_PRS12                0x00000006UL                                  /**< Mode PRS12 for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_DOWNANDPRS2          0x00000006UL                                  /**< Mode DOWNANDPRS2 for LESENSE_ST_TCONFB */
+#define _LESENSE_ST_TCONFB_PRSACT_PRS012               0x00000007UL                                  /**< Mode PRS012 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_DEFAULT               (_LESENSE_ST_TCONFB_PRSACT_DEFAULT << 12)     /**< Shifted mode DEFAULT for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_NONE                  (_LESENSE_ST_TCONFB_PRSACT_NONE << 12)        /**< Shifted mode NONE for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_PRS0                  (_LESENSE_ST_TCONFB_PRSACT_PRS0 << 12)        /**< Shifted mode PRS0 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_UP                    (_LESENSE_ST_TCONFB_PRSACT_UP << 12)          /**< Shifted mode UP for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_DOWN                  (_LESENSE_ST_TCONFB_PRSACT_DOWN << 12)        /**< Shifted mode DOWN for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_PRS1                  (_LESENSE_ST_TCONFB_PRSACT_PRS1 << 12)        /**< Shifted mode PRS1 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_PRS01                 (_LESENSE_ST_TCONFB_PRSACT_PRS01 << 12)       /**< Shifted mode PRS01 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_PRS2                  (_LESENSE_ST_TCONFB_PRSACT_PRS2 << 12)        /**< Shifted mode PRS2 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_UPANDPRS2             (_LESENSE_ST_TCONFB_PRSACT_UPANDPRS2 << 12)   /**< Shifted mode UPANDPRS2 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_PRS02                 (_LESENSE_ST_TCONFB_PRSACT_PRS02 << 12)       /**< Shifted mode PRS02 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_PRS12                 (_LESENSE_ST_TCONFB_PRSACT_PRS12 << 12)       /**< Shifted mode PRS12 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_DOWNANDPRS2           (_LESENSE_ST_TCONFB_PRSACT_DOWNANDPRS2 << 12) /**< Shifted mode DOWNANDPRS2 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_PRSACT_PRS012                (_LESENSE_ST_TCONFB_PRSACT_PRS012 << 12)      /**< Shifted mode PRS012 for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_SETIF                        (0x1UL << 16)                                 /**< Set interrupt flag */
+#define _LESENSE_ST_TCONFB_SETIF_SHIFT                 16                                            /**< Shift value for LESENSE_SETIF */
+#define _LESENSE_ST_TCONFB_SETIF_MASK                  0x10000UL                                     /**< Bit mask for LESENSE_SETIF */
+#define _LESENSE_ST_TCONFB_SETIF_DEFAULT               0x00000000UL                                  /**< Mode DEFAULT for LESENSE_ST_TCONFB */
+#define LESENSE_ST_TCONFB_SETIF_DEFAULT                (_LESENSE_ST_TCONFB_SETIF_DEFAULT << 16)      /**< Shifted mode DEFAULT for LESENSE_ST_TCONFB */
+
+/* Bit fields for LESENSE BUF_DATA */
+#define _LESENSE_BUF_DATA_RESETVALUE                   0x00000000UL                          /**< Default value for LESENSE_BUF_DATA */
+#define _LESENSE_BUF_DATA_MASK                         0x0000FFFFUL                          /**< Mask for LESENSE_BUF_DATA */
+#define _LESENSE_BUF_DATA_DATA_SHIFT                   0                                     /**< Shift value for LESENSE_DATA */
+#define _LESENSE_BUF_DATA_DATA_MASK                    0xFFFFUL                              /**< Bit mask for LESENSE_DATA */
+#define _LESENSE_BUF_DATA_DATA_DEFAULT                 0x00000000UL                          /**< Mode DEFAULT for LESENSE_BUF_DATA */
+#define LESENSE_BUF_DATA_DATA_DEFAULT                  (_LESENSE_BUF_DATA_DATA_DEFAULT << 0) /**< Shifted mode DEFAULT for LESENSE_BUF_DATA */
+
+/* Bit fields for LESENSE CH_TIMING */
+#define _LESENSE_CH_TIMING_RESETVALUE                  0x00000000UL                                  /**< Default value for LESENSE_CH_TIMING */
+#define _LESENSE_CH_TIMING_MASK                        0x000FFFFFUL                                  /**< Mask for LESENSE_CH_TIMING */
+#define _LESENSE_CH_TIMING_EXTIME_SHIFT                0                                             /**< Shift value for LESENSE_EXTIME */
+#define _LESENSE_CH_TIMING_EXTIME_MASK                 0x3FUL                                        /**< Bit mask for LESENSE_EXTIME */
+#define _LESENSE_CH_TIMING_EXTIME_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for LESENSE_CH_TIMING */
+#define LESENSE_CH_TIMING_EXTIME_DEFAULT               (_LESENSE_CH_TIMING_EXTIME_DEFAULT << 0)      /**< Shifted mode DEFAULT for LESENSE_CH_TIMING */
+#define _LESENSE_CH_TIMING_SAMPLEDLY_SHIFT             6                                             /**< Shift value for LESENSE_SAMPLEDLY */
+#define _LESENSE_CH_TIMING_SAMPLEDLY_MASK              0x1FC0UL                                      /**< Bit mask for LESENSE_SAMPLEDLY */
+#define _LESENSE_CH_TIMING_SAMPLEDLY_DEFAULT           0x00000000UL                                  /**< Mode DEFAULT for LESENSE_CH_TIMING */
+#define LESENSE_CH_TIMING_SAMPLEDLY_DEFAULT            (_LESENSE_CH_TIMING_SAMPLEDLY_DEFAULT << 6)   /**< Shifted mode DEFAULT for LESENSE_CH_TIMING */
+#define _LESENSE_CH_TIMING_MEASUREDLY_SHIFT            13                                            /**< Shift value for LESENSE_MEASUREDLY */
+#define _LESENSE_CH_TIMING_MEASUREDLY_MASK             0xFE000UL                                     /**< Bit mask for LESENSE_MEASUREDLY */
+#define _LESENSE_CH_TIMING_MEASUREDLY_DEFAULT          0x00000000UL                                  /**< Mode DEFAULT for LESENSE_CH_TIMING */
+#define LESENSE_CH_TIMING_MEASUREDLY_DEFAULT           (_LESENSE_CH_TIMING_MEASUREDLY_DEFAULT << 13) /**< Shifted mode DEFAULT for LESENSE_CH_TIMING */
+
+/* Bit fields for LESENSE CH_INTERACT */
+#define _LESENSE_CH_INTERACT_RESETVALUE                0x00000000UL                                    /**< Default value for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_MASK                      0x000FFFFFUL                                    /**< Mask for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_ACMPTHRES_SHIFT           0                                               /**< Shift value for LESENSE_ACMPTHRES */
+#define _LESENSE_CH_INTERACT_ACMPTHRES_MASK            0xFFFUL                                         /**< Bit mask for LESENSE_ACMPTHRES */
+#define _LESENSE_CH_INTERACT_ACMPTHRES_DEFAULT         0x00000000UL                                    /**< Mode DEFAULT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_ACMPTHRES_DEFAULT          (_LESENSE_CH_INTERACT_ACMPTHRES_DEFAULT << 0)   /**< Shifted mode DEFAULT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SAMPLE                     (0x1UL << 12)                                   /**< Select sample mode */
+#define _LESENSE_CH_INTERACT_SAMPLE_SHIFT              12                                              /**< Shift value for LESENSE_SAMPLE */
+#define _LESENSE_CH_INTERACT_SAMPLE_MASK               0x1000UL                                        /**< Bit mask for LESENSE_SAMPLE */
+#define _LESENSE_CH_INTERACT_SAMPLE_DEFAULT            0x00000000UL                                    /**< Mode DEFAULT for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_SAMPLE_COUNTER            0x00000000UL                                    /**< Mode COUNTER for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_SAMPLE_ACMP               0x00000001UL                                    /**< Mode ACMP for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SAMPLE_DEFAULT             (_LESENSE_CH_INTERACT_SAMPLE_DEFAULT << 12)     /**< Shifted mode DEFAULT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SAMPLE_COUNTER             (_LESENSE_CH_INTERACT_SAMPLE_COUNTER << 12)     /**< Shifted mode COUNTER for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SAMPLE_ACMP                (_LESENSE_CH_INTERACT_SAMPLE_ACMP << 12)        /**< Shifted mode ACMP for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_SETIF_SHIFT               13                                              /**< Shift value for LESENSE_SETIF */
+#define _LESENSE_CH_INTERACT_SETIF_MASK                0x6000UL                                        /**< Bit mask for LESENSE_SETIF */
+#define _LESENSE_CH_INTERACT_SETIF_DEFAULT             0x00000000UL                                    /**< Mode DEFAULT for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_SETIF_NONE                0x00000000UL                                    /**< Mode NONE for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_SETIF_LEVEL               0x00000001UL                                    /**< Mode LEVEL for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_SETIF_POSEDGE             0x00000002UL                                    /**< Mode POSEDGE for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_SETIF_NEGEDGE             0x00000003UL                                    /**< Mode NEGEDGE for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SETIF_DEFAULT              (_LESENSE_CH_INTERACT_SETIF_DEFAULT << 13)      /**< Shifted mode DEFAULT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SETIF_NONE                 (_LESENSE_CH_INTERACT_SETIF_NONE << 13)         /**< Shifted mode NONE for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SETIF_LEVEL                (_LESENSE_CH_INTERACT_SETIF_LEVEL << 13)        /**< Shifted mode LEVEL for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SETIF_POSEDGE              (_LESENSE_CH_INTERACT_SETIF_POSEDGE << 13)      /**< Shifted mode POSEDGE for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SETIF_NEGEDGE              (_LESENSE_CH_INTERACT_SETIF_NEGEDGE << 13)      /**< Shifted mode NEGEDGE for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_EXMODE_SHIFT              15                                              /**< Shift value for LESENSE_EXMODE */
+#define _LESENSE_CH_INTERACT_EXMODE_MASK               0x18000UL                                       /**< Bit mask for LESENSE_EXMODE */
+#define _LESENSE_CH_INTERACT_EXMODE_DEFAULT            0x00000000UL                                    /**< Mode DEFAULT for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_EXMODE_DISABLE            0x00000000UL                                    /**< Mode DISABLE for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_EXMODE_HIGH               0x00000001UL                                    /**< Mode HIGH for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_EXMODE_LOW                0x00000002UL                                    /**< Mode LOW for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_EXMODE_DACOUT             0x00000003UL                                    /**< Mode DACOUT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_EXMODE_DEFAULT             (_LESENSE_CH_INTERACT_EXMODE_DEFAULT << 15)     /**< Shifted mode DEFAULT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_EXMODE_DISABLE             (_LESENSE_CH_INTERACT_EXMODE_DISABLE << 15)     /**< Shifted mode DISABLE for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_EXMODE_HIGH                (_LESENSE_CH_INTERACT_EXMODE_HIGH << 15)        /**< Shifted mode HIGH for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_EXMODE_LOW                 (_LESENSE_CH_INTERACT_EXMODE_LOW << 15)         /**< Shifted mode LOW for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_EXMODE_DACOUT              (_LESENSE_CH_INTERACT_EXMODE_DACOUT << 15)      /**< Shifted mode DACOUT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_EXCLK                      (0x1UL << 17)                                   /**< Select clock used for excitation timing */
+#define _LESENSE_CH_INTERACT_EXCLK_SHIFT               17                                              /**< Shift value for LESENSE_EXCLK */
+#define _LESENSE_CH_INTERACT_EXCLK_MASK                0x20000UL                                       /**< Bit mask for LESENSE_EXCLK */
+#define _LESENSE_CH_INTERACT_EXCLK_DEFAULT             0x00000000UL                                    /**< Mode DEFAULT for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_EXCLK_LFACLK              0x00000000UL                                    /**< Mode LFACLK for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_EXCLK_AUXHFRCO            0x00000001UL                                    /**< Mode AUXHFRCO for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_EXCLK_DEFAULT              (_LESENSE_CH_INTERACT_EXCLK_DEFAULT << 17)      /**< Shifted mode DEFAULT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_EXCLK_LFACLK               (_LESENSE_CH_INTERACT_EXCLK_LFACLK << 17)       /**< Shifted mode LFACLK for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_EXCLK_AUXHFRCO             (_LESENSE_CH_INTERACT_EXCLK_AUXHFRCO << 17)     /**< Shifted mode AUXHFRCO for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SAMPLECLK                  (0x1UL << 18)                                   /**< Select clock used for timing of sample delay */
+#define _LESENSE_CH_INTERACT_SAMPLECLK_SHIFT           18                                              /**< Shift value for LESENSE_SAMPLECLK */
+#define _LESENSE_CH_INTERACT_SAMPLECLK_MASK            0x40000UL                                       /**< Bit mask for LESENSE_SAMPLECLK */
+#define _LESENSE_CH_INTERACT_SAMPLECLK_DEFAULT         0x00000000UL                                    /**< Mode DEFAULT for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_SAMPLECLK_LFACLK          0x00000000UL                                    /**< Mode LFACLK for LESENSE_CH_INTERACT */
+#define _LESENSE_CH_INTERACT_SAMPLECLK_AUXHFRCO        0x00000001UL                                    /**< Mode AUXHFRCO for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SAMPLECLK_DEFAULT          (_LESENSE_CH_INTERACT_SAMPLECLK_DEFAULT << 18)  /**< Shifted mode DEFAULT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SAMPLECLK_LFACLK           (_LESENSE_CH_INTERACT_SAMPLECLK_LFACLK << 18)   /**< Shifted mode LFACLK for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_SAMPLECLK_AUXHFRCO         (_LESENSE_CH_INTERACT_SAMPLECLK_AUXHFRCO << 18) /**< Shifted mode AUXHFRCO for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_ALTEX                      (0x1UL << 19)                                   /**< Use alternative excite pin */
+#define _LESENSE_CH_INTERACT_ALTEX_SHIFT               19                                              /**< Shift value for LESENSE_ALTEX */
+#define _LESENSE_CH_INTERACT_ALTEX_MASK                0x80000UL                                       /**< Bit mask for LESENSE_ALTEX */
+#define _LESENSE_CH_INTERACT_ALTEX_DEFAULT             0x00000000UL                                    /**< Mode DEFAULT for LESENSE_CH_INTERACT */
+#define LESENSE_CH_INTERACT_ALTEX_DEFAULT              (_LESENSE_CH_INTERACT_ALTEX_DEFAULT << 19)      /**< Shifted mode DEFAULT for LESENSE_CH_INTERACT */
+
+/* Bit fields for LESENSE CH_EVAL */
+#define _LESENSE_CH_EVAL_RESETVALUE                    0x00000000UL                                /**< Default value for LESENSE_CH_EVAL */
+#define _LESENSE_CH_EVAL_MASK                          0x000FFFFFUL                                /**< Mask for LESENSE_CH_EVAL */
+#define _LESENSE_CH_EVAL_COMPTHRES_SHIFT               0                                           /**< Shift value for LESENSE_COMPTHRES */
+#define _LESENSE_CH_EVAL_COMPTHRES_MASK                0xFFFFUL                                    /**< Bit mask for LESENSE_COMPTHRES */
+#define _LESENSE_CH_EVAL_COMPTHRES_DEFAULT             0x00000000UL                                /**< Mode DEFAULT for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_COMPTHRES_DEFAULT              (_LESENSE_CH_EVAL_COMPTHRES_DEFAULT << 0)   /**< Shifted mode DEFAULT for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_COMP                           (0x1UL << 16)                               /**< Select mode for counter comparison */
+#define _LESENSE_CH_EVAL_COMP_SHIFT                    16                                          /**< Shift value for LESENSE_COMP */
+#define _LESENSE_CH_EVAL_COMP_MASK                     0x10000UL                                   /**< Bit mask for LESENSE_COMP */
+#define _LESENSE_CH_EVAL_COMP_DEFAULT                  0x00000000UL                                /**< Mode DEFAULT for LESENSE_CH_EVAL */
+#define _LESENSE_CH_EVAL_COMP_LESS                     0x00000000UL                                /**< Mode LESS for LESENSE_CH_EVAL */
+#define _LESENSE_CH_EVAL_COMP_GE                       0x00000001UL                                /**< Mode GE for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_COMP_DEFAULT                   (_LESENSE_CH_EVAL_COMP_DEFAULT << 16)       /**< Shifted mode DEFAULT for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_COMP_LESS                      (_LESENSE_CH_EVAL_COMP_LESS << 16)          /**< Shifted mode LESS for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_COMP_GE                        (_LESENSE_CH_EVAL_COMP_GE << 16)            /**< Shifted mode GE for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_DECODE                         (0x1UL << 17)                               /**< Send result to decoder */
+#define _LESENSE_CH_EVAL_DECODE_SHIFT                  17                                          /**< Shift value for LESENSE_DECODE */
+#define _LESENSE_CH_EVAL_DECODE_MASK                   0x20000UL                                   /**< Bit mask for LESENSE_DECODE */
+#define _LESENSE_CH_EVAL_DECODE_DEFAULT                0x00000000UL                                /**< Mode DEFAULT for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_DECODE_DEFAULT                 (_LESENSE_CH_EVAL_DECODE_DEFAULT << 17)     /**< Shifted mode DEFAULT for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_STRSAMPLE                      (0x1UL << 18)                               /**< Select if counter result should be stored */
+#define _LESENSE_CH_EVAL_STRSAMPLE_SHIFT               18                                          /**< Shift value for LESENSE_STRSAMPLE */
+#define _LESENSE_CH_EVAL_STRSAMPLE_MASK                0x40000UL                                   /**< Bit mask for LESENSE_STRSAMPLE */
+#define _LESENSE_CH_EVAL_STRSAMPLE_DEFAULT             0x00000000UL                                /**< Mode DEFAULT for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_STRSAMPLE_DEFAULT              (_LESENSE_CH_EVAL_STRSAMPLE_DEFAULT << 18)  /**< Shifted mode DEFAULT for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_SCANRESINV                     (0x1UL << 19)                               /**< Enable inversion of result */
+#define _LESENSE_CH_EVAL_SCANRESINV_SHIFT              19                                          /**< Shift value for LESENSE_SCANRESINV */
+#define _LESENSE_CH_EVAL_SCANRESINV_MASK               0x80000UL                                   /**< Bit mask for LESENSE_SCANRESINV */
+#define _LESENSE_CH_EVAL_SCANRESINV_DEFAULT            0x00000000UL                                /**< Mode DEFAULT for LESENSE_CH_EVAL */
+#define LESENSE_CH_EVAL_SCANRESINV_DEFAULT             (_LESENSE_CH_EVAL_SCANRESINV_DEFAULT << 19) /**< Shifted mode DEFAULT for LESENSE_CH_EVAL */
+
+/** @} End of group EFM32TG_LESENSE */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lesense_buf.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lesense_buf.h
@@ -1,0 +1,48 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_LESENSE_BUF register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @brief LESENSE_BUF EFM32TG LESENSE BUF
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t DATA; /**< Scan results  */
+} LESENSE_BUF_TypeDef;
+
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lesense_ch.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lesense_ch.h
@@ -1,0 +1,51 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_LESENSE_CH register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @brief LESENSE_CH EFM32TG LESENSE CH
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t TIMING;        /**< Scan configuration  */
+  __IOM uint32_t INTERACT;      /**< Scan configuration  */
+  __IOM uint32_t EVAL;          /**< Scan configuration  */
+  uint32_t       RESERVED0[1U]; /**< Reserved future */
+} LESENSE_CH_TypeDef;
+
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lesense_st.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_lesense_st.h
@@ -1,0 +1,49 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_LESENSE_ST register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @brief LESENSE_ST EFM32TG LESENSE ST
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t TCONFA; /**< State transition configuration A  */
+  __IOM uint32_t TCONFB; /**< State transition configuration B  */
+} LESENSE_ST_TypeDef;
+
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_letimer.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_letimer.h
@@ -1,0 +1,415 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_LETIMER register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_LETIMER
+ * @brief EFM32TG_LETIMER Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IOM uint32_t CNT;           /**< Counter Value Register  */
+  __IOM uint32_t COMP0;         /**< Compare Value Register 0  */
+  __IOM uint32_t COMP1;         /**< Compare Value Register 1  */
+  __IOM uint32_t REP0;          /**< Repeat Counter Register 0  */
+  __IOM uint32_t REP1;          /**< Repeat Counter Register 1  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+
+  uint32_t       RESERVED0[2U]; /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+} LETIMER_TypeDef;              /**< LETIMER Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_LETIMER_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for LETIMER CTRL */
+#define _LETIMER_CTRL_RESETVALUE             0x00000000UL                           /**< Default value for LETIMER_CTRL */
+#define _LETIMER_CTRL_MASK                   0x00001FFFUL                           /**< Mask for LETIMER_CTRL */
+#define _LETIMER_CTRL_REPMODE_SHIFT          0                                      /**< Shift value for LETIMER_REPMODE */
+#define _LETIMER_CTRL_REPMODE_MASK           0x3UL                                  /**< Bit mask for LETIMER_REPMODE */
+#define _LETIMER_CTRL_REPMODE_DEFAULT        0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define _LETIMER_CTRL_REPMODE_FREE           0x00000000UL                           /**< Mode FREE for LETIMER_CTRL */
+#define _LETIMER_CTRL_REPMODE_ONESHOT        0x00000001UL                           /**< Mode ONESHOT for LETIMER_CTRL */
+#define _LETIMER_CTRL_REPMODE_BUFFERED       0x00000002UL                           /**< Mode BUFFERED for LETIMER_CTRL */
+#define _LETIMER_CTRL_REPMODE_DOUBLE         0x00000003UL                           /**< Mode DOUBLE for LETIMER_CTRL */
+#define LETIMER_CTRL_REPMODE_DEFAULT         (_LETIMER_CTRL_REPMODE_DEFAULT << 0)   /**< Shifted mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_REPMODE_FREE            (_LETIMER_CTRL_REPMODE_FREE << 0)      /**< Shifted mode FREE for LETIMER_CTRL */
+#define LETIMER_CTRL_REPMODE_ONESHOT         (_LETIMER_CTRL_REPMODE_ONESHOT << 0)   /**< Shifted mode ONESHOT for LETIMER_CTRL */
+#define LETIMER_CTRL_REPMODE_BUFFERED        (_LETIMER_CTRL_REPMODE_BUFFERED << 0)  /**< Shifted mode BUFFERED for LETIMER_CTRL */
+#define LETIMER_CTRL_REPMODE_DOUBLE          (_LETIMER_CTRL_REPMODE_DOUBLE << 0)    /**< Shifted mode DOUBLE for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA0_SHIFT            2                                      /**< Shift value for LETIMER_UFOA0 */
+#define _LETIMER_CTRL_UFOA0_MASK             0xCUL                                  /**< Bit mask for LETIMER_UFOA0 */
+#define _LETIMER_CTRL_UFOA0_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA0_NONE             0x00000000UL                           /**< Mode NONE for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA0_TOGGLE           0x00000001UL                           /**< Mode TOGGLE for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA0_PULSE            0x00000002UL                           /**< Mode PULSE for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA0_PWM              0x00000003UL                           /**< Mode PWM for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA0_DEFAULT           (_LETIMER_CTRL_UFOA0_DEFAULT << 2)     /**< Shifted mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA0_NONE              (_LETIMER_CTRL_UFOA0_NONE << 2)        /**< Shifted mode NONE for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA0_TOGGLE            (_LETIMER_CTRL_UFOA0_TOGGLE << 2)      /**< Shifted mode TOGGLE for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA0_PULSE             (_LETIMER_CTRL_UFOA0_PULSE << 2)       /**< Shifted mode PULSE for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA0_PWM               (_LETIMER_CTRL_UFOA0_PWM << 2)         /**< Shifted mode PWM for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA1_SHIFT            4                                      /**< Shift value for LETIMER_UFOA1 */
+#define _LETIMER_CTRL_UFOA1_MASK             0x30UL                                 /**< Bit mask for LETIMER_UFOA1 */
+#define _LETIMER_CTRL_UFOA1_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA1_NONE             0x00000000UL                           /**< Mode NONE for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA1_TOGGLE           0x00000001UL                           /**< Mode TOGGLE for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA1_PULSE            0x00000002UL                           /**< Mode PULSE for LETIMER_CTRL */
+#define _LETIMER_CTRL_UFOA1_PWM              0x00000003UL                           /**< Mode PWM for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA1_DEFAULT           (_LETIMER_CTRL_UFOA1_DEFAULT << 4)     /**< Shifted mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA1_NONE              (_LETIMER_CTRL_UFOA1_NONE << 4)        /**< Shifted mode NONE for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA1_TOGGLE            (_LETIMER_CTRL_UFOA1_TOGGLE << 4)      /**< Shifted mode TOGGLE for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA1_PULSE             (_LETIMER_CTRL_UFOA1_PULSE << 4)       /**< Shifted mode PULSE for LETIMER_CTRL */
+#define LETIMER_CTRL_UFOA1_PWM               (_LETIMER_CTRL_UFOA1_PWM << 4)         /**< Shifted mode PWM for LETIMER_CTRL */
+#define LETIMER_CTRL_OPOL0                   (0x1UL << 6)                           /**< Output 0 Polarity */
+#define _LETIMER_CTRL_OPOL0_SHIFT            6                                      /**< Shift value for LETIMER_OPOL0 */
+#define _LETIMER_CTRL_OPOL0_MASK             0x40UL                                 /**< Bit mask for LETIMER_OPOL0 */
+#define _LETIMER_CTRL_OPOL0_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_OPOL0_DEFAULT           (_LETIMER_CTRL_OPOL0_DEFAULT << 6)     /**< Shifted mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_OPOL1                   (0x1UL << 7)                           /**< Output 1 Polarity */
+#define _LETIMER_CTRL_OPOL1_SHIFT            7                                      /**< Shift value for LETIMER_OPOL1 */
+#define _LETIMER_CTRL_OPOL1_MASK             0x80UL                                 /**< Bit mask for LETIMER_OPOL1 */
+#define _LETIMER_CTRL_OPOL1_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_OPOL1_DEFAULT           (_LETIMER_CTRL_OPOL1_DEFAULT << 7)     /**< Shifted mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_BUFTOP                  (0x1UL << 8)                           /**< Buffered Top */
+#define _LETIMER_CTRL_BUFTOP_SHIFT           8                                      /**< Shift value for LETIMER_BUFTOP */
+#define _LETIMER_CTRL_BUFTOP_MASK            0x100UL                                /**< Bit mask for LETIMER_BUFTOP */
+#define _LETIMER_CTRL_BUFTOP_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_BUFTOP_DEFAULT          (_LETIMER_CTRL_BUFTOP_DEFAULT << 8)    /**< Shifted mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_COMP0TOP                (0x1UL << 9)                           /**< Compare Value 0 Is Top Value */
+#define _LETIMER_CTRL_COMP0TOP_SHIFT         9                                      /**< Shift value for LETIMER_COMP0TOP */
+#define _LETIMER_CTRL_COMP0TOP_MASK          0x200UL                                /**< Bit mask for LETIMER_COMP0TOP */
+#define _LETIMER_CTRL_COMP0TOP_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_COMP0TOP_DEFAULT        (_LETIMER_CTRL_COMP0TOP_DEFAULT << 9)  /**< Shifted mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_RTCC0TEN                (0x1UL << 10)                          /**< RTC Compare 0 Trigger Enable */
+#define _LETIMER_CTRL_RTCC0TEN_SHIFT         10                                     /**< Shift value for LETIMER_RTCC0TEN */
+#define _LETIMER_CTRL_RTCC0TEN_MASK          0x400UL                                /**< Bit mask for LETIMER_RTCC0TEN */
+#define _LETIMER_CTRL_RTCC0TEN_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_RTCC0TEN_DEFAULT        (_LETIMER_CTRL_RTCC0TEN_DEFAULT << 10) /**< Shifted mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_RTCC1TEN                (0x1UL << 11)                          /**< RTC Compare 1 Trigger Enable */
+#define _LETIMER_CTRL_RTCC1TEN_SHIFT         11                                     /**< Shift value for LETIMER_RTCC1TEN */
+#define _LETIMER_CTRL_RTCC1TEN_MASK          0x800UL                                /**< Bit mask for LETIMER_RTCC1TEN */
+#define _LETIMER_CTRL_RTCC1TEN_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_RTCC1TEN_DEFAULT        (_LETIMER_CTRL_RTCC1TEN_DEFAULT << 11) /**< Shifted mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_DEBUGRUN                (0x1UL << 12)                          /**< Debug Mode Run Enable */
+#define _LETIMER_CTRL_DEBUGRUN_SHIFT         12                                     /**< Shift value for LETIMER_DEBUGRUN */
+#define _LETIMER_CTRL_DEBUGRUN_MASK          0x1000UL                               /**< Bit mask for LETIMER_DEBUGRUN */
+#define _LETIMER_CTRL_DEBUGRUN_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
+#define LETIMER_CTRL_DEBUGRUN_DEFAULT        (_LETIMER_CTRL_DEBUGRUN_DEFAULT << 12) /**< Shifted mode DEFAULT for LETIMER_CTRL */
+
+/* Bit fields for LETIMER CMD */
+#define _LETIMER_CMD_RESETVALUE              0x00000000UL                      /**< Default value for LETIMER_CMD */
+#define _LETIMER_CMD_MASK                    0x0000001FUL                      /**< Mask for LETIMER_CMD */
+#define LETIMER_CMD_START                    (0x1UL << 0)                      /**< Start LETIMER */
+#define _LETIMER_CMD_START_SHIFT             0                                 /**< Shift value for LETIMER_START */
+#define _LETIMER_CMD_START_MASK              0x1UL                             /**< Bit mask for LETIMER_START */
+#define _LETIMER_CMD_START_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_CMD */
+#define LETIMER_CMD_START_DEFAULT            (_LETIMER_CMD_START_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_CMD */
+#define LETIMER_CMD_STOP                     (0x1UL << 1)                      /**< Stop LETIMER */
+#define _LETIMER_CMD_STOP_SHIFT              1                                 /**< Shift value for LETIMER_STOP */
+#define _LETIMER_CMD_STOP_MASK               0x2UL                             /**< Bit mask for LETIMER_STOP */
+#define _LETIMER_CMD_STOP_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for LETIMER_CMD */
+#define LETIMER_CMD_STOP_DEFAULT             (_LETIMER_CMD_STOP_DEFAULT << 1)  /**< Shifted mode DEFAULT for LETIMER_CMD */
+#define LETIMER_CMD_CLEAR                    (0x1UL << 2)                      /**< Clear LETIMER */
+#define _LETIMER_CMD_CLEAR_SHIFT             2                                 /**< Shift value for LETIMER_CLEAR */
+#define _LETIMER_CMD_CLEAR_MASK              0x4UL                             /**< Bit mask for LETIMER_CLEAR */
+#define _LETIMER_CMD_CLEAR_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_CMD */
+#define LETIMER_CMD_CLEAR_DEFAULT            (_LETIMER_CMD_CLEAR_DEFAULT << 2) /**< Shifted mode DEFAULT for LETIMER_CMD */
+#define LETIMER_CMD_CTO0                     (0x1UL << 3)                      /**< Clear Toggle Output 0 */
+#define _LETIMER_CMD_CTO0_SHIFT              3                                 /**< Shift value for LETIMER_CTO0 */
+#define _LETIMER_CMD_CTO0_MASK               0x8UL                             /**< Bit mask for LETIMER_CTO0 */
+#define _LETIMER_CMD_CTO0_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for LETIMER_CMD */
+#define LETIMER_CMD_CTO0_DEFAULT             (_LETIMER_CMD_CTO0_DEFAULT << 3)  /**< Shifted mode DEFAULT for LETIMER_CMD */
+#define LETIMER_CMD_CTO1                     (0x1UL << 4)                      /**< Clear Toggle Output 1 */
+#define _LETIMER_CMD_CTO1_SHIFT              4                                 /**< Shift value for LETIMER_CTO1 */
+#define _LETIMER_CMD_CTO1_MASK               0x10UL                            /**< Bit mask for LETIMER_CTO1 */
+#define _LETIMER_CMD_CTO1_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for LETIMER_CMD */
+#define LETIMER_CMD_CTO1_DEFAULT             (_LETIMER_CMD_CTO1_DEFAULT << 4)  /**< Shifted mode DEFAULT for LETIMER_CMD */
+
+/* Bit fields for LETIMER STATUS */
+#define _LETIMER_STATUS_RESETVALUE           0x00000000UL                           /**< Default value for LETIMER_STATUS */
+#define _LETIMER_STATUS_MASK                 0x00000001UL                           /**< Mask for LETIMER_STATUS */
+#define LETIMER_STATUS_RUNNING               (0x1UL << 0)                           /**< LETIMER Running */
+#define _LETIMER_STATUS_RUNNING_SHIFT        0                                      /**< Shift value for LETIMER_RUNNING */
+#define _LETIMER_STATUS_RUNNING_MASK         0x1UL                                  /**< Bit mask for LETIMER_RUNNING */
+#define _LETIMER_STATUS_RUNNING_DEFAULT      0x00000000UL                           /**< Mode DEFAULT for LETIMER_STATUS */
+#define LETIMER_STATUS_RUNNING_DEFAULT       (_LETIMER_STATUS_RUNNING_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_STATUS */
+
+/* Bit fields for LETIMER CNT */
+#define _LETIMER_CNT_RESETVALUE              0x00000000UL                    /**< Default value for LETIMER_CNT */
+#define _LETIMER_CNT_MASK                    0x0000FFFFUL                    /**< Mask for LETIMER_CNT */
+#define _LETIMER_CNT_CNT_SHIFT               0                               /**< Shift value for LETIMER_CNT */
+#define _LETIMER_CNT_CNT_MASK                0xFFFFUL                        /**< Bit mask for LETIMER_CNT */
+#define _LETIMER_CNT_CNT_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for LETIMER_CNT */
+#define LETIMER_CNT_CNT_DEFAULT              (_LETIMER_CNT_CNT_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_CNT */
+
+/* Bit fields for LETIMER COMP0 */
+#define _LETIMER_COMP0_RESETVALUE            0x00000000UL                        /**< Default value for LETIMER_COMP0 */
+#define _LETIMER_COMP0_MASK                  0x0000FFFFUL                        /**< Mask for LETIMER_COMP0 */
+#define _LETIMER_COMP0_COMP0_SHIFT           0                                   /**< Shift value for LETIMER_COMP0 */
+#define _LETIMER_COMP0_COMP0_MASK            0xFFFFUL                            /**< Bit mask for LETIMER_COMP0 */
+#define _LETIMER_COMP0_COMP0_DEFAULT         0x00000000UL                        /**< Mode DEFAULT for LETIMER_COMP0 */
+#define LETIMER_COMP0_COMP0_DEFAULT          (_LETIMER_COMP0_COMP0_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_COMP0 */
+
+/* Bit fields for LETIMER COMP1 */
+#define _LETIMER_COMP1_RESETVALUE            0x00000000UL                        /**< Default value for LETIMER_COMP1 */
+#define _LETIMER_COMP1_MASK                  0x0000FFFFUL                        /**< Mask for LETIMER_COMP1 */
+#define _LETIMER_COMP1_COMP1_SHIFT           0                                   /**< Shift value for LETIMER_COMP1 */
+#define _LETIMER_COMP1_COMP1_MASK            0xFFFFUL                            /**< Bit mask for LETIMER_COMP1 */
+#define _LETIMER_COMP1_COMP1_DEFAULT         0x00000000UL                        /**< Mode DEFAULT for LETIMER_COMP1 */
+#define LETIMER_COMP1_COMP1_DEFAULT          (_LETIMER_COMP1_COMP1_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_COMP1 */
+
+/* Bit fields for LETIMER REP0 */
+#define _LETIMER_REP0_RESETVALUE             0x00000000UL                      /**< Default value for LETIMER_REP0 */
+#define _LETIMER_REP0_MASK                   0x000000FFUL                      /**< Mask for LETIMER_REP0 */
+#define _LETIMER_REP0_REP0_SHIFT             0                                 /**< Shift value for LETIMER_REP0 */
+#define _LETIMER_REP0_REP0_MASK              0xFFUL                            /**< Bit mask for LETIMER_REP0 */
+#define _LETIMER_REP0_REP0_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_REP0 */
+#define LETIMER_REP0_REP0_DEFAULT            (_LETIMER_REP0_REP0_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_REP0 */
+
+/* Bit fields for LETIMER REP1 */
+#define _LETIMER_REP1_RESETVALUE             0x00000000UL                      /**< Default value for LETIMER_REP1 */
+#define _LETIMER_REP1_MASK                   0x000000FFUL                      /**< Mask for LETIMER_REP1 */
+#define _LETIMER_REP1_REP1_SHIFT             0                                 /**< Shift value for LETIMER_REP1 */
+#define _LETIMER_REP1_REP1_MASK              0xFFUL                            /**< Bit mask for LETIMER_REP1 */
+#define _LETIMER_REP1_REP1_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_REP1 */
+#define LETIMER_REP1_REP1_DEFAULT            (_LETIMER_REP1_REP1_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_REP1 */
+
+/* Bit fields for LETIMER IF */
+#define _LETIMER_IF_RESETVALUE               0x00000000UL                     /**< Default value for LETIMER_IF */
+#define _LETIMER_IF_MASK                     0x0000001FUL                     /**< Mask for LETIMER_IF */
+#define LETIMER_IF_COMP0                     (0x1UL << 0)                     /**< Compare Match 0 Interrupt Flag */
+#define _LETIMER_IF_COMP0_SHIFT              0                                /**< Shift value for LETIMER_COMP0 */
+#define _LETIMER_IF_COMP0_MASK               0x1UL                            /**< Bit mask for LETIMER_COMP0 */
+#define _LETIMER_IF_COMP0_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for LETIMER_IF */
+#define LETIMER_IF_COMP0_DEFAULT             (_LETIMER_IF_COMP0_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_IF */
+#define LETIMER_IF_COMP1                     (0x1UL << 1)                     /**< Compare Match 1 Interrupt Flag */
+#define _LETIMER_IF_COMP1_SHIFT              1                                /**< Shift value for LETIMER_COMP1 */
+#define _LETIMER_IF_COMP1_MASK               0x2UL                            /**< Bit mask for LETIMER_COMP1 */
+#define _LETIMER_IF_COMP1_DEFAULT            0x00000000UL                     /**< Mode DEFAULT for LETIMER_IF */
+#define LETIMER_IF_COMP1_DEFAULT             (_LETIMER_IF_COMP1_DEFAULT << 1) /**< Shifted mode DEFAULT for LETIMER_IF */
+#define LETIMER_IF_UF                        (0x1UL << 2)                     /**< Underflow Interrupt Flag */
+#define _LETIMER_IF_UF_SHIFT                 2                                /**< Shift value for LETIMER_UF */
+#define _LETIMER_IF_UF_MASK                  0x4UL                            /**< Bit mask for LETIMER_UF */
+#define _LETIMER_IF_UF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for LETIMER_IF */
+#define LETIMER_IF_UF_DEFAULT                (_LETIMER_IF_UF_DEFAULT << 2)    /**< Shifted mode DEFAULT for LETIMER_IF */
+#define LETIMER_IF_REP0                      (0x1UL << 3)                     /**< Repeat Counter 0 Interrupt Flag */
+#define _LETIMER_IF_REP0_SHIFT               3                                /**< Shift value for LETIMER_REP0 */
+#define _LETIMER_IF_REP0_MASK                0x8UL                            /**< Bit mask for LETIMER_REP0 */
+#define _LETIMER_IF_REP0_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for LETIMER_IF */
+#define LETIMER_IF_REP0_DEFAULT              (_LETIMER_IF_REP0_DEFAULT << 3)  /**< Shifted mode DEFAULT for LETIMER_IF */
+#define LETIMER_IF_REP1                      (0x1UL << 4)                     /**< Repeat Counter 1 Interrupt Flag */
+#define _LETIMER_IF_REP1_SHIFT               4                                /**< Shift value for LETIMER_REP1 */
+#define _LETIMER_IF_REP1_MASK                0x10UL                           /**< Bit mask for LETIMER_REP1 */
+#define _LETIMER_IF_REP1_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for LETIMER_IF */
+#define LETIMER_IF_REP1_DEFAULT              (_LETIMER_IF_REP1_DEFAULT << 4)  /**< Shifted mode DEFAULT for LETIMER_IF */
+
+/* Bit fields for LETIMER IFS */
+#define _LETIMER_IFS_RESETVALUE              0x00000000UL                      /**< Default value for LETIMER_IFS */
+#define _LETIMER_IFS_MASK                    0x0000001FUL                      /**< Mask for LETIMER_IFS */
+#define LETIMER_IFS_COMP0                    (0x1UL << 0)                      /**< Set Compare Match 0 Interrupt Flag */
+#define _LETIMER_IFS_COMP0_SHIFT             0                                 /**< Shift value for LETIMER_COMP0 */
+#define _LETIMER_IFS_COMP0_MASK              0x1UL                             /**< Bit mask for LETIMER_COMP0 */
+#define _LETIMER_IFS_COMP0_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFS */
+#define LETIMER_IFS_COMP0_DEFAULT            (_LETIMER_IFS_COMP0_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_IFS */
+#define LETIMER_IFS_COMP1                    (0x1UL << 1)                      /**< Set Compare Match 1 Interrupt Flag */
+#define _LETIMER_IFS_COMP1_SHIFT             1                                 /**< Shift value for LETIMER_COMP1 */
+#define _LETIMER_IFS_COMP1_MASK              0x2UL                             /**< Bit mask for LETIMER_COMP1 */
+#define _LETIMER_IFS_COMP1_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFS */
+#define LETIMER_IFS_COMP1_DEFAULT            (_LETIMER_IFS_COMP1_DEFAULT << 1) /**< Shifted mode DEFAULT for LETIMER_IFS */
+#define LETIMER_IFS_UF                       (0x1UL << 2)                      /**< Set Underflow Interrupt Flag */
+#define _LETIMER_IFS_UF_SHIFT                2                                 /**< Shift value for LETIMER_UF */
+#define _LETIMER_IFS_UF_MASK                 0x4UL                             /**< Bit mask for LETIMER_UF */
+#define _LETIMER_IFS_UF_DEFAULT              0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFS */
+#define LETIMER_IFS_UF_DEFAULT               (_LETIMER_IFS_UF_DEFAULT << 2)    /**< Shifted mode DEFAULT for LETIMER_IFS */
+#define LETIMER_IFS_REP0                     (0x1UL << 3)                      /**< Set Repeat Counter 0 Interrupt Flag */
+#define _LETIMER_IFS_REP0_SHIFT              3                                 /**< Shift value for LETIMER_REP0 */
+#define _LETIMER_IFS_REP0_MASK               0x8UL                             /**< Bit mask for LETIMER_REP0 */
+#define _LETIMER_IFS_REP0_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFS */
+#define LETIMER_IFS_REP0_DEFAULT             (_LETIMER_IFS_REP0_DEFAULT << 3)  /**< Shifted mode DEFAULT for LETIMER_IFS */
+#define LETIMER_IFS_REP1                     (0x1UL << 4)                      /**< Set Repeat Counter 1 Interrupt Flag */
+#define _LETIMER_IFS_REP1_SHIFT              4                                 /**< Shift value for LETIMER_REP1 */
+#define _LETIMER_IFS_REP1_MASK               0x10UL                            /**< Bit mask for LETIMER_REP1 */
+#define _LETIMER_IFS_REP1_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFS */
+#define LETIMER_IFS_REP1_DEFAULT             (_LETIMER_IFS_REP1_DEFAULT << 4)  /**< Shifted mode DEFAULT for LETIMER_IFS */
+
+/* Bit fields for LETIMER IFC */
+#define _LETIMER_IFC_RESETVALUE              0x00000000UL                      /**< Default value for LETIMER_IFC */
+#define _LETIMER_IFC_MASK                    0x0000001FUL                      /**< Mask for LETIMER_IFC */
+#define LETIMER_IFC_COMP0                    (0x1UL << 0)                      /**< Clear Compare Match 0 Interrupt Flag */
+#define _LETIMER_IFC_COMP0_SHIFT             0                                 /**< Shift value for LETIMER_COMP0 */
+#define _LETIMER_IFC_COMP0_MASK              0x1UL                             /**< Bit mask for LETIMER_COMP0 */
+#define _LETIMER_IFC_COMP0_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFC */
+#define LETIMER_IFC_COMP0_DEFAULT            (_LETIMER_IFC_COMP0_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_IFC */
+#define LETIMER_IFC_COMP1                    (0x1UL << 1)                      /**< Clear Compare Match 1 Interrupt Flag */
+#define _LETIMER_IFC_COMP1_SHIFT             1                                 /**< Shift value for LETIMER_COMP1 */
+#define _LETIMER_IFC_COMP1_MASK              0x2UL                             /**< Bit mask for LETIMER_COMP1 */
+#define _LETIMER_IFC_COMP1_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFC */
+#define LETIMER_IFC_COMP1_DEFAULT            (_LETIMER_IFC_COMP1_DEFAULT << 1) /**< Shifted mode DEFAULT for LETIMER_IFC */
+#define LETIMER_IFC_UF                       (0x1UL << 2)                      /**< Clear Underflow Interrupt Flag */
+#define _LETIMER_IFC_UF_SHIFT                2                                 /**< Shift value for LETIMER_UF */
+#define _LETIMER_IFC_UF_MASK                 0x4UL                             /**< Bit mask for LETIMER_UF */
+#define _LETIMER_IFC_UF_DEFAULT              0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFC */
+#define LETIMER_IFC_UF_DEFAULT               (_LETIMER_IFC_UF_DEFAULT << 2)    /**< Shifted mode DEFAULT for LETIMER_IFC */
+#define LETIMER_IFC_REP0                     (0x1UL << 3)                      /**< Clear Repeat Counter 0 Interrupt Flag */
+#define _LETIMER_IFC_REP0_SHIFT              3                                 /**< Shift value for LETIMER_REP0 */
+#define _LETIMER_IFC_REP0_MASK               0x8UL                             /**< Bit mask for LETIMER_REP0 */
+#define _LETIMER_IFC_REP0_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFC */
+#define LETIMER_IFC_REP0_DEFAULT             (_LETIMER_IFC_REP0_DEFAULT << 3)  /**< Shifted mode DEFAULT for LETIMER_IFC */
+#define LETIMER_IFC_REP1                     (0x1UL << 4)                      /**< Clear Repeat Counter 1 Interrupt Flag */
+#define _LETIMER_IFC_REP1_SHIFT              4                                 /**< Shift value for LETIMER_REP1 */
+#define _LETIMER_IFC_REP1_MASK               0x10UL                            /**< Bit mask for LETIMER_REP1 */
+#define _LETIMER_IFC_REP1_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for LETIMER_IFC */
+#define LETIMER_IFC_REP1_DEFAULT             (_LETIMER_IFC_REP1_DEFAULT << 4)  /**< Shifted mode DEFAULT for LETIMER_IFC */
+
+/* Bit fields for LETIMER IEN */
+#define _LETIMER_IEN_RESETVALUE              0x00000000UL                      /**< Default value for LETIMER_IEN */
+#define _LETIMER_IEN_MASK                    0x0000001FUL                      /**< Mask for LETIMER_IEN */
+#define LETIMER_IEN_COMP0                    (0x1UL << 0)                      /**< Compare Match 0 Interrupt Enable */
+#define _LETIMER_IEN_COMP0_SHIFT             0                                 /**< Shift value for LETIMER_COMP0 */
+#define _LETIMER_IEN_COMP0_MASK              0x1UL                             /**< Bit mask for LETIMER_COMP0 */
+#define _LETIMER_IEN_COMP0_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_IEN */
+#define LETIMER_IEN_COMP0_DEFAULT            (_LETIMER_IEN_COMP0_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_IEN */
+#define LETIMER_IEN_COMP1                    (0x1UL << 1)                      /**< Compare Match 1 Interrupt Enable */
+#define _LETIMER_IEN_COMP1_SHIFT             1                                 /**< Shift value for LETIMER_COMP1 */
+#define _LETIMER_IEN_COMP1_MASK              0x2UL                             /**< Bit mask for LETIMER_COMP1 */
+#define _LETIMER_IEN_COMP1_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for LETIMER_IEN */
+#define LETIMER_IEN_COMP1_DEFAULT            (_LETIMER_IEN_COMP1_DEFAULT << 1) /**< Shifted mode DEFAULT for LETIMER_IEN */
+#define LETIMER_IEN_UF                       (0x1UL << 2)                      /**< Underflow Interrupt Enable */
+#define _LETIMER_IEN_UF_SHIFT                2                                 /**< Shift value for LETIMER_UF */
+#define _LETIMER_IEN_UF_MASK                 0x4UL                             /**< Bit mask for LETIMER_UF */
+#define _LETIMER_IEN_UF_DEFAULT              0x00000000UL                      /**< Mode DEFAULT for LETIMER_IEN */
+#define LETIMER_IEN_UF_DEFAULT               (_LETIMER_IEN_UF_DEFAULT << 2)    /**< Shifted mode DEFAULT for LETIMER_IEN */
+#define LETIMER_IEN_REP0                     (0x1UL << 3)                      /**< Repeat Counter 0 Interrupt Enable */
+#define _LETIMER_IEN_REP0_SHIFT              3                                 /**< Shift value for LETIMER_REP0 */
+#define _LETIMER_IEN_REP0_MASK               0x8UL                             /**< Bit mask for LETIMER_REP0 */
+#define _LETIMER_IEN_REP0_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for LETIMER_IEN */
+#define LETIMER_IEN_REP0_DEFAULT             (_LETIMER_IEN_REP0_DEFAULT << 3)  /**< Shifted mode DEFAULT for LETIMER_IEN */
+#define LETIMER_IEN_REP1                     (0x1UL << 4)                      /**< Repeat Counter 1 Interrupt Enable */
+#define _LETIMER_IEN_REP1_SHIFT              4                                 /**< Shift value for LETIMER_REP1 */
+#define _LETIMER_IEN_REP1_MASK               0x10UL                            /**< Bit mask for LETIMER_REP1 */
+#define _LETIMER_IEN_REP1_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for LETIMER_IEN */
+#define LETIMER_IEN_REP1_DEFAULT             (_LETIMER_IEN_REP1_DEFAULT << 4)  /**< Shifted mode DEFAULT for LETIMER_IEN */
+
+/* Bit fields for LETIMER FREEZE */
+#define _LETIMER_FREEZE_RESETVALUE           0x00000000UL                             /**< Default value for LETIMER_FREEZE */
+#define _LETIMER_FREEZE_MASK                 0x00000001UL                             /**< Mask for LETIMER_FREEZE */
+#define LETIMER_FREEZE_REGFREEZE             (0x1UL << 0)                             /**< Register Update Freeze */
+#define _LETIMER_FREEZE_REGFREEZE_SHIFT      0                                        /**< Shift value for LETIMER_REGFREEZE */
+#define _LETIMER_FREEZE_REGFREEZE_MASK       0x1UL                                    /**< Bit mask for LETIMER_REGFREEZE */
+#define _LETIMER_FREEZE_REGFREEZE_DEFAULT    0x00000000UL                             /**< Mode DEFAULT for LETIMER_FREEZE */
+#define _LETIMER_FREEZE_REGFREEZE_UPDATE     0x00000000UL                             /**< Mode UPDATE for LETIMER_FREEZE */
+#define _LETIMER_FREEZE_REGFREEZE_FREEZE     0x00000001UL                             /**< Mode FREEZE for LETIMER_FREEZE */
+#define LETIMER_FREEZE_REGFREEZE_DEFAULT     (_LETIMER_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for LETIMER_FREEZE */
+#define LETIMER_FREEZE_REGFREEZE_UPDATE      (_LETIMER_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for LETIMER_FREEZE */
+#define LETIMER_FREEZE_REGFREEZE_FREEZE      (_LETIMER_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for LETIMER_FREEZE */
+
+/* Bit fields for LETIMER SYNCBUSY */
+#define _LETIMER_SYNCBUSY_RESETVALUE         0x00000000UL                           /**< Default value for LETIMER_SYNCBUSY */
+#define _LETIMER_SYNCBUSY_MASK               0x0000003FUL                           /**< Mask for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_CTRL                (0x1UL << 0)                           /**< CTRL Register Busy */
+#define _LETIMER_SYNCBUSY_CTRL_SHIFT         0                                      /**< Shift value for LETIMER_CTRL */
+#define _LETIMER_SYNCBUSY_CTRL_MASK          0x1UL                                  /**< Bit mask for LETIMER_CTRL */
+#define _LETIMER_SYNCBUSY_CTRL_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_CTRL_DEFAULT        (_LETIMER_SYNCBUSY_CTRL_DEFAULT << 0)  /**< Shifted mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_CMD                 (0x1UL << 1)                           /**< CMD Register Busy */
+#define _LETIMER_SYNCBUSY_CMD_SHIFT          1                                      /**< Shift value for LETIMER_CMD */
+#define _LETIMER_SYNCBUSY_CMD_MASK           0x2UL                                  /**< Bit mask for LETIMER_CMD */
+#define _LETIMER_SYNCBUSY_CMD_DEFAULT        0x00000000UL                           /**< Mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_CMD_DEFAULT         (_LETIMER_SYNCBUSY_CMD_DEFAULT << 1)   /**< Shifted mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_COMP0               (0x1UL << 2)                           /**< COMP0 Register Busy */
+#define _LETIMER_SYNCBUSY_COMP0_SHIFT        2                                      /**< Shift value for LETIMER_COMP0 */
+#define _LETIMER_SYNCBUSY_COMP0_MASK         0x4UL                                  /**< Bit mask for LETIMER_COMP0 */
+#define _LETIMER_SYNCBUSY_COMP0_DEFAULT      0x00000000UL                           /**< Mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_COMP0_DEFAULT       (_LETIMER_SYNCBUSY_COMP0_DEFAULT << 2) /**< Shifted mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_COMP1               (0x1UL << 3)                           /**< COMP1 Register Busy */
+#define _LETIMER_SYNCBUSY_COMP1_SHIFT        3                                      /**< Shift value for LETIMER_COMP1 */
+#define _LETIMER_SYNCBUSY_COMP1_MASK         0x8UL                                  /**< Bit mask for LETIMER_COMP1 */
+#define _LETIMER_SYNCBUSY_COMP1_DEFAULT      0x00000000UL                           /**< Mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_COMP1_DEFAULT       (_LETIMER_SYNCBUSY_COMP1_DEFAULT << 3) /**< Shifted mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_REP0                (0x1UL << 4)                           /**< REP0 Register Busy */
+#define _LETIMER_SYNCBUSY_REP0_SHIFT         4                                      /**< Shift value for LETIMER_REP0 */
+#define _LETIMER_SYNCBUSY_REP0_MASK          0x10UL                                 /**< Bit mask for LETIMER_REP0 */
+#define _LETIMER_SYNCBUSY_REP0_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_REP0_DEFAULT        (_LETIMER_SYNCBUSY_REP0_DEFAULT << 4)  /**< Shifted mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_REP1                (0x1UL << 5)                           /**< REP1 Register Busy */
+#define _LETIMER_SYNCBUSY_REP1_SHIFT         5                                      /**< Shift value for LETIMER_REP1 */
+#define _LETIMER_SYNCBUSY_REP1_MASK          0x20UL                                 /**< Bit mask for LETIMER_REP1 */
+#define _LETIMER_SYNCBUSY_REP1_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for LETIMER_SYNCBUSY */
+#define LETIMER_SYNCBUSY_REP1_DEFAULT        (_LETIMER_SYNCBUSY_REP1_DEFAULT << 5)  /**< Shifted mode DEFAULT for LETIMER_SYNCBUSY */
+
+/* Bit fields for LETIMER ROUTE */
+#define _LETIMER_ROUTE_RESETVALUE            0x00000000UL                           /**< Default value for LETIMER_ROUTE */
+#define _LETIMER_ROUTE_MASK                  0x00000703UL                           /**< Mask for LETIMER_ROUTE */
+#define LETIMER_ROUTE_OUT0PEN                (0x1UL << 0)                           /**< Output 0 Pin Enable */
+#define _LETIMER_ROUTE_OUT0PEN_SHIFT         0                                      /**< Shift value for LETIMER_OUT0PEN */
+#define _LETIMER_ROUTE_OUT0PEN_MASK          0x1UL                                  /**< Bit mask for LETIMER_OUT0PEN */
+#define _LETIMER_ROUTE_OUT0PEN_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for LETIMER_ROUTE */
+#define LETIMER_ROUTE_OUT0PEN_DEFAULT        (_LETIMER_ROUTE_OUT0PEN_DEFAULT << 0)  /**< Shifted mode DEFAULT for LETIMER_ROUTE */
+#define LETIMER_ROUTE_OUT1PEN                (0x1UL << 1)                           /**< Output 1 Pin Enable */
+#define _LETIMER_ROUTE_OUT1PEN_SHIFT         1                                      /**< Shift value for LETIMER_OUT1PEN */
+#define _LETIMER_ROUTE_OUT1PEN_MASK          0x2UL                                  /**< Bit mask for LETIMER_OUT1PEN */
+#define _LETIMER_ROUTE_OUT1PEN_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for LETIMER_ROUTE */
+#define LETIMER_ROUTE_OUT1PEN_DEFAULT        (_LETIMER_ROUTE_OUT1PEN_DEFAULT << 1)  /**< Shifted mode DEFAULT for LETIMER_ROUTE */
+#define _LETIMER_ROUTE_LOCATION_SHIFT        8                                      /**< Shift value for LETIMER_LOCATION */
+#define _LETIMER_ROUTE_LOCATION_MASK         0x700UL                                /**< Bit mask for LETIMER_LOCATION */
+#define _LETIMER_ROUTE_LOCATION_LOC0         0x00000000UL                           /**< Mode LOC0 for LETIMER_ROUTE */
+#define _LETIMER_ROUTE_LOCATION_DEFAULT      0x00000000UL                           /**< Mode DEFAULT for LETIMER_ROUTE */
+#define _LETIMER_ROUTE_LOCATION_LOC1         0x00000001UL                           /**< Mode LOC1 for LETIMER_ROUTE */
+#define _LETIMER_ROUTE_LOCATION_LOC2         0x00000002UL                           /**< Mode LOC2 for LETIMER_ROUTE */
+#define _LETIMER_ROUTE_LOCATION_LOC3         0x00000003UL                           /**< Mode LOC3 for LETIMER_ROUTE */
+#define LETIMER_ROUTE_LOCATION_LOC0          (_LETIMER_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for LETIMER_ROUTE */
+#define LETIMER_ROUTE_LOCATION_DEFAULT       (_LETIMER_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for LETIMER_ROUTE */
+#define LETIMER_ROUTE_LOCATION_LOC1          (_LETIMER_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for LETIMER_ROUTE */
+#define LETIMER_ROUTE_LOCATION_LOC2          (_LETIMER_ROUTE_LOCATION_LOC2 << 8)    /**< Shifted mode LOC2 for LETIMER_ROUTE */
+#define LETIMER_ROUTE_LOCATION_LOC3          (_LETIMER_ROUTE_LOCATION_LOC3 << 8)    /**< Shifted mode LOC3 for LETIMER_ROUTE */
+
+/** @} End of group EFM32TG_LETIMER */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_leuart.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_leuart.h
@@ -1,0 +1,698 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_LEUART register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_LEUART
+ * @brief EFM32TG_LEUART Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;           /**< Control Register  */
+  __IOM uint32_t CMD;            /**< Command Register  */
+  __IM uint32_t  STATUS;         /**< Status Register  */
+  __IOM uint32_t CLKDIV;         /**< Clock Control Register  */
+  __IOM uint32_t STARTFRAME;     /**< Start Frame Register  */
+  __IOM uint32_t SIGFRAME;       /**< Signal Frame Register  */
+  __IM uint32_t  RXDATAX;        /**< Receive Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;         /**< Receive Buffer Data Register  */
+  __IM uint32_t  RXDATAXP;       /**< Receive Buffer Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;        /**< Transmit Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;         /**< Transmit Buffer Data Register  */
+  __IM uint32_t  IF;             /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
+  __IOM uint32_t PULSECTRL;      /**< Pulse Control Register  */
+
+  __IOM uint32_t FREEZE;         /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;       /**< Synchronization Busy Register  */
+
+  uint32_t       RESERVED0[3U];  /**< Reserved for future use **/
+  __IOM uint32_t ROUTE;          /**< I/O Routing Register  */
+  uint32_t       RESERVED1[21U]; /**< Reserved for future use **/
+  __IOM uint32_t INPUT;          /**< LEUART Input Register  */
+} LEUART_TypeDef;                /**< LEUART Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_LEUART_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for LEUART CTRL */
+#define _LEUART_CTRL_RESETVALUE                  0x00000000UL                         /**< Default value for LEUART_CTRL */
+#define _LEUART_CTRL_MASK                        0x0000FFFFUL                         /**< Mask for LEUART_CTRL */
+#define LEUART_CTRL_AUTOTRI                      (0x1UL << 0)                         /**< Automatic Transmitter Tristate */
+#define _LEUART_CTRL_AUTOTRI_SHIFT               0                                    /**< Shift value for LEUART_AUTOTRI */
+#define _LEUART_CTRL_AUTOTRI_MASK                0x1UL                                /**< Bit mask for LEUART_AUTOTRI */
+#define _LEUART_CTRL_AUTOTRI_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_AUTOTRI_DEFAULT              (_LEUART_CTRL_AUTOTRI_DEFAULT << 0)  /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_DATABITS                     (0x1UL << 1)                         /**< Data-Bit Mode */
+#define _LEUART_CTRL_DATABITS_SHIFT              1                                    /**< Shift value for LEUART_DATABITS */
+#define _LEUART_CTRL_DATABITS_MASK               0x2UL                                /**< Bit mask for LEUART_DATABITS */
+#define _LEUART_CTRL_DATABITS_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define _LEUART_CTRL_DATABITS_EIGHT              0x00000000UL                         /**< Mode EIGHT for LEUART_CTRL */
+#define _LEUART_CTRL_DATABITS_NINE               0x00000001UL                         /**< Mode NINE for LEUART_CTRL */
+#define LEUART_CTRL_DATABITS_DEFAULT             (_LEUART_CTRL_DATABITS_DEFAULT << 1) /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_DATABITS_EIGHT               (_LEUART_CTRL_DATABITS_EIGHT << 1)   /**< Shifted mode EIGHT for LEUART_CTRL */
+#define LEUART_CTRL_DATABITS_NINE                (_LEUART_CTRL_DATABITS_NINE << 1)    /**< Shifted mode NINE for LEUART_CTRL */
+#define _LEUART_CTRL_PARITY_SHIFT                2                                    /**< Shift value for LEUART_PARITY */
+#define _LEUART_CTRL_PARITY_MASK                 0xCUL                                /**< Bit mask for LEUART_PARITY */
+#define _LEUART_CTRL_PARITY_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define _LEUART_CTRL_PARITY_NONE                 0x00000000UL                         /**< Mode NONE for LEUART_CTRL */
+#define _LEUART_CTRL_PARITY_EVEN                 0x00000002UL                         /**< Mode EVEN for LEUART_CTRL */
+#define _LEUART_CTRL_PARITY_ODD                  0x00000003UL                         /**< Mode ODD for LEUART_CTRL */
+#define LEUART_CTRL_PARITY_DEFAULT               (_LEUART_CTRL_PARITY_DEFAULT << 2)   /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_PARITY_NONE                  (_LEUART_CTRL_PARITY_NONE << 2)      /**< Shifted mode NONE for LEUART_CTRL */
+#define LEUART_CTRL_PARITY_EVEN                  (_LEUART_CTRL_PARITY_EVEN << 2)      /**< Shifted mode EVEN for LEUART_CTRL */
+#define LEUART_CTRL_PARITY_ODD                   (_LEUART_CTRL_PARITY_ODD << 2)       /**< Shifted mode ODD for LEUART_CTRL */
+#define LEUART_CTRL_STOPBITS                     (0x1UL << 4)                         /**< Stop-Bit Mode */
+#define _LEUART_CTRL_STOPBITS_SHIFT              4                                    /**< Shift value for LEUART_STOPBITS */
+#define _LEUART_CTRL_STOPBITS_MASK               0x10UL                               /**< Bit mask for LEUART_STOPBITS */
+#define _LEUART_CTRL_STOPBITS_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define _LEUART_CTRL_STOPBITS_ONE                0x00000000UL                         /**< Mode ONE for LEUART_CTRL */
+#define _LEUART_CTRL_STOPBITS_TWO                0x00000001UL                         /**< Mode TWO for LEUART_CTRL */
+#define LEUART_CTRL_STOPBITS_DEFAULT             (_LEUART_CTRL_STOPBITS_DEFAULT << 4) /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_STOPBITS_ONE                 (_LEUART_CTRL_STOPBITS_ONE << 4)     /**< Shifted mode ONE for LEUART_CTRL */
+#define LEUART_CTRL_STOPBITS_TWO                 (_LEUART_CTRL_STOPBITS_TWO << 4)     /**< Shifted mode TWO for LEUART_CTRL */
+#define LEUART_CTRL_INV                          (0x1UL << 5)                         /**< Invert Input And Output */
+#define _LEUART_CTRL_INV_SHIFT                   5                                    /**< Shift value for LEUART_INV */
+#define _LEUART_CTRL_INV_MASK                    0x20UL                               /**< Bit mask for LEUART_INV */
+#define _LEUART_CTRL_INV_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_INV_DEFAULT                  (_LEUART_CTRL_INV_DEFAULT << 5)      /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_ERRSDMA                      (0x1UL << 6)                         /**< Clear RX DMA On Error */
+#define _LEUART_CTRL_ERRSDMA_SHIFT               6                                    /**< Shift value for LEUART_ERRSDMA */
+#define _LEUART_CTRL_ERRSDMA_MASK                0x40UL                               /**< Bit mask for LEUART_ERRSDMA */
+#define _LEUART_CTRL_ERRSDMA_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_ERRSDMA_DEFAULT              (_LEUART_CTRL_ERRSDMA_DEFAULT << 6)  /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_LOOPBK                       (0x1UL << 7)                         /**< Loopback Enable */
+#define _LEUART_CTRL_LOOPBK_SHIFT                7                                    /**< Shift value for LEUART_LOOPBK */
+#define _LEUART_CTRL_LOOPBK_MASK                 0x80UL                               /**< Bit mask for LEUART_LOOPBK */
+#define _LEUART_CTRL_LOOPBK_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_LOOPBK_DEFAULT               (_LEUART_CTRL_LOOPBK_DEFAULT << 7)   /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_SFUBRX                       (0x1UL << 8)                         /**< Start-Frame UnBlock RX */
+#define _LEUART_CTRL_SFUBRX_SHIFT                8                                    /**< Shift value for LEUART_SFUBRX */
+#define _LEUART_CTRL_SFUBRX_MASK                 0x100UL                              /**< Bit mask for LEUART_SFUBRX */
+#define _LEUART_CTRL_SFUBRX_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_SFUBRX_DEFAULT               (_LEUART_CTRL_SFUBRX_DEFAULT << 8)   /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_MPM                          (0x1UL << 9)                         /**< Multi-Processor Mode */
+#define _LEUART_CTRL_MPM_SHIFT                   9                                    /**< Shift value for LEUART_MPM */
+#define _LEUART_CTRL_MPM_MASK                    0x200UL                              /**< Bit mask for LEUART_MPM */
+#define _LEUART_CTRL_MPM_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_MPM_DEFAULT                  (_LEUART_CTRL_MPM_DEFAULT << 9)      /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_MPAB                         (0x1UL << 10)                        /**< Multi-Processor Address-Bit */
+#define _LEUART_CTRL_MPAB_SHIFT                  10                                   /**< Shift value for LEUART_MPAB */
+#define _LEUART_CTRL_MPAB_MASK                   0x400UL                              /**< Bit mask for LEUART_MPAB */
+#define _LEUART_CTRL_MPAB_DEFAULT                0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_MPAB_DEFAULT                 (_LEUART_CTRL_MPAB_DEFAULT << 10)    /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_BIT8DV                       (0x1UL << 11)                        /**< Bit 8 Default Value */
+#define _LEUART_CTRL_BIT8DV_SHIFT                11                                   /**< Shift value for LEUART_BIT8DV */
+#define _LEUART_CTRL_BIT8DV_MASK                 0x800UL                              /**< Bit mask for LEUART_BIT8DV */
+#define _LEUART_CTRL_BIT8DV_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_BIT8DV_DEFAULT               (_LEUART_CTRL_BIT8DV_DEFAULT << 11)  /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_RXDMAWU                      (0x1UL << 12)                        /**< RX DMA Wakeup */
+#define _LEUART_CTRL_RXDMAWU_SHIFT               12                                   /**< Shift value for LEUART_RXDMAWU */
+#define _LEUART_CTRL_RXDMAWU_MASK                0x1000UL                             /**< Bit mask for LEUART_RXDMAWU */
+#define _LEUART_CTRL_RXDMAWU_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_RXDMAWU_DEFAULT              (_LEUART_CTRL_RXDMAWU_DEFAULT << 12) /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_TXDMAWU                      (0x1UL << 13)                        /**< TX DMA Wakeup */
+#define _LEUART_CTRL_TXDMAWU_SHIFT               13                                   /**< Shift value for LEUART_TXDMAWU */
+#define _LEUART_CTRL_TXDMAWU_MASK                0x2000UL                             /**< Bit mask for LEUART_TXDMAWU */
+#define _LEUART_CTRL_TXDMAWU_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_TXDMAWU_DEFAULT              (_LEUART_CTRL_TXDMAWU_DEFAULT << 13) /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define _LEUART_CTRL_TXDELAY_SHIFT               14                                   /**< Shift value for LEUART_TXDELAY */
+#define _LEUART_CTRL_TXDELAY_MASK                0xC000UL                             /**< Bit mask for LEUART_TXDELAY */
+#define _LEUART_CTRL_TXDELAY_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
+#define _LEUART_CTRL_TXDELAY_NONE                0x00000000UL                         /**< Mode NONE for LEUART_CTRL */
+#define _LEUART_CTRL_TXDELAY_SINGLE              0x00000001UL                         /**< Mode SINGLE for LEUART_CTRL */
+#define _LEUART_CTRL_TXDELAY_DOUBLE              0x00000002UL                         /**< Mode DOUBLE for LEUART_CTRL */
+#define _LEUART_CTRL_TXDELAY_TRIPLE              0x00000003UL                         /**< Mode TRIPLE for LEUART_CTRL */
+#define LEUART_CTRL_TXDELAY_DEFAULT              (_LEUART_CTRL_TXDELAY_DEFAULT << 14) /**< Shifted mode DEFAULT for LEUART_CTRL */
+#define LEUART_CTRL_TXDELAY_NONE                 (_LEUART_CTRL_TXDELAY_NONE << 14)    /**< Shifted mode NONE for LEUART_CTRL */
+#define LEUART_CTRL_TXDELAY_SINGLE               (_LEUART_CTRL_TXDELAY_SINGLE << 14)  /**< Shifted mode SINGLE for LEUART_CTRL */
+#define LEUART_CTRL_TXDELAY_DOUBLE               (_LEUART_CTRL_TXDELAY_DOUBLE << 14)  /**< Shifted mode DOUBLE for LEUART_CTRL */
+#define LEUART_CTRL_TXDELAY_TRIPLE               (_LEUART_CTRL_TXDELAY_TRIPLE << 14)  /**< Shifted mode TRIPLE for LEUART_CTRL */
+
+/* Bit fields for LEUART CMD */
+#define _LEUART_CMD_RESETVALUE                   0x00000000UL                          /**< Default value for LEUART_CMD */
+#define _LEUART_CMD_MASK                         0x000000FFUL                          /**< Mask for LEUART_CMD */
+#define LEUART_CMD_RXEN                          (0x1UL << 0)                          /**< Receiver Enable */
+#define _LEUART_CMD_RXEN_SHIFT                   0                                     /**< Shift value for LEUART_RXEN */
+#define _LEUART_CMD_RXEN_MASK                    0x1UL                                 /**< Bit mask for LEUART_RXEN */
+#define _LEUART_CMD_RXEN_DEFAULT                 0x00000000UL                          /**< Mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_RXEN_DEFAULT                  (_LEUART_CMD_RXEN_DEFAULT << 0)       /**< Shifted mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_RXDIS                         (0x1UL << 1)                          /**< Receiver Disable */
+#define _LEUART_CMD_RXDIS_SHIFT                  1                                     /**< Shift value for LEUART_RXDIS */
+#define _LEUART_CMD_RXDIS_MASK                   0x2UL                                 /**< Bit mask for LEUART_RXDIS */
+#define _LEUART_CMD_RXDIS_DEFAULT                0x00000000UL                          /**< Mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_RXDIS_DEFAULT                 (_LEUART_CMD_RXDIS_DEFAULT << 1)      /**< Shifted mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_TXEN                          (0x1UL << 2)                          /**< Transmitter Enable */
+#define _LEUART_CMD_TXEN_SHIFT                   2                                     /**< Shift value for LEUART_TXEN */
+#define _LEUART_CMD_TXEN_MASK                    0x4UL                                 /**< Bit mask for LEUART_TXEN */
+#define _LEUART_CMD_TXEN_DEFAULT                 0x00000000UL                          /**< Mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_TXEN_DEFAULT                  (_LEUART_CMD_TXEN_DEFAULT << 2)       /**< Shifted mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_TXDIS                         (0x1UL << 3)                          /**< Transmitter Disable */
+#define _LEUART_CMD_TXDIS_SHIFT                  3                                     /**< Shift value for LEUART_TXDIS */
+#define _LEUART_CMD_TXDIS_MASK                   0x8UL                                 /**< Bit mask for LEUART_TXDIS */
+#define _LEUART_CMD_TXDIS_DEFAULT                0x00000000UL                          /**< Mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_TXDIS_DEFAULT                 (_LEUART_CMD_TXDIS_DEFAULT << 3)      /**< Shifted mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_RXBLOCKEN                     (0x1UL << 4)                          /**< Receiver Block Enable */
+#define _LEUART_CMD_RXBLOCKEN_SHIFT              4                                     /**< Shift value for LEUART_RXBLOCKEN */
+#define _LEUART_CMD_RXBLOCKEN_MASK               0x10UL                                /**< Bit mask for LEUART_RXBLOCKEN */
+#define _LEUART_CMD_RXBLOCKEN_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_RXBLOCKEN_DEFAULT             (_LEUART_CMD_RXBLOCKEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_RXBLOCKDIS                    (0x1UL << 5)                          /**< Receiver Block Disable */
+#define _LEUART_CMD_RXBLOCKDIS_SHIFT             5                                     /**< Shift value for LEUART_RXBLOCKDIS */
+#define _LEUART_CMD_RXBLOCKDIS_MASK              0x20UL                                /**< Bit mask for LEUART_RXBLOCKDIS */
+#define _LEUART_CMD_RXBLOCKDIS_DEFAULT           0x00000000UL                          /**< Mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_RXBLOCKDIS_DEFAULT            (_LEUART_CMD_RXBLOCKDIS_DEFAULT << 5) /**< Shifted mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_CLEARTX                       (0x1UL << 6)                          /**< Clear TX */
+#define _LEUART_CMD_CLEARTX_SHIFT                6                                     /**< Shift value for LEUART_CLEARTX */
+#define _LEUART_CMD_CLEARTX_MASK                 0x40UL                                /**< Bit mask for LEUART_CLEARTX */
+#define _LEUART_CMD_CLEARTX_DEFAULT              0x00000000UL                          /**< Mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_CLEARTX_DEFAULT               (_LEUART_CMD_CLEARTX_DEFAULT << 6)    /**< Shifted mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_CLEARRX                       (0x1UL << 7)                          /**< Clear RX */
+#define _LEUART_CMD_CLEARRX_SHIFT                7                                     /**< Shift value for LEUART_CLEARRX */
+#define _LEUART_CMD_CLEARRX_MASK                 0x80UL                                /**< Bit mask for LEUART_CLEARRX */
+#define _LEUART_CMD_CLEARRX_DEFAULT              0x00000000UL                          /**< Mode DEFAULT for LEUART_CMD */
+#define LEUART_CMD_CLEARRX_DEFAULT               (_LEUART_CMD_CLEARRX_DEFAULT << 7)    /**< Shifted mode DEFAULT for LEUART_CMD */
+
+/* Bit fields for LEUART STATUS */
+#define _LEUART_STATUS_RESETVALUE                0x00000010UL                          /**< Default value for LEUART_STATUS */
+#define _LEUART_STATUS_MASK                      0x0000003FUL                          /**< Mask for LEUART_STATUS */
+#define LEUART_STATUS_RXENS                      (0x1UL << 0)                          /**< Receiver Enable Status */
+#define _LEUART_STATUS_RXENS_SHIFT               0                                     /**< Shift value for LEUART_RXENS */
+#define _LEUART_STATUS_RXENS_MASK                0x1UL                                 /**< Bit mask for LEUART_RXENS */
+#define _LEUART_STATUS_RXENS_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_RXENS_DEFAULT              (_LEUART_STATUS_RXENS_DEFAULT << 0)   /**< Shifted mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_TXENS                      (0x1UL << 1)                          /**< Transmitter Enable Status */
+#define _LEUART_STATUS_TXENS_SHIFT               1                                     /**< Shift value for LEUART_TXENS */
+#define _LEUART_STATUS_TXENS_MASK                0x2UL                                 /**< Bit mask for LEUART_TXENS */
+#define _LEUART_STATUS_TXENS_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_TXENS_DEFAULT              (_LEUART_STATUS_TXENS_DEFAULT << 1)   /**< Shifted mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_RXBLOCK                    (0x1UL << 2)                          /**< Block Incoming Data */
+#define _LEUART_STATUS_RXBLOCK_SHIFT             2                                     /**< Shift value for LEUART_RXBLOCK */
+#define _LEUART_STATUS_RXBLOCK_MASK              0x4UL                                 /**< Bit mask for LEUART_RXBLOCK */
+#define _LEUART_STATUS_RXBLOCK_DEFAULT           0x00000000UL                          /**< Mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_RXBLOCK_DEFAULT            (_LEUART_STATUS_RXBLOCK_DEFAULT << 2) /**< Shifted mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_TXC                        (0x1UL << 3)                          /**< TX Complete */
+#define _LEUART_STATUS_TXC_SHIFT                 3                                     /**< Shift value for LEUART_TXC */
+#define _LEUART_STATUS_TXC_MASK                  0x8UL                                 /**< Bit mask for LEUART_TXC */
+#define _LEUART_STATUS_TXC_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_TXC_DEFAULT                (_LEUART_STATUS_TXC_DEFAULT << 3)     /**< Shifted mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_TXBL                       (0x1UL << 4)                          /**< TX Buffer Level */
+#define _LEUART_STATUS_TXBL_SHIFT                4                                     /**< Shift value for LEUART_TXBL */
+#define _LEUART_STATUS_TXBL_MASK                 0x10UL                                /**< Bit mask for LEUART_TXBL */
+#define _LEUART_STATUS_TXBL_DEFAULT              0x00000001UL                          /**< Mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_TXBL_DEFAULT               (_LEUART_STATUS_TXBL_DEFAULT << 4)    /**< Shifted mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_RXDATAV                    (0x1UL << 5)                          /**< RX Data Valid */
+#define _LEUART_STATUS_RXDATAV_SHIFT             5                                     /**< Shift value for LEUART_RXDATAV */
+#define _LEUART_STATUS_RXDATAV_MASK              0x20UL                                /**< Bit mask for LEUART_RXDATAV */
+#define _LEUART_STATUS_RXDATAV_DEFAULT           0x00000000UL                          /**< Mode DEFAULT for LEUART_STATUS */
+#define LEUART_STATUS_RXDATAV_DEFAULT            (_LEUART_STATUS_RXDATAV_DEFAULT << 5) /**< Shifted mode DEFAULT for LEUART_STATUS */
+
+/* Bit fields for LEUART CLKDIV */
+#define _LEUART_CLKDIV_RESETVALUE                0x00000000UL                      /**< Default value for LEUART_CLKDIV */
+#define _LEUART_CLKDIV_MASK                      0x00007FF8UL                      /**< Mask for LEUART_CLKDIV */
+#define _LEUART_CLKDIV_DIV_SHIFT                 3                                 /**< Shift value for LEUART_DIV */
+#define _LEUART_CLKDIV_DIV_MASK                  0x7FF8UL                          /**< Bit mask for LEUART_DIV */
+#define _LEUART_CLKDIV_DIV_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for LEUART_CLKDIV */
+#define LEUART_CLKDIV_DIV_DEFAULT                (_LEUART_CLKDIV_DIV_DEFAULT << 3) /**< Shifted mode DEFAULT for LEUART_CLKDIV */
+
+/* Bit fields for LEUART STARTFRAME */
+#define _LEUART_STARTFRAME_RESETVALUE            0x00000000UL                                 /**< Default value for LEUART_STARTFRAME */
+#define _LEUART_STARTFRAME_MASK                  0x000001FFUL                                 /**< Mask for LEUART_STARTFRAME */
+#define _LEUART_STARTFRAME_STARTFRAME_SHIFT      0                                            /**< Shift value for LEUART_STARTFRAME */
+#define _LEUART_STARTFRAME_STARTFRAME_MASK       0x1FFUL                                      /**< Bit mask for LEUART_STARTFRAME */
+#define _LEUART_STARTFRAME_STARTFRAME_DEFAULT    0x00000000UL                                 /**< Mode DEFAULT for LEUART_STARTFRAME */
+#define LEUART_STARTFRAME_STARTFRAME_DEFAULT     (_LEUART_STARTFRAME_STARTFRAME_DEFAULT << 0) /**< Shifted mode DEFAULT for LEUART_STARTFRAME */
+
+/* Bit fields for LEUART SIGFRAME */
+#define _LEUART_SIGFRAME_RESETVALUE              0x00000000UL                             /**< Default value for LEUART_SIGFRAME */
+#define _LEUART_SIGFRAME_MASK                    0x000001FFUL                             /**< Mask for LEUART_SIGFRAME */
+#define _LEUART_SIGFRAME_SIGFRAME_SHIFT          0                                        /**< Shift value for LEUART_SIGFRAME */
+#define _LEUART_SIGFRAME_SIGFRAME_MASK           0x1FFUL                                  /**< Bit mask for LEUART_SIGFRAME */
+#define _LEUART_SIGFRAME_SIGFRAME_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for LEUART_SIGFRAME */
+#define LEUART_SIGFRAME_SIGFRAME_DEFAULT         (_LEUART_SIGFRAME_SIGFRAME_DEFAULT << 0) /**< Shifted mode DEFAULT for LEUART_SIGFRAME */
+
+/* Bit fields for LEUART RXDATAX */
+#define _LEUART_RXDATAX_RESETVALUE               0x00000000UL                          /**< Default value for LEUART_RXDATAX */
+#define _LEUART_RXDATAX_MASK                     0x0000C1FFUL                          /**< Mask for LEUART_RXDATAX */
+#define _LEUART_RXDATAX_RXDATA_SHIFT             0                                     /**< Shift value for LEUART_RXDATA */
+#define _LEUART_RXDATAX_RXDATA_MASK              0x1FFUL                               /**< Bit mask for LEUART_RXDATA */
+#define _LEUART_RXDATAX_RXDATA_DEFAULT           0x00000000UL                          /**< Mode DEFAULT for LEUART_RXDATAX */
+#define LEUART_RXDATAX_RXDATA_DEFAULT            (_LEUART_RXDATAX_RXDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for LEUART_RXDATAX */
+#define LEUART_RXDATAX_PERR                      (0x1UL << 14)                         /**< Receive Data Parity Error */
+#define _LEUART_RXDATAX_PERR_SHIFT               14                                    /**< Shift value for LEUART_PERR */
+#define _LEUART_RXDATAX_PERR_MASK                0x4000UL                              /**< Bit mask for LEUART_PERR */
+#define _LEUART_RXDATAX_PERR_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for LEUART_RXDATAX */
+#define LEUART_RXDATAX_PERR_DEFAULT              (_LEUART_RXDATAX_PERR_DEFAULT << 14)  /**< Shifted mode DEFAULT for LEUART_RXDATAX */
+#define LEUART_RXDATAX_FERR                      (0x1UL << 15)                         /**< Receive Data Framing Error */
+#define _LEUART_RXDATAX_FERR_SHIFT               15                                    /**< Shift value for LEUART_FERR */
+#define _LEUART_RXDATAX_FERR_MASK                0x8000UL                              /**< Bit mask for LEUART_FERR */
+#define _LEUART_RXDATAX_FERR_DEFAULT             0x00000000UL                          /**< Mode DEFAULT for LEUART_RXDATAX */
+#define LEUART_RXDATAX_FERR_DEFAULT              (_LEUART_RXDATAX_FERR_DEFAULT << 15)  /**< Shifted mode DEFAULT for LEUART_RXDATAX */
+
+/* Bit fields for LEUART RXDATA */
+#define _LEUART_RXDATA_RESETVALUE                0x00000000UL                         /**< Default value for LEUART_RXDATA */
+#define _LEUART_RXDATA_MASK                      0x000000FFUL                         /**< Mask for LEUART_RXDATA */
+#define _LEUART_RXDATA_RXDATA_SHIFT              0                                    /**< Shift value for LEUART_RXDATA */
+#define _LEUART_RXDATA_RXDATA_MASK               0xFFUL                               /**< Bit mask for LEUART_RXDATA */
+#define _LEUART_RXDATA_RXDATA_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for LEUART_RXDATA */
+#define LEUART_RXDATA_RXDATA_DEFAULT             (_LEUART_RXDATA_RXDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for LEUART_RXDATA */
+
+/* Bit fields for LEUART RXDATAXP */
+#define _LEUART_RXDATAXP_RESETVALUE              0x00000000UL                            /**< Default value for LEUART_RXDATAXP */
+#define _LEUART_RXDATAXP_MASK                    0x0000C1FFUL                            /**< Mask for LEUART_RXDATAXP */
+#define _LEUART_RXDATAXP_RXDATAP_SHIFT           0                                       /**< Shift value for LEUART_RXDATAP */
+#define _LEUART_RXDATAXP_RXDATAP_MASK            0x1FFUL                                 /**< Bit mask for LEUART_RXDATAP */
+#define _LEUART_RXDATAXP_RXDATAP_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for LEUART_RXDATAXP */
+#define LEUART_RXDATAXP_RXDATAP_DEFAULT          (_LEUART_RXDATAXP_RXDATAP_DEFAULT << 0) /**< Shifted mode DEFAULT for LEUART_RXDATAXP */
+#define LEUART_RXDATAXP_PERRP                    (0x1UL << 14)                           /**< Receive Data Parity Error Peek */
+#define _LEUART_RXDATAXP_PERRP_SHIFT             14                                      /**< Shift value for LEUART_PERRP */
+#define _LEUART_RXDATAXP_PERRP_MASK              0x4000UL                                /**< Bit mask for LEUART_PERRP */
+#define _LEUART_RXDATAXP_PERRP_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for LEUART_RXDATAXP */
+#define LEUART_RXDATAXP_PERRP_DEFAULT            (_LEUART_RXDATAXP_PERRP_DEFAULT << 14)  /**< Shifted mode DEFAULT for LEUART_RXDATAXP */
+#define LEUART_RXDATAXP_FERRP                    (0x1UL << 15)                           /**< Receive Data Framing Error Peek */
+#define _LEUART_RXDATAXP_FERRP_SHIFT             15                                      /**< Shift value for LEUART_FERRP */
+#define _LEUART_RXDATAXP_FERRP_MASK              0x8000UL                                /**< Bit mask for LEUART_FERRP */
+#define _LEUART_RXDATAXP_FERRP_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for LEUART_RXDATAXP */
+#define LEUART_RXDATAXP_FERRP_DEFAULT            (_LEUART_RXDATAXP_FERRP_DEFAULT << 15)  /**< Shifted mode DEFAULT for LEUART_RXDATAXP */
+
+/* Bit fields for LEUART TXDATAX */
+#define _LEUART_TXDATAX_RESETVALUE               0x00000000UL                            /**< Default value for LEUART_TXDATAX */
+#define _LEUART_TXDATAX_MASK                     0x0000E1FFUL                            /**< Mask for LEUART_TXDATAX */
+#define _LEUART_TXDATAX_TXDATA_SHIFT             0                                       /**< Shift value for LEUART_TXDATA */
+#define _LEUART_TXDATAX_TXDATA_MASK              0x1FFUL                                 /**< Bit mask for LEUART_TXDATA */
+#define _LEUART_TXDATAX_TXDATA_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for LEUART_TXDATAX */
+#define LEUART_TXDATAX_TXDATA_DEFAULT            (_LEUART_TXDATAX_TXDATA_DEFAULT << 0)   /**< Shifted mode DEFAULT for LEUART_TXDATAX */
+#define LEUART_TXDATAX_TXBREAK                   (0x1UL << 13)                           /**< Transmit Data As Break */
+#define _LEUART_TXDATAX_TXBREAK_SHIFT            13                                      /**< Shift value for LEUART_TXBREAK */
+#define _LEUART_TXDATAX_TXBREAK_MASK             0x2000UL                                /**< Bit mask for LEUART_TXBREAK */
+#define _LEUART_TXDATAX_TXBREAK_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for LEUART_TXDATAX */
+#define LEUART_TXDATAX_TXBREAK_DEFAULT           (_LEUART_TXDATAX_TXBREAK_DEFAULT << 13) /**< Shifted mode DEFAULT for LEUART_TXDATAX */
+#define LEUART_TXDATAX_TXDISAT                   (0x1UL << 14)                           /**< Disable TX After Transmission */
+#define _LEUART_TXDATAX_TXDISAT_SHIFT            14                                      /**< Shift value for LEUART_TXDISAT */
+#define _LEUART_TXDATAX_TXDISAT_MASK             0x4000UL                                /**< Bit mask for LEUART_TXDISAT */
+#define _LEUART_TXDATAX_TXDISAT_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for LEUART_TXDATAX */
+#define LEUART_TXDATAX_TXDISAT_DEFAULT           (_LEUART_TXDATAX_TXDISAT_DEFAULT << 14) /**< Shifted mode DEFAULT for LEUART_TXDATAX */
+#define LEUART_TXDATAX_RXENAT                    (0x1UL << 15)                           /**< Enable RX After Transmission */
+#define _LEUART_TXDATAX_RXENAT_SHIFT             15                                      /**< Shift value for LEUART_RXENAT */
+#define _LEUART_TXDATAX_RXENAT_MASK              0x8000UL                                /**< Bit mask for LEUART_RXENAT */
+#define _LEUART_TXDATAX_RXENAT_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for LEUART_TXDATAX */
+#define LEUART_TXDATAX_RXENAT_DEFAULT            (_LEUART_TXDATAX_RXENAT_DEFAULT << 15)  /**< Shifted mode DEFAULT for LEUART_TXDATAX */
+
+/* Bit fields for LEUART TXDATA */
+#define _LEUART_TXDATA_RESETVALUE                0x00000000UL                         /**< Default value for LEUART_TXDATA */
+#define _LEUART_TXDATA_MASK                      0x000000FFUL                         /**< Mask for LEUART_TXDATA */
+#define _LEUART_TXDATA_TXDATA_SHIFT              0                                    /**< Shift value for LEUART_TXDATA */
+#define _LEUART_TXDATA_TXDATA_MASK               0xFFUL                               /**< Bit mask for LEUART_TXDATA */
+#define _LEUART_TXDATA_TXDATA_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for LEUART_TXDATA */
+#define LEUART_TXDATA_TXDATA_DEFAULT             (_LEUART_TXDATA_TXDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for LEUART_TXDATA */
+
+/* Bit fields for LEUART IF */
+#define _LEUART_IF_RESETVALUE                    0x00000002UL                      /**< Default value for LEUART_IF */
+#define _LEUART_IF_MASK                          0x000007FFUL                      /**< Mask for LEUART_IF */
+#define LEUART_IF_TXC                            (0x1UL << 0)                      /**< TX Complete Interrupt Flag */
+#define _LEUART_IF_TXC_SHIFT                     0                                 /**< Shift value for LEUART_TXC */
+#define _LEUART_IF_TXC_MASK                      0x1UL                             /**< Bit mask for LEUART_TXC */
+#define _LEUART_IF_TXC_DEFAULT                   0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_TXC_DEFAULT                    (_LEUART_IF_TXC_DEFAULT << 0)     /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_TXBL                           (0x1UL << 1)                      /**< TX Buffer Level Interrupt Flag */
+#define _LEUART_IF_TXBL_SHIFT                    1                                 /**< Shift value for LEUART_TXBL */
+#define _LEUART_IF_TXBL_MASK                     0x2UL                             /**< Bit mask for LEUART_TXBL */
+#define _LEUART_IF_TXBL_DEFAULT                  0x00000001UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_TXBL_DEFAULT                   (_LEUART_IF_TXBL_DEFAULT << 1)    /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_RXDATAV                        (0x1UL << 2)                      /**< RX Data Valid Interrupt Flag */
+#define _LEUART_IF_RXDATAV_SHIFT                 2                                 /**< Shift value for LEUART_RXDATAV */
+#define _LEUART_IF_RXDATAV_MASK                  0x4UL                             /**< Bit mask for LEUART_RXDATAV */
+#define _LEUART_IF_RXDATAV_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_RXDATAV_DEFAULT                (_LEUART_IF_RXDATAV_DEFAULT << 2) /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_RXOF                           (0x1UL << 3)                      /**< RX Overflow Interrupt Flag */
+#define _LEUART_IF_RXOF_SHIFT                    3                                 /**< Shift value for LEUART_RXOF */
+#define _LEUART_IF_RXOF_MASK                     0x8UL                             /**< Bit mask for LEUART_RXOF */
+#define _LEUART_IF_RXOF_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_RXOF_DEFAULT                   (_LEUART_IF_RXOF_DEFAULT << 3)    /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_RXUF                           (0x1UL << 4)                      /**< RX Underflow Interrupt Flag */
+#define _LEUART_IF_RXUF_SHIFT                    4                                 /**< Shift value for LEUART_RXUF */
+#define _LEUART_IF_RXUF_MASK                     0x10UL                            /**< Bit mask for LEUART_RXUF */
+#define _LEUART_IF_RXUF_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_RXUF_DEFAULT                   (_LEUART_IF_RXUF_DEFAULT << 4)    /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_TXOF                           (0x1UL << 5)                      /**< TX Overflow Interrupt Flag */
+#define _LEUART_IF_TXOF_SHIFT                    5                                 /**< Shift value for LEUART_TXOF */
+#define _LEUART_IF_TXOF_MASK                     0x20UL                            /**< Bit mask for LEUART_TXOF */
+#define _LEUART_IF_TXOF_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_TXOF_DEFAULT                   (_LEUART_IF_TXOF_DEFAULT << 5)    /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_PERR                           (0x1UL << 6)                      /**< Parity Error Interrupt Flag */
+#define _LEUART_IF_PERR_SHIFT                    6                                 /**< Shift value for LEUART_PERR */
+#define _LEUART_IF_PERR_MASK                     0x40UL                            /**< Bit mask for LEUART_PERR */
+#define _LEUART_IF_PERR_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_PERR_DEFAULT                   (_LEUART_IF_PERR_DEFAULT << 6)    /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_FERR                           (0x1UL << 7)                      /**< Framing Error Interrupt Flag */
+#define _LEUART_IF_FERR_SHIFT                    7                                 /**< Shift value for LEUART_FERR */
+#define _LEUART_IF_FERR_MASK                     0x80UL                            /**< Bit mask for LEUART_FERR */
+#define _LEUART_IF_FERR_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_FERR_DEFAULT                   (_LEUART_IF_FERR_DEFAULT << 7)    /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_MPAF                           (0x1UL << 8)                      /**< Multi-Processor Address Frame Interrupt Flag */
+#define _LEUART_IF_MPAF_SHIFT                    8                                 /**< Shift value for LEUART_MPAF */
+#define _LEUART_IF_MPAF_MASK                     0x100UL                           /**< Bit mask for LEUART_MPAF */
+#define _LEUART_IF_MPAF_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_MPAF_DEFAULT                   (_LEUART_IF_MPAF_DEFAULT << 8)    /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_STARTF                         (0x1UL << 9)                      /**< Start Frame Interrupt Flag */
+#define _LEUART_IF_STARTF_SHIFT                  9                                 /**< Shift value for LEUART_STARTF */
+#define _LEUART_IF_STARTF_MASK                   0x200UL                           /**< Bit mask for LEUART_STARTF */
+#define _LEUART_IF_STARTF_DEFAULT                0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_STARTF_DEFAULT                 (_LEUART_IF_STARTF_DEFAULT << 9)  /**< Shifted mode DEFAULT for LEUART_IF */
+#define LEUART_IF_SIGF                           (0x1UL << 10)                     /**< Signal Frame Interrupt Flag */
+#define _LEUART_IF_SIGF_SHIFT                    10                                /**< Shift value for LEUART_SIGF */
+#define _LEUART_IF_SIGF_MASK                     0x400UL                           /**< Bit mask for LEUART_SIGF */
+#define _LEUART_IF_SIGF_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for LEUART_IF */
+#define LEUART_IF_SIGF_DEFAULT                   (_LEUART_IF_SIGF_DEFAULT << 10)   /**< Shifted mode DEFAULT for LEUART_IF */
+
+/* Bit fields for LEUART IFS */
+#define _LEUART_IFS_RESETVALUE                   0x00000000UL                      /**< Default value for LEUART_IFS */
+#define _LEUART_IFS_MASK                         0x000007F9UL                      /**< Mask for LEUART_IFS */
+#define LEUART_IFS_TXC                           (0x1UL << 0)                      /**< Set TX Complete Interrupt Flag */
+#define _LEUART_IFS_TXC_SHIFT                    0                                 /**< Shift value for LEUART_TXC */
+#define _LEUART_IFS_TXC_MASK                     0x1UL                             /**< Bit mask for LEUART_TXC */
+#define _LEUART_IFS_TXC_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_TXC_DEFAULT                   (_LEUART_IFS_TXC_DEFAULT << 0)    /**< Shifted mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_RXOF                          (0x1UL << 3)                      /**< Set RX Overflow Interrupt Flag */
+#define _LEUART_IFS_RXOF_SHIFT                   3                                 /**< Shift value for LEUART_RXOF */
+#define _LEUART_IFS_RXOF_MASK                    0x8UL                             /**< Bit mask for LEUART_RXOF */
+#define _LEUART_IFS_RXOF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_RXOF_DEFAULT                  (_LEUART_IFS_RXOF_DEFAULT << 3)   /**< Shifted mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_RXUF                          (0x1UL << 4)                      /**< Set RX Underflow Interrupt Flag */
+#define _LEUART_IFS_RXUF_SHIFT                   4                                 /**< Shift value for LEUART_RXUF */
+#define _LEUART_IFS_RXUF_MASK                    0x10UL                            /**< Bit mask for LEUART_RXUF */
+#define _LEUART_IFS_RXUF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_RXUF_DEFAULT                  (_LEUART_IFS_RXUF_DEFAULT << 4)   /**< Shifted mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_TXOF                          (0x1UL << 5)                      /**< Set TX Overflow Interrupt Flag */
+#define _LEUART_IFS_TXOF_SHIFT                   5                                 /**< Shift value for LEUART_TXOF */
+#define _LEUART_IFS_TXOF_MASK                    0x20UL                            /**< Bit mask for LEUART_TXOF */
+#define _LEUART_IFS_TXOF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_TXOF_DEFAULT                  (_LEUART_IFS_TXOF_DEFAULT << 5)   /**< Shifted mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_PERR                          (0x1UL << 6)                      /**< Set Parity Error Interrupt Flag */
+#define _LEUART_IFS_PERR_SHIFT                   6                                 /**< Shift value for LEUART_PERR */
+#define _LEUART_IFS_PERR_MASK                    0x40UL                            /**< Bit mask for LEUART_PERR */
+#define _LEUART_IFS_PERR_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_PERR_DEFAULT                  (_LEUART_IFS_PERR_DEFAULT << 6)   /**< Shifted mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_FERR                          (0x1UL << 7)                      /**< Set Framing Error Interrupt Flag */
+#define _LEUART_IFS_FERR_SHIFT                   7                                 /**< Shift value for LEUART_FERR */
+#define _LEUART_IFS_FERR_MASK                    0x80UL                            /**< Bit mask for LEUART_FERR */
+#define _LEUART_IFS_FERR_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_FERR_DEFAULT                  (_LEUART_IFS_FERR_DEFAULT << 7)   /**< Shifted mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_MPAF                          (0x1UL << 8)                      /**< Set Multi-Processor Address Frame Interrupt Flag */
+#define _LEUART_IFS_MPAF_SHIFT                   8                                 /**< Shift value for LEUART_MPAF */
+#define _LEUART_IFS_MPAF_MASK                    0x100UL                           /**< Bit mask for LEUART_MPAF */
+#define _LEUART_IFS_MPAF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_MPAF_DEFAULT                  (_LEUART_IFS_MPAF_DEFAULT << 8)   /**< Shifted mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_STARTF                        (0x1UL << 9)                      /**< Set Start Frame Interrupt Flag */
+#define _LEUART_IFS_STARTF_SHIFT                 9                                 /**< Shift value for LEUART_STARTF */
+#define _LEUART_IFS_STARTF_MASK                  0x200UL                           /**< Bit mask for LEUART_STARTF */
+#define _LEUART_IFS_STARTF_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_STARTF_DEFAULT                (_LEUART_IFS_STARTF_DEFAULT << 9) /**< Shifted mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_SIGF                          (0x1UL << 10)                     /**< Set Signal Frame Interrupt Flag */
+#define _LEUART_IFS_SIGF_SHIFT                   10                                /**< Shift value for LEUART_SIGF */
+#define _LEUART_IFS_SIGF_MASK                    0x400UL                           /**< Bit mask for LEUART_SIGF */
+#define _LEUART_IFS_SIGF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFS */
+#define LEUART_IFS_SIGF_DEFAULT                  (_LEUART_IFS_SIGF_DEFAULT << 10)  /**< Shifted mode DEFAULT for LEUART_IFS */
+
+/* Bit fields for LEUART IFC */
+#define _LEUART_IFC_RESETVALUE                   0x00000000UL                      /**< Default value for LEUART_IFC */
+#define _LEUART_IFC_MASK                         0x000007F9UL                      /**< Mask for LEUART_IFC */
+#define LEUART_IFC_TXC                           (0x1UL << 0)                      /**< Clear TX Complete Interrupt Flag */
+#define _LEUART_IFC_TXC_SHIFT                    0                                 /**< Shift value for LEUART_TXC */
+#define _LEUART_IFC_TXC_MASK                     0x1UL                             /**< Bit mask for LEUART_TXC */
+#define _LEUART_IFC_TXC_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_TXC_DEFAULT                   (_LEUART_IFC_TXC_DEFAULT << 0)    /**< Shifted mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_RXOF                          (0x1UL << 3)                      /**< Clear RX Overflow Interrupt Flag */
+#define _LEUART_IFC_RXOF_SHIFT                   3                                 /**< Shift value for LEUART_RXOF */
+#define _LEUART_IFC_RXOF_MASK                    0x8UL                             /**< Bit mask for LEUART_RXOF */
+#define _LEUART_IFC_RXOF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_RXOF_DEFAULT                  (_LEUART_IFC_RXOF_DEFAULT << 3)   /**< Shifted mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_RXUF                          (0x1UL << 4)                      /**< Clear RX Underflow Interrupt Flag */
+#define _LEUART_IFC_RXUF_SHIFT                   4                                 /**< Shift value for LEUART_RXUF */
+#define _LEUART_IFC_RXUF_MASK                    0x10UL                            /**< Bit mask for LEUART_RXUF */
+#define _LEUART_IFC_RXUF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_RXUF_DEFAULT                  (_LEUART_IFC_RXUF_DEFAULT << 4)   /**< Shifted mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_TXOF                          (0x1UL << 5)                      /**< Clear TX Overflow Interrupt Flag */
+#define _LEUART_IFC_TXOF_SHIFT                   5                                 /**< Shift value for LEUART_TXOF */
+#define _LEUART_IFC_TXOF_MASK                    0x20UL                            /**< Bit mask for LEUART_TXOF */
+#define _LEUART_IFC_TXOF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_TXOF_DEFAULT                  (_LEUART_IFC_TXOF_DEFAULT << 5)   /**< Shifted mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_PERR                          (0x1UL << 6)                      /**< Clear Parity Error Interrupt Flag */
+#define _LEUART_IFC_PERR_SHIFT                   6                                 /**< Shift value for LEUART_PERR */
+#define _LEUART_IFC_PERR_MASK                    0x40UL                            /**< Bit mask for LEUART_PERR */
+#define _LEUART_IFC_PERR_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_PERR_DEFAULT                  (_LEUART_IFC_PERR_DEFAULT << 6)   /**< Shifted mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_FERR                          (0x1UL << 7)                      /**< Clear Framing Error Interrupt Flag */
+#define _LEUART_IFC_FERR_SHIFT                   7                                 /**< Shift value for LEUART_FERR */
+#define _LEUART_IFC_FERR_MASK                    0x80UL                            /**< Bit mask for LEUART_FERR */
+#define _LEUART_IFC_FERR_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_FERR_DEFAULT                  (_LEUART_IFC_FERR_DEFAULT << 7)   /**< Shifted mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_MPAF                          (0x1UL << 8)                      /**< Clear Multi-Processor Address Frame Interrupt Flag */
+#define _LEUART_IFC_MPAF_SHIFT                   8                                 /**< Shift value for LEUART_MPAF */
+#define _LEUART_IFC_MPAF_MASK                    0x100UL                           /**< Bit mask for LEUART_MPAF */
+#define _LEUART_IFC_MPAF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_MPAF_DEFAULT                  (_LEUART_IFC_MPAF_DEFAULT << 8)   /**< Shifted mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_STARTF                        (0x1UL << 9)                      /**< Clear Start-Frame Interrupt Flag */
+#define _LEUART_IFC_STARTF_SHIFT                 9                                 /**< Shift value for LEUART_STARTF */
+#define _LEUART_IFC_STARTF_MASK                  0x200UL                           /**< Bit mask for LEUART_STARTF */
+#define _LEUART_IFC_STARTF_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_STARTF_DEFAULT                (_LEUART_IFC_STARTF_DEFAULT << 9) /**< Shifted mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_SIGF                          (0x1UL << 10)                     /**< Clear Signal-Frame Interrupt Flag */
+#define _LEUART_IFC_SIGF_SHIFT                   10                                /**< Shift value for LEUART_SIGF */
+#define _LEUART_IFC_SIGF_MASK                    0x400UL                           /**< Bit mask for LEUART_SIGF */
+#define _LEUART_IFC_SIGF_DEFAULT                 0x00000000UL                      /**< Mode DEFAULT for LEUART_IFC */
+#define LEUART_IFC_SIGF_DEFAULT                  (_LEUART_IFC_SIGF_DEFAULT << 10)  /**< Shifted mode DEFAULT for LEUART_IFC */
+
+/* Bit fields for LEUART IEN */
+#define _LEUART_IEN_RESETVALUE                   0x00000000UL                       /**< Default value for LEUART_IEN */
+#define _LEUART_IEN_MASK                         0x000007FFUL                       /**< Mask for LEUART_IEN */
+#define LEUART_IEN_TXC                           (0x1UL << 0)                       /**< TX Complete Interrupt Enable */
+#define _LEUART_IEN_TXC_SHIFT                    0                                  /**< Shift value for LEUART_TXC */
+#define _LEUART_IEN_TXC_MASK                     0x1UL                              /**< Bit mask for LEUART_TXC */
+#define _LEUART_IEN_TXC_DEFAULT                  0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_TXC_DEFAULT                   (_LEUART_IEN_TXC_DEFAULT << 0)     /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_TXBL                          (0x1UL << 1)                       /**< TX Buffer Level Interrupt Enable */
+#define _LEUART_IEN_TXBL_SHIFT                   1                                  /**< Shift value for LEUART_TXBL */
+#define _LEUART_IEN_TXBL_MASK                    0x2UL                              /**< Bit mask for LEUART_TXBL */
+#define _LEUART_IEN_TXBL_DEFAULT                 0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_TXBL_DEFAULT                  (_LEUART_IEN_TXBL_DEFAULT << 1)    /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_RXDATAV                       (0x1UL << 2)                       /**< RX Data Valid Interrupt Enable */
+#define _LEUART_IEN_RXDATAV_SHIFT                2                                  /**< Shift value for LEUART_RXDATAV */
+#define _LEUART_IEN_RXDATAV_MASK                 0x4UL                              /**< Bit mask for LEUART_RXDATAV */
+#define _LEUART_IEN_RXDATAV_DEFAULT              0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_RXDATAV_DEFAULT               (_LEUART_IEN_RXDATAV_DEFAULT << 2) /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_RXOF                          (0x1UL << 3)                       /**< RX Overflow Interrupt Enable */
+#define _LEUART_IEN_RXOF_SHIFT                   3                                  /**< Shift value for LEUART_RXOF */
+#define _LEUART_IEN_RXOF_MASK                    0x8UL                              /**< Bit mask for LEUART_RXOF */
+#define _LEUART_IEN_RXOF_DEFAULT                 0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_RXOF_DEFAULT                  (_LEUART_IEN_RXOF_DEFAULT << 3)    /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_RXUF                          (0x1UL << 4)                       /**< RX Underflow Interrupt Enable */
+#define _LEUART_IEN_RXUF_SHIFT                   4                                  /**< Shift value for LEUART_RXUF */
+#define _LEUART_IEN_RXUF_MASK                    0x10UL                             /**< Bit mask for LEUART_RXUF */
+#define _LEUART_IEN_RXUF_DEFAULT                 0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_RXUF_DEFAULT                  (_LEUART_IEN_RXUF_DEFAULT << 4)    /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_TXOF                          (0x1UL << 5)                       /**< TX Overflow Interrupt Enable */
+#define _LEUART_IEN_TXOF_SHIFT                   5                                  /**< Shift value for LEUART_TXOF */
+#define _LEUART_IEN_TXOF_MASK                    0x20UL                             /**< Bit mask for LEUART_TXOF */
+#define _LEUART_IEN_TXOF_DEFAULT                 0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_TXOF_DEFAULT                  (_LEUART_IEN_TXOF_DEFAULT << 5)    /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_PERR                          (0x1UL << 6)                       /**< Parity Error Interrupt Enable */
+#define _LEUART_IEN_PERR_SHIFT                   6                                  /**< Shift value for LEUART_PERR */
+#define _LEUART_IEN_PERR_MASK                    0x40UL                             /**< Bit mask for LEUART_PERR */
+#define _LEUART_IEN_PERR_DEFAULT                 0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_PERR_DEFAULT                  (_LEUART_IEN_PERR_DEFAULT << 6)    /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_FERR                          (0x1UL << 7)                       /**< Framing Error Interrupt Enable */
+#define _LEUART_IEN_FERR_SHIFT                   7                                  /**< Shift value for LEUART_FERR */
+#define _LEUART_IEN_FERR_MASK                    0x80UL                             /**< Bit mask for LEUART_FERR */
+#define _LEUART_IEN_FERR_DEFAULT                 0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_FERR_DEFAULT                  (_LEUART_IEN_FERR_DEFAULT << 7)    /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_MPAF                          (0x1UL << 8)                       /**< Multi-Processor Address Frame Interrupt Enable */
+#define _LEUART_IEN_MPAF_SHIFT                   8                                  /**< Shift value for LEUART_MPAF */
+#define _LEUART_IEN_MPAF_MASK                    0x100UL                            /**< Bit mask for LEUART_MPAF */
+#define _LEUART_IEN_MPAF_DEFAULT                 0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_MPAF_DEFAULT                  (_LEUART_IEN_MPAF_DEFAULT << 8)    /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_STARTF                        (0x1UL << 9)                       /**< Start Frame Interrupt Enable */
+#define _LEUART_IEN_STARTF_SHIFT                 9                                  /**< Shift value for LEUART_STARTF */
+#define _LEUART_IEN_STARTF_MASK                  0x200UL                            /**< Bit mask for LEUART_STARTF */
+#define _LEUART_IEN_STARTF_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_STARTF_DEFAULT                (_LEUART_IEN_STARTF_DEFAULT << 9)  /**< Shifted mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_SIGF                          (0x1UL << 10)                      /**< Signal Frame Interrupt Enable */
+#define _LEUART_IEN_SIGF_SHIFT                   10                                 /**< Shift value for LEUART_SIGF */
+#define _LEUART_IEN_SIGF_MASK                    0x400UL                            /**< Bit mask for LEUART_SIGF */
+#define _LEUART_IEN_SIGF_DEFAULT                 0x00000000UL                       /**< Mode DEFAULT for LEUART_IEN */
+#define LEUART_IEN_SIGF_DEFAULT                  (_LEUART_IEN_SIGF_DEFAULT << 10)   /**< Shifted mode DEFAULT for LEUART_IEN */
+
+/* Bit fields for LEUART PULSECTRL */
+#define _LEUART_PULSECTRL_RESETVALUE             0x00000000UL                               /**< Default value for LEUART_PULSECTRL */
+#define _LEUART_PULSECTRL_MASK                   0x0000003FUL                               /**< Mask for LEUART_PULSECTRL */
+#define _LEUART_PULSECTRL_PULSEW_SHIFT           0                                          /**< Shift value for LEUART_PULSEW */
+#define _LEUART_PULSECTRL_PULSEW_MASK            0xFUL                                      /**< Bit mask for LEUART_PULSEW */
+#define _LEUART_PULSECTRL_PULSEW_DEFAULT         0x00000000UL                               /**< Mode DEFAULT for LEUART_PULSECTRL */
+#define LEUART_PULSECTRL_PULSEW_DEFAULT          (_LEUART_PULSECTRL_PULSEW_DEFAULT << 0)    /**< Shifted mode DEFAULT for LEUART_PULSECTRL */
+#define LEUART_PULSECTRL_PULSEEN                 (0x1UL << 4)                               /**< Pulse Generator/Extender Enable */
+#define _LEUART_PULSECTRL_PULSEEN_SHIFT          4                                          /**< Shift value for LEUART_PULSEEN */
+#define _LEUART_PULSECTRL_PULSEEN_MASK           0x10UL                                     /**< Bit mask for LEUART_PULSEEN */
+#define _LEUART_PULSECTRL_PULSEEN_DEFAULT        0x00000000UL                               /**< Mode DEFAULT for LEUART_PULSECTRL */
+#define LEUART_PULSECTRL_PULSEEN_DEFAULT         (_LEUART_PULSECTRL_PULSEEN_DEFAULT << 4)   /**< Shifted mode DEFAULT for LEUART_PULSECTRL */
+#define LEUART_PULSECTRL_PULSEFILT               (0x1UL << 5)                               /**< Pulse Filter */
+#define _LEUART_PULSECTRL_PULSEFILT_SHIFT        5                                          /**< Shift value for LEUART_PULSEFILT */
+#define _LEUART_PULSECTRL_PULSEFILT_MASK         0x20UL                                     /**< Bit mask for LEUART_PULSEFILT */
+#define _LEUART_PULSECTRL_PULSEFILT_DEFAULT      0x00000000UL                               /**< Mode DEFAULT for LEUART_PULSECTRL */
+#define LEUART_PULSECTRL_PULSEFILT_DEFAULT       (_LEUART_PULSECTRL_PULSEFILT_DEFAULT << 5) /**< Shifted mode DEFAULT for LEUART_PULSECTRL */
+
+/* Bit fields for LEUART FREEZE */
+#define _LEUART_FREEZE_RESETVALUE                0x00000000UL                            /**< Default value for LEUART_FREEZE */
+#define _LEUART_FREEZE_MASK                      0x00000001UL                            /**< Mask for LEUART_FREEZE */
+#define LEUART_FREEZE_REGFREEZE                  (0x1UL << 0)                            /**< Register Update Freeze */
+#define _LEUART_FREEZE_REGFREEZE_SHIFT           0                                       /**< Shift value for LEUART_REGFREEZE */
+#define _LEUART_FREEZE_REGFREEZE_MASK            0x1UL                                   /**< Bit mask for LEUART_REGFREEZE */
+#define _LEUART_FREEZE_REGFREEZE_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for LEUART_FREEZE */
+#define _LEUART_FREEZE_REGFREEZE_UPDATE          0x00000000UL                            /**< Mode UPDATE for LEUART_FREEZE */
+#define _LEUART_FREEZE_REGFREEZE_FREEZE          0x00000001UL                            /**< Mode FREEZE for LEUART_FREEZE */
+#define LEUART_FREEZE_REGFREEZE_DEFAULT          (_LEUART_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for LEUART_FREEZE */
+#define LEUART_FREEZE_REGFREEZE_UPDATE           (_LEUART_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for LEUART_FREEZE */
+#define LEUART_FREEZE_REGFREEZE_FREEZE           (_LEUART_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for LEUART_FREEZE */
+
+/* Bit fields for LEUART SYNCBUSY */
+#define _LEUART_SYNCBUSY_RESETVALUE              0x00000000UL                               /**< Default value for LEUART_SYNCBUSY */
+#define _LEUART_SYNCBUSY_MASK                    0x000000FFUL                               /**< Mask for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_CTRL                     (0x1UL << 0)                               /**< CTRL Register Busy */
+#define _LEUART_SYNCBUSY_CTRL_SHIFT              0                                          /**< Shift value for LEUART_CTRL */
+#define _LEUART_SYNCBUSY_CTRL_MASK               0x1UL                                      /**< Bit mask for LEUART_CTRL */
+#define _LEUART_SYNCBUSY_CTRL_DEFAULT            0x00000000UL                               /**< Mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_CTRL_DEFAULT             (_LEUART_SYNCBUSY_CTRL_DEFAULT << 0)       /**< Shifted mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_CMD                      (0x1UL << 1)                               /**< CMD Register Busy */
+#define _LEUART_SYNCBUSY_CMD_SHIFT               1                                          /**< Shift value for LEUART_CMD */
+#define _LEUART_SYNCBUSY_CMD_MASK                0x2UL                                      /**< Bit mask for LEUART_CMD */
+#define _LEUART_SYNCBUSY_CMD_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_CMD_DEFAULT              (_LEUART_SYNCBUSY_CMD_DEFAULT << 1)        /**< Shifted mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_CLKDIV                   (0x1UL << 2)                               /**< CLKDIV Register Busy */
+#define _LEUART_SYNCBUSY_CLKDIV_SHIFT            2                                          /**< Shift value for LEUART_CLKDIV */
+#define _LEUART_SYNCBUSY_CLKDIV_MASK             0x4UL                                      /**< Bit mask for LEUART_CLKDIV */
+#define _LEUART_SYNCBUSY_CLKDIV_DEFAULT          0x00000000UL                               /**< Mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_CLKDIV_DEFAULT           (_LEUART_SYNCBUSY_CLKDIV_DEFAULT << 2)     /**< Shifted mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_STARTFRAME               (0x1UL << 3)                               /**< STARTFRAME Register Busy */
+#define _LEUART_SYNCBUSY_STARTFRAME_SHIFT        3                                          /**< Shift value for LEUART_STARTFRAME */
+#define _LEUART_SYNCBUSY_STARTFRAME_MASK         0x8UL                                      /**< Bit mask for LEUART_STARTFRAME */
+#define _LEUART_SYNCBUSY_STARTFRAME_DEFAULT      0x00000000UL                               /**< Mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_STARTFRAME_DEFAULT       (_LEUART_SYNCBUSY_STARTFRAME_DEFAULT << 3) /**< Shifted mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_SIGFRAME                 (0x1UL << 4)                               /**< SIGFRAME Register Busy */
+#define _LEUART_SYNCBUSY_SIGFRAME_SHIFT          4                                          /**< Shift value for LEUART_SIGFRAME */
+#define _LEUART_SYNCBUSY_SIGFRAME_MASK           0x10UL                                     /**< Bit mask for LEUART_SIGFRAME */
+#define _LEUART_SYNCBUSY_SIGFRAME_DEFAULT        0x00000000UL                               /**< Mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_SIGFRAME_DEFAULT         (_LEUART_SYNCBUSY_SIGFRAME_DEFAULT << 4)   /**< Shifted mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_TXDATAX                  (0x1UL << 5)                               /**< TXDATAX Register Busy */
+#define _LEUART_SYNCBUSY_TXDATAX_SHIFT           5                                          /**< Shift value for LEUART_TXDATAX */
+#define _LEUART_SYNCBUSY_TXDATAX_MASK            0x20UL                                     /**< Bit mask for LEUART_TXDATAX */
+#define _LEUART_SYNCBUSY_TXDATAX_DEFAULT         0x00000000UL                               /**< Mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_TXDATAX_DEFAULT          (_LEUART_SYNCBUSY_TXDATAX_DEFAULT << 5)    /**< Shifted mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_TXDATA                   (0x1UL << 6)                               /**< TXDATA Register Busy */
+#define _LEUART_SYNCBUSY_TXDATA_SHIFT            6                                          /**< Shift value for LEUART_TXDATA */
+#define _LEUART_SYNCBUSY_TXDATA_MASK             0x40UL                                     /**< Bit mask for LEUART_TXDATA */
+#define _LEUART_SYNCBUSY_TXDATA_DEFAULT          0x00000000UL                               /**< Mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_TXDATA_DEFAULT           (_LEUART_SYNCBUSY_TXDATA_DEFAULT << 6)     /**< Shifted mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_PULSECTRL                (0x1UL << 7)                               /**< PULSECTRL Register Busy */
+#define _LEUART_SYNCBUSY_PULSECTRL_SHIFT         7                                          /**< Shift value for LEUART_PULSECTRL */
+#define _LEUART_SYNCBUSY_PULSECTRL_MASK          0x80UL                                     /**< Bit mask for LEUART_PULSECTRL */
+#define _LEUART_SYNCBUSY_PULSECTRL_DEFAULT       0x00000000UL                               /**< Mode DEFAULT for LEUART_SYNCBUSY */
+#define LEUART_SYNCBUSY_PULSECTRL_DEFAULT        (_LEUART_SYNCBUSY_PULSECTRL_DEFAULT << 7)  /**< Shifted mode DEFAULT for LEUART_SYNCBUSY */
+
+/* Bit fields for LEUART ROUTE */
+#define _LEUART_ROUTE_RESETVALUE                 0x00000000UL                          /**< Default value for LEUART_ROUTE */
+#define _LEUART_ROUTE_MASK                       0x00000703UL                          /**< Mask for LEUART_ROUTE */
+#define LEUART_ROUTE_RXPEN                       (0x1UL << 0)                          /**< RX Pin Enable */
+#define _LEUART_ROUTE_RXPEN_SHIFT                0                                     /**< Shift value for LEUART_RXPEN */
+#define _LEUART_ROUTE_RXPEN_MASK                 0x1UL                                 /**< Bit mask for LEUART_RXPEN */
+#define _LEUART_ROUTE_RXPEN_DEFAULT              0x00000000UL                          /**< Mode DEFAULT for LEUART_ROUTE */
+#define LEUART_ROUTE_RXPEN_DEFAULT               (_LEUART_ROUTE_RXPEN_DEFAULT << 0)    /**< Shifted mode DEFAULT for LEUART_ROUTE */
+#define LEUART_ROUTE_TXPEN                       (0x1UL << 1)                          /**< TX Pin Enable */
+#define _LEUART_ROUTE_TXPEN_SHIFT                1                                     /**< Shift value for LEUART_TXPEN */
+#define _LEUART_ROUTE_TXPEN_MASK                 0x2UL                                 /**< Bit mask for LEUART_TXPEN */
+#define _LEUART_ROUTE_TXPEN_DEFAULT              0x00000000UL                          /**< Mode DEFAULT for LEUART_ROUTE */
+#define LEUART_ROUTE_TXPEN_DEFAULT               (_LEUART_ROUTE_TXPEN_DEFAULT << 1)    /**< Shifted mode DEFAULT for LEUART_ROUTE */
+#define _LEUART_ROUTE_LOCATION_SHIFT             8                                     /**< Shift value for LEUART_LOCATION */
+#define _LEUART_ROUTE_LOCATION_MASK              0x700UL                               /**< Bit mask for LEUART_LOCATION */
+#define _LEUART_ROUTE_LOCATION_LOC0              0x00000000UL                          /**< Mode LOC0 for LEUART_ROUTE */
+#define _LEUART_ROUTE_LOCATION_DEFAULT           0x00000000UL                          /**< Mode DEFAULT for LEUART_ROUTE */
+#define _LEUART_ROUTE_LOCATION_LOC1              0x00000001UL                          /**< Mode LOC1 for LEUART_ROUTE */
+#define _LEUART_ROUTE_LOCATION_LOC2              0x00000002UL                          /**< Mode LOC2 for LEUART_ROUTE */
+#define _LEUART_ROUTE_LOCATION_LOC3              0x00000003UL                          /**< Mode LOC3 for LEUART_ROUTE */
+#define _LEUART_ROUTE_LOCATION_LOC4              0x00000004UL                          /**< Mode LOC4 for LEUART_ROUTE */
+#define LEUART_ROUTE_LOCATION_LOC0               (_LEUART_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for LEUART_ROUTE */
+#define LEUART_ROUTE_LOCATION_DEFAULT            (_LEUART_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for LEUART_ROUTE */
+#define LEUART_ROUTE_LOCATION_LOC1               (_LEUART_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for LEUART_ROUTE */
+#define LEUART_ROUTE_LOCATION_LOC2               (_LEUART_ROUTE_LOCATION_LOC2 << 8)    /**< Shifted mode LOC2 for LEUART_ROUTE */
+#define LEUART_ROUTE_LOCATION_LOC3               (_LEUART_ROUTE_LOCATION_LOC3 << 8)    /**< Shifted mode LOC3 for LEUART_ROUTE */
+#define LEUART_ROUTE_LOCATION_LOC4               (_LEUART_ROUTE_LOCATION_LOC4 << 8)    /**< Shifted mode LOC4 for LEUART_ROUTE */
+
+/* Bit fields for LEUART INPUT */
+#define _LEUART_INPUT_RESETVALUE                 0x00000000UL                          /**< Default value for LEUART_INPUT */
+#define _LEUART_INPUT_MASK                       0x00000017UL                          /**< Mask for LEUART_INPUT */
+#define _LEUART_INPUT_RXPRSSEL_SHIFT             0                                     /**< Shift value for LEUART_RXPRSSEL */
+#define _LEUART_INPUT_RXPRSSEL_MASK              0x7UL                                 /**< Bit mask for LEUART_RXPRSSEL */
+#define _LEUART_INPUT_RXPRSSEL_DEFAULT           0x00000000UL                          /**< Mode DEFAULT for LEUART_INPUT */
+#define _LEUART_INPUT_RXPRSSEL_PRSCH0            0x00000000UL                          /**< Mode PRSCH0 for LEUART_INPUT */
+#define _LEUART_INPUT_RXPRSSEL_PRSCH1            0x00000001UL                          /**< Mode PRSCH1 for LEUART_INPUT */
+#define _LEUART_INPUT_RXPRSSEL_PRSCH2            0x00000002UL                          /**< Mode PRSCH2 for LEUART_INPUT */
+#define _LEUART_INPUT_RXPRSSEL_PRSCH3            0x00000003UL                          /**< Mode PRSCH3 for LEUART_INPUT */
+#define _LEUART_INPUT_RXPRSSEL_PRSCH4            0x00000004UL                          /**< Mode PRSCH4 for LEUART_INPUT */
+#define _LEUART_INPUT_RXPRSSEL_PRSCH5            0x00000005UL                          /**< Mode PRSCH5 for LEUART_INPUT */
+#define _LEUART_INPUT_RXPRSSEL_PRSCH6            0x00000006UL                          /**< Mode PRSCH6 for LEUART_INPUT */
+#define _LEUART_INPUT_RXPRSSEL_PRSCH7            0x00000007UL                          /**< Mode PRSCH7 for LEUART_INPUT */
+#define LEUART_INPUT_RXPRSSEL_DEFAULT            (_LEUART_INPUT_RXPRSSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for LEUART_INPUT */
+#define LEUART_INPUT_RXPRSSEL_PRSCH0             (_LEUART_INPUT_RXPRSSEL_PRSCH0 << 0)  /**< Shifted mode PRSCH0 for LEUART_INPUT */
+#define LEUART_INPUT_RXPRSSEL_PRSCH1             (_LEUART_INPUT_RXPRSSEL_PRSCH1 << 0)  /**< Shifted mode PRSCH1 for LEUART_INPUT */
+#define LEUART_INPUT_RXPRSSEL_PRSCH2             (_LEUART_INPUT_RXPRSSEL_PRSCH2 << 0)  /**< Shifted mode PRSCH2 for LEUART_INPUT */
+#define LEUART_INPUT_RXPRSSEL_PRSCH3             (_LEUART_INPUT_RXPRSSEL_PRSCH3 << 0)  /**< Shifted mode PRSCH3 for LEUART_INPUT */
+#define LEUART_INPUT_RXPRSSEL_PRSCH4             (_LEUART_INPUT_RXPRSSEL_PRSCH4 << 0)  /**< Shifted mode PRSCH4 for LEUART_INPUT */
+#define LEUART_INPUT_RXPRSSEL_PRSCH5             (_LEUART_INPUT_RXPRSSEL_PRSCH5 << 0)  /**< Shifted mode PRSCH5 for LEUART_INPUT */
+#define LEUART_INPUT_RXPRSSEL_PRSCH6             (_LEUART_INPUT_RXPRSSEL_PRSCH6 << 0)  /**< Shifted mode PRSCH6 for LEUART_INPUT */
+#define LEUART_INPUT_RXPRSSEL_PRSCH7             (_LEUART_INPUT_RXPRSSEL_PRSCH7 << 0)  /**< Shifted mode PRSCH7 for LEUART_INPUT */
+#define LEUART_INPUT_RXPRS                       (0x1UL << 4)                          /**< PRS RX Enable */
+#define _LEUART_INPUT_RXPRS_SHIFT                4                                     /**< Shift value for LEUART_RXPRS */
+#define _LEUART_INPUT_RXPRS_MASK                 0x10UL                                /**< Bit mask for LEUART_RXPRS */
+#define _LEUART_INPUT_RXPRS_DEFAULT              0x00000000UL                          /**< Mode DEFAULT for LEUART_INPUT */
+#define LEUART_INPUT_RXPRS_DEFAULT               (_LEUART_INPUT_RXPRS_DEFAULT << 4)    /**< Shifted mode DEFAULT for LEUART_INPUT */
+
+/** @} End of group EFM32TG_LEUART */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_msc.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_msc.h
@@ -1,0 +1,385 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_MSC register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_MSC
+ * @brief EFM32TG_MSC Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< Memory System Control Register  */
+  __IOM uint32_t READCTRL;      /**< Read Control Register  */
+  __IOM uint32_t WRITECTRL;     /**< Write Control Register  */
+  __IOM uint32_t WRITECMD;      /**< Write Command Register  */
+  __IOM uint32_t ADDRB;         /**< Page Erase/Write Address Buffer  */
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t WDATA;         /**< Write Data Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  uint32_t       RESERVED1[3U]; /**< Reserved for future use **/
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t LOCK;          /**< Configuration Lock Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  CACHEHITS;     /**< Cache Hits Performance Counter  */
+  __IM uint32_t  CACHEMISSES;   /**< Cache Misses Performance Counter  */
+  uint32_t       RESERVED2[1U]; /**< Reserved for future use **/
+  __IOM uint32_t TIMEBASE;      /**< Flash Write and Erase Timebase  */
+} MSC_TypeDef;                  /**< MSC Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_MSC_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for MSC CTRL */
+#define _MSC_CTRL_RESETVALUE                    0x00000001UL                       /**< Default value for MSC_CTRL */
+#define _MSC_CTRL_MASK                          0x00000001UL                       /**< Mask for MSC_CTRL */
+#define MSC_CTRL_BUSFAULT                       (0x1UL << 0)                       /**< Bus Fault Response Enable */
+#define _MSC_CTRL_BUSFAULT_SHIFT                0                                  /**< Shift value for MSC_BUSFAULT */
+#define _MSC_CTRL_BUSFAULT_MASK                 0x1UL                              /**< Bit mask for MSC_BUSFAULT */
+#define _MSC_CTRL_BUSFAULT_GENERATE             0x00000000UL                       /**< Mode GENERATE for MSC_CTRL */
+#define _MSC_CTRL_BUSFAULT_DEFAULT              0x00000001UL                       /**< Mode DEFAULT for MSC_CTRL */
+#define _MSC_CTRL_BUSFAULT_IGNORE               0x00000001UL                       /**< Mode IGNORE for MSC_CTRL */
+#define MSC_CTRL_BUSFAULT_GENERATE              (_MSC_CTRL_BUSFAULT_GENERATE << 0) /**< Shifted mode GENERATE for MSC_CTRL */
+#define MSC_CTRL_BUSFAULT_DEFAULT               (_MSC_CTRL_BUSFAULT_DEFAULT << 0)  /**< Shifted mode DEFAULT for MSC_CTRL */
+#define MSC_CTRL_BUSFAULT_IGNORE                (_MSC_CTRL_BUSFAULT_IGNORE << 0)   /**< Shifted mode IGNORE for MSC_CTRL */
+
+/* Bit fields for MSC READCTRL */
+#define _MSC_READCTRL_RESETVALUE                0x00000001UL                        /**< Default value for MSC_READCTRL */
+#define _MSC_READCTRL_MASK                      0x0000003FUL                        /**< Mask for MSC_READCTRL */
+#define _MSC_READCTRL_MODE_SHIFT                0                                   /**< Shift value for MSC_MODE */
+#define _MSC_READCTRL_MODE_MASK                 0x7UL                               /**< Bit mask for MSC_MODE */
+#define _MSC_READCTRL_MODE_WS0                  0x00000000UL                        /**< Mode WS0 for MSC_READCTRL */
+#define _MSC_READCTRL_MODE_DEFAULT              0x00000001UL                        /**< Mode DEFAULT for MSC_READCTRL */
+#define _MSC_READCTRL_MODE_WS1                  0x00000001UL                        /**< Mode WS1 for MSC_READCTRL */
+#define _MSC_READCTRL_MODE_WS0SCBTP             0x00000002UL                        /**< Mode WS0SCBTP for MSC_READCTRL */
+#define _MSC_READCTRL_MODE_WS1SCBTP             0x00000003UL                        /**< Mode WS1SCBTP for MSC_READCTRL */
+#define MSC_READCTRL_MODE_WS0                   (_MSC_READCTRL_MODE_WS0 << 0)       /**< Shifted mode WS0 for MSC_READCTRL */
+#define MSC_READCTRL_MODE_DEFAULT               (_MSC_READCTRL_MODE_DEFAULT << 0)   /**< Shifted mode DEFAULT for MSC_READCTRL */
+#define MSC_READCTRL_MODE_WS1                   (_MSC_READCTRL_MODE_WS1 << 0)       /**< Shifted mode WS1 for MSC_READCTRL */
+#define MSC_READCTRL_MODE_WS0SCBTP              (_MSC_READCTRL_MODE_WS0SCBTP << 0)  /**< Shifted mode WS0SCBTP for MSC_READCTRL */
+#define MSC_READCTRL_MODE_WS1SCBTP              (_MSC_READCTRL_MODE_WS1SCBTP << 0)  /**< Shifted mode WS1SCBTP for MSC_READCTRL */
+#define MSC_READCTRL_IFCDIS                     (0x1UL << 3)                        /**< Internal Flash Cache Disable */
+#define _MSC_READCTRL_IFCDIS_SHIFT              3                                   /**< Shift value for MSC_IFCDIS */
+#define _MSC_READCTRL_IFCDIS_MASK               0x8UL                               /**< Bit mask for MSC_IFCDIS */
+#define _MSC_READCTRL_IFCDIS_DEFAULT            0x00000000UL                        /**< Mode DEFAULT for MSC_READCTRL */
+#define MSC_READCTRL_IFCDIS_DEFAULT             (_MSC_READCTRL_IFCDIS_DEFAULT << 3) /**< Shifted mode DEFAULT for MSC_READCTRL */
+#define MSC_READCTRL_AIDIS                      (0x1UL << 4)                        /**< Automatic Invalidate Disable */
+#define _MSC_READCTRL_AIDIS_SHIFT               4                                   /**< Shift value for MSC_AIDIS */
+#define _MSC_READCTRL_AIDIS_MASK                0x10UL                              /**< Bit mask for MSC_AIDIS */
+#define _MSC_READCTRL_AIDIS_DEFAULT             0x00000000UL                        /**< Mode DEFAULT for MSC_READCTRL */
+#define MSC_READCTRL_AIDIS_DEFAULT              (_MSC_READCTRL_AIDIS_DEFAULT << 4)  /**< Shifted mode DEFAULT for MSC_READCTRL */
+#define MSC_READCTRL_ICCDIS                     (0x1UL << 5)                        /**< Interrupt Context Cache Disable */
+#define _MSC_READCTRL_ICCDIS_SHIFT              5                                   /**< Shift value for MSC_ICCDIS */
+#define _MSC_READCTRL_ICCDIS_MASK               0x20UL                              /**< Bit mask for MSC_ICCDIS */
+#define _MSC_READCTRL_ICCDIS_DEFAULT            0x00000000UL                        /**< Mode DEFAULT for MSC_READCTRL */
+#define MSC_READCTRL_ICCDIS_DEFAULT             (_MSC_READCTRL_ICCDIS_DEFAULT << 5) /**< Shifted mode DEFAULT for MSC_READCTRL */
+
+/* Bit fields for MSC WRITECTRL */
+#define _MSC_WRITECTRL_RESETVALUE               0x00000000UL                                /**< Default value for MSC_WRITECTRL */
+#define _MSC_WRITECTRL_MASK                     0x00000003UL                                /**< Mask for MSC_WRITECTRL */
+#define MSC_WRITECTRL_WREN                      (0x1UL << 0)                                /**< Enable Write/Erase Controller  */
+#define _MSC_WRITECTRL_WREN_SHIFT               0                                           /**< Shift value for MSC_WREN */
+#define _MSC_WRITECTRL_WREN_MASK                0x1UL                                       /**< Bit mask for MSC_WREN */
+#define _MSC_WRITECTRL_WREN_DEFAULT             0x00000000UL                                /**< Mode DEFAULT for MSC_WRITECTRL */
+#define MSC_WRITECTRL_WREN_DEFAULT              (_MSC_WRITECTRL_WREN_DEFAULT << 0)          /**< Shifted mode DEFAULT for MSC_WRITECTRL */
+#define MSC_WRITECTRL_IRQERASEABORT             (0x1UL << 1)                                /**< Abort Page Erase on Interrupt */
+#define _MSC_WRITECTRL_IRQERASEABORT_SHIFT      1                                           /**< Shift value for MSC_IRQERASEABORT */
+#define _MSC_WRITECTRL_IRQERASEABORT_MASK       0x2UL                                       /**< Bit mask for MSC_IRQERASEABORT */
+#define _MSC_WRITECTRL_IRQERASEABORT_DEFAULT    0x00000000UL                                /**< Mode DEFAULT for MSC_WRITECTRL */
+#define MSC_WRITECTRL_IRQERASEABORT_DEFAULT     (_MSC_WRITECTRL_IRQERASEABORT_DEFAULT << 1) /**< Shifted mode DEFAULT for MSC_WRITECTRL */
+
+/* Bit fields for MSC WRITECMD */
+#define _MSC_WRITECMD_RESETVALUE                0x00000000UL                            /**< Default value for MSC_WRITECMD */
+#define _MSC_WRITECMD_MASK                      0x0000003FUL                            /**< Mask for MSC_WRITECMD */
+#define MSC_WRITECMD_LADDRIM                    (0x1UL << 0)                            /**< Load MSC_ADDRB into ADDR */
+#define _MSC_WRITECMD_LADDRIM_SHIFT             0                                       /**< Shift value for MSC_LADDRIM */
+#define _MSC_WRITECMD_LADDRIM_MASK              0x1UL                                   /**< Bit mask for MSC_LADDRIM */
+#define _MSC_WRITECMD_LADDRIM_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_LADDRIM_DEFAULT            (_MSC_WRITECMD_LADDRIM_DEFAULT << 0)    /**< Shifted mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_ERASEPAGE                  (0x1UL << 1)                            /**< Erase Page */
+#define _MSC_WRITECMD_ERASEPAGE_SHIFT           1                                       /**< Shift value for MSC_ERASEPAGE */
+#define _MSC_WRITECMD_ERASEPAGE_MASK            0x2UL                                   /**< Bit mask for MSC_ERASEPAGE */
+#define _MSC_WRITECMD_ERASEPAGE_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_ERASEPAGE_DEFAULT          (_MSC_WRITECMD_ERASEPAGE_DEFAULT << 1)  /**< Shifted mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_WRITEEND                   (0x1UL << 2)                            /**< End Write Mode */
+#define _MSC_WRITECMD_WRITEEND_SHIFT            2                                       /**< Shift value for MSC_WRITEEND */
+#define _MSC_WRITECMD_WRITEEND_MASK             0x4UL                                   /**< Bit mask for MSC_WRITEEND */
+#define _MSC_WRITECMD_WRITEEND_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_WRITEEND_DEFAULT           (_MSC_WRITECMD_WRITEEND_DEFAULT << 2)   /**< Shifted mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_WRITEONCE                  (0x1UL << 3)                            /**< Word Write-Once Trigger */
+#define _MSC_WRITECMD_WRITEONCE_SHIFT           3                                       /**< Shift value for MSC_WRITEONCE */
+#define _MSC_WRITECMD_WRITEONCE_MASK            0x8UL                                   /**< Bit mask for MSC_WRITEONCE */
+#define _MSC_WRITECMD_WRITEONCE_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_WRITEONCE_DEFAULT          (_MSC_WRITECMD_WRITEONCE_DEFAULT << 3)  /**< Shifted mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_WRITETRIG                  (0x1UL << 4)                            /**< Word Write Sequence Trigger */
+#define _MSC_WRITECMD_WRITETRIG_SHIFT           4                                       /**< Shift value for MSC_WRITETRIG */
+#define _MSC_WRITECMD_WRITETRIG_MASK            0x10UL                                  /**< Bit mask for MSC_WRITETRIG */
+#define _MSC_WRITECMD_WRITETRIG_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_WRITETRIG_DEFAULT          (_MSC_WRITECMD_WRITETRIG_DEFAULT << 4)  /**< Shifted mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_ERASEABORT                 (0x1UL << 5)                            /**< Abort erase sequence */
+#define _MSC_WRITECMD_ERASEABORT_SHIFT          5                                       /**< Shift value for MSC_ERASEABORT */
+#define _MSC_WRITECMD_ERASEABORT_MASK           0x20UL                                  /**< Bit mask for MSC_ERASEABORT */
+#define _MSC_WRITECMD_ERASEABORT_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for MSC_WRITECMD */
+#define MSC_WRITECMD_ERASEABORT_DEFAULT         (_MSC_WRITECMD_ERASEABORT_DEFAULT << 5) /**< Shifted mode DEFAULT for MSC_WRITECMD */
+
+/* Bit fields for MSC ADDRB */
+#define _MSC_ADDRB_RESETVALUE                   0x00000000UL                    /**< Default value for MSC_ADDRB */
+#define _MSC_ADDRB_MASK                         0xFFFFFFFFUL                    /**< Mask for MSC_ADDRB */
+#define _MSC_ADDRB_ADDRB_SHIFT                  0                               /**< Shift value for MSC_ADDRB */
+#define _MSC_ADDRB_ADDRB_MASK                   0xFFFFFFFFUL                    /**< Bit mask for MSC_ADDRB */
+#define _MSC_ADDRB_ADDRB_DEFAULT                0x00000000UL                    /**< Mode DEFAULT for MSC_ADDRB */
+#define MSC_ADDRB_ADDRB_DEFAULT                 (_MSC_ADDRB_ADDRB_DEFAULT << 0) /**< Shifted mode DEFAULT for MSC_ADDRB */
+
+/* Bit fields for MSC WDATA */
+#define _MSC_WDATA_RESETVALUE                   0x00000000UL                    /**< Default value for MSC_WDATA */
+#define _MSC_WDATA_MASK                         0xFFFFFFFFUL                    /**< Mask for MSC_WDATA */
+#define _MSC_WDATA_WDATA_SHIFT                  0                               /**< Shift value for MSC_WDATA */
+#define _MSC_WDATA_WDATA_MASK                   0xFFFFFFFFUL                    /**< Bit mask for MSC_WDATA */
+#define _MSC_WDATA_WDATA_DEFAULT                0x00000000UL                    /**< Mode DEFAULT for MSC_WDATA */
+#define MSC_WDATA_WDATA_DEFAULT                 (_MSC_WDATA_WDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for MSC_WDATA */
+
+/* Bit fields for MSC STATUS */
+#define _MSC_STATUS_RESETVALUE                  0x00000008UL                            /**< Default value for MSC_STATUS */
+#define _MSC_STATUS_MASK                        0x0000007FUL                            /**< Mask for MSC_STATUS */
+#define MSC_STATUS_BUSY                         (0x1UL << 0)                            /**< Erase/Write Busy */
+#define _MSC_STATUS_BUSY_SHIFT                  0                                       /**< Shift value for MSC_BUSY */
+#define _MSC_STATUS_BUSY_MASK                   0x1UL                                   /**< Bit mask for MSC_BUSY */
+#define _MSC_STATUS_BUSY_DEFAULT                0x00000000UL                            /**< Mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_BUSY_DEFAULT                 (_MSC_STATUS_BUSY_DEFAULT << 0)         /**< Shifted mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_LOCKED                       (0x1UL << 1)                            /**< Access Locked */
+#define _MSC_STATUS_LOCKED_SHIFT                1                                       /**< Shift value for MSC_LOCKED */
+#define _MSC_STATUS_LOCKED_MASK                 0x2UL                                   /**< Bit mask for MSC_LOCKED */
+#define _MSC_STATUS_LOCKED_DEFAULT              0x00000000UL                            /**< Mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_LOCKED_DEFAULT               (_MSC_STATUS_LOCKED_DEFAULT << 1)       /**< Shifted mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_INVADDR                      (0x1UL << 2)                            /**< Invalid Write Address or Erase Page */
+#define _MSC_STATUS_INVADDR_SHIFT               2                                       /**< Shift value for MSC_INVADDR */
+#define _MSC_STATUS_INVADDR_MASK                0x4UL                                   /**< Bit mask for MSC_INVADDR */
+#define _MSC_STATUS_INVADDR_DEFAULT             0x00000000UL                            /**< Mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_INVADDR_DEFAULT              (_MSC_STATUS_INVADDR_DEFAULT << 2)      /**< Shifted mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_WDATAREADY                   (0x1UL << 3)                            /**< WDATA Write Ready */
+#define _MSC_STATUS_WDATAREADY_SHIFT            3                                       /**< Shift value for MSC_WDATAREADY */
+#define _MSC_STATUS_WDATAREADY_MASK             0x8UL                                   /**< Bit mask for MSC_WDATAREADY */
+#define _MSC_STATUS_WDATAREADY_DEFAULT          0x00000001UL                            /**< Mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_WDATAREADY_DEFAULT           (_MSC_STATUS_WDATAREADY_DEFAULT << 3)   /**< Shifted mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_WORDTIMEOUT                  (0x1UL << 4)                            /**< Flash Write Word Timeout */
+#define _MSC_STATUS_WORDTIMEOUT_SHIFT           4                                       /**< Shift value for MSC_WORDTIMEOUT */
+#define _MSC_STATUS_WORDTIMEOUT_MASK            0x10UL                                  /**< Bit mask for MSC_WORDTIMEOUT */
+#define _MSC_STATUS_WORDTIMEOUT_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_WORDTIMEOUT_DEFAULT          (_MSC_STATUS_WORDTIMEOUT_DEFAULT << 4)  /**< Shifted mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_ERASEABORTED                 (0x1UL << 5)                            /**< The Current Flash Erase Operation Aborted */
+#define _MSC_STATUS_ERASEABORTED_SHIFT          5                                       /**< Shift value for MSC_ERASEABORTED */
+#define _MSC_STATUS_ERASEABORTED_MASK           0x20UL                                  /**< Bit mask for MSC_ERASEABORTED */
+#define _MSC_STATUS_ERASEABORTED_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_ERASEABORTED_DEFAULT         (_MSC_STATUS_ERASEABORTED_DEFAULT << 5) /**< Shifted mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_PCRUNNING                    (0x1UL << 6)                            /**< Performance Counters Running */
+#define _MSC_STATUS_PCRUNNING_SHIFT             6                                       /**< Shift value for MSC_PCRUNNING */
+#define _MSC_STATUS_PCRUNNING_MASK              0x40UL                                  /**< Bit mask for MSC_PCRUNNING */
+#define _MSC_STATUS_PCRUNNING_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for MSC_STATUS */
+#define MSC_STATUS_PCRUNNING_DEFAULT            (_MSC_STATUS_PCRUNNING_DEFAULT << 6)    /**< Shifted mode DEFAULT for MSC_STATUS */
+
+/* Bit fields for MSC IF */
+#define _MSC_IF_RESETVALUE                      0x00000000UL                 /**< Default value for MSC_IF */
+#define _MSC_IF_MASK                            0x0000000FUL                 /**< Mask for MSC_IF */
+#define MSC_IF_ERASE                            (0x1UL << 0)                 /**< Erase Done Interrupt Read Flag */
+#define _MSC_IF_ERASE_SHIFT                     0                            /**< Shift value for MSC_ERASE */
+#define _MSC_IF_ERASE_MASK                      0x1UL                        /**< Bit mask for MSC_ERASE */
+#define _MSC_IF_ERASE_DEFAULT                   0x00000000UL                 /**< Mode DEFAULT for MSC_IF */
+#define MSC_IF_ERASE_DEFAULT                    (_MSC_IF_ERASE_DEFAULT << 0) /**< Shifted mode DEFAULT for MSC_IF */
+#define MSC_IF_WRITE                            (0x1UL << 1)                 /**< Write Done Interrupt Read Flag */
+#define _MSC_IF_WRITE_SHIFT                     1                            /**< Shift value for MSC_WRITE */
+#define _MSC_IF_WRITE_MASK                      0x2UL                        /**< Bit mask for MSC_WRITE */
+#define _MSC_IF_WRITE_DEFAULT                   0x00000000UL                 /**< Mode DEFAULT for MSC_IF */
+#define MSC_IF_WRITE_DEFAULT                    (_MSC_IF_WRITE_DEFAULT << 1) /**< Shifted mode DEFAULT for MSC_IF */
+#define MSC_IF_CHOF                             (0x1UL << 2)                 /**< Cache Hits Overflow Interrupt Flag */
+#define _MSC_IF_CHOF_SHIFT                      2                            /**< Shift value for MSC_CHOF */
+#define _MSC_IF_CHOF_MASK                       0x4UL                        /**< Bit mask for MSC_CHOF */
+#define _MSC_IF_CHOF_DEFAULT                    0x00000000UL                 /**< Mode DEFAULT for MSC_IF */
+#define MSC_IF_CHOF_DEFAULT                     (_MSC_IF_CHOF_DEFAULT << 2)  /**< Shifted mode DEFAULT for MSC_IF */
+#define MSC_IF_CMOF                             (0x1UL << 3)                 /**< Cache Misses Overflow Interrupt Flag */
+#define _MSC_IF_CMOF_SHIFT                      3                            /**< Shift value for MSC_CMOF */
+#define _MSC_IF_CMOF_MASK                       0x8UL                        /**< Bit mask for MSC_CMOF */
+#define _MSC_IF_CMOF_DEFAULT                    0x00000000UL                 /**< Mode DEFAULT for MSC_IF */
+#define MSC_IF_CMOF_DEFAULT                     (_MSC_IF_CMOF_DEFAULT << 3)  /**< Shifted mode DEFAULT for MSC_IF */
+
+/* Bit fields for MSC IFS */
+#define _MSC_IFS_RESETVALUE                     0x00000000UL                  /**< Default value for MSC_IFS */
+#define _MSC_IFS_MASK                           0x0000000FUL                  /**< Mask for MSC_IFS */
+#define MSC_IFS_ERASE                           (0x1UL << 0)                  /**< Erase Done Interrupt Set */
+#define _MSC_IFS_ERASE_SHIFT                    0                             /**< Shift value for MSC_ERASE */
+#define _MSC_IFS_ERASE_MASK                     0x1UL                         /**< Bit mask for MSC_ERASE */
+#define _MSC_IFS_ERASE_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for MSC_IFS */
+#define MSC_IFS_ERASE_DEFAULT                   (_MSC_IFS_ERASE_DEFAULT << 0) /**< Shifted mode DEFAULT for MSC_IFS */
+#define MSC_IFS_WRITE                           (0x1UL << 1)                  /**< Write Done Interrupt Set */
+#define _MSC_IFS_WRITE_SHIFT                    1                             /**< Shift value for MSC_WRITE */
+#define _MSC_IFS_WRITE_MASK                     0x2UL                         /**< Bit mask for MSC_WRITE */
+#define _MSC_IFS_WRITE_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for MSC_IFS */
+#define MSC_IFS_WRITE_DEFAULT                   (_MSC_IFS_WRITE_DEFAULT << 1) /**< Shifted mode DEFAULT for MSC_IFS */
+#define MSC_IFS_CHOF                            (0x1UL << 2)                  /**< Cache Hits Overflow Interrupt Set */
+#define _MSC_IFS_CHOF_SHIFT                     2                             /**< Shift value for MSC_CHOF */
+#define _MSC_IFS_CHOF_MASK                      0x4UL                         /**< Bit mask for MSC_CHOF */
+#define _MSC_IFS_CHOF_DEFAULT                   0x00000000UL                  /**< Mode DEFAULT for MSC_IFS */
+#define MSC_IFS_CHOF_DEFAULT                    (_MSC_IFS_CHOF_DEFAULT << 2)  /**< Shifted mode DEFAULT for MSC_IFS */
+#define MSC_IFS_CMOF                            (0x1UL << 3)                  /**< Cache Misses Overflow Interrupt Set */
+#define _MSC_IFS_CMOF_SHIFT                     3                             /**< Shift value for MSC_CMOF */
+#define _MSC_IFS_CMOF_MASK                      0x8UL                         /**< Bit mask for MSC_CMOF */
+#define _MSC_IFS_CMOF_DEFAULT                   0x00000000UL                  /**< Mode DEFAULT for MSC_IFS */
+#define MSC_IFS_CMOF_DEFAULT                    (_MSC_IFS_CMOF_DEFAULT << 3)  /**< Shifted mode DEFAULT for MSC_IFS */
+
+/* Bit fields for MSC IFC */
+#define _MSC_IFC_RESETVALUE                     0x00000000UL                  /**< Default value for MSC_IFC */
+#define _MSC_IFC_MASK                           0x0000000FUL                  /**< Mask for MSC_IFC */
+#define MSC_IFC_ERASE                           (0x1UL << 0)                  /**< Erase Done Interrupt Clear */
+#define _MSC_IFC_ERASE_SHIFT                    0                             /**< Shift value for MSC_ERASE */
+#define _MSC_IFC_ERASE_MASK                     0x1UL                         /**< Bit mask for MSC_ERASE */
+#define _MSC_IFC_ERASE_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for MSC_IFC */
+#define MSC_IFC_ERASE_DEFAULT                   (_MSC_IFC_ERASE_DEFAULT << 0) /**< Shifted mode DEFAULT for MSC_IFC */
+#define MSC_IFC_WRITE                           (0x1UL << 1)                  /**< Write Done Interrupt Clear */
+#define _MSC_IFC_WRITE_SHIFT                    1                             /**< Shift value for MSC_WRITE */
+#define _MSC_IFC_WRITE_MASK                     0x2UL                         /**< Bit mask for MSC_WRITE */
+#define _MSC_IFC_WRITE_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for MSC_IFC */
+#define MSC_IFC_WRITE_DEFAULT                   (_MSC_IFC_WRITE_DEFAULT << 1) /**< Shifted mode DEFAULT for MSC_IFC */
+#define MSC_IFC_CHOF                            (0x1UL << 2)                  /**< Cache Hits Overflow Interrupt Clear */
+#define _MSC_IFC_CHOF_SHIFT                     2                             /**< Shift value for MSC_CHOF */
+#define _MSC_IFC_CHOF_MASK                      0x4UL                         /**< Bit mask for MSC_CHOF */
+#define _MSC_IFC_CHOF_DEFAULT                   0x00000000UL                  /**< Mode DEFAULT for MSC_IFC */
+#define MSC_IFC_CHOF_DEFAULT                    (_MSC_IFC_CHOF_DEFAULT << 2)  /**< Shifted mode DEFAULT for MSC_IFC */
+#define MSC_IFC_CMOF                            (0x1UL << 3)                  /**< Cache Misses Overflow Interrupt Clear */
+#define _MSC_IFC_CMOF_SHIFT                     3                             /**< Shift value for MSC_CMOF */
+#define _MSC_IFC_CMOF_MASK                      0x8UL                         /**< Bit mask for MSC_CMOF */
+#define _MSC_IFC_CMOF_DEFAULT                   0x00000000UL                  /**< Mode DEFAULT for MSC_IFC */
+#define MSC_IFC_CMOF_DEFAULT                    (_MSC_IFC_CMOF_DEFAULT << 3)  /**< Shifted mode DEFAULT for MSC_IFC */
+
+/* Bit fields for MSC IEN */
+#define _MSC_IEN_RESETVALUE                     0x00000000UL                  /**< Default value for MSC_IEN */
+#define _MSC_IEN_MASK                           0x0000000FUL                  /**< Mask for MSC_IEN */
+#define MSC_IEN_ERASE                           (0x1UL << 0)                  /**< Erase Done Interrupt Enable */
+#define _MSC_IEN_ERASE_SHIFT                    0                             /**< Shift value for MSC_ERASE */
+#define _MSC_IEN_ERASE_MASK                     0x1UL                         /**< Bit mask for MSC_ERASE */
+#define _MSC_IEN_ERASE_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for MSC_IEN */
+#define MSC_IEN_ERASE_DEFAULT                   (_MSC_IEN_ERASE_DEFAULT << 0) /**< Shifted mode DEFAULT for MSC_IEN */
+#define MSC_IEN_WRITE                           (0x1UL << 1)                  /**< Write Done Interrupt Enable */
+#define _MSC_IEN_WRITE_SHIFT                    1                             /**< Shift value for MSC_WRITE */
+#define _MSC_IEN_WRITE_MASK                     0x2UL                         /**< Bit mask for MSC_WRITE */
+#define _MSC_IEN_WRITE_DEFAULT                  0x00000000UL                  /**< Mode DEFAULT for MSC_IEN */
+#define MSC_IEN_WRITE_DEFAULT                   (_MSC_IEN_WRITE_DEFAULT << 1) /**< Shifted mode DEFAULT for MSC_IEN */
+#define MSC_IEN_CHOF                            (0x1UL << 2)                  /**< Cache Hits Overflow Interrupt Enable */
+#define _MSC_IEN_CHOF_SHIFT                     2                             /**< Shift value for MSC_CHOF */
+#define _MSC_IEN_CHOF_MASK                      0x4UL                         /**< Bit mask for MSC_CHOF */
+#define _MSC_IEN_CHOF_DEFAULT                   0x00000000UL                  /**< Mode DEFAULT for MSC_IEN */
+#define MSC_IEN_CHOF_DEFAULT                    (_MSC_IEN_CHOF_DEFAULT << 2)  /**< Shifted mode DEFAULT for MSC_IEN */
+#define MSC_IEN_CMOF                            (0x1UL << 3)                  /**< Cache Misses Overflow Interrupt Enable */
+#define _MSC_IEN_CMOF_SHIFT                     3                             /**< Shift value for MSC_CMOF */
+#define _MSC_IEN_CMOF_MASK                      0x8UL                         /**< Bit mask for MSC_CMOF */
+#define _MSC_IEN_CMOF_DEFAULT                   0x00000000UL                  /**< Mode DEFAULT for MSC_IEN */
+#define MSC_IEN_CMOF_DEFAULT                    (_MSC_IEN_CMOF_DEFAULT << 3)  /**< Shifted mode DEFAULT for MSC_IEN */
+
+/* Bit fields for MSC LOCK */
+#define _MSC_LOCK_RESETVALUE                    0x00000000UL                      /**< Default value for MSC_LOCK */
+#define _MSC_LOCK_MASK                          0x0000FFFFUL                      /**< Mask for MSC_LOCK */
+#define _MSC_LOCK_LOCKKEY_SHIFT                 0                                 /**< Shift value for MSC_LOCKKEY */
+#define _MSC_LOCK_LOCKKEY_MASK                  0xFFFFUL                          /**< Bit mask for MSC_LOCKKEY */
+#define _MSC_LOCK_LOCKKEY_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for MSC_LOCK */
+#define _MSC_LOCK_LOCKKEY_UNLOCKED              0x00000000UL                      /**< Mode UNLOCKED for MSC_LOCK */
+#define _MSC_LOCK_LOCKKEY_LOCK                  0x00000000UL                      /**< Mode LOCK for MSC_LOCK */
+#define _MSC_LOCK_LOCKKEY_LOCKED                0x00000001UL                      /**< Mode LOCKED for MSC_LOCK */
+#define _MSC_LOCK_LOCKKEY_UNLOCK                0x00001B71UL                      /**< Mode UNLOCK for MSC_LOCK */
+#define MSC_LOCK_LOCKKEY_DEFAULT                (_MSC_LOCK_LOCKKEY_DEFAULT << 0)  /**< Shifted mode DEFAULT for MSC_LOCK */
+#define MSC_LOCK_LOCKKEY_UNLOCKED               (_MSC_LOCK_LOCKKEY_UNLOCKED << 0) /**< Shifted mode UNLOCKED for MSC_LOCK */
+#define MSC_LOCK_LOCKKEY_LOCK                   (_MSC_LOCK_LOCKKEY_LOCK << 0)     /**< Shifted mode LOCK for MSC_LOCK */
+#define MSC_LOCK_LOCKKEY_LOCKED                 (_MSC_LOCK_LOCKKEY_LOCKED << 0)   /**< Shifted mode LOCKED for MSC_LOCK */
+#define MSC_LOCK_LOCKKEY_UNLOCK                 (_MSC_LOCK_LOCKKEY_UNLOCK << 0)   /**< Shifted mode UNLOCK for MSC_LOCK */
+
+/* Bit fields for MSC CMD */
+#define _MSC_CMD_RESETVALUE                     0x00000000UL                     /**< Default value for MSC_CMD */
+#define _MSC_CMD_MASK                           0x00000007UL                     /**< Mask for MSC_CMD */
+#define MSC_CMD_INVCACHE                        (0x1UL << 0)                     /**< Invalidate Instruction Cache */
+#define _MSC_CMD_INVCACHE_SHIFT                 0                                /**< Shift value for MSC_INVCACHE */
+#define _MSC_CMD_INVCACHE_MASK                  0x1UL                            /**< Bit mask for MSC_INVCACHE */
+#define _MSC_CMD_INVCACHE_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for MSC_CMD */
+#define MSC_CMD_INVCACHE_DEFAULT                (_MSC_CMD_INVCACHE_DEFAULT << 0) /**< Shifted mode DEFAULT for MSC_CMD */
+#define MSC_CMD_STARTPC                         (0x1UL << 1)                     /**< Start Performance Counters */
+#define _MSC_CMD_STARTPC_SHIFT                  1                                /**< Shift value for MSC_STARTPC */
+#define _MSC_CMD_STARTPC_MASK                   0x2UL                            /**< Bit mask for MSC_STARTPC */
+#define _MSC_CMD_STARTPC_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for MSC_CMD */
+#define MSC_CMD_STARTPC_DEFAULT                 (_MSC_CMD_STARTPC_DEFAULT << 1)  /**< Shifted mode DEFAULT for MSC_CMD */
+#define MSC_CMD_STOPPC                          (0x1UL << 2)                     /**< Stop Performance Counters */
+#define _MSC_CMD_STOPPC_SHIFT                   2                                /**< Shift value for MSC_STOPPC */
+#define _MSC_CMD_STOPPC_MASK                    0x4UL                            /**< Bit mask for MSC_STOPPC */
+#define _MSC_CMD_STOPPC_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for MSC_CMD */
+#define MSC_CMD_STOPPC_DEFAULT                  (_MSC_CMD_STOPPC_DEFAULT << 2)   /**< Shifted mode DEFAULT for MSC_CMD */
+
+/* Bit fields for MSC CACHEHITS */
+#define _MSC_CACHEHITS_RESETVALUE               0x00000000UL                            /**< Default value for MSC_CACHEHITS */
+#define _MSC_CACHEHITS_MASK                     0x000FFFFFUL                            /**< Mask for MSC_CACHEHITS */
+#define _MSC_CACHEHITS_CACHEHITS_SHIFT          0                                       /**< Shift value for MSC_CACHEHITS */
+#define _MSC_CACHEHITS_CACHEHITS_MASK           0xFFFFFUL                               /**< Bit mask for MSC_CACHEHITS */
+#define _MSC_CACHEHITS_CACHEHITS_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for MSC_CACHEHITS */
+#define MSC_CACHEHITS_CACHEHITS_DEFAULT         (_MSC_CACHEHITS_CACHEHITS_DEFAULT << 0) /**< Shifted mode DEFAULT for MSC_CACHEHITS */
+
+/* Bit fields for MSC CACHEMISSES */
+#define _MSC_CACHEMISSES_RESETVALUE             0x00000000UL                                /**< Default value for MSC_CACHEMISSES */
+#define _MSC_CACHEMISSES_MASK                   0x000FFFFFUL                                /**< Mask for MSC_CACHEMISSES */
+#define _MSC_CACHEMISSES_CACHEMISSES_SHIFT      0                                           /**< Shift value for MSC_CACHEMISSES */
+#define _MSC_CACHEMISSES_CACHEMISSES_MASK       0xFFFFFUL                                   /**< Bit mask for MSC_CACHEMISSES */
+#define _MSC_CACHEMISSES_CACHEMISSES_DEFAULT    0x00000000UL                                /**< Mode DEFAULT for MSC_CACHEMISSES */
+#define MSC_CACHEMISSES_CACHEMISSES_DEFAULT     (_MSC_CACHEMISSES_CACHEMISSES_DEFAULT << 0) /**< Shifted mode DEFAULT for MSC_CACHEMISSES */
+
+/* Bit fields for MSC TIMEBASE */
+#define _MSC_TIMEBASE_RESETVALUE                0x00000010UL                         /**< Default value for MSC_TIMEBASE */
+#define _MSC_TIMEBASE_MASK                      0x0001003FUL                         /**< Mask for MSC_TIMEBASE */
+#define _MSC_TIMEBASE_BASE_SHIFT                0                                    /**< Shift value for MSC_BASE */
+#define _MSC_TIMEBASE_BASE_MASK                 0x3FUL                               /**< Bit mask for MSC_BASE */
+#define _MSC_TIMEBASE_BASE_DEFAULT              0x00000010UL                         /**< Mode DEFAULT for MSC_TIMEBASE */
+#define MSC_TIMEBASE_BASE_DEFAULT               (_MSC_TIMEBASE_BASE_DEFAULT << 0)    /**< Shifted mode DEFAULT for MSC_TIMEBASE */
+#define MSC_TIMEBASE_PERIOD                     (0x1UL << 16)                        /**< Sets the timebase period */
+#define _MSC_TIMEBASE_PERIOD_SHIFT              16                                   /**< Shift value for MSC_PERIOD */
+#define _MSC_TIMEBASE_PERIOD_MASK               0x10000UL                            /**< Bit mask for MSC_PERIOD */
+#define _MSC_TIMEBASE_PERIOD_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for MSC_TIMEBASE */
+#define _MSC_TIMEBASE_PERIOD_1US                0x00000000UL                         /**< Mode 1US for MSC_TIMEBASE */
+#define _MSC_TIMEBASE_PERIOD_5US                0x00000001UL                         /**< Mode 5US for MSC_TIMEBASE */
+#define MSC_TIMEBASE_PERIOD_DEFAULT             (_MSC_TIMEBASE_PERIOD_DEFAULT << 16) /**< Shifted mode DEFAULT for MSC_TIMEBASE */
+#define MSC_TIMEBASE_PERIOD_1US                 (_MSC_TIMEBASE_PERIOD_1US << 16)     /**< Shifted mode 1US for MSC_TIMEBASE */
+#define MSC_TIMEBASE_PERIOD_5US                 (_MSC_TIMEBASE_PERIOD_5US << 16)     /**< Shifted mode 5US for MSC_TIMEBASE */
+
+/** @} End of group EFM32TG_MSC */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_pcnt.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_pcnt.h
@@ -1,0 +1,408 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_PCNT register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_PCNT
+ * @brief EFM32TG_PCNT Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;          /**< Control Register  */
+  __IOM uint32_t CMD;           /**< Command Register  */
+  __IM uint32_t  STATUS;        /**< Status Register  */
+  __IM uint32_t  CNT;           /**< Counter Value Register  */
+  __IM uint32_t  TOP;           /**< Top Value Register  */
+  __IOM uint32_t TOPB;          /**< Top Value Buffer Register  */
+  __IM uint32_t  IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;           /**< Interrupt Enable Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+
+  __IOM uint32_t FREEZE;        /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY;      /**< Synchronization Busy Register  */
+
+  uint32_t       RESERVED0[1U]; /**< Reserved for future use **/
+  __IOM uint32_t AUXCNT;        /**< Auxiliary Counter Value Register  */
+  __IOM uint32_t INPUT;         /**< PCNT Input Register  */
+} PCNT_TypeDef;                 /**< PCNT Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_PCNT_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for PCNT CTRL */
+#define _PCNT_CTRL_RESETVALUE             0x00000000UL                        /**< Default value for PCNT_CTRL */
+#define _PCNT_CTRL_MASK                   0x0000CF3FUL                        /**< Mask for PCNT_CTRL */
+#define _PCNT_CTRL_MODE_SHIFT             0                                   /**< Shift value for PCNT_MODE */
+#define _PCNT_CTRL_MODE_MASK              0x3UL                               /**< Bit mask for PCNT_MODE */
+#define _PCNT_CTRL_MODE_DEFAULT           0x00000000UL                        /**< Mode DEFAULT for PCNT_CTRL */
+#define _PCNT_CTRL_MODE_DISABLE           0x00000000UL                        /**< Mode DISABLE for PCNT_CTRL */
+#define _PCNT_CTRL_MODE_OVSSINGLE         0x00000001UL                        /**< Mode OVSSINGLE for PCNT_CTRL */
+#define _PCNT_CTRL_MODE_EXTCLKSINGLE      0x00000002UL                        /**< Mode EXTCLKSINGLE for PCNT_CTRL */
+#define _PCNT_CTRL_MODE_EXTCLKQUAD        0x00000003UL                        /**< Mode EXTCLKQUAD for PCNT_CTRL */
+#define PCNT_CTRL_MODE_DEFAULT            (_PCNT_CTRL_MODE_DEFAULT << 0)      /**< Shifted mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_MODE_DISABLE            (_PCNT_CTRL_MODE_DISABLE << 0)      /**< Shifted mode DISABLE for PCNT_CTRL */
+#define PCNT_CTRL_MODE_OVSSINGLE          (_PCNT_CTRL_MODE_OVSSINGLE << 0)    /**< Shifted mode OVSSINGLE for PCNT_CTRL */
+#define PCNT_CTRL_MODE_EXTCLKSINGLE       (_PCNT_CTRL_MODE_EXTCLKSINGLE << 0) /**< Shifted mode EXTCLKSINGLE for PCNT_CTRL */
+#define PCNT_CTRL_MODE_EXTCLKQUAD         (_PCNT_CTRL_MODE_EXTCLKQUAD << 0)   /**< Shifted mode EXTCLKQUAD for PCNT_CTRL */
+#define PCNT_CTRL_CNTDIR                  (0x1UL << 2)                        /**< Non-Quadrature Mode Counter Direction Control */
+#define _PCNT_CTRL_CNTDIR_SHIFT           2                                   /**< Shift value for PCNT_CNTDIR */
+#define _PCNT_CTRL_CNTDIR_MASK            0x4UL                               /**< Bit mask for PCNT_CNTDIR */
+#define _PCNT_CTRL_CNTDIR_DEFAULT         0x00000000UL                        /**< Mode DEFAULT for PCNT_CTRL */
+#define _PCNT_CTRL_CNTDIR_UP              0x00000000UL                        /**< Mode UP for PCNT_CTRL */
+#define _PCNT_CTRL_CNTDIR_DOWN            0x00000001UL                        /**< Mode DOWN for PCNT_CTRL */
+#define PCNT_CTRL_CNTDIR_DEFAULT          (_PCNT_CTRL_CNTDIR_DEFAULT << 2)    /**< Shifted mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_CNTDIR_UP               (_PCNT_CTRL_CNTDIR_UP << 2)         /**< Shifted mode UP for PCNT_CTRL */
+#define PCNT_CTRL_CNTDIR_DOWN             (_PCNT_CTRL_CNTDIR_DOWN << 2)       /**< Shifted mode DOWN for PCNT_CTRL */
+#define PCNT_CTRL_EDGE                    (0x1UL << 3)                        /**< Edge Select */
+#define _PCNT_CTRL_EDGE_SHIFT             3                                   /**< Shift value for PCNT_EDGE */
+#define _PCNT_CTRL_EDGE_MASK              0x8UL                               /**< Bit mask for PCNT_EDGE */
+#define _PCNT_CTRL_EDGE_DEFAULT           0x00000000UL                        /**< Mode DEFAULT for PCNT_CTRL */
+#define _PCNT_CTRL_EDGE_POS               0x00000000UL                        /**< Mode POS for PCNT_CTRL */
+#define _PCNT_CTRL_EDGE_NEG               0x00000001UL                        /**< Mode NEG for PCNT_CTRL */
+#define PCNT_CTRL_EDGE_DEFAULT            (_PCNT_CTRL_EDGE_DEFAULT << 3)      /**< Shifted mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_EDGE_POS                (_PCNT_CTRL_EDGE_POS << 3)          /**< Shifted mode POS for PCNT_CTRL */
+#define PCNT_CTRL_EDGE_NEG                (_PCNT_CTRL_EDGE_NEG << 3)          /**< Shifted mode NEG for PCNT_CTRL */
+#define PCNT_CTRL_FILT                    (0x1UL << 4)                        /**< Enable Digital Pulse Width Filter */
+#define _PCNT_CTRL_FILT_SHIFT             4                                   /**< Shift value for PCNT_FILT */
+#define _PCNT_CTRL_FILT_MASK              0x10UL                              /**< Bit mask for PCNT_FILT */
+#define _PCNT_CTRL_FILT_DEFAULT           0x00000000UL                        /**< Mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_FILT_DEFAULT            (_PCNT_CTRL_FILT_DEFAULT << 4)      /**< Shifted mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_RSTEN                   (0x1UL << 5)                        /**< Enable PCNT Clock Domain Reset */
+#define _PCNT_CTRL_RSTEN_SHIFT            5                                   /**< Shift value for PCNT_RSTEN */
+#define _PCNT_CTRL_RSTEN_MASK             0x20UL                              /**< Bit mask for PCNT_RSTEN */
+#define _PCNT_CTRL_RSTEN_DEFAULT          0x00000000UL                        /**< Mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_RSTEN_DEFAULT           (_PCNT_CTRL_RSTEN_DEFAULT << 5)     /**< Shifted mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_HYST                    (0x1UL << 8)                        /**< Enable Hysteresis */
+#define _PCNT_CTRL_HYST_SHIFT             8                                   /**< Shift value for PCNT_HYST */
+#define _PCNT_CTRL_HYST_MASK              0x100UL                             /**< Bit mask for PCNT_HYST */
+#define _PCNT_CTRL_HYST_DEFAULT           0x00000000UL                        /**< Mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_HYST_DEFAULT            (_PCNT_CTRL_HYST_DEFAULT << 8)      /**< Shifted mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_S1CDIR                  (0x1UL << 9)                        /**< Count direction determined by S1 */
+#define _PCNT_CTRL_S1CDIR_SHIFT           9                                   /**< Shift value for PCNT_S1CDIR */
+#define _PCNT_CTRL_S1CDIR_MASK            0x200UL                             /**< Bit mask for PCNT_S1CDIR */
+#define _PCNT_CTRL_S1CDIR_DEFAULT         0x00000000UL                        /**< Mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_S1CDIR_DEFAULT          (_PCNT_CTRL_S1CDIR_DEFAULT << 9)    /**< Shifted mode DEFAULT for PCNT_CTRL */
+#define _PCNT_CTRL_CNTEV_SHIFT            10                                  /**< Shift value for PCNT_CNTEV */
+#define _PCNT_CTRL_CNTEV_MASK             0xC00UL                             /**< Bit mask for PCNT_CNTEV */
+#define _PCNT_CTRL_CNTEV_DEFAULT          0x00000000UL                        /**< Mode DEFAULT for PCNT_CTRL */
+#define _PCNT_CTRL_CNTEV_BOTH             0x00000000UL                        /**< Mode BOTH for PCNT_CTRL */
+#define _PCNT_CTRL_CNTEV_UP               0x00000001UL                        /**< Mode UP for PCNT_CTRL */
+#define _PCNT_CTRL_CNTEV_DOWN             0x00000002UL                        /**< Mode DOWN for PCNT_CTRL */
+#define _PCNT_CTRL_CNTEV_NONE             0x00000003UL                        /**< Mode NONE for PCNT_CTRL */
+#define PCNT_CTRL_CNTEV_DEFAULT           (_PCNT_CTRL_CNTEV_DEFAULT << 10)    /**< Shifted mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_CNTEV_BOTH              (_PCNT_CTRL_CNTEV_BOTH << 10)       /**< Shifted mode BOTH for PCNT_CTRL */
+#define PCNT_CTRL_CNTEV_UP                (_PCNT_CTRL_CNTEV_UP << 10)         /**< Shifted mode UP for PCNT_CTRL */
+#define PCNT_CTRL_CNTEV_DOWN              (_PCNT_CTRL_CNTEV_DOWN << 10)       /**< Shifted mode DOWN for PCNT_CTRL */
+#define PCNT_CTRL_CNTEV_NONE              (_PCNT_CTRL_CNTEV_NONE << 10)       /**< Shifted mode NONE for PCNT_CTRL */
+#define _PCNT_CTRL_AUXCNTEV_SHIFT         14                                  /**< Shift value for PCNT_AUXCNTEV */
+#define _PCNT_CTRL_AUXCNTEV_MASK          0xC000UL                            /**< Bit mask for PCNT_AUXCNTEV */
+#define _PCNT_CTRL_AUXCNTEV_DEFAULT       0x00000000UL                        /**< Mode DEFAULT for PCNT_CTRL */
+#define _PCNT_CTRL_AUXCNTEV_NONE          0x00000000UL                        /**< Mode NONE for PCNT_CTRL */
+#define _PCNT_CTRL_AUXCNTEV_UP            0x00000001UL                        /**< Mode UP for PCNT_CTRL */
+#define _PCNT_CTRL_AUXCNTEV_DOWN          0x00000002UL                        /**< Mode DOWN for PCNT_CTRL */
+#define _PCNT_CTRL_AUXCNTEV_BOTH          0x00000003UL                        /**< Mode BOTH for PCNT_CTRL */
+#define PCNT_CTRL_AUXCNTEV_DEFAULT        (_PCNT_CTRL_AUXCNTEV_DEFAULT << 14) /**< Shifted mode DEFAULT for PCNT_CTRL */
+#define PCNT_CTRL_AUXCNTEV_NONE           (_PCNT_CTRL_AUXCNTEV_NONE << 14)    /**< Shifted mode NONE for PCNT_CTRL */
+#define PCNT_CTRL_AUXCNTEV_UP             (_PCNT_CTRL_AUXCNTEV_UP << 14)      /**< Shifted mode UP for PCNT_CTRL */
+#define PCNT_CTRL_AUXCNTEV_DOWN           (_PCNT_CTRL_AUXCNTEV_DOWN << 14)    /**< Shifted mode DOWN for PCNT_CTRL */
+#define PCNT_CTRL_AUXCNTEV_BOTH           (_PCNT_CTRL_AUXCNTEV_BOTH << 14)    /**< Shifted mode BOTH for PCNT_CTRL */
+
+/* Bit fields for PCNT CMD */
+#define _PCNT_CMD_RESETVALUE              0x00000000UL                     /**< Default value for PCNT_CMD */
+#define _PCNT_CMD_MASK                    0x00000003UL                     /**< Mask for PCNT_CMD */
+#define PCNT_CMD_LCNTIM                   (0x1UL << 0)                     /**< Load CNT Immediately */
+#define _PCNT_CMD_LCNTIM_SHIFT            0                                /**< Shift value for PCNT_LCNTIM */
+#define _PCNT_CMD_LCNTIM_MASK             0x1UL                            /**< Bit mask for PCNT_LCNTIM */
+#define _PCNT_CMD_LCNTIM_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for PCNT_CMD */
+#define PCNT_CMD_LCNTIM_DEFAULT           (_PCNT_CMD_LCNTIM_DEFAULT << 0)  /**< Shifted mode DEFAULT for PCNT_CMD */
+#define PCNT_CMD_LTOPBIM                  (0x1UL << 1)                     /**< Load TOPB Immediately */
+#define _PCNT_CMD_LTOPBIM_SHIFT           1                                /**< Shift value for PCNT_LTOPBIM */
+#define _PCNT_CMD_LTOPBIM_MASK            0x2UL                            /**< Bit mask for PCNT_LTOPBIM */
+#define _PCNT_CMD_LTOPBIM_DEFAULT         0x00000000UL                     /**< Mode DEFAULT for PCNT_CMD */
+#define PCNT_CMD_LTOPBIM_DEFAULT          (_PCNT_CMD_LTOPBIM_DEFAULT << 1) /**< Shifted mode DEFAULT for PCNT_CMD */
+
+/* Bit fields for PCNT STATUS */
+#define _PCNT_STATUS_RESETVALUE           0x00000000UL                    /**< Default value for PCNT_STATUS */
+#define _PCNT_STATUS_MASK                 0x00000001UL                    /**< Mask for PCNT_STATUS */
+#define PCNT_STATUS_DIR                   (0x1UL << 0)                    /**< Current Counter Direction */
+#define _PCNT_STATUS_DIR_SHIFT            0                               /**< Shift value for PCNT_DIR */
+#define _PCNT_STATUS_DIR_MASK             0x1UL                           /**< Bit mask for PCNT_DIR */
+#define _PCNT_STATUS_DIR_DEFAULT          0x00000000UL                    /**< Mode DEFAULT for PCNT_STATUS */
+#define _PCNT_STATUS_DIR_UP               0x00000000UL                    /**< Mode UP for PCNT_STATUS */
+#define _PCNT_STATUS_DIR_DOWN             0x00000001UL                    /**< Mode DOWN for PCNT_STATUS */
+#define PCNT_STATUS_DIR_DEFAULT           (_PCNT_STATUS_DIR_DEFAULT << 0) /**< Shifted mode DEFAULT for PCNT_STATUS */
+#define PCNT_STATUS_DIR_UP                (_PCNT_STATUS_DIR_UP << 0)      /**< Shifted mode UP for PCNT_STATUS */
+#define PCNT_STATUS_DIR_DOWN              (_PCNT_STATUS_DIR_DOWN << 0)    /**< Shifted mode DOWN for PCNT_STATUS */
+
+/* Bit fields for PCNT CNT */
+#define _PCNT_CNT_RESETVALUE              0x00000000UL                 /**< Default value for PCNT_CNT */
+#define _PCNT_CNT_MASK                    0x0000FFFFUL                 /**< Mask for PCNT_CNT */
+#define _PCNT_CNT_CNT_SHIFT               0                            /**< Shift value for PCNT_CNT */
+#define _PCNT_CNT_CNT_MASK                0xFFFFUL                     /**< Bit mask for PCNT_CNT */
+#define _PCNT_CNT_CNT_DEFAULT             0x00000000UL                 /**< Mode DEFAULT for PCNT_CNT */
+#define PCNT_CNT_CNT_DEFAULT              (_PCNT_CNT_CNT_DEFAULT << 0) /**< Shifted mode DEFAULT for PCNT_CNT */
+
+/* Bit fields for PCNT TOP */
+#define _PCNT_TOP_RESETVALUE              0x000000FFUL                 /**< Default value for PCNT_TOP */
+#define _PCNT_TOP_MASK                    0x0000FFFFUL                 /**< Mask for PCNT_TOP */
+#define _PCNT_TOP_TOP_SHIFT               0                            /**< Shift value for PCNT_TOP */
+#define _PCNT_TOP_TOP_MASK                0xFFFFUL                     /**< Bit mask for PCNT_TOP */
+#define _PCNT_TOP_TOP_DEFAULT             0x000000FFUL                 /**< Mode DEFAULT for PCNT_TOP */
+#define PCNT_TOP_TOP_DEFAULT              (_PCNT_TOP_TOP_DEFAULT << 0) /**< Shifted mode DEFAULT for PCNT_TOP */
+
+/* Bit fields for PCNT TOPB */
+#define _PCNT_TOPB_RESETVALUE             0x000000FFUL                   /**< Default value for PCNT_TOPB */
+#define _PCNT_TOPB_MASK                   0x0000FFFFUL                   /**< Mask for PCNT_TOPB */
+#define _PCNT_TOPB_TOPB_SHIFT             0                              /**< Shift value for PCNT_TOPB */
+#define _PCNT_TOPB_TOPB_MASK              0xFFFFUL                       /**< Bit mask for PCNT_TOPB */
+#define _PCNT_TOPB_TOPB_DEFAULT           0x000000FFUL                   /**< Mode DEFAULT for PCNT_TOPB */
+#define PCNT_TOPB_TOPB_DEFAULT            (_PCNT_TOPB_TOPB_DEFAULT << 0) /**< Shifted mode DEFAULT for PCNT_TOPB */
+
+/* Bit fields for PCNT IF */
+#define _PCNT_IF_RESETVALUE               0x00000000UL                   /**< Default value for PCNT_IF */
+#define _PCNT_IF_MASK                     0x0000000FUL                   /**< Mask for PCNT_IF */
+#define PCNT_IF_UF                        (0x1UL << 0)                   /**< Underflow Interrupt Read Flag */
+#define _PCNT_IF_UF_SHIFT                 0                              /**< Shift value for PCNT_UF */
+#define _PCNT_IF_UF_MASK                  0x1UL                          /**< Bit mask for PCNT_UF */
+#define _PCNT_IF_UF_DEFAULT               0x00000000UL                   /**< Mode DEFAULT for PCNT_IF */
+#define PCNT_IF_UF_DEFAULT                (_PCNT_IF_UF_DEFAULT << 0)     /**< Shifted mode DEFAULT for PCNT_IF */
+#define PCNT_IF_OF                        (0x1UL << 1)                   /**< Overflow Interrupt Read Flag */
+#define _PCNT_IF_OF_SHIFT                 1                              /**< Shift value for PCNT_OF */
+#define _PCNT_IF_OF_MASK                  0x2UL                          /**< Bit mask for PCNT_OF */
+#define _PCNT_IF_OF_DEFAULT               0x00000000UL                   /**< Mode DEFAULT for PCNT_IF */
+#define PCNT_IF_OF_DEFAULT                (_PCNT_IF_OF_DEFAULT << 1)     /**< Shifted mode DEFAULT for PCNT_IF */
+#define PCNT_IF_DIRCNG                    (0x1UL << 2)                   /**< Direction Change Detect Interrupt Flag */
+#define _PCNT_IF_DIRCNG_SHIFT             2                              /**< Shift value for PCNT_DIRCNG */
+#define _PCNT_IF_DIRCNG_MASK              0x4UL                          /**< Bit mask for PCNT_DIRCNG */
+#define _PCNT_IF_DIRCNG_DEFAULT           0x00000000UL                   /**< Mode DEFAULT for PCNT_IF */
+#define PCNT_IF_DIRCNG_DEFAULT            (_PCNT_IF_DIRCNG_DEFAULT << 2) /**< Shifted mode DEFAULT for PCNT_IF */
+#define PCNT_IF_AUXOF                     (0x1UL << 3)                   /**< Overflow Interrupt Read Flag */
+#define _PCNT_IF_AUXOF_SHIFT              3                              /**< Shift value for PCNT_AUXOF */
+#define _PCNT_IF_AUXOF_MASK               0x8UL                          /**< Bit mask for PCNT_AUXOF */
+#define _PCNT_IF_AUXOF_DEFAULT            0x00000000UL                   /**< Mode DEFAULT for PCNT_IF */
+#define PCNT_IF_AUXOF_DEFAULT             (_PCNT_IF_AUXOF_DEFAULT << 3)  /**< Shifted mode DEFAULT for PCNT_IF */
+
+/* Bit fields for PCNT IFS */
+#define _PCNT_IFS_RESETVALUE              0x00000000UL                    /**< Default value for PCNT_IFS */
+#define _PCNT_IFS_MASK                    0x0000000FUL                    /**< Mask for PCNT_IFS */
+#define PCNT_IFS_UF                       (0x1UL << 0)                    /**< Underflow interrupt set */
+#define _PCNT_IFS_UF_SHIFT                0                               /**< Shift value for PCNT_UF */
+#define _PCNT_IFS_UF_MASK                 0x1UL                           /**< Bit mask for PCNT_UF */
+#define _PCNT_IFS_UF_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for PCNT_IFS */
+#define PCNT_IFS_UF_DEFAULT               (_PCNT_IFS_UF_DEFAULT << 0)     /**< Shifted mode DEFAULT for PCNT_IFS */
+#define PCNT_IFS_OF                       (0x1UL << 1)                    /**< Overflow Interrupt Set */
+#define _PCNT_IFS_OF_SHIFT                1                               /**< Shift value for PCNT_OF */
+#define _PCNT_IFS_OF_MASK                 0x2UL                           /**< Bit mask for PCNT_OF */
+#define _PCNT_IFS_OF_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for PCNT_IFS */
+#define PCNT_IFS_OF_DEFAULT               (_PCNT_IFS_OF_DEFAULT << 1)     /**< Shifted mode DEFAULT for PCNT_IFS */
+#define PCNT_IFS_DIRCNG                   (0x1UL << 2)                    /**< Direction Change Detect Interrupt Set */
+#define _PCNT_IFS_DIRCNG_SHIFT            2                               /**< Shift value for PCNT_DIRCNG */
+#define _PCNT_IFS_DIRCNG_MASK             0x4UL                           /**< Bit mask for PCNT_DIRCNG */
+#define _PCNT_IFS_DIRCNG_DEFAULT          0x00000000UL                    /**< Mode DEFAULT for PCNT_IFS */
+#define PCNT_IFS_DIRCNG_DEFAULT           (_PCNT_IFS_DIRCNG_DEFAULT << 2) /**< Shifted mode DEFAULT for PCNT_IFS */
+#define PCNT_IFS_AUXOF                    (0x1UL << 3)                    /**< Auxiliary Overflow Interrupt Set */
+#define _PCNT_IFS_AUXOF_SHIFT             3                               /**< Shift value for PCNT_AUXOF */
+#define _PCNT_IFS_AUXOF_MASK              0x8UL                           /**< Bit mask for PCNT_AUXOF */
+#define _PCNT_IFS_AUXOF_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for PCNT_IFS */
+#define PCNT_IFS_AUXOF_DEFAULT            (_PCNT_IFS_AUXOF_DEFAULT << 3)  /**< Shifted mode DEFAULT for PCNT_IFS */
+
+/* Bit fields for PCNT IFC */
+#define _PCNT_IFC_RESETVALUE              0x00000000UL                    /**< Default value for PCNT_IFC */
+#define _PCNT_IFC_MASK                    0x0000000FUL                    /**< Mask for PCNT_IFC */
+#define PCNT_IFC_UF                       (0x1UL << 0)                    /**< Underflow Interrupt Clear */
+#define _PCNT_IFC_UF_SHIFT                0                               /**< Shift value for PCNT_UF */
+#define _PCNT_IFC_UF_MASK                 0x1UL                           /**< Bit mask for PCNT_UF */
+#define _PCNT_IFC_UF_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for PCNT_IFC */
+#define PCNT_IFC_UF_DEFAULT               (_PCNT_IFC_UF_DEFAULT << 0)     /**< Shifted mode DEFAULT for PCNT_IFC */
+#define PCNT_IFC_OF                       (0x1UL << 1)                    /**< Overflow Interrupt Clear */
+#define _PCNT_IFC_OF_SHIFT                1                               /**< Shift value for PCNT_OF */
+#define _PCNT_IFC_OF_MASK                 0x2UL                           /**< Bit mask for PCNT_OF */
+#define _PCNT_IFC_OF_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for PCNT_IFC */
+#define PCNT_IFC_OF_DEFAULT               (_PCNT_IFC_OF_DEFAULT << 1)     /**< Shifted mode DEFAULT for PCNT_IFC */
+#define PCNT_IFC_DIRCNG                   (0x1UL << 2)                    /**< Direction Change Detect Interrupt Clear */
+#define _PCNT_IFC_DIRCNG_SHIFT            2                               /**< Shift value for PCNT_DIRCNG */
+#define _PCNT_IFC_DIRCNG_MASK             0x4UL                           /**< Bit mask for PCNT_DIRCNG */
+#define _PCNT_IFC_DIRCNG_DEFAULT          0x00000000UL                    /**< Mode DEFAULT for PCNT_IFC */
+#define PCNT_IFC_DIRCNG_DEFAULT           (_PCNT_IFC_DIRCNG_DEFAULT << 2) /**< Shifted mode DEFAULT for PCNT_IFC */
+#define PCNT_IFC_AUXOF                    (0x1UL << 3)                    /**< Auxiliary Overflow Interrupt Clear */
+#define _PCNT_IFC_AUXOF_SHIFT             3                               /**< Shift value for PCNT_AUXOF */
+#define _PCNT_IFC_AUXOF_MASK              0x8UL                           /**< Bit mask for PCNT_AUXOF */
+#define _PCNT_IFC_AUXOF_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for PCNT_IFC */
+#define PCNT_IFC_AUXOF_DEFAULT            (_PCNT_IFC_AUXOF_DEFAULT << 3)  /**< Shifted mode DEFAULT for PCNT_IFC */
+
+/* Bit fields for PCNT IEN */
+#define _PCNT_IEN_RESETVALUE              0x00000000UL                    /**< Default value for PCNT_IEN */
+#define _PCNT_IEN_MASK                    0x0000000FUL                    /**< Mask for PCNT_IEN */
+#define PCNT_IEN_UF                       (0x1UL << 0)                    /**< Underflow Interrupt Enable */
+#define _PCNT_IEN_UF_SHIFT                0                               /**< Shift value for PCNT_UF */
+#define _PCNT_IEN_UF_MASK                 0x1UL                           /**< Bit mask for PCNT_UF */
+#define _PCNT_IEN_UF_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for PCNT_IEN */
+#define PCNT_IEN_UF_DEFAULT               (_PCNT_IEN_UF_DEFAULT << 0)     /**< Shifted mode DEFAULT for PCNT_IEN */
+#define PCNT_IEN_OF                       (0x1UL << 1)                    /**< Overflow Interrupt Enable */
+#define _PCNT_IEN_OF_SHIFT                1                               /**< Shift value for PCNT_OF */
+#define _PCNT_IEN_OF_MASK                 0x2UL                           /**< Bit mask for PCNT_OF */
+#define _PCNT_IEN_OF_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for PCNT_IEN */
+#define PCNT_IEN_OF_DEFAULT               (_PCNT_IEN_OF_DEFAULT << 1)     /**< Shifted mode DEFAULT for PCNT_IEN */
+#define PCNT_IEN_DIRCNG                   (0x1UL << 2)                    /**< Direction Change Detect Interrupt Enable */
+#define _PCNT_IEN_DIRCNG_SHIFT            2                               /**< Shift value for PCNT_DIRCNG */
+#define _PCNT_IEN_DIRCNG_MASK             0x4UL                           /**< Bit mask for PCNT_DIRCNG */
+#define _PCNT_IEN_DIRCNG_DEFAULT          0x00000000UL                    /**< Mode DEFAULT for PCNT_IEN */
+#define PCNT_IEN_DIRCNG_DEFAULT           (_PCNT_IEN_DIRCNG_DEFAULT << 2) /**< Shifted mode DEFAULT for PCNT_IEN */
+#define PCNT_IEN_AUXOF                    (0x1UL << 3)                    /**< Auxiliary Overflow Interrupt Enable */
+#define _PCNT_IEN_AUXOF_SHIFT             3                               /**< Shift value for PCNT_AUXOF */
+#define _PCNT_IEN_AUXOF_MASK              0x8UL                           /**< Bit mask for PCNT_AUXOF */
+#define _PCNT_IEN_AUXOF_DEFAULT           0x00000000UL                    /**< Mode DEFAULT for PCNT_IEN */
+#define PCNT_IEN_AUXOF_DEFAULT            (_PCNT_IEN_AUXOF_DEFAULT << 3)  /**< Shifted mode DEFAULT for PCNT_IEN */
+
+/* Bit fields for PCNT ROUTE */
+#define _PCNT_ROUTE_RESETVALUE            0x00000000UL                        /**< Default value for PCNT_ROUTE */
+#define _PCNT_ROUTE_MASK                  0x00000700UL                        /**< Mask for PCNT_ROUTE */
+#define _PCNT_ROUTE_LOCATION_SHIFT        8                                   /**< Shift value for PCNT_LOCATION */
+#define _PCNT_ROUTE_LOCATION_MASK         0x700UL                             /**< Bit mask for PCNT_LOCATION */
+#define _PCNT_ROUTE_LOCATION_LOC0         0x00000000UL                        /**< Mode LOC0 for PCNT_ROUTE */
+#define _PCNT_ROUTE_LOCATION_DEFAULT      0x00000000UL                        /**< Mode DEFAULT for PCNT_ROUTE */
+#define _PCNT_ROUTE_LOCATION_LOC1         0x00000001UL                        /**< Mode LOC1 for PCNT_ROUTE */
+#define _PCNT_ROUTE_LOCATION_LOC2         0x00000002UL                        /**< Mode LOC2 for PCNT_ROUTE */
+#define _PCNT_ROUTE_LOCATION_LOC3         0x00000003UL                        /**< Mode LOC3 for PCNT_ROUTE */
+#define PCNT_ROUTE_LOCATION_LOC0          (_PCNT_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for PCNT_ROUTE */
+#define PCNT_ROUTE_LOCATION_DEFAULT       (_PCNT_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for PCNT_ROUTE */
+#define PCNT_ROUTE_LOCATION_LOC1          (_PCNT_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for PCNT_ROUTE */
+#define PCNT_ROUTE_LOCATION_LOC2          (_PCNT_ROUTE_LOCATION_LOC2 << 8)    /**< Shifted mode LOC2 for PCNT_ROUTE */
+#define PCNT_ROUTE_LOCATION_LOC3          (_PCNT_ROUTE_LOCATION_LOC3 << 8)    /**< Shifted mode LOC3 for PCNT_ROUTE */
+
+/* Bit fields for PCNT FREEZE */
+#define _PCNT_FREEZE_RESETVALUE           0x00000000UL                          /**< Default value for PCNT_FREEZE */
+#define _PCNT_FREEZE_MASK                 0x00000001UL                          /**< Mask for PCNT_FREEZE */
+#define PCNT_FREEZE_REGFREEZE             (0x1UL << 0)                          /**< Register Update Freeze */
+#define _PCNT_FREEZE_REGFREEZE_SHIFT      0                                     /**< Shift value for PCNT_REGFREEZE */
+#define _PCNT_FREEZE_REGFREEZE_MASK       0x1UL                                 /**< Bit mask for PCNT_REGFREEZE */
+#define _PCNT_FREEZE_REGFREEZE_DEFAULT    0x00000000UL                          /**< Mode DEFAULT for PCNT_FREEZE */
+#define _PCNT_FREEZE_REGFREEZE_UPDATE     0x00000000UL                          /**< Mode UPDATE for PCNT_FREEZE */
+#define _PCNT_FREEZE_REGFREEZE_FREEZE     0x00000001UL                          /**< Mode FREEZE for PCNT_FREEZE */
+#define PCNT_FREEZE_REGFREEZE_DEFAULT     (_PCNT_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for PCNT_FREEZE */
+#define PCNT_FREEZE_REGFREEZE_UPDATE      (_PCNT_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for PCNT_FREEZE */
+#define PCNT_FREEZE_REGFREEZE_FREEZE      (_PCNT_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for PCNT_FREEZE */
+
+/* Bit fields for PCNT SYNCBUSY */
+#define _PCNT_SYNCBUSY_RESETVALUE         0x00000000UL                       /**< Default value for PCNT_SYNCBUSY */
+#define _PCNT_SYNCBUSY_MASK               0x00000007UL                       /**< Mask for PCNT_SYNCBUSY */
+#define PCNT_SYNCBUSY_CTRL                (0x1UL << 0)                       /**< CTRL Register Busy */
+#define _PCNT_SYNCBUSY_CTRL_SHIFT         0                                  /**< Shift value for PCNT_CTRL */
+#define _PCNT_SYNCBUSY_CTRL_MASK          0x1UL                              /**< Bit mask for PCNT_CTRL */
+#define _PCNT_SYNCBUSY_CTRL_DEFAULT       0x00000000UL                       /**< Mode DEFAULT for PCNT_SYNCBUSY */
+#define PCNT_SYNCBUSY_CTRL_DEFAULT        (_PCNT_SYNCBUSY_CTRL_DEFAULT << 0) /**< Shifted mode DEFAULT for PCNT_SYNCBUSY */
+#define PCNT_SYNCBUSY_CMD                 (0x1UL << 1)                       /**< CMD Register Busy */
+#define _PCNT_SYNCBUSY_CMD_SHIFT          1                                  /**< Shift value for PCNT_CMD */
+#define _PCNT_SYNCBUSY_CMD_MASK           0x2UL                              /**< Bit mask for PCNT_CMD */
+#define _PCNT_SYNCBUSY_CMD_DEFAULT        0x00000000UL                       /**< Mode DEFAULT for PCNT_SYNCBUSY */
+#define PCNT_SYNCBUSY_CMD_DEFAULT         (_PCNT_SYNCBUSY_CMD_DEFAULT << 1)  /**< Shifted mode DEFAULT for PCNT_SYNCBUSY */
+#define PCNT_SYNCBUSY_TOPB                (0x1UL << 2)                       /**< TOPB Register Busy */
+#define _PCNT_SYNCBUSY_TOPB_SHIFT         2                                  /**< Shift value for PCNT_TOPB */
+#define _PCNT_SYNCBUSY_TOPB_MASK          0x4UL                              /**< Bit mask for PCNT_TOPB */
+#define _PCNT_SYNCBUSY_TOPB_DEFAULT       0x00000000UL                       /**< Mode DEFAULT for PCNT_SYNCBUSY */
+#define PCNT_SYNCBUSY_TOPB_DEFAULT        (_PCNT_SYNCBUSY_TOPB_DEFAULT << 2) /**< Shifted mode DEFAULT for PCNT_SYNCBUSY */
+
+/* Bit fields for PCNT AUXCNT */
+#define _PCNT_AUXCNT_RESETVALUE           0x00000000UL                       /**< Default value for PCNT_AUXCNT */
+#define _PCNT_AUXCNT_MASK                 0x0000FFFFUL                       /**< Mask for PCNT_AUXCNT */
+#define _PCNT_AUXCNT_AUXCNT_SHIFT         0                                  /**< Shift value for PCNT_AUXCNT */
+#define _PCNT_AUXCNT_AUXCNT_MASK          0xFFFFUL                           /**< Bit mask for PCNT_AUXCNT */
+#define _PCNT_AUXCNT_AUXCNT_DEFAULT       0x00000000UL                       /**< Mode DEFAULT for PCNT_AUXCNT */
+#define PCNT_AUXCNT_AUXCNT_DEFAULT        (_PCNT_AUXCNT_AUXCNT_DEFAULT << 0) /**< Shifted mode DEFAULT for PCNT_AUXCNT */
+
+/* Bit fields for PCNT INPUT */
+#define _PCNT_INPUT_RESETVALUE            0x00000000UL                        /**< Default value for PCNT_INPUT */
+#define _PCNT_INPUT_MASK                  0x000005D7UL                        /**< Mask for PCNT_INPUT */
+#define _PCNT_INPUT_S0PRSSEL_SHIFT        0                                   /**< Shift value for PCNT_S0PRSSEL */
+#define _PCNT_INPUT_S0PRSSEL_MASK         0x7UL                               /**< Bit mask for PCNT_S0PRSSEL */
+#define _PCNT_INPUT_S0PRSSEL_DEFAULT      0x00000000UL                        /**< Mode DEFAULT for PCNT_INPUT */
+#define _PCNT_INPUT_S0PRSSEL_PRSCH0       0x00000000UL                        /**< Mode PRSCH0 for PCNT_INPUT */
+#define _PCNT_INPUT_S0PRSSEL_PRSCH1       0x00000001UL                        /**< Mode PRSCH1 for PCNT_INPUT */
+#define _PCNT_INPUT_S0PRSSEL_PRSCH2       0x00000002UL                        /**< Mode PRSCH2 for PCNT_INPUT */
+#define _PCNT_INPUT_S0PRSSEL_PRSCH3       0x00000003UL                        /**< Mode PRSCH3 for PCNT_INPUT */
+#define _PCNT_INPUT_S0PRSSEL_PRSCH4       0x00000004UL                        /**< Mode PRSCH4 for PCNT_INPUT */
+#define _PCNT_INPUT_S0PRSSEL_PRSCH5       0x00000005UL                        /**< Mode PRSCH5 for PCNT_INPUT */
+#define _PCNT_INPUT_S0PRSSEL_PRSCH6       0x00000006UL                        /**< Mode PRSCH6 for PCNT_INPUT */
+#define _PCNT_INPUT_S0PRSSEL_PRSCH7       0x00000007UL                        /**< Mode PRSCH7 for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSSEL_DEFAULT       (_PCNT_INPUT_S0PRSSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSSEL_PRSCH0        (_PCNT_INPUT_S0PRSSEL_PRSCH0 << 0)  /**< Shifted mode PRSCH0 for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSSEL_PRSCH1        (_PCNT_INPUT_S0PRSSEL_PRSCH1 << 0)  /**< Shifted mode PRSCH1 for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSSEL_PRSCH2        (_PCNT_INPUT_S0PRSSEL_PRSCH2 << 0)  /**< Shifted mode PRSCH2 for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSSEL_PRSCH3        (_PCNT_INPUT_S0PRSSEL_PRSCH3 << 0)  /**< Shifted mode PRSCH3 for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSSEL_PRSCH4        (_PCNT_INPUT_S0PRSSEL_PRSCH4 << 0)  /**< Shifted mode PRSCH4 for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSSEL_PRSCH5        (_PCNT_INPUT_S0PRSSEL_PRSCH5 << 0)  /**< Shifted mode PRSCH5 for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSSEL_PRSCH6        (_PCNT_INPUT_S0PRSSEL_PRSCH6 << 0)  /**< Shifted mode PRSCH6 for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSSEL_PRSCH7        (_PCNT_INPUT_S0PRSSEL_PRSCH7 << 0)  /**< Shifted mode PRSCH7 for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSEN                (0x1UL << 4)                        /**< S0IN PRS Enable */
+#define _PCNT_INPUT_S0PRSEN_SHIFT         4                                   /**< Shift value for PCNT_S0PRSEN */
+#define _PCNT_INPUT_S0PRSEN_MASK          0x10UL                              /**< Bit mask for PCNT_S0PRSEN */
+#define _PCNT_INPUT_S0PRSEN_DEFAULT       0x00000000UL                        /**< Mode DEFAULT for PCNT_INPUT */
+#define PCNT_INPUT_S0PRSEN_DEFAULT        (_PCNT_INPUT_S0PRSEN_DEFAULT << 4)  /**< Shifted mode DEFAULT for PCNT_INPUT */
+#define _PCNT_INPUT_S1PRSSEL_SHIFT        6                                   /**< Shift value for PCNT_S1PRSSEL */
+#define _PCNT_INPUT_S1PRSSEL_MASK         0x1C0UL                             /**< Bit mask for PCNT_S1PRSSEL */
+#define _PCNT_INPUT_S1PRSSEL_DEFAULT      0x00000000UL                        /**< Mode DEFAULT for PCNT_INPUT */
+#define _PCNT_INPUT_S1PRSSEL_PRSCH0       0x00000000UL                        /**< Mode PRSCH0 for PCNT_INPUT */
+#define _PCNT_INPUT_S1PRSSEL_PRSCH1       0x00000001UL                        /**< Mode PRSCH1 for PCNT_INPUT */
+#define _PCNT_INPUT_S1PRSSEL_PRSCH2       0x00000002UL                        /**< Mode PRSCH2 for PCNT_INPUT */
+#define _PCNT_INPUT_S1PRSSEL_PRSCH3       0x00000003UL                        /**< Mode PRSCH3 for PCNT_INPUT */
+#define _PCNT_INPUT_S1PRSSEL_PRSCH4       0x00000004UL                        /**< Mode PRSCH4 for PCNT_INPUT */
+#define _PCNT_INPUT_S1PRSSEL_PRSCH5       0x00000005UL                        /**< Mode PRSCH5 for PCNT_INPUT */
+#define _PCNT_INPUT_S1PRSSEL_PRSCH6       0x00000006UL                        /**< Mode PRSCH6 for PCNT_INPUT */
+#define _PCNT_INPUT_S1PRSSEL_PRSCH7       0x00000007UL                        /**< Mode PRSCH7 for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSSEL_DEFAULT       (_PCNT_INPUT_S1PRSSEL_DEFAULT << 6) /**< Shifted mode DEFAULT for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSSEL_PRSCH0        (_PCNT_INPUT_S1PRSSEL_PRSCH0 << 6)  /**< Shifted mode PRSCH0 for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSSEL_PRSCH1        (_PCNT_INPUT_S1PRSSEL_PRSCH1 << 6)  /**< Shifted mode PRSCH1 for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSSEL_PRSCH2        (_PCNT_INPUT_S1PRSSEL_PRSCH2 << 6)  /**< Shifted mode PRSCH2 for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSSEL_PRSCH3        (_PCNT_INPUT_S1PRSSEL_PRSCH3 << 6)  /**< Shifted mode PRSCH3 for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSSEL_PRSCH4        (_PCNT_INPUT_S1PRSSEL_PRSCH4 << 6)  /**< Shifted mode PRSCH4 for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSSEL_PRSCH5        (_PCNT_INPUT_S1PRSSEL_PRSCH5 << 6)  /**< Shifted mode PRSCH5 for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSSEL_PRSCH6        (_PCNT_INPUT_S1PRSSEL_PRSCH6 << 6)  /**< Shifted mode PRSCH6 for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSSEL_PRSCH7        (_PCNT_INPUT_S1PRSSEL_PRSCH7 << 6)  /**< Shifted mode PRSCH7 for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSEN                (0x1UL << 10)                       /**< S1IN PRS Enable */
+#define _PCNT_INPUT_S1PRSEN_SHIFT         10                                  /**< Shift value for PCNT_S1PRSEN */
+#define _PCNT_INPUT_S1PRSEN_MASK          0x400UL                             /**< Bit mask for PCNT_S1PRSEN */
+#define _PCNT_INPUT_S1PRSEN_DEFAULT       0x00000000UL                        /**< Mode DEFAULT for PCNT_INPUT */
+#define PCNT_INPUT_S1PRSEN_DEFAULT        (_PCNT_INPUT_S1PRSEN_DEFAULT << 10) /**< Shifted mode DEFAULT for PCNT_INPUT */
+
+/** @} End of group EFM32TG_PCNT */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_prs.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_prs.h
@@ -1,0 +1,364 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_PRS register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_PRS
+ * @brief EFM32TG_PRS Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t SWPULSE;       /**< Software Pulse Register  */
+  __IOM uint32_t SWLEVEL;       /**< Software Level Register  */
+  __IOM uint32_t ROUTE;         /**< I/O Routing Register  */
+
+  uint32_t       RESERVED0[1U]; /**< Reserved registers */
+  PRS_CH_TypeDef CH[8U];        /**< Channel registers */
+} PRS_TypeDef;                  /**< PRS Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_PRS_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for PRS SWPULSE */
+#define _PRS_SWPULSE_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWPULSE */
+#define _PRS_SWPULSE_MASK                       0x000000FFUL                         /**< Mask for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE                    (0x1UL << 0)                         /**< Channel 0 Pulse Generation */
+#define _PRS_SWPULSE_CH0PULSE_SHIFT             0                                    /**< Shift value for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_MASK              0x1UL                                /**< Bit mask for PRS_CH0PULSE */
+#define _PRS_SWPULSE_CH0PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH0PULSE_DEFAULT            (_PRS_SWPULSE_CH0PULSE_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE                    (0x1UL << 1)                         /**< Channel 1 Pulse Generation */
+#define _PRS_SWPULSE_CH1PULSE_SHIFT             1                                    /**< Shift value for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_MASK              0x2UL                                /**< Bit mask for PRS_CH1PULSE */
+#define _PRS_SWPULSE_CH1PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH1PULSE_DEFAULT            (_PRS_SWPULSE_CH1PULSE_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE                    (0x1UL << 2)                         /**< Channel 2 Pulse Generation */
+#define _PRS_SWPULSE_CH2PULSE_SHIFT             2                                    /**< Shift value for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_MASK              0x4UL                                /**< Bit mask for PRS_CH2PULSE */
+#define _PRS_SWPULSE_CH2PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH2PULSE_DEFAULT            (_PRS_SWPULSE_CH2PULSE_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE                    (0x1UL << 3)                         /**< Channel 3 Pulse Generation */
+#define _PRS_SWPULSE_CH3PULSE_SHIFT             3                                    /**< Shift value for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_MASK              0x8UL                                /**< Bit mask for PRS_CH3PULSE */
+#define _PRS_SWPULSE_CH3PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH3PULSE_DEFAULT            (_PRS_SWPULSE_CH3PULSE_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE                    (0x1UL << 4)                         /**< Channel 4 Pulse Generation */
+#define _PRS_SWPULSE_CH4PULSE_SHIFT             4                                    /**< Shift value for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_MASK              0x10UL                               /**< Bit mask for PRS_CH4PULSE */
+#define _PRS_SWPULSE_CH4PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH4PULSE_DEFAULT            (_PRS_SWPULSE_CH4PULSE_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE                    (0x1UL << 5)                         /**< Channel 5 Pulse Generation */
+#define _PRS_SWPULSE_CH5PULSE_SHIFT             5                                    /**< Shift value for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_MASK              0x20UL                               /**< Bit mask for PRS_CH5PULSE */
+#define _PRS_SWPULSE_CH5PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH5PULSE_DEFAULT            (_PRS_SWPULSE_CH5PULSE_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE                    (0x1UL << 6)                         /**< Channel 6 Pulse Generation */
+#define _PRS_SWPULSE_CH6PULSE_SHIFT             6                                    /**< Shift value for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_MASK              0x40UL                               /**< Bit mask for PRS_CH6PULSE */
+#define _PRS_SWPULSE_CH6PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH6PULSE_DEFAULT            (_PRS_SWPULSE_CH6PULSE_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE                    (0x1UL << 7)                         /**< Channel 7 Pulse Generation */
+#define _PRS_SWPULSE_CH7PULSE_SHIFT             7                                    /**< Shift value for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_MASK              0x80UL                               /**< Bit mask for PRS_CH7PULSE */
+#define _PRS_SWPULSE_CH7PULSE_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWPULSE */
+#define PRS_SWPULSE_CH7PULSE_DEFAULT            (_PRS_SWPULSE_CH7PULSE_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWPULSE */
+
+/* Bit fields for PRS SWLEVEL */
+#define _PRS_SWLEVEL_RESETVALUE                 0x00000000UL                         /**< Default value for PRS_SWLEVEL */
+#define _PRS_SWLEVEL_MASK                       0x000000FFUL                         /**< Mask for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL                    (0x1UL << 0)                         /**< Channel 0 Software Level */
+#define _PRS_SWLEVEL_CH0LEVEL_SHIFT             0                                    /**< Shift value for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_MASK              0x1UL                                /**< Bit mask for PRS_CH0LEVEL */
+#define _PRS_SWLEVEL_CH0LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH0LEVEL_DEFAULT            (_PRS_SWLEVEL_CH0LEVEL_DEFAULT << 0) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL                    (0x1UL << 1)                         /**< Channel 1 Software Level */
+#define _PRS_SWLEVEL_CH1LEVEL_SHIFT             1                                    /**< Shift value for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_MASK              0x2UL                                /**< Bit mask for PRS_CH1LEVEL */
+#define _PRS_SWLEVEL_CH1LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH1LEVEL_DEFAULT            (_PRS_SWLEVEL_CH1LEVEL_DEFAULT << 1) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL                    (0x1UL << 2)                         /**< Channel 2 Software Level */
+#define _PRS_SWLEVEL_CH2LEVEL_SHIFT             2                                    /**< Shift value for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_MASK              0x4UL                                /**< Bit mask for PRS_CH2LEVEL */
+#define _PRS_SWLEVEL_CH2LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH2LEVEL_DEFAULT            (_PRS_SWLEVEL_CH2LEVEL_DEFAULT << 2) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL                    (0x1UL << 3)                         /**< Channel 3 Software Level */
+#define _PRS_SWLEVEL_CH3LEVEL_SHIFT             3                                    /**< Shift value for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_MASK              0x8UL                                /**< Bit mask for PRS_CH3LEVEL */
+#define _PRS_SWLEVEL_CH3LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH3LEVEL_DEFAULT            (_PRS_SWLEVEL_CH3LEVEL_DEFAULT << 3) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL                    (0x1UL << 4)                         /**< Channel 4 Software Level */
+#define _PRS_SWLEVEL_CH4LEVEL_SHIFT             4                                    /**< Shift value for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_MASK              0x10UL                               /**< Bit mask for PRS_CH4LEVEL */
+#define _PRS_SWLEVEL_CH4LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH4LEVEL_DEFAULT            (_PRS_SWLEVEL_CH4LEVEL_DEFAULT << 4) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL                    (0x1UL << 5)                         /**< Channel 5 Software Level */
+#define _PRS_SWLEVEL_CH5LEVEL_SHIFT             5                                    /**< Shift value for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_MASK              0x20UL                               /**< Bit mask for PRS_CH5LEVEL */
+#define _PRS_SWLEVEL_CH5LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH5LEVEL_DEFAULT            (_PRS_SWLEVEL_CH5LEVEL_DEFAULT << 5) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL                    (0x1UL << 6)                         /**< Channel 6 Software Level */
+#define _PRS_SWLEVEL_CH6LEVEL_SHIFT             6                                    /**< Shift value for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_MASK              0x40UL                               /**< Bit mask for PRS_CH6LEVEL */
+#define _PRS_SWLEVEL_CH6LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH6LEVEL_DEFAULT            (_PRS_SWLEVEL_CH6LEVEL_DEFAULT << 6) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL                    (0x1UL << 7)                         /**< Channel 7 Software Level */
+#define _PRS_SWLEVEL_CH7LEVEL_SHIFT             7                                    /**< Shift value for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_MASK              0x80UL                               /**< Bit mask for PRS_CH7LEVEL */
+#define _PRS_SWLEVEL_CH7LEVEL_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for PRS_SWLEVEL */
+#define PRS_SWLEVEL_CH7LEVEL_DEFAULT            (_PRS_SWLEVEL_CH7LEVEL_DEFAULT << 7) /**< Shifted mode DEFAULT for PRS_SWLEVEL */
+
+/* Bit fields for PRS ROUTE */
+#define _PRS_ROUTE_RESETVALUE                   0x00000000UL                       /**< Default value for PRS_ROUTE */
+#define _PRS_ROUTE_MASK                         0x0000070FUL                       /**< Mask for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN                        (0x1UL << 0)                       /**< CH0 Pin Enable */
+#define _PRS_ROUTE_CH0PEN_SHIFT                 0                                  /**< Shift value for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_MASK                  0x1UL                              /**< Bit mask for PRS_CH0PEN */
+#define _PRS_ROUTE_CH0PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH0PEN_DEFAULT                (_PRS_ROUTE_CH0PEN_DEFAULT << 0)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN                        (0x1UL << 1)                       /**< CH1 Pin Enable */
+#define _PRS_ROUTE_CH1PEN_SHIFT                 1                                  /**< Shift value for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_MASK                  0x2UL                              /**< Bit mask for PRS_CH1PEN */
+#define _PRS_ROUTE_CH1PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH1PEN_DEFAULT                (_PRS_ROUTE_CH1PEN_DEFAULT << 1)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN                        (0x1UL << 2)                       /**< CH2 Pin Enable */
+#define _PRS_ROUTE_CH2PEN_SHIFT                 2                                  /**< Shift value for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_MASK                  0x4UL                              /**< Bit mask for PRS_CH2PEN */
+#define _PRS_ROUTE_CH2PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH2PEN_DEFAULT                (_PRS_ROUTE_CH2PEN_DEFAULT << 2)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN                        (0x1UL << 3)                       /**< CH3 Pin Enable */
+#define _PRS_ROUTE_CH3PEN_SHIFT                 3                                  /**< Shift value for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_MASK                  0x8UL                              /**< Bit mask for PRS_CH3PEN */
+#define _PRS_ROUTE_CH3PEN_DEFAULT               0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_CH3PEN_DEFAULT                (_PRS_ROUTE_CH3PEN_DEFAULT << 3)   /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_SHIFT               8                                  /**< Shift value for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_MASK                0x700UL                            /**< Bit mask for PRS_LOCATION */
+#define _PRS_ROUTE_LOCATION_LOC0                0x00000000UL                       /**< Mode LOC0 for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_DEFAULT             0x00000000UL                       /**< Mode DEFAULT for PRS_ROUTE */
+#define _PRS_ROUTE_LOCATION_LOC1                0x00000001UL                       /**< Mode LOC1 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC0                 (_PRS_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_DEFAULT              (_PRS_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for PRS_ROUTE */
+#define PRS_ROUTE_LOCATION_LOC1                 (_PRS_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for PRS_ROUTE */
+
+/* Bit fields for PRS CH_CTRL */
+#define _PRS_CH_CTRL_RESETVALUE                 0x00000000UL                                /**< Default value for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_MASK                       0x133F0007UL                                /**< Mask for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_SHIFT               0                                           /**< Shift value for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_MASK                0x7UL                                       /**< Bit mask for PRS_SIGSEL */
+#define _PRS_CH_CTRL_SIGSEL_VCMPOUT             0x00000000UL                                /**< Mode VCMPOUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP0OUT            0x00000000UL                                /**< Mode ACMP0OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ACMP1OUT            0x00000000UL                                /**< Mode ACMP1OUT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_DAC0CH0             0x00000000UL                                /**< Mode DAC0CH0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ADC0SINGLE          0x00000000UL                                /**< Mode ADC0SINGLE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART0IRTX          0x00000000UL                                /**< Mode USART0IRTX for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0UF            0x00000000UL                                /**< Mode TIMER0UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1UF            0x00000000UL                                /**< Mode TIMER1UF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCOF               0x00000000UL                                /**< Mode RTCOF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN0            0x00000000UL                                /**< Mode GPIOPIN0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN8            0x00000000UL                                /**< Mode GPIOPIN8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH0         0x00000000UL                                /**< Mode LETIMER0CH0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES0     0x00000000UL                                /**< Mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES8     0x00000000UL                                /**< Mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC0         0x00000000UL                                /**< Mode LESENSEDEC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_DAC0CH1             0x00000001UL                                /**< Mode DAC0CH1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_ADC0SCAN            0x00000001UL                                /**< Mode ADC0SCAN for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART0TXC           0x00000001UL                                /**< Mode USART0TXC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1TXC           0x00000001UL                                /**< Mode USART1TXC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0OF            0x00000001UL                                /**< Mode TIMER0OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1OF            0x00000001UL                                /**< Mode TIMER1OF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP0            0x00000001UL                                /**< Mode RTCCOMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN1            0x00000001UL                                /**< Mode GPIOPIN1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN9            0x00000001UL                                /**< Mode GPIOPIN9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LETIMER0CH1         0x00000001UL                                /**< Mode LETIMER0CH1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES1     0x00000001UL                                /**< Mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES9     0x00000001UL                                /**< Mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC1         0x00000001UL                                /**< Mode LESENSEDEC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART0RXDATAV       0x00000002UL                                /**< Mode USART0RXDATAV for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_USART1RXDATAV       0x00000002UL                                /**< Mode USART1RXDATAV for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC0           0x00000002UL                                /**< Mode TIMER0CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC0           0x00000002UL                                /**< Mode TIMER1CC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_RTCCOMP1            0x00000002UL                                /**< Mode RTCCOMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN2            0x00000002UL                                /**< Mode GPIOPIN2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN10           0x00000002UL                                /**< Mode GPIOPIN10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES2     0x00000002UL                                /**< Mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES10    0x00000002UL                                /**< Mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSEDEC2         0x00000002UL                                /**< Mode LESENSEDEC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC1           0x00000003UL                                /**< Mode TIMER0CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC1           0x00000003UL                                /**< Mode TIMER1CC1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN3            0x00000003UL                                /**< Mode GPIOPIN3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN11           0x00000003UL                                /**< Mode GPIOPIN11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES3     0x00000003UL                                /**< Mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES11    0x00000003UL                                /**< Mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER0CC2           0x00000004UL                                /**< Mode TIMER0CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_TIMER1CC2           0x00000004UL                                /**< Mode TIMER1CC2 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN4            0x00000004UL                                /**< Mode GPIOPIN4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN12           0x00000004UL                                /**< Mode GPIOPIN12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES4     0x00000004UL                                /**< Mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES12    0x00000004UL                                /**< Mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN5            0x00000005UL                                /**< Mode GPIOPIN5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN13           0x00000005UL                                /**< Mode GPIOPIN13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES5     0x00000005UL                                /**< Mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES13    0x00000005UL                                /**< Mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN6            0x00000006UL                                /**< Mode GPIOPIN6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN14           0x00000006UL                                /**< Mode GPIOPIN14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES6     0x00000006UL                                /**< Mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES14    0x00000006UL                                /**< Mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN7            0x00000007UL                                /**< Mode GPIOPIN7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_GPIOPIN15           0x00000007UL                                /**< Mode GPIOPIN15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES7     0x00000007UL                                /**< Mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SIGSEL_LESENSESCANRES15    0x00000007UL                                /**< Mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_VCMPOUT              (_PRS_CH_CTRL_SIGSEL_VCMPOUT << 0)          /**< Shifted mode VCMPOUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP0OUT             (_PRS_CH_CTRL_SIGSEL_ACMP0OUT << 0)         /**< Shifted mode ACMP0OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ACMP1OUT             (_PRS_CH_CTRL_SIGSEL_ACMP1OUT << 0)         /**< Shifted mode ACMP1OUT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_DAC0CH0              (_PRS_CH_CTRL_SIGSEL_DAC0CH0 << 0)          /**< Shifted mode DAC0CH0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ADC0SINGLE           (_PRS_CH_CTRL_SIGSEL_ADC0SINGLE << 0)       /**< Shifted mode ADC0SINGLE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART0IRTX           (_PRS_CH_CTRL_SIGSEL_USART0IRTX << 0)       /**< Shifted mode USART0IRTX for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0UF             (_PRS_CH_CTRL_SIGSEL_TIMER0UF << 0)         /**< Shifted mode TIMER0UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1UF             (_PRS_CH_CTRL_SIGSEL_TIMER1UF << 0)         /**< Shifted mode TIMER1UF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCOF                (_PRS_CH_CTRL_SIGSEL_RTCOF << 0)            /**< Shifted mode RTCOF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN0             (_PRS_CH_CTRL_SIGSEL_GPIOPIN0 << 0)         /**< Shifted mode GPIOPIN0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN8             (_PRS_CH_CTRL_SIGSEL_GPIOPIN8 << 0)         /**< Shifted mode GPIOPIN8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH0          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH0 << 0)      /**< Shifted mode LETIMER0CH0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES0      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES0 << 0)  /**< Shifted mode LESENSESCANRES0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES8      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES8 << 0)  /**< Shifted mode LESENSESCANRES8 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC0          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC0 << 0)      /**< Shifted mode LESENSEDEC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_DAC0CH1              (_PRS_CH_CTRL_SIGSEL_DAC0CH1 << 0)          /**< Shifted mode DAC0CH1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_ADC0SCAN             (_PRS_CH_CTRL_SIGSEL_ADC0SCAN << 0)         /**< Shifted mode ADC0SCAN for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART0TXC            (_PRS_CH_CTRL_SIGSEL_USART0TXC << 0)        /**< Shifted mode USART0TXC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1TXC            (_PRS_CH_CTRL_SIGSEL_USART1TXC << 0)        /**< Shifted mode USART1TXC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0OF             (_PRS_CH_CTRL_SIGSEL_TIMER0OF << 0)         /**< Shifted mode TIMER0OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1OF             (_PRS_CH_CTRL_SIGSEL_TIMER1OF << 0)         /**< Shifted mode TIMER1OF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP0             (_PRS_CH_CTRL_SIGSEL_RTCCOMP0 << 0)         /**< Shifted mode RTCCOMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN1             (_PRS_CH_CTRL_SIGSEL_GPIOPIN1 << 0)         /**< Shifted mode GPIOPIN1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN9             (_PRS_CH_CTRL_SIGSEL_GPIOPIN9 << 0)         /**< Shifted mode GPIOPIN9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LETIMER0CH1          (_PRS_CH_CTRL_SIGSEL_LETIMER0CH1 << 0)      /**< Shifted mode LETIMER0CH1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES1      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES1 << 0)  /**< Shifted mode LESENSESCANRES1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES9      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES9 << 0)  /**< Shifted mode LESENSESCANRES9 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC1          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC1 << 0)      /**< Shifted mode LESENSEDEC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART0RXDATAV        (_PRS_CH_CTRL_SIGSEL_USART0RXDATAV << 0)    /**< Shifted mode USART0RXDATAV for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_USART1RXDATAV        (_PRS_CH_CTRL_SIGSEL_USART1RXDATAV << 0)    /**< Shifted mode USART1RXDATAV for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC0            (_PRS_CH_CTRL_SIGSEL_TIMER0CC0 << 0)        /**< Shifted mode TIMER0CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC0            (_PRS_CH_CTRL_SIGSEL_TIMER1CC0 << 0)        /**< Shifted mode TIMER1CC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_RTCCOMP1             (_PRS_CH_CTRL_SIGSEL_RTCCOMP1 << 0)         /**< Shifted mode RTCCOMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN2             (_PRS_CH_CTRL_SIGSEL_GPIOPIN2 << 0)         /**< Shifted mode GPIOPIN2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN10            (_PRS_CH_CTRL_SIGSEL_GPIOPIN10 << 0)        /**< Shifted mode GPIOPIN10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES2      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES2 << 0)  /**< Shifted mode LESENSESCANRES2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES10     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES10 << 0) /**< Shifted mode LESENSESCANRES10 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSEDEC2          (_PRS_CH_CTRL_SIGSEL_LESENSEDEC2 << 0)      /**< Shifted mode LESENSEDEC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC1            (_PRS_CH_CTRL_SIGSEL_TIMER0CC1 << 0)        /**< Shifted mode TIMER0CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC1            (_PRS_CH_CTRL_SIGSEL_TIMER1CC1 << 0)        /**< Shifted mode TIMER1CC1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN3             (_PRS_CH_CTRL_SIGSEL_GPIOPIN3 << 0)         /**< Shifted mode GPIOPIN3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN11            (_PRS_CH_CTRL_SIGSEL_GPIOPIN11 << 0)        /**< Shifted mode GPIOPIN11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES3      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES3 << 0)  /**< Shifted mode LESENSESCANRES3 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES11     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES11 << 0) /**< Shifted mode LESENSESCANRES11 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER0CC2            (_PRS_CH_CTRL_SIGSEL_TIMER0CC2 << 0)        /**< Shifted mode TIMER0CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_TIMER1CC2            (_PRS_CH_CTRL_SIGSEL_TIMER1CC2 << 0)        /**< Shifted mode TIMER1CC2 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN4             (_PRS_CH_CTRL_SIGSEL_GPIOPIN4 << 0)         /**< Shifted mode GPIOPIN4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN12            (_PRS_CH_CTRL_SIGSEL_GPIOPIN12 << 0)        /**< Shifted mode GPIOPIN12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES4      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES4 << 0)  /**< Shifted mode LESENSESCANRES4 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES12     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES12 << 0) /**< Shifted mode LESENSESCANRES12 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN5             (_PRS_CH_CTRL_SIGSEL_GPIOPIN5 << 0)         /**< Shifted mode GPIOPIN5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN13            (_PRS_CH_CTRL_SIGSEL_GPIOPIN13 << 0)        /**< Shifted mode GPIOPIN13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES5      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES5 << 0)  /**< Shifted mode LESENSESCANRES5 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES13     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES13 << 0) /**< Shifted mode LESENSESCANRES13 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN6             (_PRS_CH_CTRL_SIGSEL_GPIOPIN6 << 0)         /**< Shifted mode GPIOPIN6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN14            (_PRS_CH_CTRL_SIGSEL_GPIOPIN14 << 0)        /**< Shifted mode GPIOPIN14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES6      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES6 << 0)  /**< Shifted mode LESENSESCANRES6 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES14     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES14 << 0) /**< Shifted mode LESENSESCANRES14 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN7             (_PRS_CH_CTRL_SIGSEL_GPIOPIN7 << 0)         /**< Shifted mode GPIOPIN7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_GPIOPIN15            (_PRS_CH_CTRL_SIGSEL_GPIOPIN15 << 0)        /**< Shifted mode GPIOPIN15 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES7      (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES7 << 0)  /**< Shifted mode LESENSESCANRES7 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SIGSEL_LESENSESCANRES15     (_PRS_CH_CTRL_SIGSEL_LESENSESCANRES15 << 0) /**< Shifted mode LESENSESCANRES15 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_SHIFT            16                                          /**< Shift value for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_MASK             0x3F0000UL                                  /**< Bit mask for PRS_SOURCESEL */
+#define _PRS_CH_CTRL_SOURCESEL_NONE             0x00000000UL                                /**< Mode NONE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_VCMP             0x00000001UL                                /**< Mode VCMP for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP0            0x00000002UL                                /**< Mode ACMP0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ACMP1            0x00000003UL                                /**< Mode ACMP1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_DAC0             0x00000006UL                                /**< Mode DAC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_ADC0             0x00000008UL                                /**< Mode ADC0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_USART0           0x00000010UL                                /**< Mode USART0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_USART1           0x00000011UL                                /**< Mode USART1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER0           0x0000001CUL                                /**< Mode TIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_TIMER1           0x0000001DUL                                /**< Mode TIMER1 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_RTC              0x00000028UL                                /**< Mode RTC for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOL            0x00000030UL                                /**< Mode GPIOL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_GPIOH            0x00000031UL                                /**< Mode GPIOH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LETIMER0         0x00000034UL                                /**< Mode LETIMER0 for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEL         0x00000039UL                                /**< Mode LESENSEL for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSEH         0x0000003AUL                                /**< Mode LESENSEH for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_SOURCESEL_LESENSED         0x0000003BUL                                /**< Mode LESENSED for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_NONE              (_PRS_CH_CTRL_SOURCESEL_NONE << 16)         /**< Shifted mode NONE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_VCMP              (_PRS_CH_CTRL_SOURCESEL_VCMP << 16)         /**< Shifted mode VCMP for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP0             (_PRS_CH_CTRL_SOURCESEL_ACMP0 << 16)        /**< Shifted mode ACMP0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ACMP1             (_PRS_CH_CTRL_SOURCESEL_ACMP1 << 16)        /**< Shifted mode ACMP1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_DAC0              (_PRS_CH_CTRL_SOURCESEL_DAC0 << 16)         /**< Shifted mode DAC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_ADC0              (_PRS_CH_CTRL_SOURCESEL_ADC0 << 16)         /**< Shifted mode ADC0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_USART0            (_PRS_CH_CTRL_SOURCESEL_USART0 << 16)       /**< Shifted mode USART0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_USART1            (_PRS_CH_CTRL_SOURCESEL_USART1 << 16)       /**< Shifted mode USART1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER0            (_PRS_CH_CTRL_SOURCESEL_TIMER0 << 16)       /**< Shifted mode TIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_TIMER1            (_PRS_CH_CTRL_SOURCESEL_TIMER1 << 16)       /**< Shifted mode TIMER1 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_RTC               (_PRS_CH_CTRL_SOURCESEL_RTC << 16)          /**< Shifted mode RTC for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOL             (_PRS_CH_CTRL_SOURCESEL_GPIOL << 16)        /**< Shifted mode GPIOL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_GPIOH             (_PRS_CH_CTRL_SOURCESEL_GPIOH << 16)        /**< Shifted mode GPIOH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LETIMER0          (_PRS_CH_CTRL_SOURCESEL_LETIMER0 << 16)     /**< Shifted mode LETIMER0 for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEL          (_PRS_CH_CTRL_SOURCESEL_LESENSEL << 16)     /**< Shifted mode LESENSEL for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSEH          (_PRS_CH_CTRL_SOURCESEL_LESENSEH << 16)     /**< Shifted mode LESENSEH for PRS_CH_CTRL */
+#define PRS_CH_CTRL_SOURCESEL_LESENSED          (_PRS_CH_CTRL_SOURCESEL_LESENSED << 16)     /**< Shifted mode LESENSED for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_SHIFT                24                                          /**< Shift value for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_MASK                 0x3000000UL                                 /**< Bit mask for PRS_EDSEL */
+#define _PRS_CH_CTRL_EDSEL_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_OFF                  0x00000000UL                                /**< Mode OFF for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_POSEDGE              0x00000001UL                                /**< Mode POSEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_NEGEDGE              0x00000002UL                                /**< Mode NEGEDGE for PRS_CH_CTRL */
+#define _PRS_CH_CTRL_EDSEL_BOTHEDGES            0x00000003UL                                /**< Mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_DEFAULT               (_PRS_CH_CTRL_EDSEL_DEFAULT << 24)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_OFF                   (_PRS_CH_CTRL_EDSEL_OFF << 24)              /**< Shifted mode OFF for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_POSEDGE               (_PRS_CH_CTRL_EDSEL_POSEDGE << 24)          /**< Shifted mode POSEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_NEGEDGE               (_PRS_CH_CTRL_EDSEL_NEGEDGE << 24)          /**< Shifted mode NEGEDGE for PRS_CH_CTRL */
+#define PRS_CH_CTRL_EDSEL_BOTHEDGES             (_PRS_CH_CTRL_EDSEL_BOTHEDGES << 24)        /**< Shifted mode BOTHEDGES for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC                       (0x1UL << 28)                               /**< Asynchronous reflex */
+#define _PRS_CH_CTRL_ASYNC_SHIFT                28                                          /**< Shift value for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_MASK                 0x10000000UL                                /**< Bit mask for PRS_ASYNC */
+#define _PRS_CH_CTRL_ASYNC_DEFAULT              0x00000000UL                                /**< Mode DEFAULT for PRS_CH_CTRL */
+#define PRS_CH_CTRL_ASYNC_DEFAULT               (_PRS_CH_CTRL_ASYNC_DEFAULT << 28)          /**< Shifted mode DEFAULT for PRS_CH_CTRL */
+
+/** @} End of group EFM32TG_PRS */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_prs_ch.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_prs_ch.h
@@ -1,0 +1,48 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_PRS_CH register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @brief PRS_CH EFM32TG PRS CH
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL; /**< Channel Control Register  */
+} PRS_CH_TypeDef;
+
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_prs_signals.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_prs_signals.h
@@ -1,0 +1,111 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_PRS_SIGNALS register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup EFM32TG_PRS_Signals
+ * @{
+ * @brief PRS Signal names
+ ******************************************************************************/
+
+#define PRS_VCMP_OUT             ((1 << 16) + 0)  /**< PRS Voltage comparator output */
+#define PRS_ACMP0_OUT            ((2 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_ACMP1_OUT            ((3 << 16) + 0)  /**< PRS Analog comparator output */
+#define PRS_DAC0_CH0             ((6 << 16) + 0)  /**< PRS DAC ch0 conversion done */
+#define PRS_DAC0_CH1             ((6 << 16) + 1)  /**< PRS DAC ch1 conversion done */
+#define PRS_ADC0_SINGLE          ((8 << 16) + 0)  /**< PRS ADC single conversion done */
+#define PRS_ADC0_SCAN            ((8 << 16) + 1)  /**< PRS ADC scan conversion done */
+#define PRS_USART0_IRTX          ((16 << 16) + 0) /**< PRS USART 0 IRDA out */
+#define PRS_USART0_TXC           ((16 << 16) + 1) /**< PRS USART 0 TX complete */
+#define PRS_USART0_RXDATAV       ((16 << 16) + 2) /**< PRS USART 0 RX Data Valid */
+#define PRS_USART1_TXC           ((17 << 16) + 1) /**< PRS USART 1 TX complete */
+#define PRS_USART1_RXDATAV       ((17 << 16) + 2) /**< PRS USART 1 RX Data Valid */
+#define PRS_TIMER0_UF            ((28 << 16) + 0) /**< PRS Timer 0 Underflow */
+#define PRS_TIMER0_OF            ((28 << 16) + 1) /**< PRS Timer 0 Overflow */
+#define PRS_TIMER0_CC0           ((28 << 16) + 2) /**< PRS Timer 0 Compare/Capture 0 */
+#define PRS_TIMER0_CC1           ((28 << 16) + 3) /**< PRS Timer 0 Compare/Capture 1 */
+#define PRS_TIMER0_CC2           ((28 << 16) + 4) /**< PRS Timer 0 Compare/Capture 2 */
+#define PRS_TIMER1_UF            ((29 << 16) + 0) /**< PRS Timer 1 Underflow */
+#define PRS_TIMER1_OF            ((29 << 16) + 1) /**< PRS Timer 1 Overflow */
+#define PRS_TIMER1_CC0           ((29 << 16) + 2) /**< PRS Timer 1 Compare/Capture 0 */
+#define PRS_TIMER1_CC1           ((29 << 16) + 3) /**< PRS Timer 1 Compare/Capture 1 */
+#define PRS_TIMER1_CC2           ((29 << 16) + 4) /**< PRS Timer 1 Compare/Capture 2 */
+#define PRS_RTC_OF               ((40 << 16) + 0) /**< PRS RTC Overflow */
+#define PRS_RTC_COMP0            ((40 << 16) + 1) /**< PRS RTC Compare 0 */
+#define PRS_RTC_COMP1            ((40 << 16) + 2) /**< PRS RTC Compare 1 */
+#define PRS_GPIO_PIN0            ((48 << 16) + 0) /**< PRS GPIO pin 0 */
+#define PRS_GPIO_PIN1            ((48 << 16) + 1) /**< PRS GPIO pin 1 */
+#define PRS_GPIO_PIN2            ((48 << 16) + 2) /**< PRS GPIO pin 2 */
+#define PRS_GPIO_PIN3            ((48 << 16) + 3) /**< PRS GPIO pin 3 */
+#define PRS_GPIO_PIN4            ((48 << 16) + 4) /**< PRS GPIO pin 4 */
+#define PRS_GPIO_PIN5            ((48 << 16) + 5) /**< PRS GPIO pin 5 */
+#define PRS_GPIO_PIN6            ((48 << 16) + 6) /**< PRS GPIO pin 6 */
+#define PRS_GPIO_PIN7            ((48 << 16) + 7) /**< PRS GPIO pin 7 */
+#define PRS_GPIO_PIN8            ((49 << 16) + 0) /**< PRS GPIO pin 8 */
+#define PRS_GPIO_PIN9            ((49 << 16) + 1) /**< PRS GPIO pin 9 */
+#define PRS_GPIO_PIN10           ((49 << 16) + 2) /**< PRS GPIO pin 10 */
+#define PRS_GPIO_PIN11           ((49 << 16) + 3) /**< PRS GPIO pin 11 */
+#define PRS_GPIO_PIN12           ((49 << 16) + 4) /**< PRS GPIO pin 12 */
+#define PRS_GPIO_PIN13           ((49 << 16) + 5) /**< PRS GPIO pin 13 */
+#define PRS_GPIO_PIN14           ((49 << 16) + 6) /**< PRS GPIO pin 14 */
+#define PRS_GPIO_PIN15           ((49 << 16) + 7) /**< PRS GPIO pin 15 */
+#define PRS_LETIMER0_CH0         ((52 << 16) + 0) /**< PRS LETIMER CH0 Out */
+#define PRS_LETIMER0_CH1         ((52 << 16) + 1) /**< PRS LETIMER CH1 Out */
+#define PRS_LESENSE_SCANRES0     ((57 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 0 */
+#define PRS_LESENSE_SCANRES1     ((57 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 1 */
+#define PRS_LESENSE_SCANRES2     ((57 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 2 */
+#define PRS_LESENSE_SCANRES3     ((57 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 3 */
+#define PRS_LESENSE_SCANRES4     ((57 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 4 */
+#define PRS_LESENSE_SCANRES5     ((57 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 5 */
+#define PRS_LESENSE_SCANRES6     ((57 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 6 */
+#define PRS_LESENSE_SCANRES7     ((57 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 7 */
+#define PRS_LESENSE_SCANRES8     ((58 << 16) + 0) /**< PRS LESENSE SCANRES register, bit 8 */
+#define PRS_LESENSE_SCANRES9     ((58 << 16) + 1) /**< PRS LESENSE SCANRES register, bit 9 */
+#define PRS_LESENSE_SCANRES10    ((58 << 16) + 2) /**< PRS LESENSE SCANRES register, bit 10 */
+#define PRS_LESENSE_SCANRES11    ((58 << 16) + 3) /**< PRS LESENSE SCANRES register, bit 11 */
+#define PRS_LESENSE_SCANRES12    ((58 << 16) + 4) /**< PRS LESENSE SCANRES register, bit 12 */
+#define PRS_LESENSE_SCANRES13    ((58 << 16) + 5) /**< PRS LESENSE SCANRES register, bit 13 */
+#define PRS_LESENSE_SCANRES14    ((58 << 16) + 6) /**< PRS LESENSE SCANRES register, bit 14 */
+#define PRS_LESENSE_SCANRES15    ((58 << 16) + 7) /**< PRS LESENSE SCANRES register, bit 15 */
+#define PRS_LESENSE_DEC0         ((59 << 16) + 0) /**< PRS LESENSE Decoder PRS out 0 */
+#define PRS_LESENSE_DEC1         ((59 << 16) + 1) /**< PRS LESENSE Decoder PRS out 1 */
+#define PRS_LESENSE_DEC2         ((59 << 16) + 2) /**< PRS LESENSE Decoder PRS out 2 */
+
+/** @} End of group EFM32TG_PRS */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_rmu.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_rmu.h
@@ -1,0 +1,135 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_RMU register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_RMU
+ * @brief EFM32TG_RMU Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;     /**< Control Register  */
+  __IM uint32_t  RSTCAUSE; /**< Reset Cause Register  */
+  __OM uint32_t  CMD;      /**< Command Register  */
+} RMU_TypeDef;             /**< RMU Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_RMU_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for RMU CTRL */
+#define _RMU_CTRL_RESETVALUE                 0x00000000UL                        /**< Default value for RMU_CTRL */
+#define _RMU_CTRL_MASK                       0x00000001UL                        /**< Mask for RMU_CTRL */
+#define RMU_CTRL_LOCKUPRDIS                  (0x1UL << 0)                        /**< Lockup Reset Disable */
+#define _RMU_CTRL_LOCKUPRDIS_SHIFT           0                                   /**< Shift value for RMU_LOCKUPRDIS */
+#define _RMU_CTRL_LOCKUPRDIS_MASK            0x1UL                               /**< Bit mask for RMU_LOCKUPRDIS */
+#define _RMU_CTRL_LOCKUPRDIS_DEFAULT         0x00000000UL                        /**< Mode DEFAULT for RMU_CTRL */
+#define RMU_CTRL_LOCKUPRDIS_DEFAULT          (_RMU_CTRL_LOCKUPRDIS_DEFAULT << 0) /**< Shifted mode DEFAULT for RMU_CTRL */
+
+/* Bit fields for RMU RSTCAUSE */
+#define _RMU_RSTCAUSE_RESETVALUE             0x00000000UL                             /**< Default value for RMU_RSTCAUSE */
+#define _RMU_RSTCAUSE_MASK                   0x000007FFUL                             /**< Mask for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_PORST                   (0x1UL << 0)                             /**< Power On Reset */
+#define _RMU_RSTCAUSE_PORST_SHIFT            0                                        /**< Shift value for RMU_PORST */
+#define _RMU_RSTCAUSE_PORST_MASK             0x1UL                                    /**< Bit mask for RMU_PORST */
+#define _RMU_RSTCAUSE_PORST_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_PORST_DEFAULT           (_RMU_RSTCAUSE_PORST_DEFAULT << 0)       /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_BODUNREGRST             (0x1UL << 1)                             /**< Brown Out Detector Unregulated Domain Reset */
+#define _RMU_RSTCAUSE_BODUNREGRST_SHIFT      1                                        /**< Shift value for RMU_BODUNREGRST */
+#define _RMU_RSTCAUSE_BODUNREGRST_MASK       0x2UL                                    /**< Bit mask for RMU_BODUNREGRST */
+#define _RMU_RSTCAUSE_BODUNREGRST_DEFAULT    0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_BODUNREGRST_DEFAULT     (_RMU_RSTCAUSE_BODUNREGRST_DEFAULT << 1) /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_BODREGRST               (0x1UL << 2)                             /**< Brown Out Detector Regulated Domain Reset */
+#define _RMU_RSTCAUSE_BODREGRST_SHIFT        2                                        /**< Shift value for RMU_BODREGRST */
+#define _RMU_RSTCAUSE_BODREGRST_MASK         0x4UL                                    /**< Bit mask for RMU_BODREGRST */
+#define _RMU_RSTCAUSE_BODREGRST_DEFAULT      0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_BODREGRST_DEFAULT       (_RMU_RSTCAUSE_BODREGRST_DEFAULT << 2)   /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_EXTRST                  (0x1UL << 3)                             /**< External Pin Reset */
+#define _RMU_RSTCAUSE_EXTRST_SHIFT           3                                        /**< Shift value for RMU_EXTRST */
+#define _RMU_RSTCAUSE_EXTRST_MASK            0x8UL                                    /**< Bit mask for RMU_EXTRST */
+#define _RMU_RSTCAUSE_EXTRST_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_EXTRST_DEFAULT          (_RMU_RSTCAUSE_EXTRST_DEFAULT << 3)      /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_WDOGRST                 (0x1UL << 4)                             /**< Watchdog Reset */
+#define _RMU_RSTCAUSE_WDOGRST_SHIFT          4                                        /**< Shift value for RMU_WDOGRST */
+#define _RMU_RSTCAUSE_WDOGRST_MASK           0x10UL                                   /**< Bit mask for RMU_WDOGRST */
+#define _RMU_RSTCAUSE_WDOGRST_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_WDOGRST_DEFAULT         (_RMU_RSTCAUSE_WDOGRST_DEFAULT << 4)     /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_LOCKUPRST               (0x1UL << 5)                             /**< LOCKUP Reset */
+#define _RMU_RSTCAUSE_LOCKUPRST_SHIFT        5                                        /**< Shift value for RMU_LOCKUPRST */
+#define _RMU_RSTCAUSE_LOCKUPRST_MASK         0x20UL                                   /**< Bit mask for RMU_LOCKUPRST */
+#define _RMU_RSTCAUSE_LOCKUPRST_DEFAULT      0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_LOCKUPRST_DEFAULT       (_RMU_RSTCAUSE_LOCKUPRST_DEFAULT << 5)   /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_SYSREQRST               (0x1UL << 6)                             /**< System Request Reset */
+#define _RMU_RSTCAUSE_SYSREQRST_SHIFT        6                                        /**< Shift value for RMU_SYSREQRST */
+#define _RMU_RSTCAUSE_SYSREQRST_MASK         0x40UL                                   /**< Bit mask for RMU_SYSREQRST */
+#define _RMU_RSTCAUSE_SYSREQRST_DEFAULT      0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_SYSREQRST_DEFAULT       (_RMU_RSTCAUSE_SYSREQRST_DEFAULT << 6)   /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_EM4RST                  (0x1UL << 7)                             /**< EM4 Reset */
+#define _RMU_RSTCAUSE_EM4RST_SHIFT           7                                        /**< Shift value for RMU_EM4RST */
+#define _RMU_RSTCAUSE_EM4RST_MASK            0x80UL                                   /**< Bit mask for RMU_EM4RST */
+#define _RMU_RSTCAUSE_EM4RST_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_EM4RST_DEFAULT          (_RMU_RSTCAUSE_EM4RST_DEFAULT << 7)      /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_EM4WURST                (0x1UL << 8)                             /**< EM4 Wake-up Reset */
+#define _RMU_RSTCAUSE_EM4WURST_SHIFT         8                                        /**< Shift value for RMU_EM4WURST */
+#define _RMU_RSTCAUSE_EM4WURST_MASK          0x100UL                                  /**< Bit mask for RMU_EM4WURST */
+#define _RMU_RSTCAUSE_EM4WURST_DEFAULT       0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_EM4WURST_DEFAULT        (_RMU_RSTCAUSE_EM4WURST_DEFAULT << 8)    /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_BODAVDD0                (0x1UL << 9)                             /**< AVDD0 Bod Reset */
+#define _RMU_RSTCAUSE_BODAVDD0_SHIFT         9                                        /**< Shift value for RMU_BODAVDD0 */
+#define _RMU_RSTCAUSE_BODAVDD0_MASK          0x200UL                                  /**< Bit mask for RMU_BODAVDD0 */
+#define _RMU_RSTCAUSE_BODAVDD0_DEFAULT       0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_BODAVDD0_DEFAULT        (_RMU_RSTCAUSE_BODAVDD0_DEFAULT << 9)    /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_BODAVDD1                (0x1UL << 10)                            /**< AVDD1 Bod Reset */
+#define _RMU_RSTCAUSE_BODAVDD1_SHIFT         10                                       /**< Shift value for RMU_BODAVDD1 */
+#define _RMU_RSTCAUSE_BODAVDD1_MASK          0x400UL                                  /**< Bit mask for RMU_BODAVDD1 */
+#define _RMU_RSTCAUSE_BODAVDD1_DEFAULT       0x00000000UL                             /**< Mode DEFAULT for RMU_RSTCAUSE */
+#define RMU_RSTCAUSE_BODAVDD1_DEFAULT        (_RMU_RSTCAUSE_BODAVDD1_DEFAULT << 10)   /**< Shifted mode DEFAULT for RMU_RSTCAUSE */
+
+/* Bit fields for RMU CMD */
+#define _RMU_CMD_RESETVALUE                  0x00000000UL                  /**< Default value for RMU_CMD */
+#define _RMU_CMD_MASK                        0x00000001UL                  /**< Mask for RMU_CMD */
+#define RMU_CMD_RCCLR                        (0x1UL << 0)                  /**< Reset Cause Clear */
+#define _RMU_CMD_RCCLR_SHIFT                 0                             /**< Shift value for RMU_RCCLR */
+#define _RMU_CMD_RCCLR_MASK                  0x1UL                         /**< Bit mask for RMU_RCCLR */
+#define _RMU_CMD_RCCLR_DEFAULT               0x00000000UL                  /**< Mode DEFAULT for RMU_CMD */
+#define RMU_CMD_RCCLR_DEFAULT                (_RMU_CMD_RCCLR_DEFAULT << 0) /**< Shifted mode DEFAULT for RMU_CMD */
+
+/** @} End of group EFM32TG_RMU */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_romtable.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_romtable.h
@@ -1,0 +1,75 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_ROMTABLE register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_ROMTABLE
+ * @{
+ * @brief Chip Information, Revision numbers
+ ******************************************************************************/
+typedef struct {
+  __IM uint32_t PID4; /**< JEP_106_BANK */
+  __IM uint32_t PID5; /**< Unused */
+  __IM uint32_t PID6; /**< Unused */
+  __IM uint32_t PID7; /**< Unused */
+  __IM uint32_t PID0; /**< Chip family LSB, chip major revision */
+  __IM uint32_t PID1; /**< JEP_106_NO, Chip family MSB */
+  __IM uint32_t PID2; /**< Chip minor rev MSB, JEP_106_PRESENT, JEP_106_NO */
+  __IM uint32_t PID3; /**< Chip minor rev LSB */
+  __IM uint32_t CID0; /**< Unused */
+} ROMTABLE_TypeDef;   /** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_ROMTABLE_BitFields
+ * @{
+ ******************************************************************************/
+/* Bit fields for EFM32TG_ROMTABLE */
+#define _ROMTABLE_PID0_FAMILYLSB_MASK       0x000000C0UL /**< Least Significant Bits [1:0] of CHIP FAMILY, mask */
+#define _ROMTABLE_PID0_FAMILYLSB_SHIFT      6            /**< Least Significant Bits [1:0] of CHIP FAMILY, shift */
+#define _ROMTABLE_PID0_REVMAJOR_MASK        0x0000003FUL /**< CHIP MAJOR Revison, mask */
+#define _ROMTABLE_PID0_REVMAJOR_SHIFT       0            /**< CHIP MAJOR Revison, shift */
+#define _ROMTABLE_PID1_FAMILYMSB_MASK       0x0000000FUL /**< Most Significant Bits [5:2] of CHIP FAMILY, mask */
+#define _ROMTABLE_PID1_FAMILYMSB_SHIFT      0            /**< Most Significant Bits [5:2] of CHIP FAMILY, shift */
+#define _ROMTABLE_PID2_REVMINORMSB_MASK     0x000000F0UL /**< Most Significant Bits [7:4] of CHIP MINOR revision, mask */
+#define _ROMTABLE_PID2_REVMINORMSB_SHIFT    4            /**< Most Significant Bits [7:4] of CHIP MINOR revision, mask */
+#define _ROMTABLE_PID3_REVMINORLSB_MASK     0x000000F0UL /**< Least Significant Bits [3:0] of CHIP MINOR revision, mask */
+#define _ROMTABLE_PID3_REVMINORLSB_SHIFT    4            /**< Least Significant Bits [3:0] of CHIP MINOR revision, shift */
+
+/** @} End of group EFM32TG_ROMTABLE */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_rtc.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_rtc.h
@@ -1,0 +1,221 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_RTC register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_RTC
+ * @brief EFM32TG_RTC Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;     /**< Control Register  */
+  __IOM uint32_t CNT;      /**< Counter Value Register  */
+  __IOM uint32_t COMP0;    /**< Compare Value Register 0  */
+  __IOM uint32_t COMP1;    /**< Compare Value Register 1  */
+  __IM uint32_t  IF;       /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;      /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;      /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;      /**< Interrupt Enable Register  */
+
+  __IOM uint32_t FREEZE;   /**< Freeze Register  */
+  __IM uint32_t  SYNCBUSY; /**< Synchronization Busy Register  */
+} RTC_TypeDef;             /**< RTC Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_RTC_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for RTC CTRL */
+#define _RTC_CTRL_RESETVALUE             0x00000000UL                      /**< Default value for RTC_CTRL */
+#define _RTC_CTRL_MASK                   0x00000007UL                      /**< Mask for RTC_CTRL */
+#define RTC_CTRL_EN                      (0x1UL << 0)                      /**< RTC Enable */
+#define _RTC_CTRL_EN_SHIFT               0                                 /**< Shift value for RTC_EN */
+#define _RTC_CTRL_EN_MASK                0x1UL                             /**< Bit mask for RTC_EN */
+#define _RTC_CTRL_EN_DEFAULT             0x00000000UL                      /**< Mode DEFAULT for RTC_CTRL */
+#define RTC_CTRL_EN_DEFAULT              (_RTC_CTRL_EN_DEFAULT << 0)       /**< Shifted mode DEFAULT for RTC_CTRL */
+#define RTC_CTRL_DEBUGRUN                (0x1UL << 1)                      /**< Debug Mode Run Enable */
+#define _RTC_CTRL_DEBUGRUN_SHIFT         1                                 /**< Shift value for RTC_DEBUGRUN */
+#define _RTC_CTRL_DEBUGRUN_MASK          0x2UL                             /**< Bit mask for RTC_DEBUGRUN */
+#define _RTC_CTRL_DEBUGRUN_DEFAULT       0x00000000UL                      /**< Mode DEFAULT for RTC_CTRL */
+#define RTC_CTRL_DEBUGRUN_DEFAULT        (_RTC_CTRL_DEBUGRUN_DEFAULT << 1) /**< Shifted mode DEFAULT for RTC_CTRL */
+#define RTC_CTRL_COMP0TOP                (0x1UL << 2)                      /**< Compare Channel 0 is Top Value */
+#define _RTC_CTRL_COMP0TOP_SHIFT         2                                 /**< Shift value for RTC_COMP0TOP */
+#define _RTC_CTRL_COMP0TOP_MASK          0x4UL                             /**< Bit mask for RTC_COMP0TOP */
+#define _RTC_CTRL_COMP0TOP_DEFAULT       0x00000000UL                      /**< Mode DEFAULT for RTC_CTRL */
+#define _RTC_CTRL_COMP0TOP_DISABLE       0x00000000UL                      /**< Mode DISABLE for RTC_CTRL */
+#define _RTC_CTRL_COMP0TOP_ENABLE        0x00000001UL                      /**< Mode ENABLE for RTC_CTRL */
+#define RTC_CTRL_COMP0TOP_DEFAULT        (_RTC_CTRL_COMP0TOP_DEFAULT << 2) /**< Shifted mode DEFAULT for RTC_CTRL */
+#define RTC_CTRL_COMP0TOP_DISABLE        (_RTC_CTRL_COMP0TOP_DISABLE << 2) /**< Shifted mode DISABLE for RTC_CTRL */
+#define RTC_CTRL_COMP0TOP_ENABLE         (_RTC_CTRL_COMP0TOP_ENABLE << 2)  /**< Shifted mode ENABLE for RTC_CTRL */
+
+/* Bit fields for RTC CNT */
+#define _RTC_CNT_RESETVALUE              0x00000000UL                /**< Default value for RTC_CNT */
+#define _RTC_CNT_MASK                    0x00FFFFFFUL                /**< Mask for RTC_CNT */
+#define _RTC_CNT_CNT_SHIFT               0                           /**< Shift value for RTC_CNT */
+#define _RTC_CNT_CNT_MASK                0xFFFFFFUL                  /**< Bit mask for RTC_CNT */
+#define _RTC_CNT_CNT_DEFAULT             0x00000000UL                /**< Mode DEFAULT for RTC_CNT */
+#define RTC_CNT_CNT_DEFAULT              (_RTC_CNT_CNT_DEFAULT << 0) /**< Shifted mode DEFAULT for RTC_CNT */
+
+/* Bit fields for RTC COMP0 */
+#define _RTC_COMP0_RESETVALUE            0x00000000UL                    /**< Default value for RTC_COMP0 */
+#define _RTC_COMP0_MASK                  0x00FFFFFFUL                    /**< Mask for RTC_COMP0 */
+#define _RTC_COMP0_COMP0_SHIFT           0                               /**< Shift value for RTC_COMP0 */
+#define _RTC_COMP0_COMP0_MASK            0xFFFFFFUL                      /**< Bit mask for RTC_COMP0 */
+#define _RTC_COMP0_COMP0_DEFAULT         0x00000000UL                    /**< Mode DEFAULT for RTC_COMP0 */
+#define RTC_COMP0_COMP0_DEFAULT          (_RTC_COMP0_COMP0_DEFAULT << 0) /**< Shifted mode DEFAULT for RTC_COMP0 */
+
+/* Bit fields for RTC COMP1 */
+#define _RTC_COMP1_RESETVALUE            0x00000000UL                    /**< Default value for RTC_COMP1 */
+#define _RTC_COMP1_MASK                  0x00FFFFFFUL                    /**< Mask for RTC_COMP1 */
+#define _RTC_COMP1_COMP1_SHIFT           0                               /**< Shift value for RTC_COMP1 */
+#define _RTC_COMP1_COMP1_MASK            0xFFFFFFUL                      /**< Bit mask for RTC_COMP1 */
+#define _RTC_COMP1_COMP1_DEFAULT         0x00000000UL                    /**< Mode DEFAULT for RTC_COMP1 */
+#define RTC_COMP1_COMP1_DEFAULT          (_RTC_COMP1_COMP1_DEFAULT << 0) /**< Shifted mode DEFAULT for RTC_COMP1 */
+
+/* Bit fields for RTC IF */
+#define _RTC_IF_RESETVALUE               0x00000000UL                 /**< Default value for RTC_IF */
+#define _RTC_IF_MASK                     0x00000007UL                 /**< Mask for RTC_IF */
+#define RTC_IF_OF                        (0x1UL << 0)                 /**< Overflow Interrupt Flag */
+#define _RTC_IF_OF_SHIFT                 0                            /**< Shift value for RTC_OF */
+#define _RTC_IF_OF_MASK                  0x1UL                        /**< Bit mask for RTC_OF */
+#define _RTC_IF_OF_DEFAULT               0x00000000UL                 /**< Mode DEFAULT for RTC_IF */
+#define RTC_IF_OF_DEFAULT                (_RTC_IF_OF_DEFAULT << 0)    /**< Shifted mode DEFAULT for RTC_IF */
+#define RTC_IF_COMP0                     (0x1UL << 1)                 /**< Compare Match 0 Interrupt Flag */
+#define _RTC_IF_COMP0_SHIFT              1                            /**< Shift value for RTC_COMP0 */
+#define _RTC_IF_COMP0_MASK               0x2UL                        /**< Bit mask for RTC_COMP0 */
+#define _RTC_IF_COMP0_DEFAULT            0x00000000UL                 /**< Mode DEFAULT for RTC_IF */
+#define RTC_IF_COMP0_DEFAULT             (_RTC_IF_COMP0_DEFAULT << 1) /**< Shifted mode DEFAULT for RTC_IF */
+#define RTC_IF_COMP1                     (0x1UL << 2)                 /**< Compare Match 1 Interrupt Flag */
+#define _RTC_IF_COMP1_SHIFT              2                            /**< Shift value for RTC_COMP1 */
+#define _RTC_IF_COMP1_MASK               0x4UL                        /**< Bit mask for RTC_COMP1 */
+#define _RTC_IF_COMP1_DEFAULT            0x00000000UL                 /**< Mode DEFAULT for RTC_IF */
+#define RTC_IF_COMP1_DEFAULT             (_RTC_IF_COMP1_DEFAULT << 2) /**< Shifted mode DEFAULT for RTC_IF */
+
+/* Bit fields for RTC IFS */
+#define _RTC_IFS_RESETVALUE              0x00000000UL                  /**< Default value for RTC_IFS */
+#define _RTC_IFS_MASK                    0x00000007UL                  /**< Mask for RTC_IFS */
+#define RTC_IFS_OF                       (0x1UL << 0)                  /**< Set Overflow Interrupt Flag */
+#define _RTC_IFS_OF_SHIFT                0                             /**< Shift value for RTC_OF */
+#define _RTC_IFS_OF_MASK                 0x1UL                         /**< Bit mask for RTC_OF */
+#define _RTC_IFS_OF_DEFAULT              0x00000000UL                  /**< Mode DEFAULT for RTC_IFS */
+#define RTC_IFS_OF_DEFAULT               (_RTC_IFS_OF_DEFAULT << 0)    /**< Shifted mode DEFAULT for RTC_IFS */
+#define RTC_IFS_COMP0                    (0x1UL << 1)                  /**< Set Compare match 0 Interrupt Flag */
+#define _RTC_IFS_COMP0_SHIFT             1                             /**< Shift value for RTC_COMP0 */
+#define _RTC_IFS_COMP0_MASK              0x2UL                         /**< Bit mask for RTC_COMP0 */
+#define _RTC_IFS_COMP0_DEFAULT           0x00000000UL                  /**< Mode DEFAULT for RTC_IFS */
+#define RTC_IFS_COMP0_DEFAULT            (_RTC_IFS_COMP0_DEFAULT << 1) /**< Shifted mode DEFAULT for RTC_IFS */
+#define RTC_IFS_COMP1                    (0x1UL << 2)                  /**< Set Compare match 1 Interrupt Flag */
+#define _RTC_IFS_COMP1_SHIFT             2                             /**< Shift value for RTC_COMP1 */
+#define _RTC_IFS_COMP1_MASK              0x4UL                         /**< Bit mask for RTC_COMP1 */
+#define _RTC_IFS_COMP1_DEFAULT           0x00000000UL                  /**< Mode DEFAULT for RTC_IFS */
+#define RTC_IFS_COMP1_DEFAULT            (_RTC_IFS_COMP1_DEFAULT << 2) /**< Shifted mode DEFAULT for RTC_IFS */
+
+/* Bit fields for RTC IFC */
+#define _RTC_IFC_RESETVALUE              0x00000000UL                  /**< Default value for RTC_IFC */
+#define _RTC_IFC_MASK                    0x00000007UL                  /**< Mask for RTC_IFC */
+#define RTC_IFC_OF                       (0x1UL << 0)                  /**< Clear Overflow Interrupt Flag */
+#define _RTC_IFC_OF_SHIFT                0                             /**< Shift value for RTC_OF */
+#define _RTC_IFC_OF_MASK                 0x1UL                         /**< Bit mask for RTC_OF */
+#define _RTC_IFC_OF_DEFAULT              0x00000000UL                  /**< Mode DEFAULT for RTC_IFC */
+#define RTC_IFC_OF_DEFAULT               (_RTC_IFC_OF_DEFAULT << 0)    /**< Shifted mode DEFAULT for RTC_IFC */
+#define RTC_IFC_COMP0                    (0x1UL << 1)                  /**< Clear Compare match 0 Interrupt Flag */
+#define _RTC_IFC_COMP0_SHIFT             1                             /**< Shift value for RTC_COMP0 */
+#define _RTC_IFC_COMP0_MASK              0x2UL                         /**< Bit mask for RTC_COMP0 */
+#define _RTC_IFC_COMP0_DEFAULT           0x00000000UL                  /**< Mode DEFAULT for RTC_IFC */
+#define RTC_IFC_COMP0_DEFAULT            (_RTC_IFC_COMP0_DEFAULT << 1) /**< Shifted mode DEFAULT for RTC_IFC */
+#define RTC_IFC_COMP1                    (0x1UL << 2)                  /**< Clear Compare match 1 Interrupt Flag */
+#define _RTC_IFC_COMP1_SHIFT             2                             /**< Shift value for RTC_COMP1 */
+#define _RTC_IFC_COMP1_MASK              0x4UL                         /**< Bit mask for RTC_COMP1 */
+#define _RTC_IFC_COMP1_DEFAULT           0x00000000UL                  /**< Mode DEFAULT for RTC_IFC */
+#define RTC_IFC_COMP1_DEFAULT            (_RTC_IFC_COMP1_DEFAULT << 2) /**< Shifted mode DEFAULT for RTC_IFC */
+
+/* Bit fields for RTC IEN */
+#define _RTC_IEN_RESETVALUE              0x00000000UL                  /**< Default value for RTC_IEN */
+#define _RTC_IEN_MASK                    0x00000007UL                  /**< Mask for RTC_IEN */
+#define RTC_IEN_OF                       (0x1UL << 0)                  /**< Overflow Interrupt Enable */
+#define _RTC_IEN_OF_SHIFT                0                             /**< Shift value for RTC_OF */
+#define _RTC_IEN_OF_MASK                 0x1UL                         /**< Bit mask for RTC_OF */
+#define _RTC_IEN_OF_DEFAULT              0x00000000UL                  /**< Mode DEFAULT for RTC_IEN */
+#define RTC_IEN_OF_DEFAULT               (_RTC_IEN_OF_DEFAULT << 0)    /**< Shifted mode DEFAULT for RTC_IEN */
+#define RTC_IEN_COMP0                    (0x1UL << 1)                  /**< Compare Match 0 Interrupt Enable */
+#define _RTC_IEN_COMP0_SHIFT             1                             /**< Shift value for RTC_COMP0 */
+#define _RTC_IEN_COMP0_MASK              0x2UL                         /**< Bit mask for RTC_COMP0 */
+#define _RTC_IEN_COMP0_DEFAULT           0x00000000UL                  /**< Mode DEFAULT for RTC_IEN */
+#define RTC_IEN_COMP0_DEFAULT            (_RTC_IEN_COMP0_DEFAULT << 1) /**< Shifted mode DEFAULT for RTC_IEN */
+#define RTC_IEN_COMP1                    (0x1UL << 2)                  /**< Compare Match 1 Interrupt Enable */
+#define _RTC_IEN_COMP1_SHIFT             2                             /**< Shift value for RTC_COMP1 */
+#define _RTC_IEN_COMP1_MASK              0x4UL                         /**< Bit mask for RTC_COMP1 */
+#define _RTC_IEN_COMP1_DEFAULT           0x00000000UL                  /**< Mode DEFAULT for RTC_IEN */
+#define RTC_IEN_COMP1_DEFAULT            (_RTC_IEN_COMP1_DEFAULT << 2) /**< Shifted mode DEFAULT for RTC_IEN */
+
+/* Bit fields for RTC FREEZE */
+#define _RTC_FREEZE_RESETVALUE           0x00000000UL                         /**< Default value for RTC_FREEZE */
+#define _RTC_FREEZE_MASK                 0x00000001UL                         /**< Mask for RTC_FREEZE */
+#define RTC_FREEZE_REGFREEZE             (0x1UL << 0)                         /**< Register Update Freeze */
+#define _RTC_FREEZE_REGFREEZE_SHIFT      0                                    /**< Shift value for RTC_REGFREEZE */
+#define _RTC_FREEZE_REGFREEZE_MASK       0x1UL                                /**< Bit mask for RTC_REGFREEZE */
+#define _RTC_FREEZE_REGFREEZE_DEFAULT    0x00000000UL                         /**< Mode DEFAULT for RTC_FREEZE */
+#define _RTC_FREEZE_REGFREEZE_UPDATE     0x00000000UL                         /**< Mode UPDATE for RTC_FREEZE */
+#define _RTC_FREEZE_REGFREEZE_FREEZE     0x00000001UL                         /**< Mode FREEZE for RTC_FREEZE */
+#define RTC_FREEZE_REGFREEZE_DEFAULT     (_RTC_FREEZE_REGFREEZE_DEFAULT << 0) /**< Shifted mode DEFAULT for RTC_FREEZE */
+#define RTC_FREEZE_REGFREEZE_UPDATE      (_RTC_FREEZE_REGFREEZE_UPDATE << 0)  /**< Shifted mode UPDATE for RTC_FREEZE */
+#define RTC_FREEZE_REGFREEZE_FREEZE      (_RTC_FREEZE_REGFREEZE_FREEZE << 0)  /**< Shifted mode FREEZE for RTC_FREEZE */
+
+/* Bit fields for RTC SYNCBUSY */
+#define _RTC_SYNCBUSY_RESETVALUE         0x00000000UL                       /**< Default value for RTC_SYNCBUSY */
+#define _RTC_SYNCBUSY_MASK               0x00000007UL                       /**< Mask for RTC_SYNCBUSY */
+#define RTC_SYNCBUSY_CTRL                (0x1UL << 0)                       /**< CTRL Register Busy */
+#define _RTC_SYNCBUSY_CTRL_SHIFT         0                                  /**< Shift value for RTC_CTRL */
+#define _RTC_SYNCBUSY_CTRL_MASK          0x1UL                              /**< Bit mask for RTC_CTRL */
+#define _RTC_SYNCBUSY_CTRL_DEFAULT       0x00000000UL                       /**< Mode DEFAULT for RTC_SYNCBUSY */
+#define RTC_SYNCBUSY_CTRL_DEFAULT        (_RTC_SYNCBUSY_CTRL_DEFAULT << 0)  /**< Shifted mode DEFAULT for RTC_SYNCBUSY */
+#define RTC_SYNCBUSY_COMP0               (0x1UL << 1)                       /**< COMP0 Register Busy */
+#define _RTC_SYNCBUSY_COMP0_SHIFT        1                                  /**< Shift value for RTC_COMP0 */
+#define _RTC_SYNCBUSY_COMP0_MASK         0x2UL                              /**< Bit mask for RTC_COMP0 */
+#define _RTC_SYNCBUSY_COMP0_DEFAULT      0x00000000UL                       /**< Mode DEFAULT for RTC_SYNCBUSY */
+#define RTC_SYNCBUSY_COMP0_DEFAULT       (_RTC_SYNCBUSY_COMP0_DEFAULT << 1) /**< Shifted mode DEFAULT for RTC_SYNCBUSY */
+#define RTC_SYNCBUSY_COMP1               (0x1UL << 2)                       /**< COMP1 Register Busy */
+#define _RTC_SYNCBUSY_COMP1_SHIFT        2                                  /**< Shift value for RTC_COMP1 */
+#define _RTC_SYNCBUSY_COMP1_MASK         0x4UL                              /**< Bit mask for RTC_COMP1 */
+#define _RTC_SYNCBUSY_COMP1_DEFAULT      0x00000000UL                       /**< Mode DEFAULT for RTC_SYNCBUSY */
+#define RTC_SYNCBUSY_COMP1_DEFAULT       (_RTC_SYNCBUSY_COMP1_DEFAULT << 2) /**< Shifted mode DEFAULT for RTC_SYNCBUSY */
+
+/** @} End of group EFM32TG_RTC */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_timer.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_timer.h
@@ -1,0 +1,666 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_TIMER register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_TIMER
+ * @brief EFM32TG_TIMER Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t   CTRL;          /**< Control Register  */
+  __IOM uint32_t   CMD;           /**< Command Register  */
+  __IM uint32_t    STATUS;        /**< Status Register  */
+  __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
+  __IM uint32_t    IF;            /**< Interrupt Flag Register  */
+  __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
+  __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t   TOP;           /**< Counter Top Value Register  */
+  __IOM uint32_t   TOPB;          /**< Counter Top Value Buffer Register  */
+  __IOM uint32_t   CNT;           /**< Counter Value Register  */
+  __IOM uint32_t   ROUTE;         /**< I/O Routing Register  */
+
+  uint32_t         RESERVED0[1U]; /**< Reserved registers */
+  TIMER_CC_TypeDef CC[3U];        /**< Compare/Capture Channel */
+} TIMER_TypeDef;                  /**< TIMER Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_TIMER_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for TIMER CTRL */
+#define _TIMER_CTRL_RESETVALUE                     0x00000000UL                             /**< Default value for TIMER_CTRL */
+#define _TIMER_CTRL_MASK                           0x3F032FFBUL                             /**< Mask for TIMER_CTRL */
+#define _TIMER_CTRL_MODE_SHIFT                     0                                        /**< Shift value for TIMER_MODE */
+#define _TIMER_CTRL_MODE_MASK                      0x3UL                                    /**< Bit mask for TIMER_MODE */
+#define _TIMER_CTRL_MODE_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define _TIMER_CTRL_MODE_UP                        0x00000000UL                             /**< Mode UP for TIMER_CTRL */
+#define _TIMER_CTRL_MODE_DOWN                      0x00000001UL                             /**< Mode DOWN for TIMER_CTRL */
+#define _TIMER_CTRL_MODE_UPDOWN                    0x00000002UL                             /**< Mode UPDOWN for TIMER_CTRL */
+#define _TIMER_CTRL_MODE_QDEC                      0x00000003UL                             /**< Mode QDEC for TIMER_CTRL */
+#define TIMER_CTRL_MODE_DEFAULT                    (_TIMER_CTRL_MODE_DEFAULT << 0)          /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_MODE_UP                         (_TIMER_CTRL_MODE_UP << 0)               /**< Shifted mode UP for TIMER_CTRL */
+#define TIMER_CTRL_MODE_DOWN                       (_TIMER_CTRL_MODE_DOWN << 0)             /**< Shifted mode DOWN for TIMER_CTRL */
+#define TIMER_CTRL_MODE_UPDOWN                     (_TIMER_CTRL_MODE_UPDOWN << 0)           /**< Shifted mode UPDOWN for TIMER_CTRL */
+#define TIMER_CTRL_MODE_QDEC                       (_TIMER_CTRL_MODE_QDEC << 0)             /**< Shifted mode QDEC for TIMER_CTRL */
+#define TIMER_CTRL_SYNC                            (0x1UL << 3)                             /**< Timer Start/Stop/Reload Synchronization */
+#define _TIMER_CTRL_SYNC_SHIFT                     3                                        /**< Shift value for TIMER_SYNC */
+#define _TIMER_CTRL_SYNC_MASK                      0x8UL                                    /**< Bit mask for TIMER_SYNC */
+#define _TIMER_CTRL_SYNC_DEFAULT                   0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_SYNC_DEFAULT                    (_TIMER_CTRL_SYNC_DEFAULT << 3)          /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_OSMEN                           (0x1UL << 4)                             /**< One-shot Mode Enable */
+#define _TIMER_CTRL_OSMEN_SHIFT                    4                                        /**< Shift value for TIMER_OSMEN */
+#define _TIMER_CTRL_OSMEN_MASK                     0x10UL                                   /**< Bit mask for TIMER_OSMEN */
+#define _TIMER_CTRL_OSMEN_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_OSMEN_DEFAULT                   (_TIMER_CTRL_OSMEN_DEFAULT << 4)         /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_QDM                             (0x1UL << 5)                             /**< Quadrature Decoder Mode Selection */
+#define _TIMER_CTRL_QDM_SHIFT                      5                                        /**< Shift value for TIMER_QDM */
+#define _TIMER_CTRL_QDM_MASK                       0x20UL                                   /**< Bit mask for TIMER_QDM */
+#define _TIMER_CTRL_QDM_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define _TIMER_CTRL_QDM_X2                         0x00000000UL                             /**< Mode X2 for TIMER_CTRL */
+#define _TIMER_CTRL_QDM_X4                         0x00000001UL                             /**< Mode X4 for TIMER_CTRL */
+#define TIMER_CTRL_QDM_DEFAULT                     (_TIMER_CTRL_QDM_DEFAULT << 5)           /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_QDM_X2                          (_TIMER_CTRL_QDM_X2 << 5)                /**< Shifted mode X2 for TIMER_CTRL */
+#define TIMER_CTRL_QDM_X4                          (_TIMER_CTRL_QDM_X4 << 5)                /**< Shifted mode X4 for TIMER_CTRL */
+#define TIMER_CTRL_DEBUGRUN                        (0x1UL << 6)                             /**< Debug Mode Run Enable */
+#define _TIMER_CTRL_DEBUGRUN_SHIFT                 6                                        /**< Shift value for TIMER_DEBUGRUN */
+#define _TIMER_CTRL_DEBUGRUN_MASK                  0x40UL                                   /**< Bit mask for TIMER_DEBUGRUN */
+#define _TIMER_CTRL_DEBUGRUN_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_DEBUGRUN_DEFAULT                (_TIMER_CTRL_DEBUGRUN_DEFAULT << 6)      /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_DMACLRACT                       (0x1UL << 7)                             /**< DMA Request Clear on Active */
+#define _TIMER_CTRL_DMACLRACT_SHIFT                7                                        /**< Shift value for TIMER_DMACLRACT */
+#define _TIMER_CTRL_DMACLRACT_MASK                 0x80UL                                   /**< Bit mask for TIMER_DMACLRACT */
+#define _TIMER_CTRL_DMACLRACT_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_DMACLRACT_DEFAULT               (_TIMER_CTRL_DMACLRACT_DEFAULT << 7)     /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define _TIMER_CTRL_RISEA_SHIFT                    8                                        /**< Shift value for TIMER_RISEA */
+#define _TIMER_CTRL_RISEA_MASK                     0x300UL                                  /**< Bit mask for TIMER_RISEA */
+#define _TIMER_CTRL_RISEA_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define _TIMER_CTRL_RISEA_NONE                     0x00000000UL                             /**< Mode NONE for TIMER_CTRL */
+#define _TIMER_CTRL_RISEA_START                    0x00000001UL                             /**< Mode START for TIMER_CTRL */
+#define _TIMER_CTRL_RISEA_STOP                     0x00000002UL                             /**< Mode STOP for TIMER_CTRL */
+#define _TIMER_CTRL_RISEA_RELOADSTART              0x00000003UL                             /**< Mode RELOADSTART for TIMER_CTRL */
+#define TIMER_CTRL_RISEA_DEFAULT                   (_TIMER_CTRL_RISEA_DEFAULT << 8)         /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_RISEA_NONE                      (_TIMER_CTRL_RISEA_NONE << 8)            /**< Shifted mode NONE for TIMER_CTRL */
+#define TIMER_CTRL_RISEA_START                     (_TIMER_CTRL_RISEA_START << 8)           /**< Shifted mode START for TIMER_CTRL */
+#define TIMER_CTRL_RISEA_STOP                      (_TIMER_CTRL_RISEA_STOP << 8)            /**< Shifted mode STOP for TIMER_CTRL */
+#define TIMER_CTRL_RISEA_RELOADSTART               (_TIMER_CTRL_RISEA_RELOADSTART << 8)     /**< Shifted mode RELOADSTART for TIMER_CTRL */
+#define _TIMER_CTRL_FALLA_SHIFT                    10                                       /**< Shift value for TIMER_FALLA */
+#define _TIMER_CTRL_FALLA_MASK                     0xC00UL                                  /**< Bit mask for TIMER_FALLA */
+#define _TIMER_CTRL_FALLA_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define _TIMER_CTRL_FALLA_NONE                     0x00000000UL                             /**< Mode NONE for TIMER_CTRL */
+#define _TIMER_CTRL_FALLA_START                    0x00000001UL                             /**< Mode START for TIMER_CTRL */
+#define _TIMER_CTRL_FALLA_STOP                     0x00000002UL                             /**< Mode STOP for TIMER_CTRL */
+#define _TIMER_CTRL_FALLA_RELOADSTART              0x00000003UL                             /**< Mode RELOADSTART for TIMER_CTRL */
+#define TIMER_CTRL_FALLA_DEFAULT                   (_TIMER_CTRL_FALLA_DEFAULT << 10)        /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_FALLA_NONE                      (_TIMER_CTRL_FALLA_NONE << 10)           /**< Shifted mode NONE for TIMER_CTRL */
+#define TIMER_CTRL_FALLA_START                     (_TIMER_CTRL_FALLA_START << 10)          /**< Shifted mode START for TIMER_CTRL */
+#define TIMER_CTRL_FALLA_STOP                      (_TIMER_CTRL_FALLA_STOP << 10)           /**< Shifted mode STOP for TIMER_CTRL */
+#define TIMER_CTRL_FALLA_RELOADSTART               (_TIMER_CTRL_FALLA_RELOADSTART << 10)    /**< Shifted mode RELOADSTART for TIMER_CTRL */
+#define TIMER_CTRL_X2CNT                           (0x1UL << 13)                            /**< 2x Count Mode */
+#define _TIMER_CTRL_X2CNT_SHIFT                    13                                       /**< Shift value for TIMER_X2CNT */
+#define _TIMER_CTRL_X2CNT_MASK                     0x2000UL                                 /**< Bit mask for TIMER_X2CNT */
+#define _TIMER_CTRL_X2CNT_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_X2CNT_DEFAULT                   (_TIMER_CTRL_X2CNT_DEFAULT << 13)        /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define _TIMER_CTRL_CLKSEL_SHIFT                   16                                       /**< Shift value for TIMER_CLKSEL */
+#define _TIMER_CTRL_CLKSEL_MASK                    0x30000UL                                /**< Bit mask for TIMER_CLKSEL */
+#define _TIMER_CTRL_CLKSEL_DEFAULT                 0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define _TIMER_CTRL_CLKSEL_PRESCHFPERCLK           0x00000000UL                             /**< Mode PRESCHFPERCLK for TIMER_CTRL */
+#define _TIMER_CTRL_CLKSEL_CC1                     0x00000001UL                             /**< Mode CC1 for TIMER_CTRL */
+#define _TIMER_CTRL_CLKSEL_TIMEROUF                0x00000002UL                             /**< Mode TIMEROUF for TIMER_CTRL */
+#define TIMER_CTRL_CLKSEL_DEFAULT                  (_TIMER_CTRL_CLKSEL_DEFAULT << 16)       /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_CLKSEL_PRESCHFPERCLK            (_TIMER_CTRL_CLKSEL_PRESCHFPERCLK << 16) /**< Shifted mode PRESCHFPERCLK for TIMER_CTRL */
+#define TIMER_CTRL_CLKSEL_CC1                      (_TIMER_CTRL_CLKSEL_CC1 << 16)           /**< Shifted mode CC1 for TIMER_CTRL */
+#define TIMER_CTRL_CLKSEL_TIMEROUF                 (_TIMER_CTRL_CLKSEL_TIMEROUF << 16)      /**< Shifted mode TIMEROUF for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_SHIFT                    24                                       /**< Shift value for TIMER_PRESC */
+#define _TIMER_CTRL_PRESC_MASK                     0xF000000UL                              /**< Bit mask for TIMER_PRESC */
+#define _TIMER_CTRL_PRESC_DEFAULT                  0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV1                     0x00000000UL                             /**< Mode DIV1 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV2                     0x00000001UL                             /**< Mode DIV2 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV4                     0x00000002UL                             /**< Mode DIV4 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV8                     0x00000003UL                             /**< Mode DIV8 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV16                    0x00000004UL                             /**< Mode DIV16 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV32                    0x00000005UL                             /**< Mode DIV32 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV64                    0x00000006UL                             /**< Mode DIV64 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV128                   0x00000007UL                             /**< Mode DIV128 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV256                   0x00000008UL                             /**< Mode DIV256 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV512                   0x00000009UL                             /**< Mode DIV512 for TIMER_CTRL */
+#define _TIMER_CTRL_PRESC_DIV1024                  0x0000000AUL                             /**< Mode DIV1024 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DEFAULT                   (_TIMER_CTRL_PRESC_DEFAULT << 24)        /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV1                      (_TIMER_CTRL_PRESC_DIV1 << 24)           /**< Shifted mode DIV1 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV2                      (_TIMER_CTRL_PRESC_DIV2 << 24)           /**< Shifted mode DIV2 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV4                      (_TIMER_CTRL_PRESC_DIV4 << 24)           /**< Shifted mode DIV4 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV8                      (_TIMER_CTRL_PRESC_DIV8 << 24)           /**< Shifted mode DIV8 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV16                     (_TIMER_CTRL_PRESC_DIV16 << 24)          /**< Shifted mode DIV16 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV32                     (_TIMER_CTRL_PRESC_DIV32 << 24)          /**< Shifted mode DIV32 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV64                     (_TIMER_CTRL_PRESC_DIV64 << 24)          /**< Shifted mode DIV64 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV128                    (_TIMER_CTRL_PRESC_DIV128 << 24)         /**< Shifted mode DIV128 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV256                    (_TIMER_CTRL_PRESC_DIV256 << 24)         /**< Shifted mode DIV256 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV512                    (_TIMER_CTRL_PRESC_DIV512 << 24)         /**< Shifted mode DIV512 for TIMER_CTRL */
+#define TIMER_CTRL_PRESC_DIV1024                   (_TIMER_CTRL_PRESC_DIV1024 << 24)        /**< Shifted mode DIV1024 for TIMER_CTRL */
+#define TIMER_CTRL_ATI                             (0x1UL << 28)                            /**< Always Track Inputs */
+#define _TIMER_CTRL_ATI_SHIFT                      28                                       /**< Shift value for TIMER_ATI */
+#define _TIMER_CTRL_ATI_MASK                       0x10000000UL                             /**< Bit mask for TIMER_ATI */
+#define _TIMER_CTRL_ATI_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_ATI_DEFAULT                     (_TIMER_CTRL_ATI_DEFAULT << 28)          /**< Shifted mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_RSSCOIST                        (0x1UL << 29)                            /**< Reload-Start Sets Compare Output initial State */
+#define _TIMER_CTRL_RSSCOIST_SHIFT                 29                                       /**< Shift value for TIMER_RSSCOIST */
+#define _TIMER_CTRL_RSSCOIST_MASK                  0x20000000UL                             /**< Bit mask for TIMER_RSSCOIST */
+#define _TIMER_CTRL_RSSCOIST_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
+#define TIMER_CTRL_RSSCOIST_DEFAULT                (_TIMER_CTRL_RSSCOIST_DEFAULT << 29)     /**< Shifted mode DEFAULT for TIMER_CTRL */
+
+/* Bit fields for TIMER CMD */
+#define _TIMER_CMD_RESETVALUE                      0x00000000UL                    /**< Default value for TIMER_CMD */
+#define _TIMER_CMD_MASK                            0x00000003UL                    /**< Mask for TIMER_CMD */
+#define TIMER_CMD_START                            (0x1UL << 0)                    /**< Start Timer */
+#define _TIMER_CMD_START_SHIFT                     0                               /**< Shift value for TIMER_START */
+#define _TIMER_CMD_START_MASK                      0x1UL                           /**< Bit mask for TIMER_START */
+#define _TIMER_CMD_START_DEFAULT                   0x00000000UL                    /**< Mode DEFAULT for TIMER_CMD */
+#define TIMER_CMD_START_DEFAULT                    (_TIMER_CMD_START_DEFAULT << 0) /**< Shifted mode DEFAULT for TIMER_CMD */
+#define TIMER_CMD_STOP                             (0x1UL << 1)                    /**< Stop Timer */
+#define _TIMER_CMD_STOP_SHIFT                      1                               /**< Shift value for TIMER_STOP */
+#define _TIMER_CMD_STOP_MASK                       0x2UL                           /**< Bit mask for TIMER_STOP */
+#define _TIMER_CMD_STOP_DEFAULT                    0x00000000UL                    /**< Mode DEFAULT for TIMER_CMD */
+#define TIMER_CMD_STOP_DEFAULT                     (_TIMER_CMD_STOP_DEFAULT << 1)  /**< Shifted mode DEFAULT for TIMER_CMD */
+
+/* Bit fields for TIMER STATUS */
+#define _TIMER_STATUS_RESETVALUE                   0x00000000UL                          /**< Default value for TIMER_STATUS */
+#define _TIMER_STATUS_MASK                         0x07070707UL                          /**< Mask for TIMER_STATUS */
+#define TIMER_STATUS_RUNNING                       (0x1UL << 0)                          /**< Running */
+#define _TIMER_STATUS_RUNNING_SHIFT                0                                     /**< Shift value for TIMER_RUNNING */
+#define _TIMER_STATUS_RUNNING_MASK                 0x1UL                                 /**< Bit mask for TIMER_RUNNING */
+#define _TIMER_STATUS_RUNNING_DEFAULT              0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_RUNNING_DEFAULT               (_TIMER_STATUS_RUNNING_DEFAULT << 0)  /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_DIR                           (0x1UL << 1)                          /**< Direction */
+#define _TIMER_STATUS_DIR_SHIFT                    1                                     /**< Shift value for TIMER_DIR */
+#define _TIMER_STATUS_DIR_MASK                     0x2UL                                 /**< Bit mask for TIMER_DIR */
+#define _TIMER_STATUS_DIR_DEFAULT                  0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define _TIMER_STATUS_DIR_UP                       0x00000000UL                          /**< Mode UP for TIMER_STATUS */
+#define _TIMER_STATUS_DIR_DOWN                     0x00000001UL                          /**< Mode DOWN for TIMER_STATUS */
+#define TIMER_STATUS_DIR_DEFAULT                   (_TIMER_STATUS_DIR_DEFAULT << 1)      /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_DIR_UP                        (_TIMER_STATUS_DIR_UP << 1)           /**< Shifted mode UP for TIMER_STATUS */
+#define TIMER_STATUS_DIR_DOWN                      (_TIMER_STATUS_DIR_DOWN << 1)         /**< Shifted mode DOWN for TIMER_STATUS */
+#define TIMER_STATUS_TOPBV                         (0x1UL << 2)                          /**< TOPB Valid */
+#define _TIMER_STATUS_TOPBV_SHIFT                  2                                     /**< Shift value for TIMER_TOPBV */
+#define _TIMER_STATUS_TOPBV_MASK                   0x4UL                                 /**< Bit mask for TIMER_TOPBV */
+#define _TIMER_STATUS_TOPBV_DEFAULT                0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_TOPBV_DEFAULT                 (_TIMER_STATUS_TOPBV_DEFAULT << 2)    /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCVBV0                        (0x1UL << 8)                          /**< CC0 CCVB Valid */
+#define _TIMER_STATUS_CCVBV0_SHIFT                 8                                     /**< Shift value for TIMER_CCVBV0 */
+#define _TIMER_STATUS_CCVBV0_MASK                  0x100UL                               /**< Bit mask for TIMER_CCVBV0 */
+#define _TIMER_STATUS_CCVBV0_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCVBV0_DEFAULT                (_TIMER_STATUS_CCVBV0_DEFAULT << 8)   /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCVBV1                        (0x1UL << 9)                          /**< CC1 CCVB Valid */
+#define _TIMER_STATUS_CCVBV1_SHIFT                 9                                     /**< Shift value for TIMER_CCVBV1 */
+#define _TIMER_STATUS_CCVBV1_MASK                  0x200UL                               /**< Bit mask for TIMER_CCVBV1 */
+#define _TIMER_STATUS_CCVBV1_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCVBV1_DEFAULT                (_TIMER_STATUS_CCVBV1_DEFAULT << 9)   /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCVBV2                        (0x1UL << 10)                         /**< CC2 CCVB Valid */
+#define _TIMER_STATUS_CCVBV2_SHIFT                 10                                    /**< Shift value for TIMER_CCVBV2 */
+#define _TIMER_STATUS_CCVBV2_MASK                  0x400UL                               /**< Bit mask for TIMER_CCVBV2 */
+#define _TIMER_STATUS_CCVBV2_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCVBV2_DEFAULT                (_TIMER_STATUS_CCVBV2_DEFAULT << 10)  /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_ICV0                          (0x1UL << 16)                         /**< CC0 Input Capture Valid */
+#define _TIMER_STATUS_ICV0_SHIFT                   16                                    /**< Shift value for TIMER_ICV0 */
+#define _TIMER_STATUS_ICV0_MASK                    0x10000UL                             /**< Bit mask for TIMER_ICV0 */
+#define _TIMER_STATUS_ICV0_DEFAULT                 0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_ICV0_DEFAULT                  (_TIMER_STATUS_ICV0_DEFAULT << 16)    /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_ICV1                          (0x1UL << 17)                         /**< CC1 Input Capture Valid */
+#define _TIMER_STATUS_ICV1_SHIFT                   17                                    /**< Shift value for TIMER_ICV1 */
+#define _TIMER_STATUS_ICV1_MASK                    0x20000UL                             /**< Bit mask for TIMER_ICV1 */
+#define _TIMER_STATUS_ICV1_DEFAULT                 0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_ICV1_DEFAULT                  (_TIMER_STATUS_ICV1_DEFAULT << 17)    /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_ICV2                          (0x1UL << 18)                         /**< CC2 Input Capture Valid */
+#define _TIMER_STATUS_ICV2_SHIFT                   18                                    /**< Shift value for TIMER_ICV2 */
+#define _TIMER_STATUS_ICV2_MASK                    0x40000UL                             /**< Bit mask for TIMER_ICV2 */
+#define _TIMER_STATUS_ICV2_DEFAULT                 0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_ICV2_DEFAULT                  (_TIMER_STATUS_ICV2_DEFAULT << 18)    /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL0                        (0x1UL << 24)                         /**< CC0 Polarity */
+#define _TIMER_STATUS_CCPOL0_SHIFT                 24                                    /**< Shift value for TIMER_CCPOL0 */
+#define _TIMER_STATUS_CCPOL0_MASK                  0x1000000UL                           /**< Bit mask for TIMER_CCPOL0 */
+#define _TIMER_STATUS_CCPOL0_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define _TIMER_STATUS_CCPOL0_LOWRISE               0x00000000UL                          /**< Mode LOWRISE for TIMER_STATUS */
+#define _TIMER_STATUS_CCPOL0_HIGHFALL              0x00000001UL                          /**< Mode HIGHFALL for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL0_DEFAULT                (_TIMER_STATUS_CCPOL0_DEFAULT << 24)  /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL0_LOWRISE                (_TIMER_STATUS_CCPOL0_LOWRISE << 24)  /**< Shifted mode LOWRISE for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL0_HIGHFALL               (_TIMER_STATUS_CCPOL0_HIGHFALL << 24) /**< Shifted mode HIGHFALL for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL1                        (0x1UL << 25)                         /**< CC1 Polarity */
+#define _TIMER_STATUS_CCPOL1_SHIFT                 25                                    /**< Shift value for TIMER_CCPOL1 */
+#define _TIMER_STATUS_CCPOL1_MASK                  0x2000000UL                           /**< Bit mask for TIMER_CCPOL1 */
+#define _TIMER_STATUS_CCPOL1_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define _TIMER_STATUS_CCPOL1_LOWRISE               0x00000000UL                          /**< Mode LOWRISE for TIMER_STATUS */
+#define _TIMER_STATUS_CCPOL1_HIGHFALL              0x00000001UL                          /**< Mode HIGHFALL for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL1_DEFAULT                (_TIMER_STATUS_CCPOL1_DEFAULT << 25)  /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL1_LOWRISE                (_TIMER_STATUS_CCPOL1_LOWRISE << 25)  /**< Shifted mode LOWRISE for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL1_HIGHFALL               (_TIMER_STATUS_CCPOL1_HIGHFALL << 25) /**< Shifted mode HIGHFALL for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL2                        (0x1UL << 26)                         /**< CC2 Polarity */
+#define _TIMER_STATUS_CCPOL2_SHIFT                 26                                    /**< Shift value for TIMER_CCPOL2 */
+#define _TIMER_STATUS_CCPOL2_MASK                  0x4000000UL                           /**< Bit mask for TIMER_CCPOL2 */
+#define _TIMER_STATUS_CCPOL2_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_STATUS */
+#define _TIMER_STATUS_CCPOL2_LOWRISE               0x00000000UL                          /**< Mode LOWRISE for TIMER_STATUS */
+#define _TIMER_STATUS_CCPOL2_HIGHFALL              0x00000001UL                          /**< Mode HIGHFALL for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL2_DEFAULT                (_TIMER_STATUS_CCPOL2_DEFAULT << 26)  /**< Shifted mode DEFAULT for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL2_LOWRISE                (_TIMER_STATUS_CCPOL2_LOWRISE << 26)  /**< Shifted mode LOWRISE for TIMER_STATUS */
+#define TIMER_STATUS_CCPOL2_HIGHFALL               (_TIMER_STATUS_CCPOL2_HIGHFALL << 26) /**< Shifted mode HIGHFALL for TIMER_STATUS */
+
+/* Bit fields for TIMER IEN */
+#define _TIMER_IEN_RESETVALUE                      0x00000000UL                      /**< Default value for TIMER_IEN */
+#define _TIMER_IEN_MASK                            0x00000773UL                      /**< Mask for TIMER_IEN */
+#define TIMER_IEN_OF                               (0x1UL << 0)                      /**< Overflow Interrupt Enable */
+#define _TIMER_IEN_OF_SHIFT                        0                                 /**< Shift value for TIMER_OF */
+#define _TIMER_IEN_OF_MASK                         0x1UL                             /**< Bit mask for TIMER_OF */
+#define _TIMER_IEN_OF_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_OF_DEFAULT                       (_TIMER_IEN_OF_DEFAULT << 0)      /**< Shifted mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_UF                               (0x1UL << 1)                      /**< Underflow Interrupt Enable */
+#define _TIMER_IEN_UF_SHIFT                        1                                 /**< Shift value for TIMER_UF */
+#define _TIMER_IEN_UF_MASK                         0x2UL                             /**< Bit mask for TIMER_UF */
+#define _TIMER_IEN_UF_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_UF_DEFAULT                       (_TIMER_IEN_UF_DEFAULT << 1)      /**< Shifted mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_CC0                              (0x1UL << 4)                      /**< CC Channel 0 Interrupt Enable */
+#define _TIMER_IEN_CC0_SHIFT                       4                                 /**< Shift value for TIMER_CC0 */
+#define _TIMER_IEN_CC0_MASK                        0x10UL                            /**< Bit mask for TIMER_CC0 */
+#define _TIMER_IEN_CC0_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_CC0_DEFAULT                      (_TIMER_IEN_CC0_DEFAULT << 4)     /**< Shifted mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_CC1                              (0x1UL << 5)                      /**< CC Channel 1 Interrupt Enable */
+#define _TIMER_IEN_CC1_SHIFT                       5                                 /**< Shift value for TIMER_CC1 */
+#define _TIMER_IEN_CC1_MASK                        0x20UL                            /**< Bit mask for TIMER_CC1 */
+#define _TIMER_IEN_CC1_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_CC1_DEFAULT                      (_TIMER_IEN_CC1_DEFAULT << 5)     /**< Shifted mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_CC2                              (0x1UL << 6)                      /**< CC Channel 2 Interrupt Enable */
+#define _TIMER_IEN_CC2_SHIFT                       6                                 /**< Shift value for TIMER_CC2 */
+#define _TIMER_IEN_CC2_MASK                        0x40UL                            /**< Bit mask for TIMER_CC2 */
+#define _TIMER_IEN_CC2_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_CC2_DEFAULT                      (_TIMER_IEN_CC2_DEFAULT << 6)     /**< Shifted mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_ICBOF0                           (0x1UL << 8)                      /**< CC Channel 0 Input Capture Buffer Overflow Interrupt Enable */
+#define _TIMER_IEN_ICBOF0_SHIFT                    8                                 /**< Shift value for TIMER_ICBOF0 */
+#define _TIMER_IEN_ICBOF0_MASK                     0x100UL                           /**< Bit mask for TIMER_ICBOF0 */
+#define _TIMER_IEN_ICBOF0_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_ICBOF0_DEFAULT                   (_TIMER_IEN_ICBOF0_DEFAULT << 8)  /**< Shifted mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_ICBOF1                           (0x1UL << 9)                      /**< CC Channel 1 Input Capture Buffer Overflow Interrupt Enable */
+#define _TIMER_IEN_ICBOF1_SHIFT                    9                                 /**< Shift value for TIMER_ICBOF1 */
+#define _TIMER_IEN_ICBOF1_MASK                     0x200UL                           /**< Bit mask for TIMER_ICBOF1 */
+#define _TIMER_IEN_ICBOF1_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_ICBOF1_DEFAULT                   (_TIMER_IEN_ICBOF1_DEFAULT << 9)  /**< Shifted mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_ICBOF2                           (0x1UL << 10)                     /**< CC Channel 2 Input Capture Buffer Overflow Interrupt Enable */
+#define _TIMER_IEN_ICBOF2_SHIFT                    10                                /**< Shift value for TIMER_ICBOF2 */
+#define _TIMER_IEN_ICBOF2_MASK                     0x400UL                           /**< Bit mask for TIMER_ICBOF2 */
+#define _TIMER_IEN_ICBOF2_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for TIMER_IEN */
+#define TIMER_IEN_ICBOF2_DEFAULT                   (_TIMER_IEN_ICBOF2_DEFAULT << 10) /**< Shifted mode DEFAULT for TIMER_IEN */
+
+/* Bit fields for TIMER IF */
+#define _TIMER_IF_RESETVALUE                       0x00000000UL                     /**< Default value for TIMER_IF */
+#define _TIMER_IF_MASK                             0x00000773UL                     /**< Mask for TIMER_IF */
+#define TIMER_IF_OF                                (0x1UL << 0)                     /**< Overflow Interrupt Flag */
+#define _TIMER_IF_OF_SHIFT                         0                                /**< Shift value for TIMER_OF */
+#define _TIMER_IF_OF_MASK                          0x1UL                            /**< Bit mask for TIMER_OF */
+#define _TIMER_IF_OF_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for TIMER_IF */
+#define TIMER_IF_OF_DEFAULT                        (_TIMER_IF_OF_DEFAULT << 0)      /**< Shifted mode DEFAULT for TIMER_IF */
+#define TIMER_IF_UF                                (0x1UL << 1)                     /**< Underflow Interrupt Flag */
+#define _TIMER_IF_UF_SHIFT                         1                                /**< Shift value for TIMER_UF */
+#define _TIMER_IF_UF_MASK                          0x2UL                            /**< Bit mask for TIMER_UF */
+#define _TIMER_IF_UF_DEFAULT                       0x00000000UL                     /**< Mode DEFAULT for TIMER_IF */
+#define TIMER_IF_UF_DEFAULT                        (_TIMER_IF_UF_DEFAULT << 1)      /**< Shifted mode DEFAULT for TIMER_IF */
+#define TIMER_IF_CC0                               (0x1UL << 4)                     /**< CC Channel 0 Interrupt Flag */
+#define _TIMER_IF_CC0_SHIFT                        4                                /**< Shift value for TIMER_CC0 */
+#define _TIMER_IF_CC0_MASK                         0x10UL                           /**< Bit mask for TIMER_CC0 */
+#define _TIMER_IF_CC0_DEFAULT                      0x00000000UL                     /**< Mode DEFAULT for TIMER_IF */
+#define TIMER_IF_CC0_DEFAULT                       (_TIMER_IF_CC0_DEFAULT << 4)     /**< Shifted mode DEFAULT for TIMER_IF */
+#define TIMER_IF_CC1                               (0x1UL << 5)                     /**< CC Channel 1 Interrupt Flag */
+#define _TIMER_IF_CC1_SHIFT                        5                                /**< Shift value for TIMER_CC1 */
+#define _TIMER_IF_CC1_MASK                         0x20UL                           /**< Bit mask for TIMER_CC1 */
+#define _TIMER_IF_CC1_DEFAULT                      0x00000000UL                     /**< Mode DEFAULT for TIMER_IF */
+#define TIMER_IF_CC1_DEFAULT                       (_TIMER_IF_CC1_DEFAULT << 5)     /**< Shifted mode DEFAULT for TIMER_IF */
+#define TIMER_IF_CC2                               (0x1UL << 6)                     /**< CC Channel 2 Interrupt Flag */
+#define _TIMER_IF_CC2_SHIFT                        6                                /**< Shift value for TIMER_CC2 */
+#define _TIMER_IF_CC2_MASK                         0x40UL                           /**< Bit mask for TIMER_CC2 */
+#define _TIMER_IF_CC2_DEFAULT                      0x00000000UL                     /**< Mode DEFAULT for TIMER_IF */
+#define TIMER_IF_CC2_DEFAULT                       (_TIMER_IF_CC2_DEFAULT << 6)     /**< Shifted mode DEFAULT for TIMER_IF */
+#define TIMER_IF_ICBOF0                            (0x1UL << 8)                     /**< CC Channel 0 Input Capture Buffer Overflow Interrupt Flag */
+#define _TIMER_IF_ICBOF0_SHIFT                     8                                /**< Shift value for TIMER_ICBOF0 */
+#define _TIMER_IF_ICBOF0_MASK                      0x100UL                          /**< Bit mask for TIMER_ICBOF0 */
+#define _TIMER_IF_ICBOF0_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for TIMER_IF */
+#define TIMER_IF_ICBOF0_DEFAULT                    (_TIMER_IF_ICBOF0_DEFAULT << 8)  /**< Shifted mode DEFAULT for TIMER_IF */
+#define TIMER_IF_ICBOF1                            (0x1UL << 9)                     /**< CC Channel 1 Input Capture Buffer Overflow Interrupt Flag */
+#define _TIMER_IF_ICBOF1_SHIFT                     9                                /**< Shift value for TIMER_ICBOF1 */
+#define _TIMER_IF_ICBOF1_MASK                      0x200UL                          /**< Bit mask for TIMER_ICBOF1 */
+#define _TIMER_IF_ICBOF1_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for TIMER_IF */
+#define TIMER_IF_ICBOF1_DEFAULT                    (_TIMER_IF_ICBOF1_DEFAULT << 9)  /**< Shifted mode DEFAULT for TIMER_IF */
+#define TIMER_IF_ICBOF2                            (0x1UL << 10)                    /**< CC Channel 2 Input Capture Buffer Overflow Interrupt Flag */
+#define _TIMER_IF_ICBOF2_SHIFT                     10                               /**< Shift value for TIMER_ICBOF2 */
+#define _TIMER_IF_ICBOF2_MASK                      0x400UL                          /**< Bit mask for TIMER_ICBOF2 */
+#define _TIMER_IF_ICBOF2_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for TIMER_IF */
+#define TIMER_IF_ICBOF2_DEFAULT                    (_TIMER_IF_ICBOF2_DEFAULT << 10) /**< Shifted mode DEFAULT for TIMER_IF */
+
+/* Bit fields for TIMER IFS */
+#define _TIMER_IFS_RESETVALUE                      0x00000000UL                      /**< Default value for TIMER_IFS */
+#define _TIMER_IFS_MASK                            0x00000773UL                      /**< Mask for TIMER_IFS */
+#define TIMER_IFS_OF                               (0x1UL << 0)                      /**< Overflow Interrupt Flag Set */
+#define _TIMER_IFS_OF_SHIFT                        0                                 /**< Shift value for TIMER_OF */
+#define _TIMER_IFS_OF_MASK                         0x1UL                             /**< Bit mask for TIMER_OF */
+#define _TIMER_IFS_OF_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_OF_DEFAULT                       (_TIMER_IFS_OF_DEFAULT << 0)      /**< Shifted mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_UF                               (0x1UL << 1)                      /**< Underflow Interrupt Flag Set */
+#define _TIMER_IFS_UF_SHIFT                        1                                 /**< Shift value for TIMER_UF */
+#define _TIMER_IFS_UF_MASK                         0x2UL                             /**< Bit mask for TIMER_UF */
+#define _TIMER_IFS_UF_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_UF_DEFAULT                       (_TIMER_IFS_UF_DEFAULT << 1)      /**< Shifted mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_CC0                              (0x1UL << 4)                      /**< CC Channel 0 Interrupt Flag Set */
+#define _TIMER_IFS_CC0_SHIFT                       4                                 /**< Shift value for TIMER_CC0 */
+#define _TIMER_IFS_CC0_MASK                        0x10UL                            /**< Bit mask for TIMER_CC0 */
+#define _TIMER_IFS_CC0_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_CC0_DEFAULT                      (_TIMER_IFS_CC0_DEFAULT << 4)     /**< Shifted mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_CC1                              (0x1UL << 5)                      /**< CC Channel 1 Interrupt Flag Set */
+#define _TIMER_IFS_CC1_SHIFT                       5                                 /**< Shift value for TIMER_CC1 */
+#define _TIMER_IFS_CC1_MASK                        0x20UL                            /**< Bit mask for TIMER_CC1 */
+#define _TIMER_IFS_CC1_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_CC1_DEFAULT                      (_TIMER_IFS_CC1_DEFAULT << 5)     /**< Shifted mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_CC2                              (0x1UL << 6)                      /**< CC Channel 2 Interrupt Flag Set */
+#define _TIMER_IFS_CC2_SHIFT                       6                                 /**< Shift value for TIMER_CC2 */
+#define _TIMER_IFS_CC2_MASK                        0x40UL                            /**< Bit mask for TIMER_CC2 */
+#define _TIMER_IFS_CC2_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_CC2_DEFAULT                      (_TIMER_IFS_CC2_DEFAULT << 6)     /**< Shifted mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_ICBOF0                           (0x1UL << 8)                      /**< CC Channel 0 Input Capture Buffer Overflow Interrupt Flag Set */
+#define _TIMER_IFS_ICBOF0_SHIFT                    8                                 /**< Shift value for TIMER_ICBOF0 */
+#define _TIMER_IFS_ICBOF0_MASK                     0x100UL                           /**< Bit mask for TIMER_ICBOF0 */
+#define _TIMER_IFS_ICBOF0_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_ICBOF0_DEFAULT                   (_TIMER_IFS_ICBOF0_DEFAULT << 8)  /**< Shifted mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_ICBOF1                           (0x1UL << 9)                      /**< CC Channel 1 Input Capture Buffer Overflow Interrupt Flag Set */
+#define _TIMER_IFS_ICBOF1_SHIFT                    9                                 /**< Shift value for TIMER_ICBOF1 */
+#define _TIMER_IFS_ICBOF1_MASK                     0x200UL                           /**< Bit mask for TIMER_ICBOF1 */
+#define _TIMER_IFS_ICBOF1_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_ICBOF1_DEFAULT                   (_TIMER_IFS_ICBOF1_DEFAULT << 9)  /**< Shifted mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_ICBOF2                           (0x1UL << 10)                     /**< CC Channel 2 Input Capture Buffer Overflow Interrupt Flag Set */
+#define _TIMER_IFS_ICBOF2_SHIFT                    10                                /**< Shift value for TIMER_ICBOF2 */
+#define _TIMER_IFS_ICBOF2_MASK                     0x400UL                           /**< Bit mask for TIMER_ICBOF2 */
+#define _TIMER_IFS_ICBOF2_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for TIMER_IFS */
+#define TIMER_IFS_ICBOF2_DEFAULT                   (_TIMER_IFS_ICBOF2_DEFAULT << 10) /**< Shifted mode DEFAULT for TIMER_IFS */
+
+/* Bit fields for TIMER IFC */
+#define _TIMER_IFC_RESETVALUE                      0x00000000UL                      /**< Default value for TIMER_IFC */
+#define _TIMER_IFC_MASK                            0x00000773UL                      /**< Mask for TIMER_IFC */
+#define TIMER_IFC_OF                               (0x1UL << 0)                      /**< Overflow Interrupt Flag Clear */
+#define _TIMER_IFC_OF_SHIFT                        0                                 /**< Shift value for TIMER_OF */
+#define _TIMER_IFC_OF_MASK                         0x1UL                             /**< Bit mask for TIMER_OF */
+#define _TIMER_IFC_OF_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_OF_DEFAULT                       (_TIMER_IFC_OF_DEFAULT << 0)      /**< Shifted mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_UF                               (0x1UL << 1)                      /**< Underflow Interrupt Flag Clear */
+#define _TIMER_IFC_UF_SHIFT                        1                                 /**< Shift value for TIMER_UF */
+#define _TIMER_IFC_UF_MASK                         0x2UL                             /**< Bit mask for TIMER_UF */
+#define _TIMER_IFC_UF_DEFAULT                      0x00000000UL                      /**< Mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_UF_DEFAULT                       (_TIMER_IFC_UF_DEFAULT << 1)      /**< Shifted mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_CC0                              (0x1UL << 4)                      /**< CC Channel 0 Interrupt Flag Clear */
+#define _TIMER_IFC_CC0_SHIFT                       4                                 /**< Shift value for TIMER_CC0 */
+#define _TIMER_IFC_CC0_MASK                        0x10UL                            /**< Bit mask for TIMER_CC0 */
+#define _TIMER_IFC_CC0_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_CC0_DEFAULT                      (_TIMER_IFC_CC0_DEFAULT << 4)     /**< Shifted mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_CC1                              (0x1UL << 5)                      /**< CC Channel 1 Interrupt Flag Clear */
+#define _TIMER_IFC_CC1_SHIFT                       5                                 /**< Shift value for TIMER_CC1 */
+#define _TIMER_IFC_CC1_MASK                        0x20UL                            /**< Bit mask for TIMER_CC1 */
+#define _TIMER_IFC_CC1_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_CC1_DEFAULT                      (_TIMER_IFC_CC1_DEFAULT << 5)     /**< Shifted mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_CC2                              (0x1UL << 6)                      /**< CC Channel 2 Interrupt Flag Clear */
+#define _TIMER_IFC_CC2_SHIFT                       6                                 /**< Shift value for TIMER_CC2 */
+#define _TIMER_IFC_CC2_MASK                        0x40UL                            /**< Bit mask for TIMER_CC2 */
+#define _TIMER_IFC_CC2_DEFAULT                     0x00000000UL                      /**< Mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_CC2_DEFAULT                      (_TIMER_IFC_CC2_DEFAULT << 6)     /**< Shifted mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_ICBOF0                           (0x1UL << 8)                      /**< CC Channel 0 Input Capture Buffer Overflow Interrupt Flag Clear */
+#define _TIMER_IFC_ICBOF0_SHIFT                    8                                 /**< Shift value for TIMER_ICBOF0 */
+#define _TIMER_IFC_ICBOF0_MASK                     0x100UL                           /**< Bit mask for TIMER_ICBOF0 */
+#define _TIMER_IFC_ICBOF0_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_ICBOF0_DEFAULT                   (_TIMER_IFC_ICBOF0_DEFAULT << 8)  /**< Shifted mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_ICBOF1                           (0x1UL << 9)                      /**< CC Channel 1 Input Capture Buffer Overflow Interrupt Flag Clear */
+#define _TIMER_IFC_ICBOF1_SHIFT                    9                                 /**< Shift value for TIMER_ICBOF1 */
+#define _TIMER_IFC_ICBOF1_MASK                     0x200UL                           /**< Bit mask for TIMER_ICBOF1 */
+#define _TIMER_IFC_ICBOF1_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_ICBOF1_DEFAULT                   (_TIMER_IFC_ICBOF1_DEFAULT << 9)  /**< Shifted mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_ICBOF2                           (0x1UL << 10)                     /**< CC Channel 2 Input Capture Buffer Overflow Interrupt Flag Clear */
+#define _TIMER_IFC_ICBOF2_SHIFT                    10                                /**< Shift value for TIMER_ICBOF2 */
+#define _TIMER_IFC_ICBOF2_MASK                     0x400UL                           /**< Bit mask for TIMER_ICBOF2 */
+#define _TIMER_IFC_ICBOF2_DEFAULT                  0x00000000UL                      /**< Mode DEFAULT for TIMER_IFC */
+#define TIMER_IFC_ICBOF2_DEFAULT                   (_TIMER_IFC_ICBOF2_DEFAULT << 10) /**< Shifted mode DEFAULT for TIMER_IFC */
+
+/* Bit fields for TIMER TOP */
+#define _TIMER_TOP_RESETVALUE                      0x0000FFFFUL                  /**< Default value for TIMER_TOP */
+#define _TIMER_TOP_MASK                            0x0000FFFFUL                  /**< Mask for TIMER_TOP */
+#define _TIMER_TOP_TOP_SHIFT                       0                             /**< Shift value for TIMER_TOP */
+#define _TIMER_TOP_TOP_MASK                        0xFFFFUL                      /**< Bit mask for TIMER_TOP */
+#define _TIMER_TOP_TOP_DEFAULT                     0x0000FFFFUL                  /**< Mode DEFAULT for TIMER_TOP */
+#define TIMER_TOP_TOP_DEFAULT                      (_TIMER_TOP_TOP_DEFAULT << 0) /**< Shifted mode DEFAULT for TIMER_TOP */
+
+/* Bit fields for TIMER TOPB */
+#define _TIMER_TOPB_RESETVALUE                     0x00000000UL                    /**< Default value for TIMER_TOPB */
+#define _TIMER_TOPB_MASK                           0x0000FFFFUL                    /**< Mask for TIMER_TOPB */
+#define _TIMER_TOPB_TOPB_SHIFT                     0                               /**< Shift value for TIMER_TOPB */
+#define _TIMER_TOPB_TOPB_MASK                      0xFFFFUL                        /**< Bit mask for TIMER_TOPB */
+#define _TIMER_TOPB_TOPB_DEFAULT                   0x00000000UL                    /**< Mode DEFAULT for TIMER_TOPB */
+#define TIMER_TOPB_TOPB_DEFAULT                    (_TIMER_TOPB_TOPB_DEFAULT << 0) /**< Shifted mode DEFAULT for TIMER_TOPB */
+
+/* Bit fields for TIMER CNT */
+#define _TIMER_CNT_RESETVALUE                      0x00000000UL                  /**< Default value for TIMER_CNT */
+#define _TIMER_CNT_MASK                            0x0000FFFFUL                  /**< Mask for TIMER_CNT */
+#define _TIMER_CNT_CNT_SHIFT                       0                             /**< Shift value for TIMER_CNT */
+#define _TIMER_CNT_CNT_MASK                        0xFFFFUL                      /**< Bit mask for TIMER_CNT */
+#define _TIMER_CNT_CNT_DEFAULT                     0x00000000UL                  /**< Mode DEFAULT for TIMER_CNT */
+#define TIMER_CNT_CNT_DEFAULT                      (_TIMER_CNT_CNT_DEFAULT << 0) /**< Shifted mode DEFAULT for TIMER_CNT */
+
+/* Bit fields for TIMER ROUTE */
+#define _TIMER_ROUTE_RESETVALUE                    0x00000000UL                          /**< Default value for TIMER_ROUTE */
+#define _TIMER_ROUTE_MASK                          0x00070007UL                          /**< Mask for TIMER_ROUTE */
+#define TIMER_ROUTE_CC0PEN                         (0x1UL << 0)                          /**< CC Channel 0 Pin Enable */
+#define _TIMER_ROUTE_CC0PEN_SHIFT                  0                                     /**< Shift value for TIMER_CC0PEN */
+#define _TIMER_ROUTE_CC0PEN_MASK                   0x1UL                                 /**< Bit mask for TIMER_CC0PEN */
+#define _TIMER_ROUTE_CC0PEN_DEFAULT                0x00000000UL                          /**< Mode DEFAULT for TIMER_ROUTE */
+#define TIMER_ROUTE_CC0PEN_DEFAULT                 (_TIMER_ROUTE_CC0PEN_DEFAULT << 0)    /**< Shifted mode DEFAULT for TIMER_ROUTE */
+#define TIMER_ROUTE_CC1PEN                         (0x1UL << 1)                          /**< CC Channel 1 Pin Enable */
+#define _TIMER_ROUTE_CC1PEN_SHIFT                  1                                     /**< Shift value for TIMER_CC1PEN */
+#define _TIMER_ROUTE_CC1PEN_MASK                   0x2UL                                 /**< Bit mask for TIMER_CC1PEN */
+#define _TIMER_ROUTE_CC1PEN_DEFAULT                0x00000000UL                          /**< Mode DEFAULT for TIMER_ROUTE */
+#define TIMER_ROUTE_CC1PEN_DEFAULT                 (_TIMER_ROUTE_CC1PEN_DEFAULT << 1)    /**< Shifted mode DEFAULT for TIMER_ROUTE */
+#define TIMER_ROUTE_CC2PEN                         (0x1UL << 2)                          /**< CC Channel 2 Pin Enable */
+#define _TIMER_ROUTE_CC2PEN_SHIFT                  2                                     /**< Shift value for TIMER_CC2PEN */
+#define _TIMER_ROUTE_CC2PEN_MASK                   0x4UL                                 /**< Bit mask for TIMER_CC2PEN */
+#define _TIMER_ROUTE_CC2PEN_DEFAULT                0x00000000UL                          /**< Mode DEFAULT for TIMER_ROUTE */
+#define TIMER_ROUTE_CC2PEN_DEFAULT                 (_TIMER_ROUTE_CC2PEN_DEFAULT << 2)    /**< Shifted mode DEFAULT for TIMER_ROUTE */
+#define _TIMER_ROUTE_LOCATION_SHIFT                16                                    /**< Shift value for TIMER_LOCATION */
+#define _TIMER_ROUTE_LOCATION_MASK                 0x70000UL                             /**< Bit mask for TIMER_LOCATION */
+#define _TIMER_ROUTE_LOCATION_LOC0                 0x00000000UL                          /**< Mode LOC0 for TIMER_ROUTE */
+#define _TIMER_ROUTE_LOCATION_DEFAULT              0x00000000UL                          /**< Mode DEFAULT for TIMER_ROUTE */
+#define _TIMER_ROUTE_LOCATION_LOC1                 0x00000001UL                          /**< Mode LOC1 for TIMER_ROUTE */
+#define _TIMER_ROUTE_LOCATION_LOC2                 0x00000002UL                          /**< Mode LOC2 for TIMER_ROUTE */
+#define _TIMER_ROUTE_LOCATION_LOC3                 0x00000003UL                          /**< Mode LOC3 for TIMER_ROUTE */
+#define _TIMER_ROUTE_LOCATION_LOC4                 0x00000004UL                          /**< Mode LOC4 for TIMER_ROUTE */
+#define _TIMER_ROUTE_LOCATION_LOC5                 0x00000005UL                          /**< Mode LOC5 for TIMER_ROUTE */
+#define TIMER_ROUTE_LOCATION_LOC0                  (_TIMER_ROUTE_LOCATION_LOC0 << 16)    /**< Shifted mode LOC0 for TIMER_ROUTE */
+#define TIMER_ROUTE_LOCATION_DEFAULT               (_TIMER_ROUTE_LOCATION_DEFAULT << 16) /**< Shifted mode DEFAULT for TIMER_ROUTE */
+#define TIMER_ROUTE_LOCATION_LOC1                  (_TIMER_ROUTE_LOCATION_LOC1 << 16)    /**< Shifted mode LOC1 for TIMER_ROUTE */
+#define TIMER_ROUTE_LOCATION_LOC2                  (_TIMER_ROUTE_LOCATION_LOC2 << 16)    /**< Shifted mode LOC2 for TIMER_ROUTE */
+#define TIMER_ROUTE_LOCATION_LOC3                  (_TIMER_ROUTE_LOCATION_LOC3 << 16)    /**< Shifted mode LOC3 for TIMER_ROUTE */
+#define TIMER_ROUTE_LOCATION_LOC4                  (_TIMER_ROUTE_LOCATION_LOC4 << 16)    /**< Shifted mode LOC4 for TIMER_ROUTE */
+#define TIMER_ROUTE_LOCATION_LOC5                  (_TIMER_ROUTE_LOCATION_LOC5 << 16)    /**< Shifted mode LOC5 for TIMER_ROUTE */
+
+/* Bit fields for TIMER CC_CTRL */
+#define _TIMER_CC_CTRL_RESETVALUE                  0x00000000UL                                    /**< Default value for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_MASK                        0x0F373F17UL                                    /**< Mask for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_MODE_SHIFT                  0                                               /**< Shift value for TIMER_MODE */
+#define _TIMER_CC_CTRL_MODE_MASK                   0x3UL                                           /**< Bit mask for TIMER_MODE */
+#define _TIMER_CC_CTRL_MODE_DEFAULT                0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_MODE_OFF                    0x00000000UL                                    /**< Mode OFF for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_MODE_INPUTCAPTURE           0x00000001UL                                    /**< Mode INPUTCAPTURE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_MODE_OUTPUTCOMPARE          0x00000002UL                                    /**< Mode OUTPUTCOMPARE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_MODE_PWM                    0x00000003UL                                    /**< Mode PWM for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_MODE_DEFAULT                 (_TIMER_CC_CTRL_MODE_DEFAULT << 0)              /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_MODE_OFF                     (_TIMER_CC_CTRL_MODE_OFF << 0)                  /**< Shifted mode OFF for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_MODE_INPUTCAPTURE            (_TIMER_CC_CTRL_MODE_INPUTCAPTURE << 0)         /**< Shifted mode INPUTCAPTURE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_MODE_OUTPUTCOMPARE           (_TIMER_CC_CTRL_MODE_OUTPUTCOMPARE << 0)        /**< Shifted mode OUTPUTCOMPARE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_MODE_PWM                     (_TIMER_CC_CTRL_MODE_PWM << 0)                  /**< Shifted mode PWM for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_OUTINV                       (0x1UL << 2)                                    /**< Output Invert */
+#define _TIMER_CC_CTRL_OUTINV_SHIFT                2                                               /**< Shift value for TIMER_OUTINV */
+#define _TIMER_CC_CTRL_OUTINV_MASK                 0x4UL                                           /**< Bit mask for TIMER_OUTINV */
+#define _TIMER_CC_CTRL_OUTINV_DEFAULT              0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_OUTINV_DEFAULT               (_TIMER_CC_CTRL_OUTINV_DEFAULT << 2)            /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_COIST                        (0x1UL << 4)                                    /**< Compare Output Initial State */
+#define _TIMER_CC_CTRL_COIST_SHIFT                 4                                               /**< Shift value for TIMER_COIST */
+#define _TIMER_CC_CTRL_COIST_MASK                  0x10UL                                          /**< Bit mask for TIMER_COIST */
+#define _TIMER_CC_CTRL_COIST_DEFAULT               0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_COIST_DEFAULT                (_TIMER_CC_CTRL_COIST_DEFAULT << 4)             /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CMOA_SHIFT                  8                                               /**< Shift value for TIMER_CMOA */
+#define _TIMER_CC_CTRL_CMOA_MASK                   0x300UL                                         /**< Bit mask for TIMER_CMOA */
+#define _TIMER_CC_CTRL_CMOA_DEFAULT                0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CMOA_NONE                   0x00000000UL                                    /**< Mode NONE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CMOA_TOGGLE                 0x00000001UL                                    /**< Mode TOGGLE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CMOA_CLEAR                  0x00000002UL                                    /**< Mode CLEAR for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CMOA_SET                    0x00000003UL                                    /**< Mode SET for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CMOA_DEFAULT                 (_TIMER_CC_CTRL_CMOA_DEFAULT << 8)              /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CMOA_NONE                    (_TIMER_CC_CTRL_CMOA_NONE << 8)                 /**< Shifted mode NONE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CMOA_TOGGLE                  (_TIMER_CC_CTRL_CMOA_TOGGLE << 8)               /**< Shifted mode TOGGLE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CMOA_CLEAR                   (_TIMER_CC_CTRL_CMOA_CLEAR << 8)                /**< Shifted mode CLEAR for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CMOA_SET                     (_TIMER_CC_CTRL_CMOA_SET << 8)                  /**< Shifted mode SET for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_COFOA_SHIFT                 10                                              /**< Shift value for TIMER_COFOA */
+#define _TIMER_CC_CTRL_COFOA_MASK                  0xC00UL                                         /**< Bit mask for TIMER_COFOA */
+#define _TIMER_CC_CTRL_COFOA_DEFAULT               0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_COFOA_NONE                  0x00000000UL                                    /**< Mode NONE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_COFOA_TOGGLE                0x00000001UL                                    /**< Mode TOGGLE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_COFOA_CLEAR                 0x00000002UL                                    /**< Mode CLEAR for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_COFOA_SET                   0x00000003UL                                    /**< Mode SET for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_COFOA_DEFAULT                (_TIMER_CC_CTRL_COFOA_DEFAULT << 10)            /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_COFOA_NONE                   (_TIMER_CC_CTRL_COFOA_NONE << 10)               /**< Shifted mode NONE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_COFOA_TOGGLE                 (_TIMER_CC_CTRL_COFOA_TOGGLE << 10)             /**< Shifted mode TOGGLE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_COFOA_CLEAR                  (_TIMER_CC_CTRL_COFOA_CLEAR << 10)              /**< Shifted mode CLEAR for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_COFOA_SET                    (_TIMER_CC_CTRL_COFOA_SET << 10)                /**< Shifted mode SET for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CUFOA_SHIFT                 12                                              /**< Shift value for TIMER_CUFOA */
+#define _TIMER_CC_CTRL_CUFOA_MASK                  0x3000UL                                        /**< Bit mask for TIMER_CUFOA */
+#define _TIMER_CC_CTRL_CUFOA_DEFAULT               0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CUFOA_NONE                  0x00000000UL                                    /**< Mode NONE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CUFOA_TOGGLE                0x00000001UL                                    /**< Mode TOGGLE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CUFOA_CLEAR                 0x00000002UL                                    /**< Mode CLEAR for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_CUFOA_SET                   0x00000003UL                                    /**< Mode SET for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CUFOA_DEFAULT                (_TIMER_CC_CTRL_CUFOA_DEFAULT << 12)            /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CUFOA_NONE                   (_TIMER_CC_CTRL_CUFOA_NONE << 12)               /**< Shifted mode NONE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CUFOA_TOGGLE                 (_TIMER_CC_CTRL_CUFOA_TOGGLE << 12)             /**< Shifted mode TOGGLE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CUFOA_CLEAR                  (_TIMER_CC_CTRL_CUFOA_CLEAR << 12)              /**< Shifted mode CLEAR for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_CUFOA_SET                    (_TIMER_CC_CTRL_CUFOA_SET << 12)                /**< Shifted mode SET for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_PRSSEL_SHIFT                16                                              /**< Shift value for TIMER_PRSSEL */
+#define _TIMER_CC_CTRL_PRSSEL_MASK                 0x70000UL                                       /**< Bit mask for TIMER_PRSSEL */
+#define _TIMER_CC_CTRL_PRSSEL_DEFAULT              0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_PRSSEL_PRSCH0               0x00000000UL                                    /**< Mode PRSCH0 for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_PRSSEL_PRSCH1               0x00000001UL                                    /**< Mode PRSCH1 for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_PRSSEL_PRSCH2               0x00000002UL                                    /**< Mode PRSCH2 for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_PRSSEL_PRSCH3               0x00000003UL                                    /**< Mode PRSCH3 for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_PRSSEL_PRSCH4               0x00000004UL                                    /**< Mode PRSCH4 for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_PRSSEL_PRSCH5               0x00000005UL                                    /**< Mode PRSCH5 for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_PRSSEL_PRSCH6               0x00000006UL                                    /**< Mode PRSCH6 for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_PRSSEL_PRSCH7               0x00000007UL                                    /**< Mode PRSCH7 for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_PRSSEL_DEFAULT               (_TIMER_CC_CTRL_PRSSEL_DEFAULT << 16)           /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_PRSSEL_PRSCH0                (_TIMER_CC_CTRL_PRSSEL_PRSCH0 << 16)            /**< Shifted mode PRSCH0 for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_PRSSEL_PRSCH1                (_TIMER_CC_CTRL_PRSSEL_PRSCH1 << 16)            /**< Shifted mode PRSCH1 for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_PRSSEL_PRSCH2                (_TIMER_CC_CTRL_PRSSEL_PRSCH2 << 16)            /**< Shifted mode PRSCH2 for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_PRSSEL_PRSCH3                (_TIMER_CC_CTRL_PRSSEL_PRSCH3 << 16)            /**< Shifted mode PRSCH3 for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_PRSSEL_PRSCH4                (_TIMER_CC_CTRL_PRSSEL_PRSCH4 << 16)            /**< Shifted mode PRSCH4 for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_PRSSEL_PRSCH5                (_TIMER_CC_CTRL_PRSSEL_PRSCH5 << 16)            /**< Shifted mode PRSCH5 for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_PRSSEL_PRSCH6                (_TIMER_CC_CTRL_PRSSEL_PRSCH6 << 16)            /**< Shifted mode PRSCH6 for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_PRSSEL_PRSCH7                (_TIMER_CC_CTRL_PRSSEL_PRSCH7 << 16)            /**< Shifted mode PRSCH7 for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_INSEL                        (0x1UL << 20)                                   /**< Input Selection */
+#define _TIMER_CC_CTRL_INSEL_SHIFT                 20                                              /**< Shift value for TIMER_INSEL */
+#define _TIMER_CC_CTRL_INSEL_MASK                  0x100000UL                                      /**< Bit mask for TIMER_INSEL */
+#define _TIMER_CC_CTRL_INSEL_DEFAULT               0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_INSEL_PIN                   0x00000000UL                                    /**< Mode PIN for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_INSEL_PRS                   0x00000001UL                                    /**< Mode PRS for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_INSEL_DEFAULT                (_TIMER_CC_CTRL_INSEL_DEFAULT << 20)            /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_INSEL_PIN                    (_TIMER_CC_CTRL_INSEL_PIN << 20)                /**< Shifted mode PIN for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_INSEL_PRS                    (_TIMER_CC_CTRL_INSEL_PRS << 20)                /**< Shifted mode PRS for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_FILT                         (0x1UL << 21)                                   /**< Digital Filter */
+#define _TIMER_CC_CTRL_FILT_SHIFT                  21                                              /**< Shift value for TIMER_FILT */
+#define _TIMER_CC_CTRL_FILT_MASK                   0x200000UL                                      /**< Bit mask for TIMER_FILT */
+#define _TIMER_CC_CTRL_FILT_DEFAULT                0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_FILT_DISABLE                0x00000000UL                                    /**< Mode DISABLE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_FILT_ENABLE                 0x00000001UL                                    /**< Mode ENABLE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_FILT_DEFAULT                 (_TIMER_CC_CTRL_FILT_DEFAULT << 21)             /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_FILT_DISABLE                 (_TIMER_CC_CTRL_FILT_DISABLE << 21)             /**< Shifted mode DISABLE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_FILT_ENABLE                  (_TIMER_CC_CTRL_FILT_ENABLE << 21)              /**< Shifted mode ENABLE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEDGE_SHIFT                24                                              /**< Shift value for TIMER_ICEDGE */
+#define _TIMER_CC_CTRL_ICEDGE_MASK                 0x3000000UL                                     /**< Bit mask for TIMER_ICEDGE */
+#define _TIMER_CC_CTRL_ICEDGE_DEFAULT              0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEDGE_RISING               0x00000000UL                                    /**< Mode RISING for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEDGE_FALLING              0x00000001UL                                    /**< Mode FALLING for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEDGE_BOTH                 0x00000002UL                                    /**< Mode BOTH for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEDGE_NONE                 0x00000003UL                                    /**< Mode NONE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEDGE_DEFAULT               (_TIMER_CC_CTRL_ICEDGE_DEFAULT << 24)           /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEDGE_RISING                (_TIMER_CC_CTRL_ICEDGE_RISING << 24)            /**< Shifted mode RISING for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEDGE_FALLING               (_TIMER_CC_CTRL_ICEDGE_FALLING << 24)           /**< Shifted mode FALLING for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEDGE_BOTH                  (_TIMER_CC_CTRL_ICEDGE_BOTH << 24)              /**< Shifted mode BOTH for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEDGE_NONE                  (_TIMER_CC_CTRL_ICEDGE_NONE << 24)              /**< Shifted mode NONE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEVCTRL_SHIFT              26                                              /**< Shift value for TIMER_ICEVCTRL */
+#define _TIMER_CC_CTRL_ICEVCTRL_MASK               0xC000000UL                                     /**< Bit mask for TIMER_ICEVCTRL */
+#define _TIMER_CC_CTRL_ICEVCTRL_DEFAULT            0x00000000UL                                    /**< Mode DEFAULT for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEVCTRL_EVERYEDGE          0x00000000UL                                    /**< Mode EVERYEDGE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEVCTRL_EVERYSECONDEDGE    0x00000001UL                                    /**< Mode EVERYSECONDEDGE for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEVCTRL_RISING             0x00000002UL                                    /**< Mode RISING for TIMER_CC_CTRL */
+#define _TIMER_CC_CTRL_ICEVCTRL_FALLING            0x00000003UL                                    /**< Mode FALLING for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEVCTRL_DEFAULT             (_TIMER_CC_CTRL_ICEVCTRL_DEFAULT << 26)         /**< Shifted mode DEFAULT for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEVCTRL_EVERYEDGE           (_TIMER_CC_CTRL_ICEVCTRL_EVERYEDGE << 26)       /**< Shifted mode EVERYEDGE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEVCTRL_EVERYSECONDEDGE     (_TIMER_CC_CTRL_ICEVCTRL_EVERYSECONDEDGE << 26) /**< Shifted mode EVERYSECONDEDGE for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEVCTRL_RISING              (_TIMER_CC_CTRL_ICEVCTRL_RISING << 26)          /**< Shifted mode RISING for TIMER_CC_CTRL */
+#define TIMER_CC_CTRL_ICEVCTRL_FALLING             (_TIMER_CC_CTRL_ICEVCTRL_FALLING << 26)         /**< Shifted mode FALLING for TIMER_CC_CTRL */
+
+/* Bit fields for TIMER CC_CCV */
+#define _TIMER_CC_CCV_RESETVALUE                   0x00000000UL                     /**< Default value for TIMER_CC_CCV */
+#define _TIMER_CC_CCV_MASK                         0x0000FFFFUL                     /**< Mask for TIMER_CC_CCV */
+#define _TIMER_CC_CCV_CCV_SHIFT                    0                                /**< Shift value for TIMER_CCV */
+#define _TIMER_CC_CCV_CCV_MASK                     0xFFFFUL                         /**< Bit mask for TIMER_CCV */
+#define _TIMER_CC_CCV_CCV_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for TIMER_CC_CCV */
+#define TIMER_CC_CCV_CCV_DEFAULT                   (_TIMER_CC_CCV_CCV_DEFAULT << 0) /**< Shifted mode DEFAULT for TIMER_CC_CCV */
+
+/* Bit fields for TIMER CC_CCVP */
+#define _TIMER_CC_CCVP_RESETVALUE                  0x00000000UL                       /**< Default value for TIMER_CC_CCVP */
+#define _TIMER_CC_CCVP_MASK                        0x0000FFFFUL                       /**< Mask for TIMER_CC_CCVP */
+#define _TIMER_CC_CCVP_CCVP_SHIFT                  0                                  /**< Shift value for TIMER_CCVP */
+#define _TIMER_CC_CCVP_CCVP_MASK                   0xFFFFUL                           /**< Bit mask for TIMER_CCVP */
+#define _TIMER_CC_CCVP_CCVP_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for TIMER_CC_CCVP */
+#define TIMER_CC_CCVP_CCVP_DEFAULT                 (_TIMER_CC_CCVP_CCVP_DEFAULT << 0) /**< Shifted mode DEFAULT for TIMER_CC_CCVP */
+
+/* Bit fields for TIMER CC_CCVB */
+#define _TIMER_CC_CCVB_RESETVALUE                  0x00000000UL                       /**< Default value for TIMER_CC_CCVB */
+#define _TIMER_CC_CCVB_MASK                        0x0000FFFFUL                       /**< Mask for TIMER_CC_CCVB */
+#define _TIMER_CC_CCVB_CCVB_SHIFT                  0                                  /**< Shift value for TIMER_CCVB */
+#define _TIMER_CC_CCVB_CCVB_MASK                   0xFFFFUL                           /**< Bit mask for TIMER_CCVB */
+#define _TIMER_CC_CCVB_CCVB_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for TIMER_CC_CCVB */
+#define TIMER_CC_CCVB_CCVB_DEFAULT                 (_TIMER_CC_CCVB_CCVB_DEFAULT << 0) /**< Shifted mode DEFAULT for TIMER_CC_CCVB */
+
+/** @} End of group EFM32TG_TIMER */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_timer_cc.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_timer_cc.h
@@ -1,0 +1,51 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_TIMER_CC register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @brief TIMER_CC EFM32TG TIMER CC
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL; /**< CC Channel Control Register  */
+  __IOM uint32_t CCV;  /**< CC Channel Value Register  */
+  __IM uint32_t  CCVP; /**< CC Channel Value Peek Register  */
+  __IOM uint32_t CCVB; /**< CC Channel Buffer Register  */
+} TIMER_CC_TypeDef;
+
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_usart.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_usart.h
@@ -1,0 +1,1148 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_USART register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_USART
+ * @brief EFM32TG_USART Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;       /**< Control Register  */
+  __IOM uint32_t FRAME;      /**< USART Frame Format Register  */
+  __IOM uint32_t TRIGCTRL;   /**< USART Trigger Control register  */
+  __IOM uint32_t CMD;        /**< Command Register  */
+  __IM uint32_t  STATUS;     /**< USART Status Register  */
+  __IOM uint32_t CLKDIV;     /**< Clock Control Register  */
+  __IM uint32_t  RXDATAX;    /**< RX Buffer Data Extended Register  */
+  __IM uint32_t  RXDATA;     /**< RX Buffer Data Register  */
+  __IM uint32_t  RXDOUBLEX;  /**< RX Buffer Double Data Extended Register  */
+  __IM uint32_t  RXDOUBLE;   /**< RX FIFO Double Data Register  */
+  __IM uint32_t  RXDATAXP;   /**< RX Buffer Data Extended Peek Register  */
+  __IM uint32_t  RXDOUBLEXP; /**< RX Buffer Double Data Extended Peek Register  */
+  __IOM uint32_t TXDATAX;    /**< TX Buffer Data Extended Register  */
+  __IOM uint32_t TXDATA;     /**< TX Buffer Data Register  */
+  __IOM uint32_t TXDOUBLEX;  /**< TX Buffer Double Data Extended Register  */
+  __IOM uint32_t TXDOUBLE;   /**< TX Buffer Double Data Register  */
+  __IM uint32_t  IF;         /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;        /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;        /**< Interrupt Flag Clear Register  */
+  __IOM uint32_t IEN;        /**< Interrupt Enable Register  */
+  __IOM uint32_t IRCTRL;     /**< IrDA Control Register  */
+  __IOM uint32_t ROUTE;      /**< I/O Routing Register  */
+  __IOM uint32_t INPUT;      /**< USART Input Register  */
+  __IOM uint32_t I2SCTRL;    /**< I2S Control Register  */
+} USART_TypeDef;             /**< USART Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_USART_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for USART CTRL */
+#define _USART_CTRL_RESETVALUE                0x00000000UL                             /**< Default value for USART_CTRL */
+#define _USART_CTRL_MASK                      0x7DFFFF7FUL                             /**< Mask for USART_CTRL */
+#define USART_CTRL_SYNC                       (0x1UL << 0)                             /**< USART Synchronous Mode */
+#define _USART_CTRL_SYNC_SHIFT                0                                        /**< Shift value for USART_SYNC */
+#define _USART_CTRL_SYNC_MASK                 0x1UL                                    /**< Bit mask for USART_SYNC */
+#define _USART_CTRL_SYNC_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_SYNC_DEFAULT               (_USART_CTRL_SYNC_DEFAULT << 0)          /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_LOOPBK                     (0x1UL << 1)                             /**< Loopback Enable */
+#define _USART_CTRL_LOOPBK_SHIFT              1                                        /**< Shift value for USART_LOOPBK */
+#define _USART_CTRL_LOOPBK_MASK               0x2UL                                    /**< Bit mask for USART_LOOPBK */
+#define _USART_CTRL_LOOPBK_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_LOOPBK_DEFAULT             (_USART_CTRL_LOOPBK_DEFAULT << 1)        /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_CCEN                       (0x1UL << 2)                             /**< Collision Check Enable */
+#define _USART_CTRL_CCEN_SHIFT                2                                        /**< Shift value for USART_CCEN */
+#define _USART_CTRL_CCEN_MASK                 0x4UL                                    /**< Bit mask for USART_CCEN */
+#define _USART_CTRL_CCEN_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_CCEN_DEFAULT               (_USART_CTRL_CCEN_DEFAULT << 2)          /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_MPM                        (0x1UL << 3)                             /**< Multi-Processor Mode */
+#define _USART_CTRL_MPM_SHIFT                 3                                        /**< Shift value for USART_MPM */
+#define _USART_CTRL_MPM_MASK                  0x8UL                                    /**< Bit mask for USART_MPM */
+#define _USART_CTRL_MPM_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_MPM_DEFAULT                (_USART_CTRL_MPM_DEFAULT << 3)           /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_MPAB                       (0x1UL << 4)                             /**< Multi-Processor Address-Bit */
+#define _USART_CTRL_MPAB_SHIFT                4                                        /**< Shift value for USART_MPAB */
+#define _USART_CTRL_MPAB_MASK                 0x10UL                                   /**< Bit mask for USART_MPAB */
+#define _USART_CTRL_MPAB_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_MPAB_DEFAULT               (_USART_CTRL_MPAB_DEFAULT << 4)          /**< Shifted mode DEFAULT for USART_CTRL */
+#define _USART_CTRL_OVS_SHIFT                 5                                        /**< Shift value for USART_OVS */
+#define _USART_CTRL_OVS_MASK                  0x60UL                                   /**< Bit mask for USART_OVS */
+#define _USART_CTRL_OVS_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define _USART_CTRL_OVS_X16                   0x00000000UL                             /**< Mode X16 for USART_CTRL */
+#define _USART_CTRL_OVS_X8                    0x00000001UL                             /**< Mode X8 for USART_CTRL */
+#define _USART_CTRL_OVS_X6                    0x00000002UL                             /**< Mode X6 for USART_CTRL */
+#define _USART_CTRL_OVS_X4                    0x00000003UL                             /**< Mode X4 for USART_CTRL */
+#define USART_CTRL_OVS_DEFAULT                (_USART_CTRL_OVS_DEFAULT << 5)           /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_OVS_X16                    (_USART_CTRL_OVS_X16 << 5)               /**< Shifted mode X16 for USART_CTRL */
+#define USART_CTRL_OVS_X8                     (_USART_CTRL_OVS_X8 << 5)                /**< Shifted mode X8 for USART_CTRL */
+#define USART_CTRL_OVS_X6                     (_USART_CTRL_OVS_X6 << 5)                /**< Shifted mode X6 for USART_CTRL */
+#define USART_CTRL_OVS_X4                     (_USART_CTRL_OVS_X4 << 5)                /**< Shifted mode X4 for USART_CTRL */
+#define USART_CTRL_CLKPOL                     (0x1UL << 8)                             /**< Clock Polarity */
+#define _USART_CTRL_CLKPOL_SHIFT              8                                        /**< Shift value for USART_CLKPOL */
+#define _USART_CTRL_CLKPOL_MASK               0x100UL                                  /**< Bit mask for USART_CLKPOL */
+#define _USART_CTRL_CLKPOL_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define _USART_CTRL_CLKPOL_IDLELOW            0x00000000UL                             /**< Mode IDLELOW for USART_CTRL */
+#define _USART_CTRL_CLKPOL_IDLEHIGH           0x00000001UL                             /**< Mode IDLEHIGH for USART_CTRL */
+#define USART_CTRL_CLKPOL_DEFAULT             (_USART_CTRL_CLKPOL_DEFAULT << 8)        /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_CLKPOL_IDLELOW             (_USART_CTRL_CLKPOL_IDLELOW << 8)        /**< Shifted mode IDLELOW for USART_CTRL */
+#define USART_CTRL_CLKPOL_IDLEHIGH            (_USART_CTRL_CLKPOL_IDLEHIGH << 8)       /**< Shifted mode IDLEHIGH for USART_CTRL */
+#define USART_CTRL_CLKPHA                     (0x1UL << 9)                             /**< Clock Edge For Setup/Sample */
+#define _USART_CTRL_CLKPHA_SHIFT              9                                        /**< Shift value for USART_CLKPHA */
+#define _USART_CTRL_CLKPHA_MASK               0x200UL                                  /**< Bit mask for USART_CLKPHA */
+#define _USART_CTRL_CLKPHA_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define _USART_CTRL_CLKPHA_SAMPLELEADING      0x00000000UL                             /**< Mode SAMPLELEADING for USART_CTRL */
+#define _USART_CTRL_CLKPHA_SAMPLETRAILING     0x00000001UL                             /**< Mode SAMPLETRAILING for USART_CTRL */
+#define USART_CTRL_CLKPHA_DEFAULT             (_USART_CTRL_CLKPHA_DEFAULT << 9)        /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_CLKPHA_SAMPLELEADING       (_USART_CTRL_CLKPHA_SAMPLELEADING << 9)  /**< Shifted mode SAMPLELEADING for USART_CTRL */
+#define USART_CTRL_CLKPHA_SAMPLETRAILING      (_USART_CTRL_CLKPHA_SAMPLETRAILING << 9) /**< Shifted mode SAMPLETRAILING for USART_CTRL */
+#define USART_CTRL_MSBF                       (0x1UL << 10)                            /**< Most Significant Bit First */
+#define _USART_CTRL_MSBF_SHIFT                10                                       /**< Shift value for USART_MSBF */
+#define _USART_CTRL_MSBF_MASK                 0x400UL                                  /**< Bit mask for USART_MSBF */
+#define _USART_CTRL_MSBF_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_MSBF_DEFAULT               (_USART_CTRL_MSBF_DEFAULT << 10)         /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_CSMA                       (0x1UL << 11)                            /**< Action On Slave-Select In Master Mode */
+#define _USART_CTRL_CSMA_SHIFT                11                                       /**< Shift value for USART_CSMA */
+#define _USART_CTRL_CSMA_MASK                 0x800UL                                  /**< Bit mask for USART_CSMA */
+#define _USART_CTRL_CSMA_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define _USART_CTRL_CSMA_NOACTION             0x00000000UL                             /**< Mode NOACTION for USART_CTRL */
+#define _USART_CTRL_CSMA_GOTOSLAVEMODE        0x00000001UL                             /**< Mode GOTOSLAVEMODE for USART_CTRL */
+#define USART_CTRL_CSMA_DEFAULT               (_USART_CTRL_CSMA_DEFAULT << 11)         /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_CSMA_NOACTION              (_USART_CTRL_CSMA_NOACTION << 11)        /**< Shifted mode NOACTION for USART_CTRL */
+#define USART_CTRL_CSMA_GOTOSLAVEMODE         (_USART_CTRL_CSMA_GOTOSLAVEMODE << 11)   /**< Shifted mode GOTOSLAVEMODE for USART_CTRL */
+#define USART_CTRL_TXBIL                      (0x1UL << 12)                            /**< TX Buffer Interrupt Level */
+#define _USART_CTRL_TXBIL_SHIFT               12                                       /**< Shift value for USART_TXBIL */
+#define _USART_CTRL_TXBIL_MASK                0x1000UL                                 /**< Bit mask for USART_TXBIL */
+#define _USART_CTRL_TXBIL_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define _USART_CTRL_TXBIL_EMPTY               0x00000000UL                             /**< Mode EMPTY for USART_CTRL */
+#define _USART_CTRL_TXBIL_HALFFULL            0x00000001UL                             /**< Mode HALFFULL for USART_CTRL */
+#define USART_CTRL_TXBIL_DEFAULT              (_USART_CTRL_TXBIL_DEFAULT << 12)        /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_TXBIL_EMPTY                (_USART_CTRL_TXBIL_EMPTY << 12)          /**< Shifted mode EMPTY for USART_CTRL */
+#define USART_CTRL_TXBIL_HALFFULL             (_USART_CTRL_TXBIL_HALFFULL << 12)       /**< Shifted mode HALFFULL for USART_CTRL */
+#define USART_CTRL_RXINV                      (0x1UL << 13)                            /**< Receiver Input Invert */
+#define _USART_CTRL_RXINV_SHIFT               13                                       /**< Shift value for USART_RXINV */
+#define _USART_CTRL_RXINV_MASK                0x2000UL                                 /**< Bit mask for USART_RXINV */
+#define _USART_CTRL_RXINV_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_RXINV_DEFAULT              (_USART_CTRL_RXINV_DEFAULT << 13)        /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_TXINV                      (0x1UL << 14)                            /**< Transmitter output Invert */
+#define _USART_CTRL_TXINV_SHIFT               14                                       /**< Shift value for USART_TXINV */
+#define _USART_CTRL_TXINV_MASK                0x4000UL                                 /**< Bit mask for USART_TXINV */
+#define _USART_CTRL_TXINV_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_TXINV_DEFAULT              (_USART_CTRL_TXINV_DEFAULT << 14)        /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_CSINV                      (0x1UL << 15)                            /**< Chip Select Invert */
+#define _USART_CTRL_CSINV_SHIFT               15                                       /**< Shift value for USART_CSINV */
+#define _USART_CTRL_CSINV_MASK                0x8000UL                                 /**< Bit mask for USART_CSINV */
+#define _USART_CTRL_CSINV_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_CSINV_DEFAULT              (_USART_CTRL_CSINV_DEFAULT << 15)        /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_AUTOCS                     (0x1UL << 16)                            /**< Automatic Chip Select */
+#define _USART_CTRL_AUTOCS_SHIFT              16                                       /**< Shift value for USART_AUTOCS */
+#define _USART_CTRL_AUTOCS_MASK               0x10000UL                                /**< Bit mask for USART_AUTOCS */
+#define _USART_CTRL_AUTOCS_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_AUTOCS_DEFAULT             (_USART_CTRL_AUTOCS_DEFAULT << 16)       /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_AUTOTRI                    (0x1UL << 17)                            /**< Automatic TX Tristate */
+#define _USART_CTRL_AUTOTRI_SHIFT             17                                       /**< Shift value for USART_AUTOTRI */
+#define _USART_CTRL_AUTOTRI_MASK              0x20000UL                                /**< Bit mask for USART_AUTOTRI */
+#define _USART_CTRL_AUTOTRI_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_AUTOTRI_DEFAULT            (_USART_CTRL_AUTOTRI_DEFAULT << 17)      /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_SCMODE                     (0x1UL << 18)                            /**< SmartCard Mode */
+#define _USART_CTRL_SCMODE_SHIFT              18                                       /**< Shift value for USART_SCMODE */
+#define _USART_CTRL_SCMODE_MASK               0x40000UL                                /**< Bit mask for USART_SCMODE */
+#define _USART_CTRL_SCMODE_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_SCMODE_DEFAULT             (_USART_CTRL_SCMODE_DEFAULT << 18)       /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_SCRETRANS                  (0x1UL << 19)                            /**< SmartCard Retransmit */
+#define _USART_CTRL_SCRETRANS_SHIFT           19                                       /**< Shift value for USART_SCRETRANS */
+#define _USART_CTRL_SCRETRANS_MASK            0x80000UL                                /**< Bit mask for USART_SCRETRANS */
+#define _USART_CTRL_SCRETRANS_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_SCRETRANS_DEFAULT          (_USART_CTRL_SCRETRANS_DEFAULT << 19)    /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_SKIPPERRF                  (0x1UL << 20)                            /**< Skip Parity Error Frames */
+#define _USART_CTRL_SKIPPERRF_SHIFT           20                                       /**< Shift value for USART_SKIPPERRF */
+#define _USART_CTRL_SKIPPERRF_MASK            0x100000UL                               /**< Bit mask for USART_SKIPPERRF */
+#define _USART_CTRL_SKIPPERRF_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_SKIPPERRF_DEFAULT          (_USART_CTRL_SKIPPERRF_DEFAULT << 20)    /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_BIT8DV                     (0x1UL << 21)                            /**< Bit 8 Default Value */
+#define _USART_CTRL_BIT8DV_SHIFT              21                                       /**< Shift value for USART_BIT8DV */
+#define _USART_CTRL_BIT8DV_MASK               0x200000UL                               /**< Bit mask for USART_BIT8DV */
+#define _USART_CTRL_BIT8DV_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_BIT8DV_DEFAULT             (_USART_CTRL_BIT8DV_DEFAULT << 21)       /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_ERRSDMA                    (0x1UL << 22)                            /**< Halt DMA On Error */
+#define _USART_CTRL_ERRSDMA_SHIFT             22                                       /**< Shift value for USART_ERRSDMA */
+#define _USART_CTRL_ERRSDMA_MASK              0x400000UL                               /**< Bit mask for USART_ERRSDMA */
+#define _USART_CTRL_ERRSDMA_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_ERRSDMA_DEFAULT            (_USART_CTRL_ERRSDMA_DEFAULT << 22)      /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_ERRSRX                     (0x1UL << 23)                            /**< Disable RX On Error */
+#define _USART_CTRL_ERRSRX_SHIFT              23                                       /**< Shift value for USART_ERRSRX */
+#define _USART_CTRL_ERRSRX_MASK               0x800000UL                               /**< Bit mask for USART_ERRSRX */
+#define _USART_CTRL_ERRSRX_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_ERRSRX_DEFAULT             (_USART_CTRL_ERRSRX_DEFAULT << 23)       /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_ERRSTX                     (0x1UL << 24)                            /**< Disable TX On Error */
+#define _USART_CTRL_ERRSTX_SHIFT              24                                       /**< Shift value for USART_ERRSTX */
+#define _USART_CTRL_ERRSTX_MASK               0x1000000UL                              /**< Bit mask for USART_ERRSTX */
+#define _USART_CTRL_ERRSTX_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_ERRSTX_DEFAULT             (_USART_CTRL_ERRSTX_DEFAULT << 24)       /**< Shifted mode DEFAULT for USART_CTRL */
+#define _USART_CTRL_TXDELAY_SHIFT             26                                       /**< Shift value for USART_TXDELAY */
+#define _USART_CTRL_TXDELAY_MASK              0xC000000UL                              /**< Bit mask for USART_TXDELAY */
+#define _USART_CTRL_TXDELAY_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define _USART_CTRL_TXDELAY_NONE              0x00000000UL                             /**< Mode NONE for USART_CTRL */
+#define _USART_CTRL_TXDELAY_SINGLE            0x00000001UL                             /**< Mode SINGLE for USART_CTRL */
+#define _USART_CTRL_TXDELAY_DOUBLE            0x00000002UL                             /**< Mode DOUBLE for USART_CTRL */
+#define _USART_CTRL_TXDELAY_TRIPLE            0x00000003UL                             /**< Mode TRIPLE for USART_CTRL */
+#define USART_CTRL_TXDELAY_DEFAULT            (_USART_CTRL_TXDELAY_DEFAULT << 26)      /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_TXDELAY_NONE               (_USART_CTRL_TXDELAY_NONE << 26)         /**< Shifted mode NONE for USART_CTRL */
+#define USART_CTRL_TXDELAY_SINGLE             (_USART_CTRL_TXDELAY_SINGLE << 26)       /**< Shifted mode SINGLE for USART_CTRL */
+#define USART_CTRL_TXDELAY_DOUBLE             (_USART_CTRL_TXDELAY_DOUBLE << 26)       /**< Shifted mode DOUBLE for USART_CTRL */
+#define USART_CTRL_TXDELAY_TRIPLE             (_USART_CTRL_TXDELAY_TRIPLE << 26)       /**< Shifted mode TRIPLE for USART_CTRL */
+#define USART_CTRL_BYTESWAP                   (0x1UL << 28)                            /**< Byteswap In Double Accesses */
+#define _USART_CTRL_BYTESWAP_SHIFT            28                                       /**< Shift value for USART_BYTESWAP */
+#define _USART_CTRL_BYTESWAP_MASK             0x10000000UL                             /**< Bit mask for USART_BYTESWAP */
+#define _USART_CTRL_BYTESWAP_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_BYTESWAP_DEFAULT           (_USART_CTRL_BYTESWAP_DEFAULT << 28)     /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_AUTOTX                     (0x1UL << 29)                            /**< Always Transmit When RX Not Full */
+#define _USART_CTRL_AUTOTX_SHIFT              29                                       /**< Shift value for USART_AUTOTX */
+#define _USART_CTRL_AUTOTX_MASK               0x20000000UL                             /**< Bit mask for USART_AUTOTX */
+#define _USART_CTRL_AUTOTX_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_AUTOTX_DEFAULT             (_USART_CTRL_AUTOTX_DEFAULT << 29)       /**< Shifted mode DEFAULT for USART_CTRL */
+#define USART_CTRL_MVDIS                      (0x1UL << 30)                            /**< Majority Vote Disable */
+#define _USART_CTRL_MVDIS_SHIFT               30                                       /**< Shift value for USART_MVDIS */
+#define _USART_CTRL_MVDIS_MASK                0x40000000UL                             /**< Bit mask for USART_MVDIS */
+#define _USART_CTRL_MVDIS_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
+#define USART_CTRL_MVDIS_DEFAULT              (_USART_CTRL_MVDIS_DEFAULT << 30)        /**< Shifted mode DEFAULT for USART_CTRL */
+
+/* Bit fields for USART FRAME */
+#define _USART_FRAME_RESETVALUE               0x00001005UL                              /**< Default value for USART_FRAME */
+#define _USART_FRAME_MASK                     0x0000330FUL                              /**< Mask for USART_FRAME */
+#define _USART_FRAME_DATABITS_SHIFT           0                                         /**< Shift value for USART_DATABITS */
+#define _USART_FRAME_DATABITS_MASK            0xFUL                                     /**< Bit mask for USART_DATABITS */
+#define _USART_FRAME_DATABITS_FOUR            0x00000001UL                              /**< Mode FOUR for USART_FRAME */
+#define _USART_FRAME_DATABITS_FIVE            0x00000002UL                              /**< Mode FIVE for USART_FRAME */
+#define _USART_FRAME_DATABITS_SIX             0x00000003UL                              /**< Mode SIX for USART_FRAME */
+#define _USART_FRAME_DATABITS_SEVEN           0x00000004UL                              /**< Mode SEVEN for USART_FRAME */
+#define _USART_FRAME_DATABITS_DEFAULT         0x00000005UL                              /**< Mode DEFAULT for USART_FRAME */
+#define _USART_FRAME_DATABITS_EIGHT           0x00000005UL                              /**< Mode EIGHT for USART_FRAME */
+#define _USART_FRAME_DATABITS_NINE            0x00000006UL                              /**< Mode NINE for USART_FRAME */
+#define _USART_FRAME_DATABITS_TEN             0x00000007UL                              /**< Mode TEN for USART_FRAME */
+#define _USART_FRAME_DATABITS_ELEVEN          0x00000008UL                              /**< Mode ELEVEN for USART_FRAME */
+#define _USART_FRAME_DATABITS_TWELVE          0x00000009UL                              /**< Mode TWELVE for USART_FRAME */
+#define _USART_FRAME_DATABITS_THIRTEEN        0x0000000AUL                              /**< Mode THIRTEEN for USART_FRAME */
+#define _USART_FRAME_DATABITS_FOURTEEN        0x0000000BUL                              /**< Mode FOURTEEN for USART_FRAME */
+#define _USART_FRAME_DATABITS_FIFTEEN         0x0000000CUL                              /**< Mode FIFTEEN for USART_FRAME */
+#define _USART_FRAME_DATABITS_SIXTEEN         0x0000000DUL                              /**< Mode SIXTEEN for USART_FRAME */
+#define USART_FRAME_DATABITS_FOUR             (_USART_FRAME_DATABITS_FOUR << 0)         /**< Shifted mode FOUR for USART_FRAME */
+#define USART_FRAME_DATABITS_FIVE             (_USART_FRAME_DATABITS_FIVE << 0)         /**< Shifted mode FIVE for USART_FRAME */
+#define USART_FRAME_DATABITS_SIX              (_USART_FRAME_DATABITS_SIX << 0)          /**< Shifted mode SIX for USART_FRAME */
+#define USART_FRAME_DATABITS_SEVEN            (_USART_FRAME_DATABITS_SEVEN << 0)        /**< Shifted mode SEVEN for USART_FRAME */
+#define USART_FRAME_DATABITS_DEFAULT          (_USART_FRAME_DATABITS_DEFAULT << 0)      /**< Shifted mode DEFAULT for USART_FRAME */
+#define USART_FRAME_DATABITS_EIGHT            (_USART_FRAME_DATABITS_EIGHT << 0)        /**< Shifted mode EIGHT for USART_FRAME */
+#define USART_FRAME_DATABITS_NINE             (_USART_FRAME_DATABITS_NINE << 0)         /**< Shifted mode NINE for USART_FRAME */
+#define USART_FRAME_DATABITS_TEN              (_USART_FRAME_DATABITS_TEN << 0)          /**< Shifted mode TEN for USART_FRAME */
+#define USART_FRAME_DATABITS_ELEVEN           (_USART_FRAME_DATABITS_ELEVEN << 0)       /**< Shifted mode ELEVEN for USART_FRAME */
+#define USART_FRAME_DATABITS_TWELVE           (_USART_FRAME_DATABITS_TWELVE << 0)       /**< Shifted mode TWELVE for USART_FRAME */
+#define USART_FRAME_DATABITS_THIRTEEN         (_USART_FRAME_DATABITS_THIRTEEN << 0)     /**< Shifted mode THIRTEEN for USART_FRAME */
+#define USART_FRAME_DATABITS_FOURTEEN         (_USART_FRAME_DATABITS_FOURTEEN << 0)     /**< Shifted mode FOURTEEN for USART_FRAME */
+#define USART_FRAME_DATABITS_FIFTEEN          (_USART_FRAME_DATABITS_FIFTEEN << 0)      /**< Shifted mode FIFTEEN for USART_FRAME */
+#define USART_FRAME_DATABITS_SIXTEEN          (_USART_FRAME_DATABITS_SIXTEEN << 0)      /**< Shifted mode SIXTEEN for USART_FRAME */
+#define _USART_FRAME_PARITY_SHIFT             8                                         /**< Shift value for USART_PARITY */
+#define _USART_FRAME_PARITY_MASK              0x300UL                                   /**< Bit mask for USART_PARITY */
+#define _USART_FRAME_PARITY_DEFAULT           0x00000000UL                              /**< Mode DEFAULT for USART_FRAME */
+#define _USART_FRAME_PARITY_NONE              0x00000000UL                              /**< Mode NONE for USART_FRAME */
+#define _USART_FRAME_PARITY_EVEN              0x00000002UL                              /**< Mode EVEN for USART_FRAME */
+#define _USART_FRAME_PARITY_ODD               0x00000003UL                              /**< Mode ODD for USART_FRAME */
+#define USART_FRAME_PARITY_DEFAULT            (_USART_FRAME_PARITY_DEFAULT << 8)        /**< Shifted mode DEFAULT for USART_FRAME */
+#define USART_FRAME_PARITY_NONE               (_USART_FRAME_PARITY_NONE << 8)           /**< Shifted mode NONE for USART_FRAME */
+#define USART_FRAME_PARITY_EVEN               (_USART_FRAME_PARITY_EVEN << 8)           /**< Shifted mode EVEN for USART_FRAME */
+#define USART_FRAME_PARITY_ODD                (_USART_FRAME_PARITY_ODD << 8)            /**< Shifted mode ODD for USART_FRAME */
+#define _USART_FRAME_STOPBITS_SHIFT           12                                        /**< Shift value for USART_STOPBITS */
+#define _USART_FRAME_STOPBITS_MASK            0x3000UL                                  /**< Bit mask for USART_STOPBITS */
+#define _USART_FRAME_STOPBITS_HALF            0x00000000UL                              /**< Mode HALF for USART_FRAME */
+#define _USART_FRAME_STOPBITS_DEFAULT         0x00000001UL                              /**< Mode DEFAULT for USART_FRAME */
+#define _USART_FRAME_STOPBITS_ONE             0x00000001UL                              /**< Mode ONE for USART_FRAME */
+#define _USART_FRAME_STOPBITS_ONEANDAHALF     0x00000002UL                              /**< Mode ONEANDAHALF for USART_FRAME */
+#define _USART_FRAME_STOPBITS_TWO             0x00000003UL                              /**< Mode TWO for USART_FRAME */
+#define USART_FRAME_STOPBITS_HALF             (_USART_FRAME_STOPBITS_HALF << 12)        /**< Shifted mode HALF for USART_FRAME */
+#define USART_FRAME_STOPBITS_DEFAULT          (_USART_FRAME_STOPBITS_DEFAULT << 12)     /**< Shifted mode DEFAULT for USART_FRAME */
+#define USART_FRAME_STOPBITS_ONE              (_USART_FRAME_STOPBITS_ONE << 12)         /**< Shifted mode ONE for USART_FRAME */
+#define USART_FRAME_STOPBITS_ONEANDAHALF      (_USART_FRAME_STOPBITS_ONEANDAHALF << 12) /**< Shifted mode ONEANDAHALF for USART_FRAME */
+#define USART_FRAME_STOPBITS_TWO              (_USART_FRAME_STOPBITS_TWO << 12)         /**< Shifted mode TWO for USART_FRAME */
+
+/* Bit fields for USART TRIGCTRL */
+#define _USART_TRIGCTRL_RESETVALUE            0x00000000UL                             /**< Default value for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_MASK                  0x00000077UL                             /**< Mask for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_TSEL_SHIFT            0                                        /**< Shift value for USART_TSEL */
+#define _USART_TRIGCTRL_TSEL_MASK             0x7UL                                    /**< Bit mask for USART_TSEL */
+#define _USART_TRIGCTRL_TSEL_DEFAULT          0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_TSEL_PRSCH0           0x00000000UL                             /**< Mode PRSCH0 for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_TSEL_PRSCH1           0x00000001UL                             /**< Mode PRSCH1 for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_TSEL_PRSCH2           0x00000002UL                             /**< Mode PRSCH2 for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_TSEL_PRSCH3           0x00000003UL                             /**< Mode PRSCH3 for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_TSEL_PRSCH4           0x00000004UL                             /**< Mode PRSCH4 for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_TSEL_PRSCH5           0x00000005UL                             /**< Mode PRSCH5 for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_TSEL_PRSCH6           0x00000006UL                             /**< Mode PRSCH6 for USART_TRIGCTRL */
+#define _USART_TRIGCTRL_TSEL_PRSCH7           0x00000007UL                             /**< Mode PRSCH7 for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TSEL_DEFAULT           (_USART_TRIGCTRL_TSEL_DEFAULT << 0)      /**< Shifted mode DEFAULT for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TSEL_PRSCH0            (_USART_TRIGCTRL_TSEL_PRSCH0 << 0)       /**< Shifted mode PRSCH0 for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TSEL_PRSCH1            (_USART_TRIGCTRL_TSEL_PRSCH1 << 0)       /**< Shifted mode PRSCH1 for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TSEL_PRSCH2            (_USART_TRIGCTRL_TSEL_PRSCH2 << 0)       /**< Shifted mode PRSCH2 for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TSEL_PRSCH3            (_USART_TRIGCTRL_TSEL_PRSCH3 << 0)       /**< Shifted mode PRSCH3 for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TSEL_PRSCH4            (_USART_TRIGCTRL_TSEL_PRSCH4 << 0)       /**< Shifted mode PRSCH4 for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TSEL_PRSCH5            (_USART_TRIGCTRL_TSEL_PRSCH5 << 0)       /**< Shifted mode PRSCH5 for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TSEL_PRSCH6            (_USART_TRIGCTRL_TSEL_PRSCH6 << 0)       /**< Shifted mode PRSCH6 for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TSEL_PRSCH7            (_USART_TRIGCTRL_TSEL_PRSCH7 << 0)       /**< Shifted mode PRSCH7 for USART_TRIGCTRL */
+#define USART_TRIGCTRL_RXTEN                  (0x1UL << 4)                             /**< Receive Trigger Enable */
+#define _USART_TRIGCTRL_RXTEN_SHIFT           4                                        /**< Shift value for USART_RXTEN */
+#define _USART_TRIGCTRL_RXTEN_MASK            0x10UL                                   /**< Bit mask for USART_RXTEN */
+#define _USART_TRIGCTRL_RXTEN_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
+#define USART_TRIGCTRL_RXTEN_DEFAULT          (_USART_TRIGCTRL_RXTEN_DEFAULT << 4)     /**< Shifted mode DEFAULT for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TXTEN                  (0x1UL << 5)                             /**< Transmit Trigger Enable */
+#define _USART_TRIGCTRL_TXTEN_SHIFT           5                                        /**< Shift value for USART_TXTEN */
+#define _USART_TRIGCTRL_TXTEN_MASK            0x20UL                                   /**< Bit mask for USART_TXTEN */
+#define _USART_TRIGCTRL_TXTEN_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
+#define USART_TRIGCTRL_TXTEN_DEFAULT          (_USART_TRIGCTRL_TXTEN_DEFAULT << 5)     /**< Shifted mode DEFAULT for USART_TRIGCTRL */
+#define USART_TRIGCTRL_AUTOTXTEN              (0x1UL << 6)                             /**< AUTOTX Trigger Enable */
+#define _USART_TRIGCTRL_AUTOTXTEN_SHIFT       6                                        /**< Shift value for USART_AUTOTXTEN */
+#define _USART_TRIGCTRL_AUTOTXTEN_MASK        0x40UL                                   /**< Bit mask for USART_AUTOTXTEN */
+#define _USART_TRIGCTRL_AUTOTXTEN_DEFAULT     0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
+#define USART_TRIGCTRL_AUTOTXTEN_DEFAULT      (_USART_TRIGCTRL_AUTOTXTEN_DEFAULT << 6) /**< Shifted mode DEFAULT for USART_TRIGCTRL */
+
+/* Bit fields for USART CMD */
+#define _USART_CMD_RESETVALUE                 0x00000000UL                         /**< Default value for USART_CMD */
+#define _USART_CMD_MASK                       0x00000FFFUL                         /**< Mask for USART_CMD */
+#define USART_CMD_RXEN                        (0x1UL << 0)                         /**< Receiver Enable */
+#define _USART_CMD_RXEN_SHIFT                 0                                    /**< Shift value for USART_RXEN */
+#define _USART_CMD_RXEN_MASK                  0x1UL                                /**< Bit mask for USART_RXEN */
+#define _USART_CMD_RXEN_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_RXEN_DEFAULT                (_USART_CMD_RXEN_DEFAULT << 0)       /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_RXDIS                       (0x1UL << 1)                         /**< Receiver Disable */
+#define _USART_CMD_RXDIS_SHIFT                1                                    /**< Shift value for USART_RXDIS */
+#define _USART_CMD_RXDIS_MASK                 0x2UL                                /**< Bit mask for USART_RXDIS */
+#define _USART_CMD_RXDIS_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_RXDIS_DEFAULT               (_USART_CMD_RXDIS_DEFAULT << 1)      /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_TXEN                        (0x1UL << 2)                         /**< Transmitter Enable */
+#define _USART_CMD_TXEN_SHIFT                 2                                    /**< Shift value for USART_TXEN */
+#define _USART_CMD_TXEN_MASK                  0x4UL                                /**< Bit mask for USART_TXEN */
+#define _USART_CMD_TXEN_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_TXEN_DEFAULT                (_USART_CMD_TXEN_DEFAULT << 2)       /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_TXDIS                       (0x1UL << 3)                         /**< Transmitter Disable */
+#define _USART_CMD_TXDIS_SHIFT                3                                    /**< Shift value for USART_TXDIS */
+#define _USART_CMD_TXDIS_MASK                 0x8UL                                /**< Bit mask for USART_TXDIS */
+#define _USART_CMD_TXDIS_DEFAULT              0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_TXDIS_DEFAULT               (_USART_CMD_TXDIS_DEFAULT << 3)      /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_MASTEREN                    (0x1UL << 4)                         /**< Master Enable */
+#define _USART_CMD_MASTEREN_SHIFT             4                                    /**< Shift value for USART_MASTEREN */
+#define _USART_CMD_MASTEREN_MASK              0x10UL                               /**< Bit mask for USART_MASTEREN */
+#define _USART_CMD_MASTEREN_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_MASTEREN_DEFAULT            (_USART_CMD_MASTEREN_DEFAULT << 4)   /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_MASTERDIS                   (0x1UL << 5)                         /**< Master Disable */
+#define _USART_CMD_MASTERDIS_SHIFT            5                                    /**< Shift value for USART_MASTERDIS */
+#define _USART_CMD_MASTERDIS_MASK             0x20UL                               /**< Bit mask for USART_MASTERDIS */
+#define _USART_CMD_MASTERDIS_DEFAULT          0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_MASTERDIS_DEFAULT           (_USART_CMD_MASTERDIS_DEFAULT << 5)  /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_RXBLOCKEN                   (0x1UL << 6)                         /**< Receiver Block Enable */
+#define _USART_CMD_RXBLOCKEN_SHIFT            6                                    /**< Shift value for USART_RXBLOCKEN */
+#define _USART_CMD_RXBLOCKEN_MASK             0x40UL                               /**< Bit mask for USART_RXBLOCKEN */
+#define _USART_CMD_RXBLOCKEN_DEFAULT          0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_RXBLOCKEN_DEFAULT           (_USART_CMD_RXBLOCKEN_DEFAULT << 6)  /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_RXBLOCKDIS                  (0x1UL << 7)                         /**< Receiver Block Disable */
+#define _USART_CMD_RXBLOCKDIS_SHIFT           7                                    /**< Shift value for USART_RXBLOCKDIS */
+#define _USART_CMD_RXBLOCKDIS_MASK            0x80UL                               /**< Bit mask for USART_RXBLOCKDIS */
+#define _USART_CMD_RXBLOCKDIS_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_RXBLOCKDIS_DEFAULT          (_USART_CMD_RXBLOCKDIS_DEFAULT << 7) /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_TXTRIEN                     (0x1UL << 8)                         /**< Transmitter Tristate Enable */
+#define _USART_CMD_TXTRIEN_SHIFT              8                                    /**< Shift value for USART_TXTRIEN */
+#define _USART_CMD_TXTRIEN_MASK               0x100UL                              /**< Bit mask for USART_TXTRIEN */
+#define _USART_CMD_TXTRIEN_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_TXTRIEN_DEFAULT             (_USART_CMD_TXTRIEN_DEFAULT << 8)    /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_TXTRIDIS                    (0x1UL << 9)                         /**< Transmitter Tristate Disable */
+#define _USART_CMD_TXTRIDIS_SHIFT             9                                    /**< Shift value for USART_TXTRIDIS */
+#define _USART_CMD_TXTRIDIS_MASK              0x200UL                              /**< Bit mask for USART_TXTRIDIS */
+#define _USART_CMD_TXTRIDIS_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_TXTRIDIS_DEFAULT            (_USART_CMD_TXTRIDIS_DEFAULT << 9)   /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_CLEARTX                     (0x1UL << 10)                        /**< Clear TX */
+#define _USART_CMD_CLEARTX_SHIFT              10                                   /**< Shift value for USART_CLEARTX */
+#define _USART_CMD_CLEARTX_MASK               0x400UL                              /**< Bit mask for USART_CLEARTX */
+#define _USART_CMD_CLEARTX_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_CLEARTX_DEFAULT             (_USART_CMD_CLEARTX_DEFAULT << 10)   /**< Shifted mode DEFAULT for USART_CMD */
+#define USART_CMD_CLEARRX                     (0x1UL << 11)                        /**< Clear RX */
+#define _USART_CMD_CLEARRX_SHIFT              11                                   /**< Shift value for USART_CLEARRX */
+#define _USART_CMD_CLEARRX_MASK               0x800UL                              /**< Bit mask for USART_CLEARRX */
+#define _USART_CMD_CLEARRX_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for USART_CMD */
+#define USART_CMD_CLEARRX_DEFAULT             (_USART_CMD_CLEARRX_DEFAULT << 11)   /**< Shifted mode DEFAULT for USART_CMD */
+
+/* Bit fields for USART STATUS */
+#define _USART_STATUS_RESETVALUE              0x00000040UL                               /**< Default value for USART_STATUS */
+#define _USART_STATUS_MASK                    0x00001FFFUL                               /**< Mask for USART_STATUS */
+#define USART_STATUS_RXENS                    (0x1UL << 0)                               /**< Receiver Enable Status */
+#define _USART_STATUS_RXENS_SHIFT             0                                          /**< Shift value for USART_RXENS */
+#define _USART_STATUS_RXENS_MASK              0x1UL                                      /**< Bit mask for USART_RXENS */
+#define _USART_STATUS_RXENS_DEFAULT           0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXENS_DEFAULT            (_USART_STATUS_RXENS_DEFAULT << 0)         /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXENS                    (0x1UL << 1)                               /**< Transmitter Enable Status */
+#define _USART_STATUS_TXENS_SHIFT             1                                          /**< Shift value for USART_TXENS */
+#define _USART_STATUS_TXENS_MASK              0x2UL                                      /**< Bit mask for USART_TXENS */
+#define _USART_STATUS_TXENS_DEFAULT           0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXENS_DEFAULT            (_USART_STATUS_TXENS_DEFAULT << 1)         /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_MASTER                   (0x1UL << 2)                               /**< SPI Master Mode */
+#define _USART_STATUS_MASTER_SHIFT            2                                          /**< Shift value for USART_MASTER */
+#define _USART_STATUS_MASTER_MASK             0x4UL                                      /**< Bit mask for USART_MASTER */
+#define _USART_STATUS_MASTER_DEFAULT          0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_MASTER_DEFAULT           (_USART_STATUS_MASTER_DEFAULT << 2)        /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXBLOCK                  (0x1UL << 3)                               /**< Block Incoming Data */
+#define _USART_STATUS_RXBLOCK_SHIFT           3                                          /**< Shift value for USART_RXBLOCK */
+#define _USART_STATUS_RXBLOCK_MASK            0x8UL                                      /**< Bit mask for USART_RXBLOCK */
+#define _USART_STATUS_RXBLOCK_DEFAULT         0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXBLOCK_DEFAULT          (_USART_STATUS_RXBLOCK_DEFAULT << 3)       /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXTRI                    (0x1UL << 4)                               /**< Transmitter Tristated */
+#define _USART_STATUS_TXTRI_SHIFT             4                                          /**< Shift value for USART_TXTRI */
+#define _USART_STATUS_TXTRI_MASK              0x10UL                                     /**< Bit mask for USART_TXTRI */
+#define _USART_STATUS_TXTRI_DEFAULT           0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXTRI_DEFAULT            (_USART_STATUS_TXTRI_DEFAULT << 4)         /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXC                      (0x1UL << 5)                               /**< TX Complete */
+#define _USART_STATUS_TXC_SHIFT               5                                          /**< Shift value for USART_TXC */
+#define _USART_STATUS_TXC_MASK                0x20UL                                     /**< Bit mask for USART_TXC */
+#define _USART_STATUS_TXC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXC_DEFAULT              (_USART_STATUS_TXC_DEFAULT << 5)           /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXBL                     (0x1UL << 6)                               /**< TX Buffer Level */
+#define _USART_STATUS_TXBL_SHIFT              6                                          /**< Shift value for USART_TXBL */
+#define _USART_STATUS_TXBL_MASK               0x40UL                                     /**< Bit mask for USART_TXBL */
+#define _USART_STATUS_TXBL_DEFAULT            0x00000001UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXBL_DEFAULT             (_USART_STATUS_TXBL_DEFAULT << 6)          /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXDATAV                  (0x1UL << 7)                               /**< RX Data Valid */
+#define _USART_STATUS_RXDATAV_SHIFT           7                                          /**< Shift value for USART_RXDATAV */
+#define _USART_STATUS_RXDATAV_MASK            0x80UL                                     /**< Bit mask for USART_RXDATAV */
+#define _USART_STATUS_RXDATAV_DEFAULT         0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXDATAV_DEFAULT          (_USART_STATUS_RXDATAV_DEFAULT << 7)       /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXFULL                   (0x1UL << 8)                               /**< RX FIFO Full */
+#define _USART_STATUS_RXFULL_SHIFT            8                                          /**< Shift value for USART_RXFULL */
+#define _USART_STATUS_RXFULL_MASK             0x100UL                                    /**< Bit mask for USART_RXFULL */
+#define _USART_STATUS_RXFULL_DEFAULT          0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXFULL_DEFAULT           (_USART_STATUS_RXFULL_DEFAULT << 8)        /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXBDRIGHT                (0x1UL << 9)                               /**< TX Buffer Expects Double Right Data */
+#define _USART_STATUS_TXBDRIGHT_SHIFT         9                                          /**< Shift value for USART_TXBDRIGHT */
+#define _USART_STATUS_TXBDRIGHT_MASK          0x200UL                                    /**< Bit mask for USART_TXBDRIGHT */
+#define _USART_STATUS_TXBDRIGHT_DEFAULT       0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXBDRIGHT_DEFAULT        (_USART_STATUS_TXBDRIGHT_DEFAULT << 9)     /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXBSRIGHT                (0x1UL << 10)                              /**< TX Buffer Expects Single Right Data */
+#define _USART_STATUS_TXBSRIGHT_SHIFT         10                                         /**< Shift value for USART_TXBSRIGHT */
+#define _USART_STATUS_TXBSRIGHT_MASK          0x400UL                                    /**< Bit mask for USART_TXBSRIGHT */
+#define _USART_STATUS_TXBSRIGHT_DEFAULT       0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_TXBSRIGHT_DEFAULT        (_USART_STATUS_TXBSRIGHT_DEFAULT << 10)    /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXDATAVRIGHT             (0x1UL << 11)                              /**< RX Data Right */
+#define _USART_STATUS_RXDATAVRIGHT_SHIFT      11                                         /**< Shift value for USART_RXDATAVRIGHT */
+#define _USART_STATUS_RXDATAVRIGHT_MASK       0x800UL                                    /**< Bit mask for USART_RXDATAVRIGHT */
+#define _USART_STATUS_RXDATAVRIGHT_DEFAULT    0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXDATAVRIGHT_DEFAULT     (_USART_STATUS_RXDATAVRIGHT_DEFAULT << 11) /**< Shifted mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXFULLRIGHT              (0x1UL << 12)                              /**< RX Full of Right Data */
+#define _USART_STATUS_RXFULLRIGHT_SHIFT       12                                         /**< Shift value for USART_RXFULLRIGHT */
+#define _USART_STATUS_RXFULLRIGHT_MASK        0x1000UL                                   /**< Bit mask for USART_RXFULLRIGHT */
+#define _USART_STATUS_RXFULLRIGHT_DEFAULT     0x00000000UL                               /**< Mode DEFAULT for USART_STATUS */
+#define USART_STATUS_RXFULLRIGHT_DEFAULT      (_USART_STATUS_RXFULLRIGHT_DEFAULT << 12)  /**< Shifted mode DEFAULT for USART_STATUS */
+
+/* Bit fields for USART CLKDIV */
+#define _USART_CLKDIV_RESETVALUE              0x00000000UL                     /**< Default value for USART_CLKDIV */
+#define _USART_CLKDIV_MASK                    0x001FFFC0UL                     /**< Mask for USART_CLKDIV */
+#define _USART_CLKDIV_DIV_SHIFT               6                                /**< Shift value for USART_DIV */
+#define _USART_CLKDIV_DIV_MASK                0x1FFFC0UL                       /**< Bit mask for USART_DIV */
+#define _USART_CLKDIV_DIV_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for USART_CLKDIV */
+#define USART_CLKDIV_DIV_DEFAULT              (_USART_CLKDIV_DIV_DEFAULT << 6) /**< Shifted mode DEFAULT for USART_CLKDIV */
+
+/* Bit fields for USART RXDATAX */
+#define _USART_RXDATAX_RESETVALUE             0x00000000UL                         /**< Default value for USART_RXDATAX */
+#define _USART_RXDATAX_MASK                   0x0000C1FFUL                         /**< Mask for USART_RXDATAX */
+#define _USART_RXDATAX_RXDATA_SHIFT           0                                    /**< Shift value for USART_RXDATA */
+#define _USART_RXDATAX_RXDATA_MASK            0x1FFUL                              /**< Bit mask for USART_RXDATA */
+#define _USART_RXDATAX_RXDATA_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for USART_RXDATAX */
+#define USART_RXDATAX_RXDATA_DEFAULT          (_USART_RXDATAX_RXDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for USART_RXDATAX */
+#define USART_RXDATAX_PERR                    (0x1UL << 14)                        /**< Data Parity Error */
+#define _USART_RXDATAX_PERR_SHIFT             14                                   /**< Shift value for USART_PERR */
+#define _USART_RXDATAX_PERR_MASK              0x4000UL                             /**< Bit mask for USART_PERR */
+#define _USART_RXDATAX_PERR_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for USART_RXDATAX */
+#define USART_RXDATAX_PERR_DEFAULT            (_USART_RXDATAX_PERR_DEFAULT << 14)  /**< Shifted mode DEFAULT for USART_RXDATAX */
+#define USART_RXDATAX_FERR                    (0x1UL << 15)                        /**< Data Framing Error */
+#define _USART_RXDATAX_FERR_SHIFT             15                                   /**< Shift value for USART_FERR */
+#define _USART_RXDATAX_FERR_MASK              0x8000UL                             /**< Bit mask for USART_FERR */
+#define _USART_RXDATAX_FERR_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for USART_RXDATAX */
+#define USART_RXDATAX_FERR_DEFAULT            (_USART_RXDATAX_FERR_DEFAULT << 15)  /**< Shifted mode DEFAULT for USART_RXDATAX */
+
+/* Bit fields for USART RXDATA */
+#define _USART_RXDATA_RESETVALUE              0x00000000UL                        /**< Default value for USART_RXDATA */
+#define _USART_RXDATA_MASK                    0x000000FFUL                        /**< Mask for USART_RXDATA */
+#define _USART_RXDATA_RXDATA_SHIFT            0                                   /**< Shift value for USART_RXDATA */
+#define _USART_RXDATA_RXDATA_MASK             0xFFUL                              /**< Bit mask for USART_RXDATA */
+#define _USART_RXDATA_RXDATA_DEFAULT          0x00000000UL                        /**< Mode DEFAULT for USART_RXDATA */
+#define USART_RXDATA_RXDATA_DEFAULT           (_USART_RXDATA_RXDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for USART_RXDATA */
+
+/* Bit fields for USART RXDOUBLEX */
+#define _USART_RXDOUBLEX_RESETVALUE           0x00000000UL                             /**< Default value for USART_RXDOUBLEX */
+#define _USART_RXDOUBLEX_MASK                 0xC1FFC1FFUL                             /**< Mask for USART_RXDOUBLEX */
+#define _USART_RXDOUBLEX_RXDATA0_SHIFT        0                                        /**< Shift value for USART_RXDATA0 */
+#define _USART_RXDOUBLEX_RXDATA0_MASK         0x1FFUL                                  /**< Bit mask for USART_RXDATA0 */
+#define _USART_RXDOUBLEX_RXDATA0_DEFAULT      0x00000000UL                             /**< Mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_RXDATA0_DEFAULT       (_USART_RXDOUBLEX_RXDATA0_DEFAULT << 0)  /**< Shifted mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_PERR0                 (0x1UL << 14)                            /**< Data Parity Error 0 */
+#define _USART_RXDOUBLEX_PERR0_SHIFT          14                                       /**< Shift value for USART_PERR0 */
+#define _USART_RXDOUBLEX_PERR0_MASK           0x4000UL                                 /**< Bit mask for USART_PERR0 */
+#define _USART_RXDOUBLEX_PERR0_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_PERR0_DEFAULT         (_USART_RXDOUBLEX_PERR0_DEFAULT << 14)   /**< Shifted mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_FERR0                 (0x1UL << 15)                            /**< Data Framing Error 0 */
+#define _USART_RXDOUBLEX_FERR0_SHIFT          15                                       /**< Shift value for USART_FERR0 */
+#define _USART_RXDOUBLEX_FERR0_MASK           0x8000UL                                 /**< Bit mask for USART_FERR0 */
+#define _USART_RXDOUBLEX_FERR0_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_FERR0_DEFAULT         (_USART_RXDOUBLEX_FERR0_DEFAULT << 15)   /**< Shifted mode DEFAULT for USART_RXDOUBLEX */
+#define _USART_RXDOUBLEX_RXDATA1_SHIFT        16                                       /**< Shift value for USART_RXDATA1 */
+#define _USART_RXDOUBLEX_RXDATA1_MASK         0x1FF0000UL                              /**< Bit mask for USART_RXDATA1 */
+#define _USART_RXDOUBLEX_RXDATA1_DEFAULT      0x00000000UL                             /**< Mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_RXDATA1_DEFAULT       (_USART_RXDOUBLEX_RXDATA1_DEFAULT << 16) /**< Shifted mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_PERR1                 (0x1UL << 30)                            /**< Data Parity Error 1 */
+#define _USART_RXDOUBLEX_PERR1_SHIFT          30                                       /**< Shift value for USART_PERR1 */
+#define _USART_RXDOUBLEX_PERR1_MASK           0x40000000UL                             /**< Bit mask for USART_PERR1 */
+#define _USART_RXDOUBLEX_PERR1_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_PERR1_DEFAULT         (_USART_RXDOUBLEX_PERR1_DEFAULT << 30)   /**< Shifted mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_FERR1                 (0x1UL << 31)                            /**< Data Framing Error 1 */
+#define _USART_RXDOUBLEX_FERR1_SHIFT          31                                       /**< Shift value for USART_FERR1 */
+#define _USART_RXDOUBLEX_FERR1_MASK           0x80000000UL                             /**< Bit mask for USART_FERR1 */
+#define _USART_RXDOUBLEX_FERR1_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_RXDOUBLEX */
+#define USART_RXDOUBLEX_FERR1_DEFAULT         (_USART_RXDOUBLEX_FERR1_DEFAULT << 31)   /**< Shifted mode DEFAULT for USART_RXDOUBLEX */
+
+/* Bit fields for USART RXDOUBLE */
+#define _USART_RXDOUBLE_RESETVALUE            0x00000000UL                           /**< Default value for USART_RXDOUBLE */
+#define _USART_RXDOUBLE_MASK                  0x0000FFFFUL                           /**< Mask for USART_RXDOUBLE */
+#define _USART_RXDOUBLE_RXDATA0_SHIFT         0                                      /**< Shift value for USART_RXDATA0 */
+#define _USART_RXDOUBLE_RXDATA0_MASK          0xFFUL                                 /**< Bit mask for USART_RXDATA0 */
+#define _USART_RXDOUBLE_RXDATA0_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for USART_RXDOUBLE */
+#define USART_RXDOUBLE_RXDATA0_DEFAULT        (_USART_RXDOUBLE_RXDATA0_DEFAULT << 0) /**< Shifted mode DEFAULT for USART_RXDOUBLE */
+#define _USART_RXDOUBLE_RXDATA1_SHIFT         8                                      /**< Shift value for USART_RXDATA1 */
+#define _USART_RXDOUBLE_RXDATA1_MASK          0xFF00UL                               /**< Bit mask for USART_RXDATA1 */
+#define _USART_RXDOUBLE_RXDATA1_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for USART_RXDOUBLE */
+#define USART_RXDOUBLE_RXDATA1_DEFAULT        (_USART_RXDOUBLE_RXDATA1_DEFAULT << 8) /**< Shifted mode DEFAULT for USART_RXDOUBLE */
+
+/* Bit fields for USART RXDATAXP */
+#define _USART_RXDATAXP_RESETVALUE            0x00000000UL                           /**< Default value for USART_RXDATAXP */
+#define _USART_RXDATAXP_MASK                  0x0000C1FFUL                           /**< Mask for USART_RXDATAXP */
+#define _USART_RXDATAXP_RXDATAP_SHIFT         0                                      /**< Shift value for USART_RXDATAP */
+#define _USART_RXDATAXP_RXDATAP_MASK          0x1FFUL                                /**< Bit mask for USART_RXDATAP */
+#define _USART_RXDATAXP_RXDATAP_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for USART_RXDATAXP */
+#define USART_RXDATAXP_RXDATAP_DEFAULT        (_USART_RXDATAXP_RXDATAP_DEFAULT << 0) /**< Shifted mode DEFAULT for USART_RXDATAXP */
+#define USART_RXDATAXP_PERRP                  (0x1UL << 14)                          /**< Data Parity Error Peek */
+#define _USART_RXDATAXP_PERRP_SHIFT           14                                     /**< Shift value for USART_PERRP */
+#define _USART_RXDATAXP_PERRP_MASK            0x4000UL                               /**< Bit mask for USART_PERRP */
+#define _USART_RXDATAXP_PERRP_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for USART_RXDATAXP */
+#define USART_RXDATAXP_PERRP_DEFAULT          (_USART_RXDATAXP_PERRP_DEFAULT << 14)  /**< Shifted mode DEFAULT for USART_RXDATAXP */
+#define USART_RXDATAXP_FERRP                  (0x1UL << 15)                          /**< Data Framing Error Peek */
+#define _USART_RXDATAXP_FERRP_SHIFT           15                                     /**< Shift value for USART_FERRP */
+#define _USART_RXDATAXP_FERRP_MASK            0x8000UL                               /**< Bit mask for USART_FERRP */
+#define _USART_RXDATAXP_FERRP_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for USART_RXDATAXP */
+#define USART_RXDATAXP_FERRP_DEFAULT          (_USART_RXDATAXP_FERRP_DEFAULT << 15)  /**< Shifted mode DEFAULT for USART_RXDATAXP */
+
+/* Bit fields for USART RXDOUBLEXP */
+#define _USART_RXDOUBLEXP_RESETVALUE          0x00000000UL                               /**< Default value for USART_RXDOUBLEXP */
+#define _USART_RXDOUBLEXP_MASK                0xC1FFC1FFUL                               /**< Mask for USART_RXDOUBLEXP */
+#define _USART_RXDOUBLEXP_RXDATAP0_SHIFT      0                                          /**< Shift value for USART_RXDATAP0 */
+#define _USART_RXDOUBLEXP_RXDATAP0_MASK       0x1FFUL                                    /**< Bit mask for USART_RXDATAP0 */
+#define _USART_RXDOUBLEXP_RXDATAP0_DEFAULT    0x00000000UL                               /**< Mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_RXDATAP0_DEFAULT     (_USART_RXDOUBLEXP_RXDATAP0_DEFAULT << 0)  /**< Shifted mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_PERRP0               (0x1UL << 14)                              /**< Data Parity Error 0 Peek */
+#define _USART_RXDOUBLEXP_PERRP0_SHIFT        14                                         /**< Shift value for USART_PERRP0 */
+#define _USART_RXDOUBLEXP_PERRP0_MASK         0x4000UL                                   /**< Bit mask for USART_PERRP0 */
+#define _USART_RXDOUBLEXP_PERRP0_DEFAULT      0x00000000UL                               /**< Mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_PERRP0_DEFAULT       (_USART_RXDOUBLEXP_PERRP0_DEFAULT << 14)   /**< Shifted mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_FERRP0               (0x1UL << 15)                              /**< Data Framing Error 0 Peek */
+#define _USART_RXDOUBLEXP_FERRP0_SHIFT        15                                         /**< Shift value for USART_FERRP0 */
+#define _USART_RXDOUBLEXP_FERRP0_MASK         0x8000UL                                   /**< Bit mask for USART_FERRP0 */
+#define _USART_RXDOUBLEXP_FERRP0_DEFAULT      0x00000000UL                               /**< Mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_FERRP0_DEFAULT       (_USART_RXDOUBLEXP_FERRP0_DEFAULT << 15)   /**< Shifted mode DEFAULT for USART_RXDOUBLEXP */
+#define _USART_RXDOUBLEXP_RXDATAP1_SHIFT      16                                         /**< Shift value for USART_RXDATAP1 */
+#define _USART_RXDOUBLEXP_RXDATAP1_MASK       0x1FF0000UL                                /**< Bit mask for USART_RXDATAP1 */
+#define _USART_RXDOUBLEXP_RXDATAP1_DEFAULT    0x00000000UL                               /**< Mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_RXDATAP1_DEFAULT     (_USART_RXDOUBLEXP_RXDATAP1_DEFAULT << 16) /**< Shifted mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_PERRP1               (0x1UL << 30)                              /**< Data Parity Error 1 Peek */
+#define _USART_RXDOUBLEXP_PERRP1_SHIFT        30                                         /**< Shift value for USART_PERRP1 */
+#define _USART_RXDOUBLEXP_PERRP1_MASK         0x40000000UL                               /**< Bit mask for USART_PERRP1 */
+#define _USART_RXDOUBLEXP_PERRP1_DEFAULT      0x00000000UL                               /**< Mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_PERRP1_DEFAULT       (_USART_RXDOUBLEXP_PERRP1_DEFAULT << 30)   /**< Shifted mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_FERRP1               (0x1UL << 31)                              /**< Data Framing Error 1 Peek */
+#define _USART_RXDOUBLEXP_FERRP1_SHIFT        31                                         /**< Shift value for USART_FERRP1 */
+#define _USART_RXDOUBLEXP_FERRP1_MASK         0x80000000UL                               /**< Bit mask for USART_FERRP1 */
+#define _USART_RXDOUBLEXP_FERRP1_DEFAULT      0x00000000UL                               /**< Mode DEFAULT for USART_RXDOUBLEXP */
+#define USART_RXDOUBLEXP_FERRP1_DEFAULT       (_USART_RXDOUBLEXP_FERRP1_DEFAULT << 31)   /**< Shifted mode DEFAULT for USART_RXDOUBLEXP */
+
+/* Bit fields for USART TXDATAX */
+#define _USART_TXDATAX_RESETVALUE             0x00000000UL                           /**< Default value for USART_TXDATAX */
+#define _USART_TXDATAX_MASK                   0x0000F9FFUL                           /**< Mask for USART_TXDATAX */
+#define _USART_TXDATAX_TXDATAX_SHIFT          0                                      /**< Shift value for USART_TXDATAX */
+#define _USART_TXDATAX_TXDATAX_MASK           0x1FFUL                                /**< Bit mask for USART_TXDATAX */
+#define _USART_TXDATAX_TXDATAX_DEFAULT        0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_TXDATAX_DEFAULT         (_USART_TXDATAX_TXDATAX_DEFAULT << 0)  /**< Shifted mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_UBRXAT                  (0x1UL << 11)                          /**< Unblock RX After Transmission */
+#define _USART_TXDATAX_UBRXAT_SHIFT           11                                     /**< Shift value for USART_UBRXAT */
+#define _USART_TXDATAX_UBRXAT_MASK            0x800UL                                /**< Bit mask for USART_UBRXAT */
+#define _USART_TXDATAX_UBRXAT_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_UBRXAT_DEFAULT          (_USART_TXDATAX_UBRXAT_DEFAULT << 11)  /**< Shifted mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_TXTRIAT                 (0x1UL << 12)                          /**< Set TXTRI After Transmission */
+#define _USART_TXDATAX_TXTRIAT_SHIFT          12                                     /**< Shift value for USART_TXTRIAT */
+#define _USART_TXDATAX_TXTRIAT_MASK           0x1000UL                               /**< Bit mask for USART_TXTRIAT */
+#define _USART_TXDATAX_TXTRIAT_DEFAULT        0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_TXTRIAT_DEFAULT         (_USART_TXDATAX_TXTRIAT_DEFAULT << 12) /**< Shifted mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_TXBREAK                 (0x1UL << 13)                          /**< Transmit Data As Break */
+#define _USART_TXDATAX_TXBREAK_SHIFT          13                                     /**< Shift value for USART_TXBREAK */
+#define _USART_TXDATAX_TXBREAK_MASK           0x2000UL                               /**< Bit mask for USART_TXBREAK */
+#define _USART_TXDATAX_TXBREAK_DEFAULT        0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_TXBREAK_DEFAULT         (_USART_TXDATAX_TXBREAK_DEFAULT << 13) /**< Shifted mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_TXDISAT                 (0x1UL << 14)                          /**< Clear TXEN After Transmission */
+#define _USART_TXDATAX_TXDISAT_SHIFT          14                                     /**< Shift value for USART_TXDISAT */
+#define _USART_TXDATAX_TXDISAT_MASK           0x4000UL                               /**< Bit mask for USART_TXDISAT */
+#define _USART_TXDATAX_TXDISAT_DEFAULT        0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_TXDISAT_DEFAULT         (_USART_TXDATAX_TXDISAT_DEFAULT << 14) /**< Shifted mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_RXENAT                  (0x1UL << 15)                          /**< Enable RX After Transmission */
+#define _USART_TXDATAX_RXENAT_SHIFT           15                                     /**< Shift value for USART_RXENAT */
+#define _USART_TXDATAX_RXENAT_MASK            0x8000UL                               /**< Bit mask for USART_RXENAT */
+#define _USART_TXDATAX_RXENAT_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
+#define USART_TXDATAX_RXENAT_DEFAULT          (_USART_TXDATAX_RXENAT_DEFAULT << 15)  /**< Shifted mode DEFAULT for USART_TXDATAX */
+
+/* Bit fields for USART TXDATA */
+#define _USART_TXDATA_RESETVALUE              0x00000000UL                        /**< Default value for USART_TXDATA */
+#define _USART_TXDATA_MASK                    0x000000FFUL                        /**< Mask for USART_TXDATA */
+#define _USART_TXDATA_TXDATA_SHIFT            0                                   /**< Shift value for USART_TXDATA */
+#define _USART_TXDATA_TXDATA_MASK             0xFFUL                              /**< Bit mask for USART_TXDATA */
+#define _USART_TXDATA_TXDATA_DEFAULT          0x00000000UL                        /**< Mode DEFAULT for USART_TXDATA */
+#define USART_TXDATA_TXDATA_DEFAULT           (_USART_TXDATA_TXDATA_DEFAULT << 0) /**< Shifted mode DEFAULT for USART_TXDATA */
+
+/* Bit fields for USART TXDOUBLEX */
+#define _USART_TXDOUBLEX_RESETVALUE           0x00000000UL                              /**< Default value for USART_TXDOUBLEX */
+#define _USART_TXDOUBLEX_MASK                 0xF9FFF9FFUL                              /**< Mask for USART_TXDOUBLEX */
+#define _USART_TXDOUBLEX_TXDATA0_SHIFT        0                                         /**< Shift value for USART_TXDATA0 */
+#define _USART_TXDOUBLEX_TXDATA0_MASK         0x1FFUL                                   /**< Bit mask for USART_TXDATA0 */
+#define _USART_TXDOUBLEX_TXDATA0_DEFAULT      0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXDATA0_DEFAULT       (_USART_TXDOUBLEX_TXDATA0_DEFAULT << 0)   /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_UBRXAT0               (0x1UL << 11)                             /**< Unblock RX After Transmission */
+#define _USART_TXDOUBLEX_UBRXAT0_SHIFT        11                                        /**< Shift value for USART_UBRXAT0 */
+#define _USART_TXDOUBLEX_UBRXAT0_MASK         0x800UL                                   /**< Bit mask for USART_UBRXAT0 */
+#define _USART_TXDOUBLEX_UBRXAT0_DEFAULT      0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_UBRXAT0_DEFAULT       (_USART_TXDOUBLEX_UBRXAT0_DEFAULT << 11)  /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXTRIAT0              (0x1UL << 12)                             /**< Set TXTRI After Transmission */
+#define _USART_TXDOUBLEX_TXTRIAT0_SHIFT       12                                        /**< Shift value for USART_TXTRIAT0 */
+#define _USART_TXDOUBLEX_TXTRIAT0_MASK        0x1000UL                                  /**< Bit mask for USART_TXTRIAT0 */
+#define _USART_TXDOUBLEX_TXTRIAT0_DEFAULT     0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXTRIAT0_DEFAULT      (_USART_TXDOUBLEX_TXTRIAT0_DEFAULT << 12) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXBREAK0              (0x1UL << 13)                             /**< Transmit Data As Break */
+#define _USART_TXDOUBLEX_TXBREAK0_SHIFT       13                                        /**< Shift value for USART_TXBREAK0 */
+#define _USART_TXDOUBLEX_TXBREAK0_MASK        0x2000UL                                  /**< Bit mask for USART_TXBREAK0 */
+#define _USART_TXDOUBLEX_TXBREAK0_DEFAULT     0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXBREAK0_DEFAULT      (_USART_TXDOUBLEX_TXBREAK0_DEFAULT << 13) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXDISAT0              (0x1UL << 14)                             /**< Clear TXEN After Transmission */
+#define _USART_TXDOUBLEX_TXDISAT0_SHIFT       14                                        /**< Shift value for USART_TXDISAT0 */
+#define _USART_TXDOUBLEX_TXDISAT0_MASK        0x4000UL                                  /**< Bit mask for USART_TXDISAT0 */
+#define _USART_TXDOUBLEX_TXDISAT0_DEFAULT     0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXDISAT0_DEFAULT      (_USART_TXDOUBLEX_TXDISAT0_DEFAULT << 14) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_RXENAT0               (0x1UL << 15)                             /**< Enable RX After Transmission */
+#define _USART_TXDOUBLEX_RXENAT0_SHIFT        15                                        /**< Shift value for USART_RXENAT0 */
+#define _USART_TXDOUBLEX_RXENAT0_MASK         0x8000UL                                  /**< Bit mask for USART_RXENAT0 */
+#define _USART_TXDOUBLEX_RXENAT0_DEFAULT      0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_RXENAT0_DEFAULT       (_USART_TXDOUBLEX_RXENAT0_DEFAULT << 15)  /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define _USART_TXDOUBLEX_TXDATA1_SHIFT        16                                        /**< Shift value for USART_TXDATA1 */
+#define _USART_TXDOUBLEX_TXDATA1_MASK         0x1FF0000UL                               /**< Bit mask for USART_TXDATA1 */
+#define _USART_TXDOUBLEX_TXDATA1_DEFAULT      0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXDATA1_DEFAULT       (_USART_TXDOUBLEX_TXDATA1_DEFAULT << 16)  /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_UBRXAT1               (0x1UL << 27)                             /**< Unblock RX After Transmission */
+#define _USART_TXDOUBLEX_UBRXAT1_SHIFT        27                                        /**< Shift value for USART_UBRXAT1 */
+#define _USART_TXDOUBLEX_UBRXAT1_MASK         0x8000000UL                               /**< Bit mask for USART_UBRXAT1 */
+#define _USART_TXDOUBLEX_UBRXAT1_DEFAULT      0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_UBRXAT1_DEFAULT       (_USART_TXDOUBLEX_UBRXAT1_DEFAULT << 27)  /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXTRIAT1              (0x1UL << 28)                             /**< Set TXTRI After Transmission */
+#define _USART_TXDOUBLEX_TXTRIAT1_SHIFT       28                                        /**< Shift value for USART_TXTRIAT1 */
+#define _USART_TXDOUBLEX_TXTRIAT1_MASK        0x10000000UL                              /**< Bit mask for USART_TXTRIAT1 */
+#define _USART_TXDOUBLEX_TXTRIAT1_DEFAULT     0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXTRIAT1_DEFAULT      (_USART_TXDOUBLEX_TXTRIAT1_DEFAULT << 28) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXBREAK1              (0x1UL << 29)                             /**< Transmit Data As Break */
+#define _USART_TXDOUBLEX_TXBREAK1_SHIFT       29                                        /**< Shift value for USART_TXBREAK1 */
+#define _USART_TXDOUBLEX_TXBREAK1_MASK        0x20000000UL                              /**< Bit mask for USART_TXBREAK1 */
+#define _USART_TXDOUBLEX_TXBREAK1_DEFAULT     0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXBREAK1_DEFAULT      (_USART_TXDOUBLEX_TXBREAK1_DEFAULT << 29) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXDISAT1              (0x1UL << 30)                             /**< Clear TXEN After Transmission */
+#define _USART_TXDOUBLEX_TXDISAT1_SHIFT       30                                        /**< Shift value for USART_TXDISAT1 */
+#define _USART_TXDOUBLEX_TXDISAT1_MASK        0x40000000UL                              /**< Bit mask for USART_TXDISAT1 */
+#define _USART_TXDOUBLEX_TXDISAT1_DEFAULT     0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_TXDISAT1_DEFAULT      (_USART_TXDOUBLEX_TXDISAT1_DEFAULT << 30) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_RXENAT1               (0x1UL << 31)                             /**< Enable RX After Transmission */
+#define _USART_TXDOUBLEX_RXENAT1_SHIFT        31                                        /**< Shift value for USART_RXENAT1 */
+#define _USART_TXDOUBLEX_RXENAT1_MASK         0x80000000UL                              /**< Bit mask for USART_RXENAT1 */
+#define _USART_TXDOUBLEX_RXENAT1_DEFAULT      0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
+#define USART_TXDOUBLEX_RXENAT1_DEFAULT       (_USART_TXDOUBLEX_RXENAT1_DEFAULT << 31)  /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
+
+/* Bit fields for USART TXDOUBLE */
+#define _USART_TXDOUBLE_RESETVALUE            0x00000000UL                           /**< Default value for USART_TXDOUBLE */
+#define _USART_TXDOUBLE_MASK                  0x0000FFFFUL                           /**< Mask for USART_TXDOUBLE */
+#define _USART_TXDOUBLE_TXDATA0_SHIFT         0                                      /**< Shift value for USART_TXDATA0 */
+#define _USART_TXDOUBLE_TXDATA0_MASK          0xFFUL                                 /**< Bit mask for USART_TXDATA0 */
+#define _USART_TXDOUBLE_TXDATA0_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for USART_TXDOUBLE */
+#define USART_TXDOUBLE_TXDATA0_DEFAULT        (_USART_TXDOUBLE_TXDATA0_DEFAULT << 0) /**< Shifted mode DEFAULT for USART_TXDOUBLE */
+#define _USART_TXDOUBLE_TXDATA1_SHIFT         8                                      /**< Shift value for USART_TXDATA1 */
+#define _USART_TXDOUBLE_TXDATA1_MASK          0xFF00UL                               /**< Bit mask for USART_TXDATA1 */
+#define _USART_TXDOUBLE_TXDATA1_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for USART_TXDOUBLE */
+#define USART_TXDOUBLE_TXDATA1_DEFAULT        (_USART_TXDOUBLE_TXDATA1_DEFAULT << 8) /**< Shifted mode DEFAULT for USART_TXDOUBLE */
+
+/* Bit fields for USART IF */
+#define _USART_IF_RESETVALUE                  0x00000002UL                     /**< Default value for USART_IF */
+#define _USART_IF_MASK                        0x00001FFFUL                     /**< Mask for USART_IF */
+#define USART_IF_TXC                          (0x1UL << 0)                     /**< TX Complete Interrupt Flag */
+#define _USART_IF_TXC_SHIFT                   0                                /**< Shift value for USART_TXC */
+#define _USART_IF_TXC_MASK                    0x1UL                            /**< Bit mask for USART_TXC */
+#define _USART_IF_TXC_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_TXC_DEFAULT                  (_USART_IF_TXC_DEFAULT << 0)     /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_TXBL                         (0x1UL << 1)                     /**< TX Buffer Level Interrupt Flag */
+#define _USART_IF_TXBL_SHIFT                  1                                /**< Shift value for USART_TXBL */
+#define _USART_IF_TXBL_MASK                   0x2UL                            /**< Bit mask for USART_TXBL */
+#define _USART_IF_TXBL_DEFAULT                0x00000001UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_TXBL_DEFAULT                 (_USART_IF_TXBL_DEFAULT << 1)    /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_RXDATAV                      (0x1UL << 2)                     /**< RX Data Valid Interrupt Flag */
+#define _USART_IF_RXDATAV_SHIFT               2                                /**< Shift value for USART_RXDATAV */
+#define _USART_IF_RXDATAV_MASK                0x4UL                            /**< Bit mask for USART_RXDATAV */
+#define _USART_IF_RXDATAV_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_RXDATAV_DEFAULT              (_USART_IF_RXDATAV_DEFAULT << 2) /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_RXFULL                       (0x1UL << 3)                     /**< RX Buffer Full Interrupt Flag */
+#define _USART_IF_RXFULL_SHIFT                3                                /**< Shift value for USART_RXFULL */
+#define _USART_IF_RXFULL_MASK                 0x8UL                            /**< Bit mask for USART_RXFULL */
+#define _USART_IF_RXFULL_DEFAULT              0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_RXFULL_DEFAULT               (_USART_IF_RXFULL_DEFAULT << 3)  /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_RXOF                         (0x1UL << 4)                     /**< RX Overflow Interrupt Flag */
+#define _USART_IF_RXOF_SHIFT                  4                                /**< Shift value for USART_RXOF */
+#define _USART_IF_RXOF_MASK                   0x10UL                           /**< Bit mask for USART_RXOF */
+#define _USART_IF_RXOF_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_RXOF_DEFAULT                 (_USART_IF_RXOF_DEFAULT << 4)    /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_RXUF                         (0x1UL << 5)                     /**< RX Underflow Interrupt Flag */
+#define _USART_IF_RXUF_SHIFT                  5                                /**< Shift value for USART_RXUF */
+#define _USART_IF_RXUF_MASK                   0x20UL                           /**< Bit mask for USART_RXUF */
+#define _USART_IF_RXUF_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_RXUF_DEFAULT                 (_USART_IF_RXUF_DEFAULT << 5)    /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_TXOF                         (0x1UL << 6)                     /**< TX Overflow Interrupt Flag */
+#define _USART_IF_TXOF_SHIFT                  6                                /**< Shift value for USART_TXOF */
+#define _USART_IF_TXOF_MASK                   0x40UL                           /**< Bit mask for USART_TXOF */
+#define _USART_IF_TXOF_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_TXOF_DEFAULT                 (_USART_IF_TXOF_DEFAULT << 6)    /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_TXUF                         (0x1UL << 7)                     /**< TX Underflow Interrupt Flag */
+#define _USART_IF_TXUF_SHIFT                  7                                /**< Shift value for USART_TXUF */
+#define _USART_IF_TXUF_MASK                   0x80UL                           /**< Bit mask for USART_TXUF */
+#define _USART_IF_TXUF_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_TXUF_DEFAULT                 (_USART_IF_TXUF_DEFAULT << 7)    /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_PERR                         (0x1UL << 8)                     /**< Parity Error Interrupt Flag */
+#define _USART_IF_PERR_SHIFT                  8                                /**< Shift value for USART_PERR */
+#define _USART_IF_PERR_MASK                   0x100UL                          /**< Bit mask for USART_PERR */
+#define _USART_IF_PERR_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_PERR_DEFAULT                 (_USART_IF_PERR_DEFAULT << 8)    /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_FERR                         (0x1UL << 9)                     /**< Framing Error Interrupt Flag */
+#define _USART_IF_FERR_SHIFT                  9                                /**< Shift value for USART_FERR */
+#define _USART_IF_FERR_MASK                   0x200UL                          /**< Bit mask for USART_FERR */
+#define _USART_IF_FERR_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_FERR_DEFAULT                 (_USART_IF_FERR_DEFAULT << 9)    /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_MPAF                         (0x1UL << 10)                    /**< Multi-Processor Address Frame Interrupt Flag */
+#define _USART_IF_MPAF_SHIFT                  10                               /**< Shift value for USART_MPAF */
+#define _USART_IF_MPAF_MASK                   0x400UL                          /**< Bit mask for USART_MPAF */
+#define _USART_IF_MPAF_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_MPAF_DEFAULT                 (_USART_IF_MPAF_DEFAULT << 10)   /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_SSM                          (0x1UL << 11)                    /**< Slave-Select In Master Mode Interrupt Flag */
+#define _USART_IF_SSM_SHIFT                   11                               /**< Shift value for USART_SSM */
+#define _USART_IF_SSM_MASK                    0x800UL                          /**< Bit mask for USART_SSM */
+#define _USART_IF_SSM_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_SSM_DEFAULT                  (_USART_IF_SSM_DEFAULT << 11)    /**< Shifted mode DEFAULT for USART_IF */
+#define USART_IF_CCF                          (0x1UL << 12)                    /**< Collision Check Fail Interrupt Flag */
+#define _USART_IF_CCF_SHIFT                   12                               /**< Shift value for USART_CCF */
+#define _USART_IF_CCF_MASK                    0x1000UL                         /**< Bit mask for USART_CCF */
+#define _USART_IF_CCF_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for USART_IF */
+#define USART_IF_CCF_DEFAULT                  (_USART_IF_CCF_DEFAULT << 12)    /**< Shifted mode DEFAULT for USART_IF */
+
+/* Bit fields for USART IFS */
+#define _USART_IFS_RESETVALUE                 0x00000000UL                     /**< Default value for USART_IFS */
+#define _USART_IFS_MASK                       0x00001FF9UL                     /**< Mask for USART_IFS */
+#define USART_IFS_TXC                         (0x1UL << 0)                     /**< Set TX Complete Interrupt Flag */
+#define _USART_IFS_TXC_SHIFT                  0                                /**< Shift value for USART_TXC */
+#define _USART_IFS_TXC_MASK                   0x1UL                            /**< Bit mask for USART_TXC */
+#define _USART_IFS_TXC_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_TXC_DEFAULT                 (_USART_IFS_TXC_DEFAULT << 0)    /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_RXFULL                      (0x1UL << 3)                     /**< Set RX Buffer Full Interrupt Flag */
+#define _USART_IFS_RXFULL_SHIFT               3                                /**< Shift value for USART_RXFULL */
+#define _USART_IFS_RXFULL_MASK                0x8UL                            /**< Bit mask for USART_RXFULL */
+#define _USART_IFS_RXFULL_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_RXFULL_DEFAULT              (_USART_IFS_RXFULL_DEFAULT << 3) /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_RXOF                        (0x1UL << 4)                     /**< Set RX Overflow Interrupt Flag */
+#define _USART_IFS_RXOF_SHIFT                 4                                /**< Shift value for USART_RXOF */
+#define _USART_IFS_RXOF_MASK                  0x10UL                           /**< Bit mask for USART_RXOF */
+#define _USART_IFS_RXOF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_RXOF_DEFAULT                (_USART_IFS_RXOF_DEFAULT << 4)   /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_RXUF                        (0x1UL << 5)                     /**< Set RX Underflow Interrupt Flag */
+#define _USART_IFS_RXUF_SHIFT                 5                                /**< Shift value for USART_RXUF */
+#define _USART_IFS_RXUF_MASK                  0x20UL                           /**< Bit mask for USART_RXUF */
+#define _USART_IFS_RXUF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_RXUF_DEFAULT                (_USART_IFS_RXUF_DEFAULT << 5)   /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_TXOF                        (0x1UL << 6)                     /**< Set TX Overflow Interrupt Flag */
+#define _USART_IFS_TXOF_SHIFT                 6                                /**< Shift value for USART_TXOF */
+#define _USART_IFS_TXOF_MASK                  0x40UL                           /**< Bit mask for USART_TXOF */
+#define _USART_IFS_TXOF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_TXOF_DEFAULT                (_USART_IFS_TXOF_DEFAULT << 6)   /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_TXUF                        (0x1UL << 7)                     /**< Set TX Underflow Interrupt Flag */
+#define _USART_IFS_TXUF_SHIFT                 7                                /**< Shift value for USART_TXUF */
+#define _USART_IFS_TXUF_MASK                  0x80UL                           /**< Bit mask for USART_TXUF */
+#define _USART_IFS_TXUF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_TXUF_DEFAULT                (_USART_IFS_TXUF_DEFAULT << 7)   /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_PERR                        (0x1UL << 8)                     /**< Set Parity Error Interrupt Flag */
+#define _USART_IFS_PERR_SHIFT                 8                                /**< Shift value for USART_PERR */
+#define _USART_IFS_PERR_MASK                  0x100UL                          /**< Bit mask for USART_PERR */
+#define _USART_IFS_PERR_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_PERR_DEFAULT                (_USART_IFS_PERR_DEFAULT << 8)   /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_FERR                        (0x1UL << 9)                     /**< Set Framing Error Interrupt Flag */
+#define _USART_IFS_FERR_SHIFT                 9                                /**< Shift value for USART_FERR */
+#define _USART_IFS_FERR_MASK                  0x200UL                          /**< Bit mask for USART_FERR */
+#define _USART_IFS_FERR_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_FERR_DEFAULT                (_USART_IFS_FERR_DEFAULT << 9)   /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_MPAF                        (0x1UL << 10)                    /**< Set Multi-Processor Address Frame Interrupt Flag */
+#define _USART_IFS_MPAF_SHIFT                 10                               /**< Shift value for USART_MPAF */
+#define _USART_IFS_MPAF_MASK                  0x400UL                          /**< Bit mask for USART_MPAF */
+#define _USART_IFS_MPAF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_MPAF_DEFAULT                (_USART_IFS_MPAF_DEFAULT << 10)  /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_SSM                         (0x1UL << 11)                    /**< Set Slave-Select in Master mode Interrupt Flag */
+#define _USART_IFS_SSM_SHIFT                  11                               /**< Shift value for USART_SSM */
+#define _USART_IFS_SSM_MASK                   0x800UL                          /**< Bit mask for USART_SSM */
+#define _USART_IFS_SSM_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_SSM_DEFAULT                 (_USART_IFS_SSM_DEFAULT << 11)   /**< Shifted mode DEFAULT for USART_IFS */
+#define USART_IFS_CCF                         (0x1UL << 12)                    /**< Set Collision Check Fail Interrupt Flag */
+#define _USART_IFS_CCF_SHIFT                  12                               /**< Shift value for USART_CCF */
+#define _USART_IFS_CCF_MASK                   0x1000UL                         /**< Bit mask for USART_CCF */
+#define _USART_IFS_CCF_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IFS */
+#define USART_IFS_CCF_DEFAULT                 (_USART_IFS_CCF_DEFAULT << 12)   /**< Shifted mode DEFAULT for USART_IFS */
+
+/* Bit fields for USART IFC */
+#define _USART_IFC_RESETVALUE                 0x00000000UL                     /**< Default value for USART_IFC */
+#define _USART_IFC_MASK                       0x00001FF9UL                     /**< Mask for USART_IFC */
+#define USART_IFC_TXC                         (0x1UL << 0)                     /**< Clear TX Complete Interrupt Flag */
+#define _USART_IFC_TXC_SHIFT                  0                                /**< Shift value for USART_TXC */
+#define _USART_IFC_TXC_MASK                   0x1UL                            /**< Bit mask for USART_TXC */
+#define _USART_IFC_TXC_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_TXC_DEFAULT                 (_USART_IFC_TXC_DEFAULT << 0)    /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_RXFULL                      (0x1UL << 3)                     /**< Clear RX Buffer Full Interrupt Flag */
+#define _USART_IFC_RXFULL_SHIFT               3                                /**< Shift value for USART_RXFULL */
+#define _USART_IFC_RXFULL_MASK                0x8UL                            /**< Bit mask for USART_RXFULL */
+#define _USART_IFC_RXFULL_DEFAULT             0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_RXFULL_DEFAULT              (_USART_IFC_RXFULL_DEFAULT << 3) /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_RXOF                        (0x1UL << 4)                     /**< Clear RX Overflow Interrupt Flag */
+#define _USART_IFC_RXOF_SHIFT                 4                                /**< Shift value for USART_RXOF */
+#define _USART_IFC_RXOF_MASK                  0x10UL                           /**< Bit mask for USART_RXOF */
+#define _USART_IFC_RXOF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_RXOF_DEFAULT                (_USART_IFC_RXOF_DEFAULT << 4)   /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_RXUF                        (0x1UL << 5)                     /**< Clear RX Underflow Interrupt Flag */
+#define _USART_IFC_RXUF_SHIFT                 5                                /**< Shift value for USART_RXUF */
+#define _USART_IFC_RXUF_MASK                  0x20UL                           /**< Bit mask for USART_RXUF */
+#define _USART_IFC_RXUF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_RXUF_DEFAULT                (_USART_IFC_RXUF_DEFAULT << 5)   /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_TXOF                        (0x1UL << 6)                     /**< Clear TX Overflow Interrupt Flag */
+#define _USART_IFC_TXOF_SHIFT                 6                                /**< Shift value for USART_TXOF */
+#define _USART_IFC_TXOF_MASK                  0x40UL                           /**< Bit mask for USART_TXOF */
+#define _USART_IFC_TXOF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_TXOF_DEFAULT                (_USART_IFC_TXOF_DEFAULT << 6)   /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_TXUF                        (0x1UL << 7)                     /**< Clear TX Underflow Interrupt Flag */
+#define _USART_IFC_TXUF_SHIFT                 7                                /**< Shift value for USART_TXUF */
+#define _USART_IFC_TXUF_MASK                  0x80UL                           /**< Bit mask for USART_TXUF */
+#define _USART_IFC_TXUF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_TXUF_DEFAULT                (_USART_IFC_TXUF_DEFAULT << 7)   /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_PERR                        (0x1UL << 8)                     /**< Clear Parity Error Interrupt Flag */
+#define _USART_IFC_PERR_SHIFT                 8                                /**< Shift value for USART_PERR */
+#define _USART_IFC_PERR_MASK                  0x100UL                          /**< Bit mask for USART_PERR */
+#define _USART_IFC_PERR_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_PERR_DEFAULT                (_USART_IFC_PERR_DEFAULT << 8)   /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_FERR                        (0x1UL << 9)                     /**< Clear Framing Error Interrupt Flag */
+#define _USART_IFC_FERR_SHIFT                 9                                /**< Shift value for USART_FERR */
+#define _USART_IFC_FERR_MASK                  0x200UL                          /**< Bit mask for USART_FERR */
+#define _USART_IFC_FERR_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_FERR_DEFAULT                (_USART_IFC_FERR_DEFAULT << 9)   /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_MPAF                        (0x1UL << 10)                    /**< Clear Multi-Processor Address Frame Interrupt Flag */
+#define _USART_IFC_MPAF_SHIFT                 10                               /**< Shift value for USART_MPAF */
+#define _USART_IFC_MPAF_MASK                  0x400UL                          /**< Bit mask for USART_MPAF */
+#define _USART_IFC_MPAF_DEFAULT               0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_MPAF_DEFAULT                (_USART_IFC_MPAF_DEFAULT << 10)  /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_SSM                         (0x1UL << 11)                    /**< Clear Slave-Select In Master Mode Interrupt Flag */
+#define _USART_IFC_SSM_SHIFT                  11                               /**< Shift value for USART_SSM */
+#define _USART_IFC_SSM_MASK                   0x800UL                          /**< Bit mask for USART_SSM */
+#define _USART_IFC_SSM_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_SSM_DEFAULT                 (_USART_IFC_SSM_DEFAULT << 11)   /**< Shifted mode DEFAULT for USART_IFC */
+#define USART_IFC_CCF                         (0x1UL << 12)                    /**< Clear Collision Check Fail Interrupt Flag */
+#define _USART_IFC_CCF_SHIFT                  12                               /**< Shift value for USART_CCF */
+#define _USART_IFC_CCF_MASK                   0x1000UL                         /**< Bit mask for USART_CCF */
+#define _USART_IFC_CCF_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IFC */
+#define USART_IFC_CCF_DEFAULT                 (_USART_IFC_CCF_DEFAULT << 12)   /**< Shifted mode DEFAULT for USART_IFC */
+
+/* Bit fields for USART IEN */
+#define _USART_IEN_RESETVALUE                 0x00000000UL                      /**< Default value for USART_IEN */
+#define _USART_IEN_MASK                       0x00001FFFUL                      /**< Mask for USART_IEN */
+#define USART_IEN_TXC                         (0x1UL << 0)                      /**< TX Complete Interrupt Enable */
+#define _USART_IEN_TXC_SHIFT                  0                                 /**< Shift value for USART_TXC */
+#define _USART_IEN_TXC_MASK                   0x1UL                             /**< Bit mask for USART_TXC */
+#define _USART_IEN_TXC_DEFAULT                0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_TXC_DEFAULT                 (_USART_IEN_TXC_DEFAULT << 0)     /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_TXBL                        (0x1UL << 1)                      /**< TX Buffer Level Interrupt Enable */
+#define _USART_IEN_TXBL_SHIFT                 1                                 /**< Shift value for USART_TXBL */
+#define _USART_IEN_TXBL_MASK                  0x2UL                             /**< Bit mask for USART_TXBL */
+#define _USART_IEN_TXBL_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_TXBL_DEFAULT                (_USART_IEN_TXBL_DEFAULT << 1)    /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_RXDATAV                     (0x1UL << 2)                      /**< RX Data Valid Interrupt Enable */
+#define _USART_IEN_RXDATAV_SHIFT              2                                 /**< Shift value for USART_RXDATAV */
+#define _USART_IEN_RXDATAV_MASK               0x4UL                             /**< Bit mask for USART_RXDATAV */
+#define _USART_IEN_RXDATAV_DEFAULT            0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_RXDATAV_DEFAULT             (_USART_IEN_RXDATAV_DEFAULT << 2) /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_RXFULL                      (0x1UL << 3)                      /**< RX Buffer Full Interrupt Enable */
+#define _USART_IEN_RXFULL_SHIFT               3                                 /**< Shift value for USART_RXFULL */
+#define _USART_IEN_RXFULL_MASK                0x8UL                             /**< Bit mask for USART_RXFULL */
+#define _USART_IEN_RXFULL_DEFAULT             0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_RXFULL_DEFAULT              (_USART_IEN_RXFULL_DEFAULT << 3)  /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_RXOF                        (0x1UL << 4)                      /**< RX Overflow Interrupt Enable */
+#define _USART_IEN_RXOF_SHIFT                 4                                 /**< Shift value for USART_RXOF */
+#define _USART_IEN_RXOF_MASK                  0x10UL                            /**< Bit mask for USART_RXOF */
+#define _USART_IEN_RXOF_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_RXOF_DEFAULT                (_USART_IEN_RXOF_DEFAULT << 4)    /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_RXUF                        (0x1UL << 5)                      /**< RX Underflow Interrupt Enable */
+#define _USART_IEN_RXUF_SHIFT                 5                                 /**< Shift value for USART_RXUF */
+#define _USART_IEN_RXUF_MASK                  0x20UL                            /**< Bit mask for USART_RXUF */
+#define _USART_IEN_RXUF_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_RXUF_DEFAULT                (_USART_IEN_RXUF_DEFAULT << 5)    /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_TXOF                        (0x1UL << 6)                      /**< TX Overflow Interrupt Enable */
+#define _USART_IEN_TXOF_SHIFT                 6                                 /**< Shift value for USART_TXOF */
+#define _USART_IEN_TXOF_MASK                  0x40UL                            /**< Bit mask for USART_TXOF */
+#define _USART_IEN_TXOF_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_TXOF_DEFAULT                (_USART_IEN_TXOF_DEFAULT << 6)    /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_TXUF                        (0x1UL << 7)                      /**< TX Underflow Interrupt Enable */
+#define _USART_IEN_TXUF_SHIFT                 7                                 /**< Shift value for USART_TXUF */
+#define _USART_IEN_TXUF_MASK                  0x80UL                            /**< Bit mask for USART_TXUF */
+#define _USART_IEN_TXUF_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_TXUF_DEFAULT                (_USART_IEN_TXUF_DEFAULT << 7)    /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_PERR                        (0x1UL << 8)                      /**< Parity Error Interrupt Enable */
+#define _USART_IEN_PERR_SHIFT                 8                                 /**< Shift value for USART_PERR */
+#define _USART_IEN_PERR_MASK                  0x100UL                           /**< Bit mask for USART_PERR */
+#define _USART_IEN_PERR_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_PERR_DEFAULT                (_USART_IEN_PERR_DEFAULT << 8)    /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_FERR                        (0x1UL << 9)                      /**< Framing Error Interrupt Enable */
+#define _USART_IEN_FERR_SHIFT                 9                                 /**< Shift value for USART_FERR */
+#define _USART_IEN_FERR_MASK                  0x200UL                           /**< Bit mask for USART_FERR */
+#define _USART_IEN_FERR_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_FERR_DEFAULT                (_USART_IEN_FERR_DEFAULT << 9)    /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_MPAF                        (0x1UL << 10)                     /**< Multi-Processor Address Frame Interrupt Enable */
+#define _USART_IEN_MPAF_SHIFT                 10                                /**< Shift value for USART_MPAF */
+#define _USART_IEN_MPAF_MASK                  0x400UL                           /**< Bit mask for USART_MPAF */
+#define _USART_IEN_MPAF_DEFAULT               0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_MPAF_DEFAULT                (_USART_IEN_MPAF_DEFAULT << 10)   /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_SSM                         (0x1UL << 11)                     /**< Slave-Select In Master Mode Interrupt Enable */
+#define _USART_IEN_SSM_SHIFT                  11                                /**< Shift value for USART_SSM */
+#define _USART_IEN_SSM_MASK                   0x800UL                           /**< Bit mask for USART_SSM */
+#define _USART_IEN_SSM_DEFAULT                0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_SSM_DEFAULT                 (_USART_IEN_SSM_DEFAULT << 11)    /**< Shifted mode DEFAULT for USART_IEN */
+#define USART_IEN_CCF                         (0x1UL << 12)                     /**< Collision Check Fail Interrupt Enable */
+#define _USART_IEN_CCF_SHIFT                  12                                /**< Shift value for USART_CCF */
+#define _USART_IEN_CCF_MASK                   0x1000UL                          /**< Bit mask for USART_CCF */
+#define _USART_IEN_CCF_DEFAULT                0x00000000UL                      /**< Mode DEFAULT for USART_IEN */
+#define USART_IEN_CCF_DEFAULT                 (_USART_IEN_CCF_DEFAULT << 12)    /**< Shifted mode DEFAULT for USART_IEN */
+
+/* Bit fields for USART IRCTRL */
+#define _USART_IRCTRL_RESETVALUE              0x00000000UL                          /**< Default value for USART_IRCTRL */
+#define _USART_IRCTRL_MASK                    0x000000FFUL                          /**< Mask for USART_IRCTRL */
+#define USART_IRCTRL_IREN                     (0x1UL << 0)                          /**< Enable IrDA Module */
+#define _USART_IRCTRL_IREN_SHIFT              0                                     /**< Shift value for USART_IREN */
+#define _USART_IRCTRL_IREN_MASK               0x1UL                                 /**< Bit mask for USART_IREN */
+#define _USART_IRCTRL_IREN_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for USART_IRCTRL */
+#define USART_IRCTRL_IREN_DEFAULT             (_USART_IRCTRL_IREN_DEFAULT << 0)     /**< Shifted mode DEFAULT for USART_IRCTRL */
+#define _USART_IRCTRL_IRPW_SHIFT              1                                     /**< Shift value for USART_IRPW */
+#define _USART_IRCTRL_IRPW_MASK               0x6UL                                 /**< Bit mask for USART_IRPW */
+#define _USART_IRCTRL_IRPW_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for USART_IRCTRL */
+#define _USART_IRCTRL_IRPW_ONE                0x00000000UL                          /**< Mode ONE for USART_IRCTRL */
+#define _USART_IRCTRL_IRPW_TWO                0x00000001UL                          /**< Mode TWO for USART_IRCTRL */
+#define _USART_IRCTRL_IRPW_THREE              0x00000002UL                          /**< Mode THREE for USART_IRCTRL */
+#define _USART_IRCTRL_IRPW_FOUR               0x00000003UL                          /**< Mode FOUR for USART_IRCTRL */
+#define USART_IRCTRL_IRPW_DEFAULT             (_USART_IRCTRL_IRPW_DEFAULT << 1)     /**< Shifted mode DEFAULT for USART_IRCTRL */
+#define USART_IRCTRL_IRPW_ONE                 (_USART_IRCTRL_IRPW_ONE << 1)         /**< Shifted mode ONE for USART_IRCTRL */
+#define USART_IRCTRL_IRPW_TWO                 (_USART_IRCTRL_IRPW_TWO << 1)         /**< Shifted mode TWO for USART_IRCTRL */
+#define USART_IRCTRL_IRPW_THREE               (_USART_IRCTRL_IRPW_THREE << 1)       /**< Shifted mode THREE for USART_IRCTRL */
+#define USART_IRCTRL_IRPW_FOUR                (_USART_IRCTRL_IRPW_FOUR << 1)        /**< Shifted mode FOUR for USART_IRCTRL */
+#define USART_IRCTRL_IRFILT                   (0x1UL << 3)                          /**< IrDA RX Filter */
+#define _USART_IRCTRL_IRFILT_SHIFT            3                                     /**< Shift value for USART_IRFILT */
+#define _USART_IRCTRL_IRFILT_MASK             0x8UL                                 /**< Bit mask for USART_IRFILT */
+#define _USART_IRCTRL_IRFILT_DEFAULT          0x00000000UL                          /**< Mode DEFAULT for USART_IRCTRL */
+#define USART_IRCTRL_IRFILT_DEFAULT           (_USART_IRCTRL_IRFILT_DEFAULT << 3)   /**< Shifted mode DEFAULT for USART_IRCTRL */
+#define _USART_IRCTRL_IRPRSSEL_SHIFT          4                                     /**< Shift value for USART_IRPRSSEL */
+#define _USART_IRCTRL_IRPRSSEL_MASK           0x70UL                                /**< Bit mask for USART_IRPRSSEL */
+#define _USART_IRCTRL_IRPRSSEL_DEFAULT        0x00000000UL                          /**< Mode DEFAULT for USART_IRCTRL */
+#define _USART_IRCTRL_IRPRSSEL_PRSCH0         0x00000000UL                          /**< Mode PRSCH0 for USART_IRCTRL */
+#define _USART_IRCTRL_IRPRSSEL_PRSCH1         0x00000001UL                          /**< Mode PRSCH1 for USART_IRCTRL */
+#define _USART_IRCTRL_IRPRSSEL_PRSCH2         0x00000002UL                          /**< Mode PRSCH2 for USART_IRCTRL */
+#define _USART_IRCTRL_IRPRSSEL_PRSCH3         0x00000003UL                          /**< Mode PRSCH3 for USART_IRCTRL */
+#define _USART_IRCTRL_IRPRSSEL_PRSCH4         0x00000004UL                          /**< Mode PRSCH4 for USART_IRCTRL */
+#define _USART_IRCTRL_IRPRSSEL_PRSCH5         0x00000005UL                          /**< Mode PRSCH5 for USART_IRCTRL */
+#define _USART_IRCTRL_IRPRSSEL_PRSCH6         0x00000006UL                          /**< Mode PRSCH6 for USART_IRCTRL */
+#define _USART_IRCTRL_IRPRSSEL_PRSCH7         0x00000007UL                          /**< Mode PRSCH7 for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSSEL_DEFAULT         (_USART_IRCTRL_IRPRSSEL_DEFAULT << 4) /**< Shifted mode DEFAULT for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSSEL_PRSCH0          (_USART_IRCTRL_IRPRSSEL_PRSCH0 << 4)  /**< Shifted mode PRSCH0 for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSSEL_PRSCH1          (_USART_IRCTRL_IRPRSSEL_PRSCH1 << 4)  /**< Shifted mode PRSCH1 for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSSEL_PRSCH2          (_USART_IRCTRL_IRPRSSEL_PRSCH2 << 4)  /**< Shifted mode PRSCH2 for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSSEL_PRSCH3          (_USART_IRCTRL_IRPRSSEL_PRSCH3 << 4)  /**< Shifted mode PRSCH3 for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSSEL_PRSCH4          (_USART_IRCTRL_IRPRSSEL_PRSCH4 << 4)  /**< Shifted mode PRSCH4 for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSSEL_PRSCH5          (_USART_IRCTRL_IRPRSSEL_PRSCH5 << 4)  /**< Shifted mode PRSCH5 for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSSEL_PRSCH6          (_USART_IRCTRL_IRPRSSEL_PRSCH6 << 4)  /**< Shifted mode PRSCH6 for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSSEL_PRSCH7          (_USART_IRCTRL_IRPRSSEL_PRSCH7 << 4)  /**< Shifted mode PRSCH7 for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSEN                  (0x1UL << 7)                          /**< IrDA PRS Channel Enable */
+#define _USART_IRCTRL_IRPRSEN_SHIFT           7                                     /**< Shift value for USART_IRPRSEN */
+#define _USART_IRCTRL_IRPRSEN_MASK            0x80UL                                /**< Bit mask for USART_IRPRSEN */
+#define _USART_IRCTRL_IRPRSEN_DEFAULT         0x00000000UL                          /**< Mode DEFAULT for USART_IRCTRL */
+#define USART_IRCTRL_IRPRSEN_DEFAULT          (_USART_IRCTRL_IRPRSEN_DEFAULT << 7)  /**< Shifted mode DEFAULT for USART_IRCTRL */
+
+/* Bit fields for USART ROUTE */
+#define _USART_ROUTE_RESETVALUE               0x00000000UL                         /**< Default value for USART_ROUTE */
+#define _USART_ROUTE_MASK                     0x0000070FUL                         /**< Mask for USART_ROUTE */
+#define USART_ROUTE_RXPEN                     (0x1UL << 0)                         /**< RX Pin Enable */
+#define _USART_ROUTE_RXPEN_SHIFT              0                                    /**< Shift value for USART_RXPEN */
+#define _USART_ROUTE_RXPEN_MASK               0x1UL                                /**< Bit mask for USART_RXPEN */
+#define _USART_ROUTE_RXPEN_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for USART_ROUTE */
+#define USART_ROUTE_RXPEN_DEFAULT             (_USART_ROUTE_RXPEN_DEFAULT << 0)    /**< Shifted mode DEFAULT for USART_ROUTE */
+#define USART_ROUTE_TXPEN                     (0x1UL << 1)                         /**< TX Pin Enable */
+#define _USART_ROUTE_TXPEN_SHIFT              1                                    /**< Shift value for USART_TXPEN */
+#define _USART_ROUTE_TXPEN_MASK               0x2UL                                /**< Bit mask for USART_TXPEN */
+#define _USART_ROUTE_TXPEN_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for USART_ROUTE */
+#define USART_ROUTE_TXPEN_DEFAULT             (_USART_ROUTE_TXPEN_DEFAULT << 1)    /**< Shifted mode DEFAULT for USART_ROUTE */
+#define USART_ROUTE_CSPEN                     (0x1UL << 2)                         /**< CS Pin Enable */
+#define _USART_ROUTE_CSPEN_SHIFT              2                                    /**< Shift value for USART_CSPEN */
+#define _USART_ROUTE_CSPEN_MASK               0x4UL                                /**< Bit mask for USART_CSPEN */
+#define _USART_ROUTE_CSPEN_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for USART_ROUTE */
+#define USART_ROUTE_CSPEN_DEFAULT             (_USART_ROUTE_CSPEN_DEFAULT << 2)    /**< Shifted mode DEFAULT for USART_ROUTE */
+#define USART_ROUTE_CLKPEN                    (0x1UL << 3)                         /**< CLK Pin Enable */
+#define _USART_ROUTE_CLKPEN_SHIFT             3                                    /**< Shift value for USART_CLKPEN */
+#define _USART_ROUTE_CLKPEN_MASK              0x8UL                                /**< Bit mask for USART_CLKPEN */
+#define _USART_ROUTE_CLKPEN_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for USART_ROUTE */
+#define USART_ROUTE_CLKPEN_DEFAULT            (_USART_ROUTE_CLKPEN_DEFAULT << 3)   /**< Shifted mode DEFAULT for USART_ROUTE */
+#define _USART_ROUTE_LOCATION_SHIFT           8                                    /**< Shift value for USART_LOCATION */
+#define _USART_ROUTE_LOCATION_MASK            0x700UL                              /**< Bit mask for USART_LOCATION */
+#define _USART_ROUTE_LOCATION_LOC0            0x00000000UL                         /**< Mode LOC0 for USART_ROUTE */
+#define _USART_ROUTE_LOCATION_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for USART_ROUTE */
+#define _USART_ROUTE_LOCATION_LOC1            0x00000001UL                         /**< Mode LOC1 for USART_ROUTE */
+#define _USART_ROUTE_LOCATION_LOC2            0x00000002UL                         /**< Mode LOC2 for USART_ROUTE */
+#define _USART_ROUTE_LOCATION_LOC3            0x00000003UL                         /**< Mode LOC3 for USART_ROUTE */
+#define _USART_ROUTE_LOCATION_LOC4            0x00000004UL                         /**< Mode LOC4 for USART_ROUTE */
+#define _USART_ROUTE_LOCATION_LOC5            0x00000005UL                         /**< Mode LOC5 for USART_ROUTE */
+#define USART_ROUTE_LOCATION_LOC0             (_USART_ROUTE_LOCATION_LOC0 << 8)    /**< Shifted mode LOC0 for USART_ROUTE */
+#define USART_ROUTE_LOCATION_DEFAULT          (_USART_ROUTE_LOCATION_DEFAULT << 8) /**< Shifted mode DEFAULT for USART_ROUTE */
+#define USART_ROUTE_LOCATION_LOC1             (_USART_ROUTE_LOCATION_LOC1 << 8)    /**< Shifted mode LOC1 for USART_ROUTE */
+#define USART_ROUTE_LOCATION_LOC2             (_USART_ROUTE_LOCATION_LOC2 << 8)    /**< Shifted mode LOC2 for USART_ROUTE */
+#define USART_ROUTE_LOCATION_LOC3             (_USART_ROUTE_LOCATION_LOC3 << 8)    /**< Shifted mode LOC3 for USART_ROUTE */
+#define USART_ROUTE_LOCATION_LOC4             (_USART_ROUTE_LOCATION_LOC4 << 8)    /**< Shifted mode LOC4 for USART_ROUTE */
+#define USART_ROUTE_LOCATION_LOC5             (_USART_ROUTE_LOCATION_LOC5 << 8)    /**< Shifted mode LOC5 for USART_ROUTE */
+
+/* Bit fields for USART INPUT */
+#define _USART_INPUT_RESETVALUE               0x00000000UL                         /**< Default value for USART_INPUT */
+#define _USART_INPUT_MASK                     0x00000017UL                         /**< Mask for USART_INPUT */
+#define _USART_INPUT_RXPRSSEL_SHIFT           0                                    /**< Shift value for USART_RXPRSSEL */
+#define _USART_INPUT_RXPRSSEL_MASK            0x7UL                                /**< Bit mask for USART_RXPRSSEL */
+#define _USART_INPUT_RXPRSSEL_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for USART_INPUT */
+#define _USART_INPUT_RXPRSSEL_PRSCH0          0x00000000UL                         /**< Mode PRSCH0 for USART_INPUT */
+#define _USART_INPUT_RXPRSSEL_PRSCH1          0x00000001UL                         /**< Mode PRSCH1 for USART_INPUT */
+#define _USART_INPUT_RXPRSSEL_PRSCH2          0x00000002UL                         /**< Mode PRSCH2 for USART_INPUT */
+#define _USART_INPUT_RXPRSSEL_PRSCH3          0x00000003UL                         /**< Mode PRSCH3 for USART_INPUT */
+#define _USART_INPUT_RXPRSSEL_PRSCH4          0x00000004UL                         /**< Mode PRSCH4 for USART_INPUT */
+#define _USART_INPUT_RXPRSSEL_PRSCH5          0x00000005UL                         /**< Mode PRSCH5 for USART_INPUT */
+#define _USART_INPUT_RXPRSSEL_PRSCH6          0x00000006UL                         /**< Mode PRSCH6 for USART_INPUT */
+#define _USART_INPUT_RXPRSSEL_PRSCH7          0x00000007UL                         /**< Mode PRSCH7 for USART_INPUT */
+#define USART_INPUT_RXPRSSEL_DEFAULT          (_USART_INPUT_RXPRSSEL_DEFAULT << 0) /**< Shifted mode DEFAULT for USART_INPUT */
+#define USART_INPUT_RXPRSSEL_PRSCH0           (_USART_INPUT_RXPRSSEL_PRSCH0 << 0)  /**< Shifted mode PRSCH0 for USART_INPUT */
+#define USART_INPUT_RXPRSSEL_PRSCH1           (_USART_INPUT_RXPRSSEL_PRSCH1 << 0)  /**< Shifted mode PRSCH1 for USART_INPUT */
+#define USART_INPUT_RXPRSSEL_PRSCH2           (_USART_INPUT_RXPRSSEL_PRSCH2 << 0)  /**< Shifted mode PRSCH2 for USART_INPUT */
+#define USART_INPUT_RXPRSSEL_PRSCH3           (_USART_INPUT_RXPRSSEL_PRSCH3 << 0)  /**< Shifted mode PRSCH3 for USART_INPUT */
+#define USART_INPUT_RXPRSSEL_PRSCH4           (_USART_INPUT_RXPRSSEL_PRSCH4 << 0)  /**< Shifted mode PRSCH4 for USART_INPUT */
+#define USART_INPUT_RXPRSSEL_PRSCH5           (_USART_INPUT_RXPRSSEL_PRSCH5 << 0)  /**< Shifted mode PRSCH5 for USART_INPUT */
+#define USART_INPUT_RXPRSSEL_PRSCH6           (_USART_INPUT_RXPRSSEL_PRSCH6 << 0)  /**< Shifted mode PRSCH6 for USART_INPUT */
+#define USART_INPUT_RXPRSSEL_PRSCH7           (_USART_INPUT_RXPRSSEL_PRSCH7 << 0)  /**< Shifted mode PRSCH7 for USART_INPUT */
+#define USART_INPUT_RXPRS                     (0x1UL << 4)                         /**< PRS RX Enable */
+#define _USART_INPUT_RXPRS_SHIFT              4                                    /**< Shift value for USART_RXPRS */
+#define _USART_INPUT_RXPRS_MASK               0x10UL                               /**< Bit mask for USART_RXPRS */
+#define _USART_INPUT_RXPRS_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for USART_INPUT */
+#define USART_INPUT_RXPRS_DEFAULT             (_USART_INPUT_RXPRS_DEFAULT << 4)    /**< Shifted mode DEFAULT for USART_INPUT */
+
+/* Bit fields for USART I2SCTRL */
+#define _USART_I2SCTRL_RESETVALUE             0x00000000UL                           /**< Default value for USART_I2SCTRL */
+#define _USART_I2SCTRL_MASK                   0x0000071FUL                           /**< Mask for USART_I2SCTRL */
+#define USART_I2SCTRL_EN                      (0x1UL << 0)                           /**< Enable I2S Mode */
+#define _USART_I2SCTRL_EN_SHIFT               0                                      /**< Shift value for USART_EN */
+#define _USART_I2SCTRL_EN_MASK                0x1UL                                  /**< Bit mask for USART_EN */
+#define _USART_I2SCTRL_EN_DEFAULT             0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
+#define USART_I2SCTRL_EN_DEFAULT              (_USART_I2SCTRL_EN_DEFAULT << 0)       /**< Shifted mode DEFAULT for USART_I2SCTRL */
+#define USART_I2SCTRL_MONO                    (0x1UL << 1)                           /**< Stero or Mono */
+#define _USART_I2SCTRL_MONO_SHIFT             1                                      /**< Shift value for USART_MONO */
+#define _USART_I2SCTRL_MONO_MASK              0x2UL                                  /**< Bit mask for USART_MONO */
+#define _USART_I2SCTRL_MONO_DEFAULT           0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
+#define USART_I2SCTRL_MONO_DEFAULT            (_USART_I2SCTRL_MONO_DEFAULT << 1)     /**< Shifted mode DEFAULT for USART_I2SCTRL */
+#define USART_I2SCTRL_JUSTIFY                 (0x1UL << 2)                           /**< Justification of I2S Data */
+#define _USART_I2SCTRL_JUSTIFY_SHIFT          2                                      /**< Shift value for USART_JUSTIFY */
+#define _USART_I2SCTRL_JUSTIFY_MASK           0x4UL                                  /**< Bit mask for USART_JUSTIFY */
+#define _USART_I2SCTRL_JUSTIFY_DEFAULT        0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
+#define _USART_I2SCTRL_JUSTIFY_LEFT           0x00000000UL                           /**< Mode LEFT for USART_I2SCTRL */
+#define _USART_I2SCTRL_JUSTIFY_RIGHT          0x00000001UL                           /**< Mode RIGHT for USART_I2SCTRL */
+#define USART_I2SCTRL_JUSTIFY_DEFAULT         (_USART_I2SCTRL_JUSTIFY_DEFAULT << 2)  /**< Shifted mode DEFAULT for USART_I2SCTRL */
+#define USART_I2SCTRL_JUSTIFY_LEFT            (_USART_I2SCTRL_JUSTIFY_LEFT << 2)     /**< Shifted mode LEFT for USART_I2SCTRL */
+#define USART_I2SCTRL_JUSTIFY_RIGHT           (_USART_I2SCTRL_JUSTIFY_RIGHT << 2)    /**< Shifted mode RIGHT for USART_I2SCTRL */
+#define USART_I2SCTRL_DMASPLIT                (0x1UL << 3)                           /**< Separate DMA Request For Left/Right Data */
+#define _USART_I2SCTRL_DMASPLIT_SHIFT         3                                      /**< Shift value for USART_DMASPLIT */
+#define _USART_I2SCTRL_DMASPLIT_MASK          0x8UL                                  /**< Bit mask for USART_DMASPLIT */
+#define _USART_I2SCTRL_DMASPLIT_DEFAULT       0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
+#define USART_I2SCTRL_DMASPLIT_DEFAULT        (_USART_I2SCTRL_DMASPLIT_DEFAULT << 3) /**< Shifted mode DEFAULT for USART_I2SCTRL */
+#define USART_I2SCTRL_DELAY                   (0x1UL << 4)                           /**< Delay on I2S data */
+#define _USART_I2SCTRL_DELAY_SHIFT            4                                      /**< Shift value for USART_DELAY */
+#define _USART_I2SCTRL_DELAY_MASK             0x10UL                                 /**< Bit mask for USART_DELAY */
+#define _USART_I2SCTRL_DELAY_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
+#define USART_I2SCTRL_DELAY_DEFAULT           (_USART_I2SCTRL_DELAY_DEFAULT << 4)    /**< Shifted mode DEFAULT for USART_I2SCTRL */
+#define _USART_I2SCTRL_FORMAT_SHIFT           8                                      /**< Shift value for USART_FORMAT */
+#define _USART_I2SCTRL_FORMAT_MASK            0x700UL                                /**< Bit mask for USART_FORMAT */
+#define _USART_I2SCTRL_FORMAT_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
+#define _USART_I2SCTRL_FORMAT_W32D32          0x00000000UL                           /**< Mode W32D32 for USART_I2SCTRL */
+#define _USART_I2SCTRL_FORMAT_W32D24M         0x00000001UL                           /**< Mode W32D24M for USART_I2SCTRL */
+#define _USART_I2SCTRL_FORMAT_W32D24          0x00000002UL                           /**< Mode W32D24 for USART_I2SCTRL */
+#define _USART_I2SCTRL_FORMAT_W32D16          0x00000003UL                           /**< Mode W32D16 for USART_I2SCTRL */
+#define _USART_I2SCTRL_FORMAT_W32D8           0x00000004UL                           /**< Mode W32D8 for USART_I2SCTRL */
+#define _USART_I2SCTRL_FORMAT_W16D16          0x00000005UL                           /**< Mode W16D16 for USART_I2SCTRL */
+#define _USART_I2SCTRL_FORMAT_W16D8           0x00000006UL                           /**< Mode W16D8 for USART_I2SCTRL */
+#define _USART_I2SCTRL_FORMAT_W8D8            0x00000007UL                           /**< Mode W8D8 for USART_I2SCTRL */
+#define USART_I2SCTRL_FORMAT_DEFAULT          (_USART_I2SCTRL_FORMAT_DEFAULT << 8)   /**< Shifted mode DEFAULT for USART_I2SCTRL */
+#define USART_I2SCTRL_FORMAT_W32D32           (_USART_I2SCTRL_FORMAT_W32D32 << 8)    /**< Shifted mode W32D32 for USART_I2SCTRL */
+#define USART_I2SCTRL_FORMAT_W32D24M          (_USART_I2SCTRL_FORMAT_W32D24M << 8)   /**< Shifted mode W32D24M for USART_I2SCTRL */
+#define USART_I2SCTRL_FORMAT_W32D24           (_USART_I2SCTRL_FORMAT_W32D24 << 8)    /**< Shifted mode W32D24 for USART_I2SCTRL */
+#define USART_I2SCTRL_FORMAT_W32D16           (_USART_I2SCTRL_FORMAT_W32D16 << 8)    /**< Shifted mode W32D16 for USART_I2SCTRL */
+#define USART_I2SCTRL_FORMAT_W32D8            (_USART_I2SCTRL_FORMAT_W32D8 << 8)     /**< Shifted mode W32D8 for USART_I2SCTRL */
+#define USART_I2SCTRL_FORMAT_W16D16           (_USART_I2SCTRL_FORMAT_W16D16 << 8)    /**< Shifted mode W16D16 for USART_I2SCTRL */
+#define USART_I2SCTRL_FORMAT_W16D8            (_USART_I2SCTRL_FORMAT_W16D8 << 8)     /**< Shifted mode W16D8 for USART_I2SCTRL */
+#define USART_I2SCTRL_FORMAT_W8D8             (_USART_I2SCTRL_FORMAT_W8D8 << 8)      /**< Shifted mode W8D8 for USART_I2SCTRL */
+
+/** @} End of group EFM32TG_USART */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_vcmp.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_vcmp.h
@@ -1,0 +1,203 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_VCMP register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_VCMP
+ * @brief EFM32TG_VCMP Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;     /**< Control Register  */
+  __IOM uint32_t INPUTSEL; /**< Input Selection Register  */
+  __IM uint32_t  STATUS;   /**< Status Register  */
+  __IOM uint32_t IEN;      /**< Interrupt Enable Register  */
+  __IM uint32_t  IF;       /**< Interrupt Flag Register  */
+  __IOM uint32_t IFS;      /**< Interrupt Flag Set Register  */
+  __IOM uint32_t IFC;      /**< Interrupt Flag Clear Register  */
+} VCMP_TypeDef;            /**< VCMP Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_VCMP_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for VCMP CTRL */
+#define _VCMP_CTRL_RESETVALUE               0x47000000UL                         /**< Default value for VCMP_CTRL */
+#define _VCMP_CTRL_MASK                     0x4F030715UL                         /**< Mask for VCMP_CTRL */
+#define VCMP_CTRL_EN                        (0x1UL << 0)                         /**< Voltage Supply Comparator Enable */
+#define _VCMP_CTRL_EN_SHIFT                 0                                    /**< Shift value for VCMP_EN */
+#define _VCMP_CTRL_EN_MASK                  0x1UL                                /**< Bit mask for VCMP_EN */
+#define _VCMP_CTRL_EN_DEFAULT               0x00000000UL                         /**< Mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_EN_DEFAULT                (_VCMP_CTRL_EN_DEFAULT << 0)         /**< Shifted mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_INACTVAL                  (0x1UL << 2)                         /**< Inactive Value */
+#define _VCMP_CTRL_INACTVAL_SHIFT           2                                    /**< Shift value for VCMP_INACTVAL */
+#define _VCMP_CTRL_INACTVAL_MASK            0x4UL                                /**< Bit mask for VCMP_INACTVAL */
+#define _VCMP_CTRL_INACTVAL_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_INACTVAL_DEFAULT          (_VCMP_CTRL_INACTVAL_DEFAULT << 2)   /**< Shifted mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_HYSTEN                    (0x1UL << 4)                         /**< Hysteresis Enable */
+#define _VCMP_CTRL_HYSTEN_SHIFT             4                                    /**< Shift value for VCMP_HYSTEN */
+#define _VCMP_CTRL_HYSTEN_MASK              0x10UL                               /**< Bit mask for VCMP_HYSTEN */
+#define _VCMP_CTRL_HYSTEN_DEFAULT           0x00000000UL                         /**< Mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_HYSTEN_DEFAULT            (_VCMP_CTRL_HYSTEN_DEFAULT << 4)     /**< Shifted mode DEFAULT for VCMP_CTRL */
+#define _VCMP_CTRL_WARMTIME_SHIFT           8                                    /**< Shift value for VCMP_WARMTIME */
+#define _VCMP_CTRL_WARMTIME_MASK            0x700UL                              /**< Bit mask for VCMP_WARMTIME */
+#define _VCMP_CTRL_WARMTIME_DEFAULT         0x00000000UL                         /**< Mode DEFAULT for VCMP_CTRL */
+#define _VCMP_CTRL_WARMTIME_4CYCLES         0x00000000UL                         /**< Mode 4CYCLES for VCMP_CTRL */
+#define _VCMP_CTRL_WARMTIME_8CYCLES         0x00000001UL                         /**< Mode 8CYCLES for VCMP_CTRL */
+#define _VCMP_CTRL_WARMTIME_16CYCLES        0x00000002UL                         /**< Mode 16CYCLES for VCMP_CTRL */
+#define _VCMP_CTRL_WARMTIME_32CYCLES        0x00000003UL                         /**< Mode 32CYCLES for VCMP_CTRL */
+#define _VCMP_CTRL_WARMTIME_64CYCLES        0x00000004UL                         /**< Mode 64CYCLES for VCMP_CTRL */
+#define _VCMP_CTRL_WARMTIME_128CYCLES       0x00000005UL                         /**< Mode 128CYCLES for VCMP_CTRL */
+#define _VCMP_CTRL_WARMTIME_256CYCLES       0x00000006UL                         /**< Mode 256CYCLES for VCMP_CTRL */
+#define _VCMP_CTRL_WARMTIME_512CYCLES       0x00000007UL                         /**< Mode 512CYCLES for VCMP_CTRL */
+#define VCMP_CTRL_WARMTIME_DEFAULT          (_VCMP_CTRL_WARMTIME_DEFAULT << 8)   /**< Shifted mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_WARMTIME_4CYCLES          (_VCMP_CTRL_WARMTIME_4CYCLES << 8)   /**< Shifted mode 4CYCLES for VCMP_CTRL */
+#define VCMP_CTRL_WARMTIME_8CYCLES          (_VCMP_CTRL_WARMTIME_8CYCLES << 8)   /**< Shifted mode 8CYCLES for VCMP_CTRL */
+#define VCMP_CTRL_WARMTIME_16CYCLES         (_VCMP_CTRL_WARMTIME_16CYCLES << 8)  /**< Shifted mode 16CYCLES for VCMP_CTRL */
+#define VCMP_CTRL_WARMTIME_32CYCLES         (_VCMP_CTRL_WARMTIME_32CYCLES << 8)  /**< Shifted mode 32CYCLES for VCMP_CTRL */
+#define VCMP_CTRL_WARMTIME_64CYCLES         (_VCMP_CTRL_WARMTIME_64CYCLES << 8)  /**< Shifted mode 64CYCLES for VCMP_CTRL */
+#define VCMP_CTRL_WARMTIME_128CYCLES        (_VCMP_CTRL_WARMTIME_128CYCLES << 8) /**< Shifted mode 128CYCLES for VCMP_CTRL */
+#define VCMP_CTRL_WARMTIME_256CYCLES        (_VCMP_CTRL_WARMTIME_256CYCLES << 8) /**< Shifted mode 256CYCLES for VCMP_CTRL */
+#define VCMP_CTRL_WARMTIME_512CYCLES        (_VCMP_CTRL_WARMTIME_512CYCLES << 8) /**< Shifted mode 512CYCLES for VCMP_CTRL */
+#define VCMP_CTRL_IRISE                     (0x1UL << 16)                        /**< Rising Edge Interrupt Sense */
+#define _VCMP_CTRL_IRISE_SHIFT              16                                   /**< Shift value for VCMP_IRISE */
+#define _VCMP_CTRL_IRISE_MASK               0x10000UL                            /**< Bit mask for VCMP_IRISE */
+#define _VCMP_CTRL_IRISE_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_IRISE_DEFAULT             (_VCMP_CTRL_IRISE_DEFAULT << 16)     /**< Shifted mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_IFALL                     (0x1UL << 17)                        /**< Falling Edge Interrupt Sense */
+#define _VCMP_CTRL_IFALL_SHIFT              17                                   /**< Shift value for VCMP_IFALL */
+#define _VCMP_CTRL_IFALL_MASK               0x20000UL                            /**< Bit mask for VCMP_IFALL */
+#define _VCMP_CTRL_IFALL_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_IFALL_DEFAULT             (_VCMP_CTRL_IFALL_DEFAULT << 17)     /**< Shifted mode DEFAULT for VCMP_CTRL */
+#define _VCMP_CTRL_BIASPROG_SHIFT           24                                   /**< Shift value for VCMP_BIASPROG */
+#define _VCMP_CTRL_BIASPROG_MASK            0xF000000UL                          /**< Bit mask for VCMP_BIASPROG */
+#define _VCMP_CTRL_BIASPROG_DEFAULT         0x00000007UL                         /**< Mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_BIASPROG_DEFAULT          (_VCMP_CTRL_BIASPROG_DEFAULT << 24)  /**< Shifted mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_HALFBIAS                  (0x1UL << 30)                        /**< Half Bias Current */
+#define _VCMP_CTRL_HALFBIAS_SHIFT           30                                   /**< Shift value for VCMP_HALFBIAS */
+#define _VCMP_CTRL_HALFBIAS_MASK            0x40000000UL                         /**< Bit mask for VCMP_HALFBIAS */
+#define _VCMP_CTRL_HALFBIAS_DEFAULT         0x00000001UL                         /**< Mode DEFAULT for VCMP_CTRL */
+#define VCMP_CTRL_HALFBIAS_DEFAULT          (_VCMP_CTRL_HALFBIAS_DEFAULT << 30)  /**< Shifted mode DEFAULT for VCMP_CTRL */
+
+/* Bit fields for VCMP INPUTSEL */
+#define _VCMP_INPUTSEL_RESETVALUE           0x00000000UL                            /**< Default value for VCMP_INPUTSEL */
+#define _VCMP_INPUTSEL_MASK                 0x0000013FUL                            /**< Mask for VCMP_INPUTSEL */
+#define _VCMP_INPUTSEL_TRIGLEVEL_SHIFT      0                                       /**< Shift value for VCMP_TRIGLEVEL */
+#define _VCMP_INPUTSEL_TRIGLEVEL_MASK       0x3FUL                                  /**< Bit mask for VCMP_TRIGLEVEL */
+#define _VCMP_INPUTSEL_TRIGLEVEL_DEFAULT    0x00000000UL                            /**< Mode DEFAULT for VCMP_INPUTSEL */
+#define VCMP_INPUTSEL_TRIGLEVEL_DEFAULT     (_VCMP_INPUTSEL_TRIGLEVEL_DEFAULT << 0) /**< Shifted mode DEFAULT for VCMP_INPUTSEL */
+#define VCMP_INPUTSEL_LPREF                 (0x1UL << 8)                            /**< Low Power Reference */
+#define _VCMP_INPUTSEL_LPREF_SHIFT          8                                       /**< Shift value for VCMP_LPREF */
+#define _VCMP_INPUTSEL_LPREF_MASK           0x100UL                                 /**< Bit mask for VCMP_LPREF */
+#define _VCMP_INPUTSEL_LPREF_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for VCMP_INPUTSEL */
+#define VCMP_INPUTSEL_LPREF_DEFAULT         (_VCMP_INPUTSEL_LPREF_DEFAULT << 8)     /**< Shifted mode DEFAULT for VCMP_INPUTSEL */
+
+/* Bit fields for VCMP STATUS */
+#define _VCMP_STATUS_RESETVALUE             0x00000000UL                        /**< Default value for VCMP_STATUS */
+#define _VCMP_STATUS_MASK                   0x00000003UL                        /**< Mask for VCMP_STATUS */
+#define VCMP_STATUS_VCMPACT                 (0x1UL << 0)                        /**< Voltage Supply Comparator Active */
+#define _VCMP_STATUS_VCMPACT_SHIFT          0                                   /**< Shift value for VCMP_VCMPACT */
+#define _VCMP_STATUS_VCMPACT_MASK           0x1UL                               /**< Bit mask for VCMP_VCMPACT */
+#define _VCMP_STATUS_VCMPACT_DEFAULT        0x00000000UL                        /**< Mode DEFAULT for VCMP_STATUS */
+#define VCMP_STATUS_VCMPACT_DEFAULT         (_VCMP_STATUS_VCMPACT_DEFAULT << 0) /**< Shifted mode DEFAULT for VCMP_STATUS */
+#define VCMP_STATUS_VCMPOUT                 (0x1UL << 1)                        /**< Voltage Supply Comparator Output */
+#define _VCMP_STATUS_VCMPOUT_SHIFT          1                                   /**< Shift value for VCMP_VCMPOUT */
+#define _VCMP_STATUS_VCMPOUT_MASK           0x2UL                               /**< Bit mask for VCMP_VCMPOUT */
+#define _VCMP_STATUS_VCMPOUT_DEFAULT        0x00000000UL                        /**< Mode DEFAULT for VCMP_STATUS */
+#define VCMP_STATUS_VCMPOUT_DEFAULT         (_VCMP_STATUS_VCMPOUT_DEFAULT << 1) /**< Shifted mode DEFAULT for VCMP_STATUS */
+
+/* Bit fields for VCMP IEN */
+#define _VCMP_IEN_RESETVALUE                0x00000000UL                    /**< Default value for VCMP_IEN */
+#define _VCMP_IEN_MASK                      0x00000003UL                    /**< Mask for VCMP_IEN */
+#define VCMP_IEN_EDGE                       (0x1UL << 0)                    /**< Edge Trigger Interrupt Enable */
+#define _VCMP_IEN_EDGE_SHIFT                0                               /**< Shift value for VCMP_EDGE */
+#define _VCMP_IEN_EDGE_MASK                 0x1UL                           /**< Bit mask for VCMP_EDGE */
+#define _VCMP_IEN_EDGE_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for VCMP_IEN */
+#define VCMP_IEN_EDGE_DEFAULT               (_VCMP_IEN_EDGE_DEFAULT << 0)   /**< Shifted mode DEFAULT for VCMP_IEN */
+#define VCMP_IEN_WARMUP                     (0x1UL << 1)                    /**< Warm-up Interrupt Enable */
+#define _VCMP_IEN_WARMUP_SHIFT              1                               /**< Shift value for VCMP_WARMUP */
+#define _VCMP_IEN_WARMUP_MASK               0x2UL                           /**< Bit mask for VCMP_WARMUP */
+#define _VCMP_IEN_WARMUP_DEFAULT            0x00000000UL                    /**< Mode DEFAULT for VCMP_IEN */
+#define VCMP_IEN_WARMUP_DEFAULT             (_VCMP_IEN_WARMUP_DEFAULT << 1) /**< Shifted mode DEFAULT for VCMP_IEN */
+
+/* Bit fields for VCMP IF */
+#define _VCMP_IF_RESETVALUE                 0x00000000UL                   /**< Default value for VCMP_IF */
+#define _VCMP_IF_MASK                       0x00000003UL                   /**< Mask for VCMP_IF */
+#define VCMP_IF_EDGE                        (0x1UL << 0)                   /**< Edge Triggered Interrupt Flag */
+#define _VCMP_IF_EDGE_SHIFT                 0                              /**< Shift value for VCMP_EDGE */
+#define _VCMP_IF_EDGE_MASK                  0x1UL                          /**< Bit mask for VCMP_EDGE */
+#define _VCMP_IF_EDGE_DEFAULT               0x00000000UL                   /**< Mode DEFAULT for VCMP_IF */
+#define VCMP_IF_EDGE_DEFAULT                (_VCMP_IF_EDGE_DEFAULT << 0)   /**< Shifted mode DEFAULT for VCMP_IF */
+#define VCMP_IF_WARMUP                      (0x1UL << 1)                   /**< Warm-up Interrupt Flag */
+#define _VCMP_IF_WARMUP_SHIFT               1                              /**< Shift value for VCMP_WARMUP */
+#define _VCMP_IF_WARMUP_MASK                0x2UL                          /**< Bit mask for VCMP_WARMUP */
+#define _VCMP_IF_WARMUP_DEFAULT             0x00000000UL                   /**< Mode DEFAULT for VCMP_IF */
+#define VCMP_IF_WARMUP_DEFAULT              (_VCMP_IF_WARMUP_DEFAULT << 1) /**< Shifted mode DEFAULT for VCMP_IF */
+
+/* Bit fields for VCMP IFS */
+#define _VCMP_IFS_RESETVALUE                0x00000000UL                    /**< Default value for VCMP_IFS */
+#define _VCMP_IFS_MASK                      0x00000003UL                    /**< Mask for VCMP_IFS */
+#define VCMP_IFS_EDGE                       (0x1UL << 0)                    /**< Edge Triggered Interrupt Flag Set */
+#define _VCMP_IFS_EDGE_SHIFT                0                               /**< Shift value for VCMP_EDGE */
+#define _VCMP_IFS_EDGE_MASK                 0x1UL                           /**< Bit mask for VCMP_EDGE */
+#define _VCMP_IFS_EDGE_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for VCMP_IFS */
+#define VCMP_IFS_EDGE_DEFAULT               (_VCMP_IFS_EDGE_DEFAULT << 0)   /**< Shifted mode DEFAULT for VCMP_IFS */
+#define VCMP_IFS_WARMUP                     (0x1UL << 1)                    /**< Warm-up Interrupt Flag Set */
+#define _VCMP_IFS_WARMUP_SHIFT              1                               /**< Shift value for VCMP_WARMUP */
+#define _VCMP_IFS_WARMUP_MASK               0x2UL                           /**< Bit mask for VCMP_WARMUP */
+#define _VCMP_IFS_WARMUP_DEFAULT            0x00000000UL                    /**< Mode DEFAULT for VCMP_IFS */
+#define VCMP_IFS_WARMUP_DEFAULT             (_VCMP_IFS_WARMUP_DEFAULT << 1) /**< Shifted mode DEFAULT for VCMP_IFS */
+
+/* Bit fields for VCMP IFC */
+#define _VCMP_IFC_RESETVALUE                0x00000000UL                    /**< Default value for VCMP_IFC */
+#define _VCMP_IFC_MASK                      0x00000003UL                    /**< Mask for VCMP_IFC */
+#define VCMP_IFC_EDGE                       (0x1UL << 0)                    /**< Edge Triggered Interrupt Flag Clear */
+#define _VCMP_IFC_EDGE_SHIFT                0                               /**< Shift value for VCMP_EDGE */
+#define _VCMP_IFC_EDGE_MASK                 0x1UL                           /**< Bit mask for VCMP_EDGE */
+#define _VCMP_IFC_EDGE_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for VCMP_IFC */
+#define VCMP_IFC_EDGE_DEFAULT               (_VCMP_IFC_EDGE_DEFAULT << 0)   /**< Shifted mode DEFAULT for VCMP_IFC */
+#define VCMP_IFC_WARMUP                     (0x1UL << 1)                    /**< Warm-up Interrupt Flag Clear */
+#define _VCMP_IFC_WARMUP_SHIFT              1                               /**< Shift value for VCMP_WARMUP */
+#define _VCMP_IFC_WARMUP_MASK               0x2UL                           /**< Bit mask for VCMP_WARMUP */
+#define _VCMP_IFC_WARMUP_DEFAULT            0x00000000UL                    /**< Mode DEFAULT for VCMP_IFC */
+#define VCMP_IFC_WARMUP_DEFAULT             (_VCMP_IFC_WARMUP_DEFAULT << 1) /**< Shifted mode DEFAULT for VCMP_IFC */
+
+/** @} End of group EFM32TG_VCMP */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_wdog.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/efm32tg_wdog.h
@@ -1,0 +1,139 @@
+/***************************************************************************//**
+ * @file
+ * @brief EFM32TG_WDOG register and bit field definitions
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @defgroup EFM32TG_WDOG
+ * @brief EFM32TG_WDOG Register Declaration
+ * @{
+ ******************************************************************************/
+typedef struct {
+  __IOM uint32_t CTRL;     /**< Control Register  */
+  __IOM uint32_t CMD;      /**< Command Register  */
+
+  __IM uint32_t  SYNCBUSY; /**< Synchronization Busy Register  */
+} WDOG_TypeDef;            /**< WDOG Register Declaration *//** @} */
+
+/***************************************************************************//**
+ * @defgroup EFM32TG_WDOG_BitFields
+ * @{
+ ******************************************************************************/
+
+/* Bit fields for WDOG CTRL */
+#define _WDOG_CTRL_RESETVALUE            0x00000F00UL                         /**< Default value for WDOG_CTRL */
+#define _WDOG_CTRL_MASK                  0x00003F7FUL                         /**< Mask for WDOG_CTRL */
+#define WDOG_CTRL_EN                     (0x1UL << 0)                         /**< Watchdog Timer Enable */
+#define _WDOG_CTRL_EN_SHIFT              0                                    /**< Shift value for WDOG_EN */
+#define _WDOG_CTRL_EN_MASK               0x1UL                                /**< Bit mask for WDOG_EN */
+#define _WDOG_CTRL_EN_DEFAULT            0x00000000UL                         /**< Mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_EN_DEFAULT             (_WDOG_CTRL_EN_DEFAULT << 0)         /**< Shifted mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_DEBUGRUN               (0x1UL << 1)                         /**< Debug Mode Run Enable */
+#define _WDOG_CTRL_DEBUGRUN_SHIFT        1                                    /**< Shift value for WDOG_DEBUGRUN */
+#define _WDOG_CTRL_DEBUGRUN_MASK         0x2UL                                /**< Bit mask for WDOG_DEBUGRUN */
+#define _WDOG_CTRL_DEBUGRUN_DEFAULT      0x00000000UL                         /**< Mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_DEBUGRUN_DEFAULT       (_WDOG_CTRL_DEBUGRUN_DEFAULT << 1)   /**< Shifted mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_EM2RUN                 (0x1UL << 2)                         /**< Energy Mode 2 Run Enable */
+#define _WDOG_CTRL_EM2RUN_SHIFT          2                                    /**< Shift value for WDOG_EM2RUN */
+#define _WDOG_CTRL_EM2RUN_MASK           0x4UL                                /**< Bit mask for WDOG_EM2RUN */
+#define _WDOG_CTRL_EM2RUN_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_EM2RUN_DEFAULT         (_WDOG_CTRL_EM2RUN_DEFAULT << 2)     /**< Shifted mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_EM3RUN                 (0x1UL << 3)                         /**< Energy Mode 3 Run Enable */
+#define _WDOG_CTRL_EM3RUN_SHIFT          3                                    /**< Shift value for WDOG_EM3RUN */
+#define _WDOG_CTRL_EM3RUN_MASK           0x8UL                                /**< Bit mask for WDOG_EM3RUN */
+#define _WDOG_CTRL_EM3RUN_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_EM3RUN_DEFAULT         (_WDOG_CTRL_EM3RUN_DEFAULT << 3)     /**< Shifted mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_LOCK                   (0x1UL << 4)                         /**< Configuration lock */
+#define _WDOG_CTRL_LOCK_SHIFT            4                                    /**< Shift value for WDOG_LOCK */
+#define _WDOG_CTRL_LOCK_MASK             0x10UL                               /**< Bit mask for WDOG_LOCK */
+#define _WDOG_CTRL_LOCK_DEFAULT          0x00000000UL                         /**< Mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_LOCK_DEFAULT           (_WDOG_CTRL_LOCK_DEFAULT << 4)       /**< Shifted mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_EM4BLOCK               (0x1UL << 5)                         /**< Energy Mode 4 Block */
+#define _WDOG_CTRL_EM4BLOCK_SHIFT        5                                    /**< Shift value for WDOG_EM4BLOCK */
+#define _WDOG_CTRL_EM4BLOCK_MASK         0x20UL                               /**< Bit mask for WDOG_EM4BLOCK */
+#define _WDOG_CTRL_EM4BLOCK_DEFAULT      0x00000000UL                         /**< Mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_EM4BLOCK_DEFAULT       (_WDOG_CTRL_EM4BLOCK_DEFAULT << 5)   /**< Shifted mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_SWOSCBLOCK             (0x1UL << 6)                         /**< Software Oscillator Disable Block */
+#define _WDOG_CTRL_SWOSCBLOCK_SHIFT      6                                    /**< Shift value for WDOG_SWOSCBLOCK */
+#define _WDOG_CTRL_SWOSCBLOCK_MASK       0x40UL                               /**< Bit mask for WDOG_SWOSCBLOCK */
+#define _WDOG_CTRL_SWOSCBLOCK_DEFAULT    0x00000000UL                         /**< Mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_SWOSCBLOCK_DEFAULT     (_WDOG_CTRL_SWOSCBLOCK_DEFAULT << 6) /**< Shifted mode DEFAULT for WDOG_CTRL */
+#define _WDOG_CTRL_PERSEL_SHIFT          8                                    /**< Shift value for WDOG_PERSEL */
+#define _WDOG_CTRL_PERSEL_MASK           0xF00UL                              /**< Bit mask for WDOG_PERSEL */
+#define _WDOG_CTRL_PERSEL_DEFAULT        0x0000000FUL                         /**< Mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_PERSEL_DEFAULT         (_WDOG_CTRL_PERSEL_DEFAULT << 8)     /**< Shifted mode DEFAULT for WDOG_CTRL */
+#define _WDOG_CTRL_CLKSEL_SHIFT          12                                   /**< Shift value for WDOG_CLKSEL */
+#define _WDOG_CTRL_CLKSEL_MASK           0x3000UL                             /**< Bit mask for WDOG_CLKSEL */
+#define _WDOG_CTRL_CLKSEL_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for WDOG_CTRL */
+#define _WDOG_CTRL_CLKSEL_ULFRCO         0x00000000UL                         /**< Mode ULFRCO for WDOG_CTRL */
+#define _WDOG_CTRL_CLKSEL_LFRCO          0x00000001UL                         /**< Mode LFRCO for WDOG_CTRL */
+#define _WDOG_CTRL_CLKSEL_LFXO           0x00000002UL                         /**< Mode LFXO for WDOG_CTRL */
+#define WDOG_CTRL_CLKSEL_DEFAULT         (_WDOG_CTRL_CLKSEL_DEFAULT << 12)    /**< Shifted mode DEFAULT for WDOG_CTRL */
+#define WDOG_CTRL_CLKSEL_ULFRCO          (_WDOG_CTRL_CLKSEL_ULFRCO << 12)     /**< Shifted mode ULFRCO for WDOG_CTRL */
+#define WDOG_CTRL_CLKSEL_LFRCO           (_WDOG_CTRL_CLKSEL_LFRCO << 12)      /**< Shifted mode LFRCO for WDOG_CTRL */
+#define WDOG_CTRL_CLKSEL_LFXO            (_WDOG_CTRL_CLKSEL_LFXO << 12)       /**< Shifted mode LFXO for WDOG_CTRL */
+
+/* Bit fields for WDOG CMD */
+#define _WDOG_CMD_RESETVALUE             0x00000000UL                     /**< Default value for WDOG_CMD */
+#define _WDOG_CMD_MASK                   0x00000001UL                     /**< Mask for WDOG_CMD */
+#define WDOG_CMD_CLEAR                   (0x1UL << 0)                     /**< Watchdog Timer Clear */
+#define _WDOG_CMD_CLEAR_SHIFT            0                                /**< Shift value for WDOG_CLEAR */
+#define _WDOG_CMD_CLEAR_MASK             0x1UL                            /**< Bit mask for WDOG_CLEAR */
+#define _WDOG_CMD_CLEAR_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for WDOG_CMD */
+#define _WDOG_CMD_CLEAR_UNCHANGED        0x00000000UL                     /**< Mode UNCHANGED for WDOG_CMD */
+#define _WDOG_CMD_CLEAR_CLEARED          0x00000001UL                     /**< Mode CLEARED for WDOG_CMD */
+#define WDOG_CMD_CLEAR_DEFAULT           (_WDOG_CMD_CLEAR_DEFAULT << 0)   /**< Shifted mode DEFAULT for WDOG_CMD */
+#define WDOG_CMD_CLEAR_UNCHANGED         (_WDOG_CMD_CLEAR_UNCHANGED << 0) /**< Shifted mode UNCHANGED for WDOG_CMD */
+#define WDOG_CMD_CLEAR_CLEARED           (_WDOG_CMD_CLEAR_CLEARED << 0)   /**< Shifted mode CLEARED for WDOG_CMD */
+
+/* Bit fields for WDOG SYNCBUSY */
+#define _WDOG_SYNCBUSY_RESETVALUE        0x00000000UL                       /**< Default value for WDOG_SYNCBUSY */
+#define _WDOG_SYNCBUSY_MASK              0x00000003UL                       /**< Mask for WDOG_SYNCBUSY */
+#define WDOG_SYNCBUSY_CTRL               (0x1UL << 0)                       /**< CTRL Register Busy */
+#define _WDOG_SYNCBUSY_CTRL_SHIFT        0                                  /**< Shift value for WDOG_CTRL */
+#define _WDOG_SYNCBUSY_CTRL_MASK         0x1UL                              /**< Bit mask for WDOG_CTRL */
+#define _WDOG_SYNCBUSY_CTRL_DEFAULT      0x00000000UL                       /**< Mode DEFAULT for WDOG_SYNCBUSY */
+#define WDOG_SYNCBUSY_CTRL_DEFAULT       (_WDOG_SYNCBUSY_CTRL_DEFAULT << 0) /**< Shifted mode DEFAULT for WDOG_SYNCBUSY */
+#define WDOG_SYNCBUSY_CMD                (0x1UL << 1)                       /**< CMD Register Busy */
+#define _WDOG_SYNCBUSY_CMD_SHIFT         1                                  /**< Shift value for WDOG_CMD */
+#define _WDOG_SYNCBUSY_CMD_MASK          0x2UL                              /**< Bit mask for WDOG_CMD */
+#define _WDOG_SYNCBUSY_CMD_DEFAULT       0x00000000UL                       /**< Mode DEFAULT for WDOG_SYNCBUSY */
+#define WDOG_SYNCBUSY_CMD_DEFAULT        (_WDOG_SYNCBUSY_CMD_DEFAULT << 1)  /**< Shifted mode DEFAULT for WDOG_SYNCBUSY */
+
+/** @} End of group EFM32TG_WDOG */
+/** @} End of group Parts */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/em_device.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/em_device.h
@@ -1,0 +1,153 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M Peripheral Access Layer for Silicon Laboratories
+ *        microcontroller devices
+ *
+ * This is a convenience header file for defining the part number on the
+ * build command line, instead of specifying the part specific header file.
+ *
+ * @verbatim
+ * Example: Add "-DEFM32G890F128" to your build options, to define part
+ *          Add "#include "em_device.h" to your source files
+ * @endverbatim
+ *
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef EM_DEVICE_H
+#define EM_DEVICE_H
+
+#if defined(EFM32TG108F16)
+#include "efm32tg108f16.h"
+
+#elif defined(EFM32TG108F32)
+#include "efm32tg108f32.h"
+
+#elif defined(EFM32TG108F4)
+#include "efm32tg108f4.h"
+
+#elif defined(EFM32TG108F8)
+#include "efm32tg108f8.h"
+
+#elif defined(EFM32TG110F16)
+#include "efm32tg110f16.h"
+
+#elif defined(EFM32TG110F32)
+#include "efm32tg110f32.h"
+
+#elif defined(EFM32TG110F4)
+#include "efm32tg110f4.h"
+
+#elif defined(EFM32TG110F8)
+#include "efm32tg110f8.h"
+
+#elif defined(EFM32TG210F16)
+#include "efm32tg210f16.h"
+
+#elif defined(EFM32TG210F32)
+#include "efm32tg210f32.h"
+
+#elif defined(EFM32TG210F8)
+#include "efm32tg210f8.h"
+
+#elif defined(EFM32TG222F16)
+#include "efm32tg222f16.h"
+
+#elif defined(EFM32TG222F32)
+#include "efm32tg222f32.h"
+
+#elif defined(EFM32TG222F8)
+#include "efm32tg222f8.h"
+
+#elif defined(EFM32TG225F16)
+#include "efm32tg225f16.h"
+
+#elif defined(EFM32TG225F32)
+#include "efm32tg225f32.h"
+
+#elif defined(EFM32TG225F8)
+#include "efm32tg225f8.h"
+
+#elif defined(EFM32TG230F16)
+#include "efm32tg230f16.h"
+
+#elif defined(EFM32TG230F32)
+#include "efm32tg230f32.h"
+
+#elif defined(EFM32TG230F8)
+#include "efm32tg230f8.h"
+
+#elif defined(EFM32TG232F16)
+#include "efm32tg232f16.h"
+
+#elif defined(EFM32TG232F32)
+#include "efm32tg232f32.h"
+
+#elif defined(EFM32TG232F8)
+#include "efm32tg232f8.h"
+
+#elif defined(EFM32TG822F16)
+#include "efm32tg822f16.h"
+
+#elif defined(EFM32TG822F32)
+#include "efm32tg822f32.h"
+
+#elif defined(EFM32TG822F8)
+#include "efm32tg822f8.h"
+
+#elif defined(EFM32TG825F16)
+#include "efm32tg825f16.h"
+
+#elif defined(EFM32TG825F32)
+#include "efm32tg825f32.h"
+
+#elif defined(EFM32TG825F8)
+#include "efm32tg825f8.h"
+
+#elif defined(EFM32TG840F16)
+#include "efm32tg840f16.h"
+
+#elif defined(EFM32TG840F32)
+#include "efm32tg840f32.h"
+
+#elif defined(EFM32TG840F8)
+#include "efm32tg840f8.h"
+
+#elif defined(EFM32TG842F16)
+#include "efm32tg842f16.h"
+
+#elif defined(EFM32TG842F32)
+#include "efm32tg842f32.h"
+
+#elif defined(EFM32TG842F8)
+#include "efm32tg842f8.h"
+
+#else
+#error "em_device.h: PART NUMBER undefined"
+#endif
+
+#endif /* EM_DEVICE_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Include/system_efm32tg.h
+++ b/gecko/Device/SiliconLabs/EFM32TG/Include/system_efm32tg.h
@@ -1,0 +1,143 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 System Layer for EFM32TG devices.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SYSTEM_EFM32TG_H
+#define SYSTEM_EFM32TG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/***************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ ******************************************************************************/
+/***************************************************************************//**
+ * @addtogroup EFM32TG EFM32TG
+ * @{
+ ******************************************************************************/
+
+/*******************************************************************************
+ ******************************   TYPEDEFS   ***********************************
+ ******************************************************************************/
+
+/* Interrupt vectortable entry */
+typedef union {
+  void (*VECTOR_TABLE_Type)(void);
+  void *topOfStack;
+} tVectorEntry;
+
+/*******************************************************************************
+ **************************   GLOBAL VARIABLES   *******************************
+ ******************************************************************************/
+
+extern uint32_t SystemCoreClock;    /**< System Clock Frequency (Core Clock) */
+
+/*******************************************************************************
+ *****************************   PROTOTYPES   **********************************
+ ******************************************************************************/
+
+/* Interrupt routines - prototypes */
+void Reset_Handler(void);           /**< Reset Handler */
+void NMI_Handler(void);             /**< NMI Handler */
+void HardFault_Handler(void);       /**< Hard Fault Handler */
+void MemManage_Handler(void);       /**< MPU Fault Handler */
+void BusFault_Handler(void);        /**< Bus Fault Handler */
+void UsageFault_Handler(void);      /**< Usage Fault Handler */
+void SVC_Handler(void);             /**< SVCall Handler */
+void DebugMon_Handler(void);        /**< Debug Monitor Handler */
+void PendSV_Handler(void);          /**< PendSV Handler */
+void SysTick_Handler(void);         /**< SysTick Handler */
+
+void DMA_IRQHandler(void);          /**< DMA IRQ Handler */
+void GPIO_EVEN_IRQHandler(void);    /**< GPIO EVEN IRQ Handler */
+void TIMER0_IRQHandler(void);       /**< TIMER0 IRQ Handler */
+void USART0_RX_IRQHandler(void);    /**< USART0 RX IRQ Handler */
+void USART0_TX_IRQHandler(void);    /**< USART0 TX IRQ Handler */
+void ACMP0_IRQHandler(void);        /**< ACMP0 IRQ Handler */
+void ADC0_IRQHandler(void);         /**< ADC0 IRQ Handler */
+void DAC0_IRQHandler(void);         /**< DAC0 IRQ Handler */
+void I2C0_IRQHandler(void);         /**< I2C0 IRQ Handler */
+void GPIO_ODD_IRQHandler(void);     /**< GPIO ODD IRQ Handler */
+void TIMER1_IRQHandler(void);       /**< TIMER1 IRQ Handler */
+void USART1_RX_IRQHandler(void);    /**< USART1 RX IRQ Handler */
+void USART1_TX_IRQHandler(void);    /**< USART1 TX IRQ Handler */
+void LESENSE_IRQHandler(void);      /**< LESENSE IRQ Handler */
+void LEUART0_IRQHandler(void);      /**< LEUART0 IRQ Handler */
+void LETIMER0_IRQHandler(void);     /**< LETIMER0 IRQ Handler */
+void PCNT0_IRQHandler(void);        /**< PCNT0 IRQ Handler */
+void RTC_IRQHandler(void);          /**< RTC IRQ Handler */
+void CMU_IRQHandler(void);          /**< CMU IRQ Handler */
+void VCMP_IRQHandler(void);         /**< VCMP IRQ Handler */
+void LCD_IRQHandler(void);          /**< LCD IRQ Handler */
+void MSC_IRQHandler(void);          /**< MSC IRQ Handler */
+void AES_IRQHandler(void);          /**< AES IRQ Handler */
+
+uint32_t SystemCoreClockGet(void);
+uint32_t SystemMaxCoreClockGet(void);
+
+/***************************************************************************//**
+ * @brief
+ *   Update CMSIS SystemCoreClock variable.
+ *
+ * @details
+ *   CMSIS defines a global variable SystemCoreClock that shall hold the
+ *   core frequency in Hz. If the core frequency is dynamically changed, the
+ *   variable must be kept updated in order to be CMSIS compliant.
+ *
+ *   Notice that if only changing core clock frequency through the EFM32 CMU
+ *   API, this variable will be kept updated. This function is only provided
+ *   for CMSIS compliance and if a user modifies the the core clock outside
+ *   the CMU API.
+ ******************************************************************************/
+static __INLINE void SystemCoreClockUpdate(void)
+{
+  (void)SystemCoreClockGet();
+}
+
+void SystemInit(void);
+uint32_t SystemHFClockGet(void);
+uint32_t SystemHFXOClockGet(void);
+void SystemHFXOClockSet(uint32_t freq);
+uint32_t SystemLFRCOClockGet(void);
+uint32_t SystemULFRCOClockGet(void);
+uint32_t SystemLFXOClockGet(void);
+void SystemLFXOClockSet(uint32_t freq);
+
+/** @} End of group EFM32TG */
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_EFM32TG_H */

--- a/gecko/Device/SiliconLabs/EFM32TG/Source/GCC/efm32tg.ld
+++ b/gecko/Device/SiliconLabs/EFM32TG/Source/GCC/efm32tg.ld
@@ -1,0 +1,281 @@
+/***************************************************************************//**
+ * Linker script for Silicon Labs EFM32TG devices
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 32768
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 4096
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  /*
+   * SG veneers:
+   * All SG veneers are placed in the special output section .gnu.sgstubs. Its start address
+   * must be set, either with the command line option ‘--section-start’ or in a linker script,
+   * to indicate where to place these veneers in memory.
+   */
+/*
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > FLASH
+*/
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    /* Add each additional bss section here */
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /*
+   *
+   * Location counter can end up 2byte aligned with narrow Thumb code but
+   * __etext is assumed by startup code to be the LMA of a section in RAM
+   * which must be 4byte aligned
+   */
+  __etext = ALIGN (4);
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data*)
+    . = ALIGN (4);
+    PROVIDE (__ram_func_section_start = .);
+    *(.ram)
+    PROVIDE (__ram_func_section_end = .);
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  __etext2 = ALIGN (4);
+
+  .data2 : AT (__etext2)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (COPY) :
+  {
+    __HeapBase = .;
+    __end__ = .;
+    end = __end__;
+    _end = __end__;
+    KEEP(*(.heap*))
+    __HeapLimit = .;
+  } > RAM
+
+  /* .stack_dummy section doesn't contains any symbols. It is only
+   * used for linker to calculate size of stack sections, and assign
+   * values to stack symbols later */
+   .stack_dummy (COPY):
+  {
+    KEEP(*(.stack*))
+  } > RAM
+
+  /* Set stack top to end of RAM, and stack limit move down by
+   * size of stack_dummy section */
+  __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+  __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+
+  /* Check if FLASH usage exceeds FLASH size */
+  ASSERT( LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
+}

--- a/gecko/Device/SiliconLabs/EFM32TG/Source/system_efm32tg.c
+++ b/gecko/Device/SiliconLabs/EFM32TG/Source/system_efm32tg.c
@@ -1,0 +1,404 @@
+/***************************************************************************//**
+ * @file
+ * @brief CMSIS Cortex-M3 System Layer for EFM32TG devices.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include <stdint.h>
+#include "em_device.h"
+
+/*******************************************************************************
+ ******************************   DEFINES   ************************************
+ ******************************************************************************/
+
+/** LFRCO frequency, tuned to below frequency during manufacturing. */
+#define EFM32_LFRCO_FREQ  (32768UL)
+/** ULFRCO frequency. */
+#define EFM32_ULFRCO_FREQ (1000UL)
+
+/*******************************************************************************
+ **************************   LOCAL VARIABLES   ********************************
+ ******************************************************************************/
+
+/* System oscillator frequencies. These frequencies are normally constant */
+/* for a target, but they are made configurable in order to allow run-time */
+/* handling of different boards. The crystal oscillator clocks can be set */
+/* compile time to a non-default value by defining respective EFM32_nFXO_FREQ */
+/* values according to board design. By defining the EFM32_nFXO_FREQ to 0, */
+/* one indicates that the oscillator is not present, in order to save some */
+/* SW footprint. */
+
+#ifndef EFM32_HFXO_FREQ
+/** HFXO frequency. */
+#define EFM32_HFXO_FREQ (32000000UL)
+#endif
+
+/** Maximum HFRCO frequency. */
+#define EFM32_HFRCO_MAX_FREQ (28000000UL)
+
+/* Do not define variable if HF crystal oscillator not present */
+#if (EFM32_HFXO_FREQ > 0U)
+/** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
+/** System HFXO clock. */
+static uint32_t SystemHFXOClock = EFM32_HFXO_FREQ;
+/** @endcond (DO_NOT_INCLUDE_WITH_DOXYGEN) */
+#endif
+
+#ifndef EFM32_LFXO_FREQ
+/** LFXO frequency. */
+#define EFM32_LFXO_FREQ (EFM32_LFRCO_FREQ)
+#endif
+
+/* Do not define variable if LF crystal oscillator not present */
+#if (EFM32_LFXO_FREQ > 0U)
+/** @cond DO_NOT_INCLUDE_WITH_DOXYGEN */
+/** System LFXO clock. */
+static uint32_t SystemLFXOClock = EFM32_LFXO_FREQ;
+/** @endcond (DO_NOT_INCLUDE_WITH_DOXYGEN) */
+#endif
+
+/* Inline function to get the chip's Production Revision. */
+__STATIC_INLINE uint8_t GetProdRev(void)
+{
+  return (uint8_t)((DEVINFO->PART & _DEVINFO_PART_PROD_REV_MASK)
+                   >> _DEVINFO_PART_PROD_REV_SHIFT);
+}
+
+/*******************************************************************************
+ **************************   GLOBAL VARIABLES   *******************************
+ ******************************************************************************/
+
+/**
+ * @brief
+ *   System System Clock Frequency (Core Clock).
+ *
+ * @details
+ *   Required CMSIS global variable that must be kept up-to-date.
+ */
+uint32_t SystemCoreClock = 14000000UL;
+
+/*---------------------------------------------------------------------------
+   Exception / Interrupt Vector table
+ *---------------------------------------------------------------------------*/
+extern const tVectorEntry __VECTOR_TABLE[16 + EXT_IRQ_COUNT];
+
+/*******************************************************************************
+ **************************   GLOBAL FUNCTIONS   *******************************
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @brief
+ *   Get the current core clock frequency.
+ *
+ * @details
+ *   Calculate and get the current core clock frequency based on the current
+ *   configuration. Assuming that the SystemCoreClock global variable is
+ *   maintained, the core clock frequency is stored in that variable as well.
+ *   This function will however calculate the core clock based on actual HW
+ *   configuration. It will also update the SystemCoreClock global variable.
+ *
+ * @note
+ *   This is an EFM32 proprietary function, not part of the CMSIS definition.
+ *
+ * @return
+ *   The current core clock frequency in Hz.
+ ******************************************************************************/
+uint32_t SystemCoreClockGet(void)
+{
+  uint32_t ret;
+
+  ret = SystemHFClockGet();
+  ret >>= (CMU->HFCORECLKDIV & _CMU_HFCORECLKDIV_HFCORECLKDIV_MASK)
+          >> _CMU_HFCORECLKDIV_HFCORECLKDIV_SHIFT;
+
+  /* Keep CMSIS variable up-to-date just in case */
+  SystemCoreClock = ret;
+
+  return ret;
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Get the maximum core clock frequency.
+ *
+ * @note
+ *   This is an EFM32 proprietary function, not part of the CMSIS definition.
+ *
+ * @return
+ *   The maximum core clock frequency in Hz.
+ ******************************************************************************/
+uint32_t SystemMaxCoreClockGet(void)
+{
+#if (EFM32_HFRCO_MAX_FREQ > EFM32_HFXO_FREQ)
+  return EFM32_HFRCO_MAX_FREQ;
+#else
+  return EFM32_HFXO_FREQ;
+#endif
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Get the current HFCLK frequency.
+ *
+ * @note
+ *   This is an EFM32 proprietary function, not part of the CMSIS definition.
+ *
+ * @return
+ *   The current HFCLK frequency in Hz.
+ ******************************************************************************/
+uint32_t SystemHFClockGet(void)
+{
+  uint32_t ret;
+
+  switch (CMU->STATUS & (CMU_STATUS_HFRCOSEL | CMU_STATUS_HFXOSEL
+                         | CMU_STATUS_LFRCOSEL | CMU_STATUS_LFXOSEL)) {
+    case CMU_STATUS_LFXOSEL:
+#if (EFM32_LFXO_FREQ > 0U)
+      ret = SystemLFXOClock;
+#else
+      /* We should not get here, since core should not be clocked. May */
+      /* be caused by a misconfiguration though. */
+      ret = 0U;
+#endif
+      break;
+
+    case CMU_STATUS_LFRCOSEL:
+      ret = EFM32_LFRCO_FREQ;
+      break;
+
+    case CMU_STATUS_HFXOSEL:
+#if (EFM32_HFXO_FREQ > 0U)
+      ret = SystemHFXOClock;
+#else
+      /* We should not get here, since core should not be clocked. May */
+      /* be caused by a misconfiguration though. */
+      ret = 0U;
+#endif
+      break;
+
+    default: /* CMU_STATUS_HFRCOSEL */
+      switch (CMU->HFRCOCTRL & _CMU_HFRCOCTRL_BAND_MASK) {
+        case CMU_HFRCOCTRL_BAND_28MHZ:
+          ret = 28000000U;
+          break;
+
+        case CMU_HFRCOCTRL_BAND_21MHZ:
+          ret = 21000000U;
+          break;
+
+        case CMU_HFRCOCTRL_BAND_14MHZ:
+          ret = 14000000U;
+          break;
+
+        case CMU_HFRCOCTRL_BAND_11MHZ:
+          ret = 11000000U;
+          break;
+
+        case CMU_HFRCOCTRL_BAND_7MHZ:
+          if ( GetProdRev() >= 19U ) {
+            ret = 6600000U;
+          } else {
+            ret = 7000000U;
+          }
+          break;
+
+        case CMU_HFRCOCTRL_BAND_1MHZ:
+          if ( GetProdRev() >= 19U ) {
+            ret = 1200000U;
+          } else {
+            ret = 1000000U;
+          }
+          break;
+
+        default:
+          ret = 0U;
+          break;
+      }
+      break;
+  }
+
+  return ret;
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Get high frequency crystal oscillator clock frequency for target system.
+ *
+ * @note
+ *   This is an EFM32 proprietary function, not part of the CMSIS definition.
+ *
+ * @return
+ *   HFXO frequency in Hz.
+ ******************************************************************************/
+uint32_t SystemHFXOClockGet(void)
+{
+  /* External crystal oscillator present? */
+#if (EFM32_HFXO_FREQ > 0U)
+  return SystemHFXOClock;
+#else
+  return 0U;
+#endif
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Set high frequency crystal oscillator clock frequency for target system.
+ *
+ * @note
+ *   This function is mainly provided for being able to handle target systems
+ *   with different HF crystal oscillator frequencies run-time. If used, it
+ *   should probably only be used once during system startup.
+ *
+ * @note
+ *   This is an EFM32 proprietary function, not part of the CMSIS definition.
+ *
+ * @param[in] freq
+ *   HFXO frequency in Hz used for target.
+ ******************************************************************************/
+void SystemHFXOClockSet(uint32_t freq)
+{
+  /* External crystal oscillator present? */
+#if (EFM32_HFXO_FREQ > 0U)
+  SystemHFXOClock = freq;
+
+  /* Update core clock frequency if HFXO is used to clock core */
+  if ((CMU->STATUS & CMU_STATUS_HFXOSEL) != 0U) {
+    /* The function will update the global variable */
+    (void)SystemCoreClockGet();
+  }
+#else
+  (void)freq; /* Unused parameter */
+#endif
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Initialize the system.
+ *
+ * @details
+ *   Do required generic HW system init.
+ *
+ * @note
+ *   This function is invoked during system init, before the main() routine
+ *   and any data has been initialized. For this reason, it cannot do any
+ *   initialization of variables etc.
+ ******************************************************************************/
+void SystemInit(void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t)(&__VECTOR_TABLE[0]);
+#endif
+
+#if defined(UNALIGNED_SUPPORT_DISABLE)
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Get low frequency RC oscillator clock frequency for target system.
+ *
+ * @note
+ *   This is an EFM32 proprietary function, not part of the CMSIS definition.
+ *
+ * @return
+ *   LFRCO frequency in Hz.
+ ******************************************************************************/
+uint32_t SystemLFRCOClockGet(void)
+{
+  /* Currently we assume that this frequency is properly tuned during */
+  /* manufacturing and is not changed after reset. If future requirements */
+  /* for re-tuning by user, we can add support for that. */
+  return EFM32_LFRCO_FREQ;
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Get ultra low frequency RC oscillator clock frequency for target system.
+ *
+ * @note
+ *   This is an EFM32 proprietary function, not part of the CMSIS definition.
+ *
+ * @return
+ *   ULFRCO frequency in Hz.
+ ******************************************************************************/
+uint32_t SystemULFRCOClockGet(void)
+{
+  /* The ULFRCO frequency is not tuned, and can be very inaccurate */
+  return EFM32_ULFRCO_FREQ;
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Get low frequency crystal oscillator clock frequency for target system.
+ *
+ * @note
+ *   This is an EFM32 proprietary function, not part of the CMSIS definition.
+ *
+ * @return
+ *   LFXO frequency in Hz.
+ ******************************************************************************/
+uint32_t SystemLFXOClockGet(void)
+{
+  /* External crystal oscillator present? */
+#if (EFM32_LFXO_FREQ > 0U)
+  return SystemLFXOClock;
+#else
+  return 0U;
+#endif
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Set low frequency crystal oscillator clock frequency for target system.
+ *
+ * @note
+ *   This function is mainly provided for being able to handle target systems
+ *   with different HF crystal oscillator frequencies run-time. If used, it
+ *   should probably only be used once during system startup.
+ *
+ * @note
+ *   This is an EFM32 proprietary function, not part of the CMSIS definition.
+ *
+ * @param[in] freq
+ *   LFXO frequency in Hz used for target.
+ ******************************************************************************/
+void SystemLFXOClockSet(uint32_t freq)
+{
+  /* External crystal oscillator present? */
+#if (EFM32_LFXO_FREQ > 0U)
+  SystemLFXOClock = freq;
+
+  /* Update core clock frequency if LFXO is used to clock core */
+  if ((CMU->STATUS & CMU_STATUS_LFXOSEL) != 0U) {
+    /* The function will update the global variable */
+    (void)SystemCoreClockGet();
+  }
+#else
+  (void)freq; /* Unused parameter */
+#endif
+}


### PR DESCRIPTION
Origin: Silicon Labs Gecko SDK
URL: https://github.com/SiliconLabs/Gecko_SDK
Version: v4.4.6 (SHA: 59d2160fe448b13730a91c0f019a8b4c53c43eb2)
Purpose: Add support for Silicon Labs EXX32 SoCs
License: Zlib
Maintained-by: External