### PR TITLE
wiseconnect: Drop non-required dependency on CMSIS API

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/mcu/hal/src/sl_si91x_hal_soc_soft_reset.c
+++ b/wiseconnect/components/device/silabs/si91x/mcu/hal/src/sl_si91x_hal_soc_soft_reset.c
@@ -28,7 +28,6 @@
  *
  ******************************************************************************/
 #include "rsi_wwdt.h"
-#include "cmsis_os2.h"
 #include "sl_si91x_hal_soc_soft_reset.h"
 
 /*


### PR DESCRIPTION
Inclusion of cmsis_os2.h creates a dependency to CMSIS in Zephyr. However, it seems this include is just a mistake since:
  - Nothing in sl_si91x_hal_soc_soft_reset.c depends on CMSIS API
  - This include has been removed in Wiseconnect v3.5.2

So, let's remove it.