### PR TITLE
wiseconnect: Drop UDMAX_Table

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/mcu/drivers/cmsis_driver/UDMA.c
+++ b/wiseconnect/components/device/silabs/si91x/mcu/drivers/cmsis_driver/UDMA.c
@@ -79,8 +79,8 @@ RSI_UDMA_DESC_T UDMA1_Table[CONTROL_STRUCT1] __attribute__ ((at(UDMA1_SRAM_BASE)
 #endif /* defined (__CC_ARM) */
 
 #if defined( __GNUC__ )
-RSI_UDMA_DESC_T __attribute__ ((section(".udma_addr0"))) UDMA0_Table[CONTROL_STRUCT0];
-RSI_UDMA_DESC_T __attribute__ ((section(".udma_addr1"))) UDMA1_Table[CONTROL_STRUCT1];
+RSI_UDMA_DESC_T UDMA0_Table[0];
+RSI_UDMA_DESC_T UDMA1_Table[0];
 #endif /* defined (__GNUC__) */
 
 UDMA_Channel_Info udma0_chnl_info[32] = { 0U } ;


### PR DESCRIPTION
The test benchmark.kernel.footprints.pm currently generate these warnings during the link:

    [204/209] Linking C executable zephyr/zephyr_pre0.elf
    .../ld.bfd: warning: orphan section `.udma_addr1' from \
        `zephyr/libzephyr.a(UDMA.c.obj)' being placed in   \
        section `.udma_addr1'
    [209/209] Linking C executable zephyr/zephyr.elf
    .../ld.bfd: warning: orphan section `.udma_addr1' from \
        `zephyr/libzephyr.a(UDMA.c.obj)' being placed in   \
        section `.udma_addr1'

The error can be reproduced with:

    west build -p -b siwx917_rb4338a/siwg917m111mgtba \
        tests/benchmarks/footprints -T benchmark.kernel.footprints.pm

A few comments:

  - The variable `UDMA0_Table` and `UDMA1_Table` expect to be placed at specific place in RAM. In the Zephyr driver there is a similar constraint but is managed by the DT. You can found this address in `dma_cfg_X->sram_desc_addr`.

  - This code has probably never worked since the section are dropped

  - The code in `UDMA.c` definitely conflict with the Zephyr driver.

  - This has probably passed the tests because the relevant code is never called.

So, removing the `UDMA0_Table` and `UDMA1_Table` does not break the code more than the current situation. 

Since these variable are referenced, we can't fully remove the declaration, but we can remove the memory associated.