### PR TITLE
si91x: Don't use uint8_t for sl_si91x_gpio_wakeup_t parameter

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/mcu/drivers/unified_peripheral_drivers/src/sl_si91x_peripheral_gpio.c
+++ b/wiseconnect/components/device/silabs/si91x/mcu/drivers/unified_peripheral_drivers/src/sl_si91x_peripheral_gpio.c
@@ -859,7 +859,7 @@ uint32_t sl_si91x_gpio_get_group_interrupt_status(uint8_t port, sl_si91x_group_i
  ******************************************************************************/
 void sl_si91x_gpio_select_group_interrupt_wakeup(uint8_t port,
                                                  sl_si91x_group_interrupt_t group_interrupt,
-                                                 uint8_t flags)
+                                                 sl_si91x_gpio_wakeup_t flags)
 {
   SL_GPIO_ASSERT(SL_GPIO_VALIDATE_PORT(port));
   SL_GPIO_ASSERT(SL_GPIO_VALIDATE_PARAMETER(group_interrupt));


### PR DESCRIPTION
GCC 14.3 complains when a function declaration and definition have a mismatch between an enum and an integer type.  Adjust the definition of sl_si91x_gpio_select_group_interrupt_wakeup so that the definition matches the prototype so that both use the enum type.