### PR TITLE
simplicity_sdk: Patch in sl_power_manager_hal_s2.c

### DIFF
--- a/simplicity_sdk/platform/service/power_manager/src/sleep_loop/sl_power_manager_hal_s2.c
+++ b/simplicity_sdk/platform/service/power_manager/src/sleep_loop/sl_power_manager_hal_s2.c
@@ -615,6 +615,8 @@ void sli_power_manager_apply_em(sl_power_manager_em_t em)
     case SL_POWER_MANAGER_EM2:
     case SL_POWER_MANAGER_EM3:
       EMU_EnterEM2(false);
+      // Clear the SLEEPDEEP bit after sleep.
+      SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
       break;
 
     default:


### PR DESCRIPTION
The goal of this PR is to add a patch needed to fix a bug where the SLEEPDEEP bit is not cleared properly after a wakeup from EM2.