### PR TITLE
wiseconnect: Implement MFP and RTS APIs

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_rsi_utility.h
+++ b/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_rsi_utility.h
@@ -156,8 +156,20 @@ bool sli_get_card_ready_required();
 /* Function used to set the maximum transmission power */
 void sli_save_max_tx_power(uint8_t max_scan_tx_power, uint8_t max_join_tx_power);
 
+/* Function used to set the RTS threshold */
+void sli_save_rts_threshold(uint16_t rts_threshold);
+
+/* Function used to save the MFP mode */
+sl_status_t sli_save_mfp_mode(const sl_wifi_mfp_config_t *mfp_config);
+
 /* Function used to get maximum transmission power */
 sl_wifi_max_tx_power_t sli_get_max_tx_power();
+
+/* Function used to get RTS threshold */
+sl_wifi_rts_threshold_t sli_get_rts_threshold();
+
+/* Function used to get MFP mode */
+sl_wifi_mfp_config_t sli_get_mfp_mode();
 
 /* Function used to set maximum transmission power to default value(31 dBm) */
 void sli_reset_max_tx_power();

--- a/wiseconnect/components/device/silabs/si91x/wireless/src/sl_rsi_utility.c
+++ b/wiseconnect/components/device/silabs/si91x/wireless/src/sl_rsi_utility.c
@@ -211,6 +211,16 @@ static sl_wifi_max_tx_power_t wifi_max_tx_power = {
   .join_tx_power = 0x1f, //Default power value set to max value supported in dBm
 };
 
+// This value will be used in set RTS threshold command to set the RTS threshold of the module
+static sl_wifi_rts_threshold_t wifi_rts_threshold = {
+  .rts_threshold = SLI_RTS_THRESHOLD // Default RTS threshold value
+};
+
+// This value will be used in set MFP mode command to set the MFP mode of the module
+static sl_wifi_mfp_config_t wifi_mfp_config = { .mfp_mode      = SL_WIFI_MFP_DISABLED,
+                                                .is_configured = false,
+                                                .reserved      = { 0 } };
+
 static sl_wifi_rate_t saved_wifi_data_rate = SL_WIFI_AUTO_RATE;
 
 static sl_wifi_ap_configuration_t ap_configuration;
@@ -721,6 +731,21 @@ void sli_save_max_tx_power(uint8_t max_scan_tx_power, uint8_t max_join_tx_power)
   wifi_max_tx_power.join_tx_power = max_join_tx_power;
 }
 
+void sli_save_rts_threshold(uint16_t rts_threshold)
+{
+  wifi_rts_threshold.rts_threshold = rts_threshold;
+}
+
+sl_status_t sli_save_mfp_mode(const sl_wifi_mfp_config_t *config)
+{
+  if (config == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+  wifi_mfp_config.mfp_mode      = config->mfp_mode;
+  wifi_mfp_config.is_configured = true;
+  return SL_STATUS_OK;
+}
+
 sl_wifi_max_tx_power_t sli_get_max_tx_power()
 {
   return wifi_max_tx_power;
@@ -730,6 +755,16 @@ void sli_reset_max_tx_power()
 {
   wifi_max_tx_power.scan_tx_power = 0x1f;
   wifi_max_tx_power.join_tx_power = 0x1f;
+}
+
+sl_wifi_rts_threshold_t sli_get_rts_threshold()
+{
+  return wifi_rts_threshold;
+}
+
+sl_wifi_mfp_config_t sli_get_mfp_mode()
+{
+  return wifi_mfp_config;
 }
 
 void sli_set_card_ready_required(bool card_ready_required)

--- a/wiseconnect/components/protocol/wifi/inc/sl_wifi.h
+++ b/wiseconnect/components/protocol/wifi/inc/sl_wifi.h
@@ -239,6 +239,65 @@ sl_status_t sl_wifi_set_max_tx_power(sl_wifi_interface_t interface, sl_wifi_max_
 
 /***************************************************************************/ /**
  * @brief
+ *   Set the Request to Send (RTS) threshold for the specified Wi-Fi interface.
+ * @param[in] interface
+ *   Wi-Fi interface as identified by @ref sl_wifi_interface_t
+ * @param[in] rts_threshold
+ *   RTS threshold value to set, in bytes. Valid range: 0 to 2347.
+ *   A value of 0 has a special meaning: an RTS frame will precede every transmitted frame.
+ * @pre Pre-conditions:
+ * -   @ref sl_wifi_init should be called before this API
+ * @return
+ *   sl_status_t. See https://docs.silabs.com/gecko-platform/latest/platform-common/status for details.
+ ******************************************************************************/
+sl_status_t sl_wifi_set_rts_threshold(sl_wifi_interface_t interface, uint16_t rts_threshold);
+
+/***************************************************************************/ /**
+ * @brief
+ *   Get the current Request to Send (RTS) threshold for the specified Wi-Fi interface.
+ * @param[in] interface
+ *   Wi-Fi interface as identified by @ref sl_wifi_interface_t
+ * @param[out] rts_threshold
+ *   Pointer to a variable that will receive the current RTS threshold value.
+ * @pre Pre-conditions:
+ * -   @ref sl_wifi_init should be called before this API.
+ * @return
+ *   sl_status_t. See https://docs.silabs.com/gecko-platform/latest/platform-common/status for details.
+ ******************************************************************************/
+sl_status_t sl_wifi_get_rts_threshold(sl_wifi_interface_t interface, uint16_t *rts_threshold);
+
+/***************************************************************************/ /**
+ * @brief
+ *   Set the Management Frame Protection (MFP) mode for the specified Wi-Fi interface.
+ * @param[in] interface
+ *   Wi-Fi interface as identified by @ref sl_wifi_interface_t
+ * @param[in] config
+ *   MFP configuration as identified by @ref sl_wifi_mfp_mode_t
+ * @note
+ *   This API needs to be called before @ref sl_wifi_init
+ * @note
+ *   This API is currently supported only in STA mode
+ * @return
+ *   sl_status_t. See https://docs.silabs.com/gecko-platform/latest/platform-common/status for details.
+ ******************************************************************************/
+sl_status_t sl_wifi_set_mfp(sl_wifi_interface_t interface, const sl_wifi_mfp_mode_t config);
+
+/***************************************************************************/ /**
+ * @brief
+ *   Get the Management Frame Protection (MFP) mode for the specified Wi-Fi interface.
+ * @param[in] interface
+ *   Wi-Fi interface as identified by @ref sl_wifi_interface_t
+ * @param[out] config
+ *   MFP configuration as identified by @ref sl_wifi_mfp_mode_t
+ * @note
+ *   This API is currently supported only in STA mode
+ * @return
+ *   sl_status_t. See https://docs.silabs.com/gecko-platform/latest/platform-common/status for details.
+ ******************************************************************************/
+sl_status_t sl_wifi_get_mfp(sl_wifi_interface_t interface, sl_wifi_mfp_mode_t *config);
+
+/***************************************************************************/ /**
+ * @brief
  *   Set the Wi-Fi antenna for an interface.
  * @pre Pre-conditions:
  * - 

--- a/wiseconnect/components/protocol/wifi/inc/sl_wifi_types.h
+++ b/wiseconnect/components/protocol/wifi/inc/sl_wifi_types.h
@@ -689,6 +689,58 @@ typedef struct {
 } sl_wifi_max_tx_power_t;
 
 /**
+ * @struct sl_wifi_rts_threshold_t
+ * @brief Wi-Fi Request to Send (RTS) threshold structure.
+ * 
+ * This structure is used to configure the RTS threshold for Wi-Fi operations.
+ * 
+ * Members:
+ * - rts_threshold: RTS threshold in bytes. The device performs an RTS/CTS handshake when the packet size exceeds the threshold.
+ * - reserved: Reserved fields for future use, should be set to zero.
+ * 
+ */
+typedef struct {
+  uint16_t rts_threshold; ///< Request to Send (RTS) threshold in bytes
+  uint8_t reserved[2];    ///< Reserved fields
+} sl_wifi_rts_threshold_t;
+
+/**
+ * @enum sl_wifi_mfp_mode_t
+ * @brief Wi-Fi Management Frame Protection (MFP) mode enumeration.
+ *
+ * This enumeration defines the modes for Management Frame Protection (MFP) in Wi-Fi.
+ * MFP is used to protect management frames from spoofing and other attacks.
+ * The modes are:
+ * - SL_WIFI_MFP_DISABLED: MFP is disabled (0b00)
+ * - SL_WIFI_MFP_CAPABLE: MFP is capable/optional (0b01)
+ * - SL_WIFI_MFP_REQUIRED: MFP is required/mandatory (0b10)
+ * 
+ */
+typedef enum {
+  SL_WIFI_MFP_DISABLED = 0, ///< MFP disabled (0b00)
+  SL_WIFI_MFP_CAPABLE  = 1, ///< MFP capable/optional (0b01)
+  SL_WIFI_MFP_REQUIRED = 2  ///< MFP required/mandatory (0b10)
+} sl_wifi_mfp_mode_t;
+
+/**
+ * @struct sl_wifi_mfp_config_t
+ * @brief Wi-Fi Management Frame Protection (MFP) configuration structure.
+ *
+ * This structure is used to configure the MFP mode for Wi-Fi operations.
+ * It includes the MFP mode and a flag indicating whether the MFP mode is explicitly configured or automatically detected.
+ * Members:
+ * - mfp_mode: MFP mode setting of type @ref sl_wifi_mfp_mode_t
+ * - is_configured: True if MFP mode is explicitly configured, false for automatic detection.
+ * - reserved: Reserved for future use and alignment.
+ * 
+ */
+typedef struct {
+  sl_wifi_mfp_mode_t mfp_mode; ///< MFP mode setting of type @ref sl_wifi_mfp_mode_t
+  bool is_configured;          ///< True if MFP mode is explicitly configured, false for automatic detection
+  uint8_t reserved[2];         ///< Reserved for future use and alignment
+} sl_wifi_mfp_config_t;
+
+/**
  * @struct sl_wifi_async_stats_response_t
  * @brief Structure representing asynchronous Wi-Fi statistics response.
  *

--- a/wiseconnect/components/protocol/wifi/si91x/sl_wifi.c
+++ b/wiseconnect/components/protocol/wifi/si91x/sl_wifi.c
@@ -161,6 +161,39 @@ static sl_status_t fill_join_request_security_using_encryption(sl_wifi_encryptio
   return SL_STATUS_OK;
 }
 
+static sl_status_t sli_configure_mfp_mode(sl_wifi_mfp_config_t *mfp_config,
+                                          uint8_t security_type,
+                                          uint8_t *join_feature_bitmap)
+{
+  sl_status_t status = SL_STATUS_OK;
+  if (mfp_config->is_configured) {
+    switch (mfp_config->mfp_mode) {
+      case SL_WIFI_MFP_REQUIRED:
+        *join_feature_bitmap |= SL_WIFI_JOIN_FEAT_MFP_CAPABLE_REQUIRED;
+        break;
+      case SL_WIFI_MFP_CAPABLE:
+        *join_feature_bitmap |= SL_WIFI_JOIN_FEAT_MFP_CAPABLE_ONLY;
+        break;
+      default:
+        break;
+    }
+  } else {
+    if ((security_type == SL_WIFI_WPA3) || (security_type == SL_WIFI_WPA3_ENTERPRISE)) {
+      *join_feature_bitmap |= SL_WIFI_JOIN_FEAT_MFP_CAPABLE_REQUIRED;
+      mfp_config->mfp_mode = SL_WIFI_MFP_REQUIRED;
+    } else if ((security_type == SL_WIFI_WPA3_TRANSITION) || (security_type == SL_WIFI_WPA3_TRANSITION_ENTERPRISE)) {
+      *join_feature_bitmap &= ~(SL_WIFI_JOIN_FEAT_MFP_CAPABLE_REQUIRED);
+      *join_feature_bitmap |= SL_WIFI_JOIN_FEAT_MFP_CAPABLE_ONLY;
+      mfp_config->mfp_mode = SL_WIFI_MFP_CAPABLE;
+    } else if (security_type == SL_WIFI_WPA2 || security_type == SL_WIFI_WPA_WPA2_MIXED) {
+      *join_feature_bitmap |= SL_WIFI_JOIN_FEAT_MFP_CAPABLE_ONLY;
+      mfp_config->mfp_mode = SL_WIFI_MFP_CAPABLE;
+    }
+    status = sli_save_mfp_mode(mfp_config);
+  }
+  return status;
+}
+
 static sl_status_t get_configured_join_request(sl_wifi_interface_t module_interface,
                                                const void *configuration,
                                                sli_si91x_join_request_t *join_request)
@@ -184,16 +217,10 @@ static sl_status_t get_configured_join_request(sl_wifi_interface_t module_interf
 
     join_request->ssid_len      = client_configuration->ssid.length;
     join_request->security_type = (uint8_t)client_configuration->security;
-    if ((join_request->security_type == SL_WIFI_WPA3)
-        || (join_request->security_type == SL_WIFI_WPA3_ENTERPRISE)) { //check for WPA3 security
-      join_request->join_feature_bitmap |= SL_SI91X_JOIN_FEAT_MFP_CAPABLE_REQUIRED;
-    } else if ((join_request->security_type == SL_WIFI_WPA3_TRANSITION)
-               || join_request->security_type == SL_WIFI_WPA3_TRANSITION_ENTERPRISE) {
-      join_request->join_feature_bitmap &= ~(SL_SI91X_JOIN_FEAT_MFP_CAPABLE_REQUIRED);
-      join_request->join_feature_bitmap |= SL_SI91X_JOIN_FEAT_MFP_CAPABLE_ONLY;
-    } else if (join_request->security_type == SL_WIFI_WPA2 || join_request->security_type == SL_WIFI_WPA_WPA2_MIXED) {
-      join_request->join_feature_bitmap |= SL_SI91X_JOIN_FEAT_MFP_CAPABLE_ONLY;
-    }
+
+    sl_wifi_mfp_config_t mfp_config = sli_get_mfp_mode();
+    status = sli_configure_mfp_mode(&mfp_config, join_request->security_type, &join_request->join_feature_bitmap);
+    VERIFY_STATUS_AND_RETURN(status);
 
     fill_join_request_security_using_encryption(client_configuration->encryption, &(join_request->security_type));
 
@@ -214,13 +241,10 @@ static sl_status_t get_configured_join_request(sl_wifi_interface_t module_interf
     join_request->ssid_len      = ap_configuration->ssid.length;
     join_request->security_type = (uint8_t)ap_configuration->security;
     join_request->vap_id        = 0;
-    if (join_request->security_type == SL_WIFI_WPA3) { //check for WPA3 security
-      join_request->join_feature_bitmap |= SL_SI91X_JOIN_FEAT_MFP_CAPABLE_REQUIRED;
-    } else if (join_request->security_type == SL_WIFI_WPA3_TRANSITION) { //check for WPA3 Tranisition security
-      join_request->join_feature_bitmap &= ~(SL_SI91X_JOIN_FEAT_MFP_CAPABLE_REQUIRED);
-      join_request->join_feature_bitmap |= SL_SI91X_JOIN_FEAT_MFP_CAPABLE_ONLY;
-    }
 
+    sl_wifi_mfp_config_t mfp_config = sli_get_mfp_mode();
+    status = sli_configure_mfp_mode(&mfp_config, join_request->security_type, &join_request->join_feature_bitmap);
+    VERIFY_STATUS_AND_RETURN(status);
     if (sli_get_opermode() == SL_SI91X_CONCURRENT_MODE) {
       join_request->vap_id = SL_WIFI_AP_VAP_ID; // For Concurrent mode AP vap_id should be 1 else 0.
     }
@@ -1021,6 +1045,74 @@ sl_status_t sl_wifi_get_max_tx_power(sl_wifi_interface_t interface, sl_wifi_max_
 
   *max_tx_power = sli_get_max_tx_power();
 
+  return SL_STATUS_OK;
+}
+
+sl_status_t sl_wifi_set_rts_threshold(sl_wifi_interface_t interface, uint16_t rts_threshold)
+{
+  UNUSED_PARAMETER(interface);
+
+  if (!device_initialized) {
+    return SL_STATUS_NOT_INITIALIZED;
+  }
+
+  sli_si91x_config_request_t config_request = { .config_type = SLI_CONFIG_RTSTHRESHOLD, .value = rts_threshold };
+  sl_status_t status                        = sli_si91x_driver_send_command(SLI_WLAN_REQ_CONFIG,
+                                                     SLI_SI91X_WLAN_CMD,
+                                                     &config_request,
+                                                     sizeof(config_request),
+                                                     SLI_SI91X_WAIT_FOR_COMMAND_SUCCESS,
+                                                     NULL,
+                                                     NULL);
+  if (status == SL_STATUS_OK) {
+    sli_save_rts_threshold(rts_threshold);
+  }
+  VERIFY_STATUS_AND_RETURN(status);
+  return status;
+}
+
+sl_status_t sl_wifi_get_rts_threshold(sl_wifi_interface_t interface, uint16_t *rts_threshold)
+{
+  UNUSED_PARAMETER(interface);
+  if (!device_initialized) {
+    return SL_STATUS_NOT_INITIALIZED;
+  }
+
+  SL_WIFI_ARGS_CHECK_NULL_POINTER(rts_threshold);
+
+  *rts_threshold = sli_get_rts_threshold().rts_threshold;
+
+  return SL_STATUS_OK;
+}
+
+sl_status_t sl_wifi_set_mfp(sl_wifi_interface_t interface, const sl_wifi_mfp_mode_t config)
+{
+  // only supported in STA mode
+  if ((interface & SL_WIFI_CLIENT_INTERFACE) == 0 || (interface & SL_WIFI_AP_INTERFACE) != 0) {
+    return SL_STATUS_NOT_SUPPORTED;
+  }
+
+  // Store the MFP configuration for future join operations
+  sl_wifi_mfp_config_t mfp_config = sli_get_mfp_mode();
+  sl_status_t status;
+  mfp_config.mfp_mode      = config;
+  mfp_config.is_configured = true;
+  status                   = sli_save_mfp_mode(&mfp_config);
+  return status;
+}
+
+sl_status_t sl_wifi_get_mfp(sl_wifi_interface_t interface, sl_wifi_mfp_mode_t *config)
+{
+  // only supported in STA mode
+  if ((interface & SL_WIFI_CLIENT_INTERFACE) == 0 || (interface & SL_WIFI_AP_INTERFACE) != 0) {
+    return SL_STATUS_NOT_SUPPORTED;
+  }
+  // Parameter validation
+  SL_WIFI_ARGS_CHECK_NULL_POINTER(config);
+
+  sl_wifi_mfp_config_t mfp_config = sli_get_mfp_mode();
+  // Return current MFP mode
+  *config = mfp_config.mfp_mode;
   return SL_STATUS_OK;
 }
 


### PR DESCRIPTION
Port implementation of MFP and RTS APIs from [RTS threshold and MFP mode configuration to Wi-Fi module](https://stash.silabs.com/projects/REDPINE/repos/sl_net/pull-requests/7021/overview)