### PR TITLE
wiseconnect: device: si91x: wireless: ncp_interface: Add necessary fi…

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_rsi_utility.h
+++ b/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_rsi_utility.h
@@ -80,7 +80,7 @@ typedef struct {
  * adding -DSL_SI91X_EVENT_HANDLER_STACK_SIZE=<new value> to your compiler command line options.
  */
 #ifndef SL_SI91X_EVENT_HANDLER_STACK_SIZE
-#define SL_SI91X_EVENT_HANDLER_STACK_SIZE 1536
+#define SL_SI91X_EVENT_HANDLER_STACK_SIZE 5000
 #endif
 typedef bool (*sli_si91x_wifi_buffer_comparator)(const sl_wifi_buffer_t *buffer, const void *userdata);
 typedef uint32_t sl_si91x_host_timestamp_t;

--- a/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_si91x_spi_constants.h
+++ b/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_si91x_spi_constants.h
@@ -1,0 +1,159 @@
+/***************************************************************************/ /**
+ * @file
+ * @brief
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#pragma once
+
+//C1 Register Bit Field Defines
+#define SLI_C1_INIT_CMD 0x15
+// sent to spi interface after reset/powerup to init the spi interface
+
+//STM 32 Init Sequence
+#define SLI_SI91X_INIT_CMD 0x005c4a12
+
+// SPI Start Token
+#define SLI_SPI_START_TOKEN 0x55
+
+#define SLI_C1_INIT_RESP 0x55
+// response from spi interface to successful init
+
+#define SLI_C176_INIT      0b00111111 //@ and
+#define SLI_C176_RW        0b01000000 //@ or
+#define SLI_C15_RD         0b11011111 //@ and
+#define SLI_C15_WR         0b00100000 //@ or
+#define SLI_C14_SPISLV     0b11101111 //@ and
+#define SLI_C14_AHBBUS     0b00010000 //@ or
+#define SLI_C13_AHBMEM     0b11110111 //@ and
+#define SLI_C13_AHBFRM     0b00001000 //@ or
+#define SLI_C12_02BITXFR   0b11111011 //@ and
+#define SLI_C12_16BITXFR   0b00000100 //@ or
+#define SLI_C110_4BYTESLEN 0b11111100
+// and number of C bytes transferred, usually 4
+#define SLI_C110_1BYTESLEN 0b00000001
+// or/~and number of C bytes transferred
+#define SLI_C110_2BYTESLEN 0b00000010
+// or/~and number of C bytes transferred
+#define SLI_C110_3BYTESLEN 0b00000011
+// or number of C bytes transferred
+
+/*=========================================================*/
+// C2 Register Defines
+#define SLI_C276_08BIT      0b00111111 //@ and
+#define SLI_C276_32BIT      0b01000000 //@ or
+#define SLI_C250_SPIADDR    0b00111111 //@ and
+#define SLI_C250_DATAPACKET 0b00000010 //@ or
+#define SLI_C250_MGMTPACKET 0b00000100 //@ or
+
+//#define SLI_C3_XFERLENLSB  0x00                 //@ set value
+//#define SLI_C4_XFERLENMSB  0x00                 //@ set value
+
+/*==========================================================*/
+// C1 Register Defines
+// Internal Read
+#define SLI_C1INTREAD2BYTES 0x42
+// (((((0x00 & C176_INT) & C15_RD) & C14_SPISLV) & C13_AHBMEM) & C12_02BITXFR) | C110_2BYTESLEN // 01000010
+#define SLI_C1INTREAD1BYTES 0x41
+
+// Memory ReadWrite (AHB Master Read/Write, Internal Legacy Name)
+// Memory read/write is normally done using 16-bit transfer length with 4 C bytes transferred
+#define SLI_C1MEMWR16BIT1BYTE 0x75
+// (((0x00 | C176_RW | C15_WR | C14_AHBBUS) & C13_AHBMEM) & C12_16BITXFR) | C110_1BYTESLEN // 01110101
+#define SLI_C1MEMRD16BIT1BYTE 0x55
+// (((0x00 | C176_RW & C15_RD | C14_AHBBUS) & C13_AHBMEM) & C12_16BITXFR) | C110_1BYTESLEN // 01010101
+
+#define SLI_C1MEMWR16BIT4BYTE 0x74
+// (((0x00 | C176_RW | C15_WR | C14_AHBBUS) & C13_AHBMEM) & C12_16BITXFR) & C110_4BYTESLEN // 01110100
+#define SLI_C1MEMRD16BIT4BYTE 0x54
+// ((((0x00 | C176_RW & C15_RD) | C14_AHBBUS) & C13_AHBMEM) & C12_16BITXFR) & C110_4BYTESLEN // 01010100
+
+// Normally, 2-bit transfer length is not used for memory read/write
+#define SLI_C1MEMWR02BIT1BYTE 0x71
+// (((0x00 | C176_RW | C15_WR | C14_AHBBUS) & C13_AHBMEM) & C12_02BITXFR) | C110_1BYTESLEN // 01110001
+#define SLI_C1MEMRD02BIT1BYTE 0x51
+// (((0x00 | C176_RW & C15_RD | C14_AHBBUS) & C13_AHBMEM) & C12_02BITXFR) | C110_1BYTESLEN // 01010001
+#define SLI_C1MEMWR02BIT4BYTE 0x70
+// (((0x00 | C176_RW | C15_WR | C14_AHBBUS) & C13_AHBMEM) & C12_02BITXFR) & C110_4BYTESLEN // 01110000
+#define SLI_C1MEMRD02BIT4BYTE 0x50
+// ((((0x00 | C176_RW & C15_RD) | C14_AHBBUS) & C13_AHBMEM) & C12_02BITXFR) & C110_4BYTESLEN // 01010000
+
+// Frame ReadWrite
+// Frame read/writes normally  use 16-bit transfer length
+#define SLI_C1FRMWR16BIT1BYTE 0x7d
+// ((C176_RW | C15_WR | C14_AHBBUS | C13_AHBFRM) & C12_16BITXFR) | C110_1BYTESLEN // 01111101
+#define SLI_C1FRMRD16BIT1BYTE 0x5d
+// ((C176_RW & C15_RD | C14_AHBBUS | C13_AHBFRM) & C12_16BITXFR) | C110_1BYTESLEN // 01011101
+
+#define SLI_C1FRMWR16BIT4BYTE 0x7c
+// ((C176_RW | C15_WR | C14_AHBBUS | C13_AHBFRM) & C12_16BITXFR) | C110_4BYTESLEN // 01111100
+#define SLI_C1FRMRD16BIT4BYTE 0x5c
+// ((C176_RW & C15_RD | C14_AHBBUS | C13_AHBFRM) & C12_16BITXFR) | C110_4BYTESLEN // 01011100
+
+// Frame read/writes normally do not use 2-bit transfer length
+#define SLI_C1FRMWR02BIT1BYTE 0x79
+// ((C176_RW | C15_WR | C14_AHBBUS | C13_AHBFRM) & C12_02BITXFR) | C110_1BYTESLEN // 01111001
+#define SLI_C1FRMRD02BIT1BYTE 0x59
+// ((C176_RW & C15_RD | C14_AHBBUS | C13_AHBFRM) & C12_02BITXFR) | C110_1BYTESLEN // 01011001
+
+#define SLI_C1FRMWR02BIT4BYTE 0x78
+// ((C176_RW | C15_WR | C14_AHBBUS | C13_AHBFRM) & C12_02BITXFR) | C110_4BYTESLEN // 01111000
+#define SLI_C1FRMRD02BIT4BYTE 0x58
+// ((C176_RW & C15_RD | C14_AHBBUS | C13_AHBFRM) & C12_02BITXFR) | C110_4BYTESLEN // 01011000
+
+// SPI Register ReadWrite
+#define SLI_C1SPIREGWR16BIT4BYTE 0x64
+// ((((C176_RW | C15_WR) & C14_SPISLV) & C13_AHBMEM) & C12_16BITXFR) | C110_4BYTESLEN // 01100100
+#define SLI_C1SPIREGRD16BIT4BYTE 0x44
+// ((((C176_RW & C15_RD) & C14_SPISLV) & C13_AHBMEM) & C12_16BITXFR) | C110_4BYTESLEN // 01000100
+
+#define SLI_C1SPIREGWR02BIT4BYTE 0x60
+// ((((C176_RW | C15_WR) & C14_SPISLV) & C13_AHBMEM) & C12_02BITXFR) | C110_4BYTESLEN // 01100000
+#define SLI_C1SPIREGRD02BIT4BYTE 0x40
+// ((((C176_RW & C15_RD) & C14_SPISLV) & C13_AHBMEM) & C12_02BITXFR) | C110_4BYTESLEN // 01000000
+
+#define SLI_C1SPIREGWR02BIT1BYTE 0x61
+// ((((C176_RW | C15_WR) & C14_SPISLV) & C13_AHBMEM) & C12_02BITXFR) | C110_1BYTESLEN // 01100001
+#define SLI_C1SPIREGRD02BIT1BYTE 0x41
+// ((((C176_RW & C15_RD) & C14_SPISLV) & C13_AHBMEM) & C12_02BITXFR) | C110_1BYTESLEN // 01000001
+
+//C2 Register Defines
+#define SLI_C2RDWR4BYTE 0x40 //@ 0x00 | C276_32BIT | C250_DATAPACKET   // 01000010
+#define SLI_C2RDWR4BYTE 0x40 //@ 0x00 | C276_32BIT | C250_MGMTPACKET   // 01000100
+
+#define SLI_C2RDWR1BYTE 0x00 //@ (0x00 & C276_08BIT) | C250_DATAPACKET // 00000010
+#define SLI_C2RDWR1BYTE 0x00 //@ (0x00 & C276_08BIT) | C250_MGMTPACKET
+//@ 00000100
+#define SLI_C2MGMT 0x04
+#define SLI_C2DATA 0x02
+#define SLI_C2WPS  0x08
+
+#define SLI_C2SPIADDR1BYTE  0x00 //@(0x00 & C276_08BIT) | C250_SPIADDR   // 00xxxxxx
+#define SLI_C2MEMRDWRNOCARE 0x00 //@0x00 or ANYTHING                     // 00000000
+#define SLI_C2SPIADDR4BYTE  0x40 //@(0x00 | C276_32BIT) | C250_SPIADDR   // 01xxxxxx
+
+#define SLI_C1INTWRITE1BYTES 0x61
+#define SLI_C1INTWRITE2BYTES 0x62

--- a/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_status.h
+++ b/wiseconnect/components/device/silabs/si91x/wireless/inc/sl_status.h
@@ -1,0 +1,451 @@
+/*******************************************************************************
+ * @file
+ * @brief SL Status Codes.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_STATUS_H
+#define SL_STATUS_H
+
+#include <stdint.h>
+
+/*******************************************************************************
+ * @addtogroup status Status Codes
+ * @details Status Codes contains error and status code definitions used by SiSDK(formerly GSDK)
+ *          software components and stacks. This module also provides routines to
+ *          read the string linked with the error and status codes.
+ * @{
+ ******************************************************************************/
+
+// -----------------------------------------------------------------------------
+// Space Defines
+
+#define SL_STATUS_SPACE_MASK              ((sl_status_t)0xFF00)
+
+#define SL_STATUS_GENERIC_SPACE           ((sl_status_t)0x0000)
+
+#define SL_STATUS_PLATFORM_1_SPACE        ((sl_status_t)0x0100)
+#define SL_STATUS_PLATFORM_2_SPACE        ((sl_status_t)0x0200)
+#define SL_STATUS_HARDWARE_SPACE          ((sl_status_t)0x0300)
+
+#define SL_STATUS_BLUETOOTH_SPACE         ((sl_status_t)0x0400)
+#define SL_STATUS_BLUETOOTH_MESH_SPACE    ((sl_status_t)0x0500)
+#define SL_STATUS_CAN_CANOPEN_SPACE       ((sl_status_t)0x0600)
+#define SL_STATUS_CONNECT_SPACE           ((sl_status_t)0x0700)
+#define SL_STATUS_NET_SUITE_SPACE         ((sl_status_t)0x0800)
+#define SL_STATUS_THREAD_SPACE            ((sl_status_t)0x0900)
+#define SL_STATUS_USB_SPACE               ((sl_status_t)0x0A00)
+#define SL_STATUS_WIFI_SPACE              ((sl_status_t)0x0B00)
+#define SL_STATUS_ZIGBEE_SPACE            ((sl_status_t)0x0C00)
+#define SL_STATUS_Z_WAVE_SPACE            ((sl_status_t)0x0D00)
+
+#define SL_STATUS_GECKO_OS_1_SPACE        ((sl_status_t)0x0E00)
+#define SL_STATUS_GECKO_OS_2_SPACE        ((sl_status_t)0x0F00)
+
+#define SL_STATUS_BLUETOOTH_CTRL_SPACE    ((sl_status_t)0x1000)
+#define SL_STATUS_BLUETOOTH_ATT_SPACE     ((sl_status_t)0x1100)
+#define SL_STATUS_BLUETOOTH_SMP_SPACE     ((sl_status_t)0x1200)
+#define SL_STATUS_BLUETOOTH_MESH_FOUNDATION_SPACE     ((sl_status_t)0x1300)
+
+#define SL_STATUS_WISUN_SPACE             ((sl_status_t)0x1400)
+
+#define SL_STATUS_COMPUTE_SPACE           ((sl_status_t)0x1500)
+
+// -----------------------------------------------------------------------------
+// Status Defines
+
+// -----------------------------------------------------------------------------
+// Generic Errors
+
+#define SL_STATUS_OK    ((sl_status_t)0x0000)  ///< No error.
+#define SL_STATUS_FAIL  ((sl_status_t)0x0001)  ///< Generic error.
+
+// State Errors
+#define SL_STATUS_INVALID_STATE         ((sl_status_t)0x0002)  ///< Generic invalid state error.
+#define SL_STATUS_NOT_READY             ((sl_status_t)0x0003)  ///< Module is not ready for requested operation.
+#define SL_STATUS_BUSY                  ((sl_status_t)0x0004)  ///< Module is busy and cannot carry out requested operation.
+#define SL_STATUS_IN_PROGRESS           ((sl_status_t)0x0005)  ///< Operation is in progress and not yet complete (pass or fail).
+#define SL_STATUS_ABORT                 ((sl_status_t)0x0006)  ///< Operation aborted.
+#define SL_STATUS_TIMEOUT               ((sl_status_t)0x0007)  ///< Operation timed out.
+#define SL_STATUS_PERMISSION            ((sl_status_t)0x0008)  ///< Operation not allowed per permissions.
+#define SL_STATUS_WOULD_BLOCK           ((sl_status_t)0x0009)  ///< Non-blocking operation would block.
+#define SL_STATUS_IDLE                  ((sl_status_t)0x000A)  ///< Operation/module is Idle, cannot carry requested operation.
+#define SL_STATUS_IS_WAITING            ((sl_status_t)0x000B)  ///< Operation cannot be done while construct is waiting.
+#define SL_STATUS_NONE_WAITING          ((sl_status_t)0x000C)  ///< No task/construct waiting/pending for that action/event.
+#define SL_STATUS_SUSPENDED             ((sl_status_t)0x000D)  ///< Operation cannot be done while construct is suspended.
+#define SL_STATUS_NOT_AVAILABLE         ((sl_status_t)0x000E)  ///< Feature not available due to software configuration.
+#define SL_STATUS_NOT_SUPPORTED         ((sl_status_t)0x000F)  ///< Feature not supported.
+#define SL_STATUS_INITIALIZATION        ((sl_status_t)0x0010)  ///< Initialization failed.
+#define SL_STATUS_NOT_INITIALIZED       ((sl_status_t)0x0011)  ///< Module has not been initialized.
+#define SL_STATUS_ALREADY_INITIALIZED   ((sl_status_t)0x0012)  ///< Module has already been initialized.
+#define SL_STATUS_DELETED               ((sl_status_t)0x0013)  ///< Object/construct has been deleted.
+#define SL_STATUS_ISR                   ((sl_status_t)0x0014)  ///< Illegal call from ISR.
+#define SL_STATUS_NETWORK_UP            ((sl_status_t)0x0015)  ///< Illegal call because network is up.
+#define SL_STATUS_NETWORK_DOWN          ((sl_status_t)0x0016)  ///< Illegal call because network is down.
+#define SL_STATUS_NOT_JOINED            ((sl_status_t)0x0017)  ///< Failure due to not being joined in a network.
+#define SL_STATUS_NO_BEACONS            ((sl_status_t)0x0018)  ///< Invalid operation as there are no beacons.
+
+// Allocation/ownership Errors
+#define SL_STATUS_ALLOCATION_FAILED   ((sl_status_t)0x0019)  ///< Generic allocation error.
+#define SL_STATUS_NO_MORE_RESOURCE    ((sl_status_t)0x001A)  ///< No more resource available to perform the operation.
+#define SL_STATUS_EMPTY               ((sl_status_t)0x001B)  ///< Item/list/queue is empty.
+#define SL_STATUS_FULL                ((sl_status_t)0x001C)  ///< Item/list/queue is full.
+#define SL_STATUS_WOULD_OVERFLOW      ((sl_status_t)0x001D)  ///< Item would overflow.
+#define SL_STATUS_HAS_OVERFLOWED      ((sl_status_t)0x001E)  ///< Item/list/queue has been overflowed.
+#define SL_STATUS_OWNERSHIP           ((sl_status_t)0x001F)  ///< Generic ownership error.
+#define SL_STATUS_IS_OWNER            ((sl_status_t)0x0020)  ///< Already/still owning resource.
+
+// Invalid Parameters Errors
+#define SL_STATUS_INVALID_PARAMETER       ((sl_status_t)0x0021)  ///< Generic invalid argument or consequence of invalid argument.
+#define SL_STATUS_NULL_POINTER            ((sl_status_t)0x0022)  ///< Invalid null pointer received as argument.
+#define SL_STATUS_INVALID_CONFIGURATION   ((sl_status_t)0x0023)  ///< Invalid configuration provided.
+#define SL_STATUS_INVALID_MODE            ((sl_status_t)0x0024)  ///< Invalid mode.
+#define SL_STATUS_INVALID_HANDLE          ((sl_status_t)0x0025)  ///< Invalid handle.
+#define SL_STATUS_INVALID_TYPE            ((sl_status_t)0x0026)  ///< Invalid type for operation.
+#define SL_STATUS_INVALID_INDEX           ((sl_status_t)0x0027)  ///< Invalid index.
+#define SL_STATUS_INVALID_RANGE           ((sl_status_t)0x0028)  ///< Invalid range.
+#define SL_STATUS_INVALID_KEY             ((sl_status_t)0x0029)  ///< Invalid key.
+#define SL_STATUS_INVALID_CREDENTIALS     ((sl_status_t)0x002A)  ///< Invalid credentials.
+#define SL_STATUS_INVALID_COUNT           ((sl_status_t)0x002B)  ///< Invalid count.
+#define SL_STATUS_INVALID_SIGNATURE       ((sl_status_t)0x002C)  ///< Invalid signature / verification failed.
+#define SL_STATUS_NOT_FOUND               ((sl_status_t)0x002D)  ///< Item could not be found.
+#define SL_STATUS_ALREADY_EXISTS          ((sl_status_t)0x002E)  ///< Item already exists.
+
+// IO/Communication Errors
+#define SL_STATUS_IO                    ((sl_status_t)0x002F)  ///< Generic I/O failure.
+#define SL_STATUS_IO_TIMEOUT            ((sl_status_t)0x0030)  ///< I/O failure due to timeout.
+#define SL_STATUS_TRANSMIT              ((sl_status_t)0x0031)  ///< Generic transmission error.
+#define SL_STATUS_TRANSMIT_UNDERFLOW    ((sl_status_t)0x0032)  ///< Transmit underflowed.
+#define SL_STATUS_TRANSMIT_INCOMPLETE   ((sl_status_t)0x0033)  ///< Transmit is incomplete.
+#define SL_STATUS_TRANSMIT_BUSY         ((sl_status_t)0x0034)  ///< Transmit is busy.
+#define SL_STATUS_RECEIVE               ((sl_status_t)0x0035)  ///< Generic reception error.
+#define SL_STATUS_OBJECT_READ           ((sl_status_t)0x0036)  ///< Failed to read on/via given object.
+#define SL_STATUS_OBJECT_WRITE          ((sl_status_t)0x0037)  ///< Failed to write on/via given object.
+#define SL_STATUS_MESSAGE_TOO_LONG      ((sl_status_t)0x0038)  ///< Message is too long.
+
+// EEPROM/Flash Errors
+#define SL_STATUS_EEPROM_MFG_VERSION_MISMATCH     ((sl_status_t)0x0039)  ///<
+#define SL_STATUS_EEPROM_STACK_VERSION_MISMATCH   ((sl_status_t)0x003A)  ///<
+#define SL_STATUS_FLASH_WRITE_INHIBITED           ((sl_status_t)0x003B)  ///< Flash write is inhibited.
+#define SL_STATUS_FLASH_VERIFY_FAILED             ((sl_status_t)0x003C)  ///< Flash verification failed.
+#define SL_STATUS_FLASH_PROGRAM_FAILED            ((sl_status_t)0x003D)  ///< Flash programming failed.
+#define SL_STATUS_FLASH_ERASE_FAILED              ((sl_status_t)0x003E)  ///< Flash erase failed.
+
+// MAC Errors
+#define SL_STATUS_MAC_NO_DATA                   ((sl_status_t)0x003F)  ///<
+#define SL_STATUS_MAC_NO_ACK_RECEIVED           ((sl_status_t)0x0040)  ///<
+#define SL_STATUS_MAC_INDIRECT_TIMEOUT          ((sl_status_t)0x0041)  ///<
+#define SL_STATUS_MAC_UNKNOWN_HEADER_TYPE       ((sl_status_t)0x0042)  ///<
+#define SL_STATUS_MAC_ACK_HEADER_TYPE           ((sl_status_t)0x0043)  ///<
+#define SL_STATUS_MAC_COMMAND_TRANSMIT_FAILURE  ((sl_status_t)0x0044)  ///<
+
+// CLI_STORAGE Errors
+#define SL_STATUS_CLI_STORAGE_NVM_OPEN_ERROR    ((sl_status_t)0x0045)  ///< Error in open NVM
+
+// Security status codes
+#define SL_STATUS_SECURITY_IMAGE_CHECKSUM_ERROR ((sl_status_t)0x0046)  ///< Image checksum is not valid.
+#define SL_STATUS_SECURITY_DECRYPT_ERROR        ((sl_status_t)0x0047)  ///< Decryption failed
+
+// Command status codes
+#define SL_STATUS_COMMAND_IS_INVALID            ((sl_status_t)0x0048)  ///< Command was not recognized
+#define SL_STATUS_COMMAND_TOO_LONG              ((sl_status_t)0x0049)  ///< Command or parameter maximum length exceeded
+#define SL_STATUS_COMMAND_INCOMPLETE            ((sl_status_t)0x004A)  ///< Data received does not form a complete command
+
+// Misc Errors
+#define SL_STATUS_BUS_ERROR                     ((sl_status_t)0x004B)  ///< Bus error, e.g. invalid DMA address
+
+// Unified MAC Errors
+#define SL_STATUS_CCA_FAILURE                   ((sl_status_t)0x004C)  ///<
+
+// Scan errors
+#define SL_STATUS_MAC_SCANNING                  ((sl_status_t)0x004D)  ///<
+#define SL_STATUS_MAC_INCORRECT_SCAN_TYPE       ((sl_status_t)0x004E)  ///<
+#define SL_STATUS_INVALID_CHANNEL_MASK          ((sl_status_t)0x004F)  ///<
+#define SL_STATUS_BAD_SCAN_DURATION             ((sl_status_t)0x0050)  ///<
+
+// Bluetooth status codes
+#define SL_STATUS_BT_OUT_OF_BONDS                                                                        ((sl_status_t)0x0402)        ///< Bonding procedure can't be started because device has no space left for bond.
+#define SL_STATUS_BT_UNSPECIFIED                                                                         ((sl_status_t)0x0403)        ///< Unspecified error
+#define SL_STATUS_BT_HARDWARE                                                                            ((sl_status_t)0x0404)        ///< Hardware failure
+#define SL_STATUS_BT_NO_BONDING                                                                          ((sl_status_t)0x0406)        ///< The bonding does not exist.
+#define SL_STATUS_BT_CRYPTO                                                                              ((sl_status_t)0x0407)        ///< Error using crypto functions
+#define SL_STATUS_BT_DATA_CORRUPTED                                                                      ((sl_status_t)0x0408)        ///< Data was corrupted.
+#define SL_STATUS_BT_INVALID_SYNC_HANDLE                                                                 ((sl_status_t)0x040A)        ///< Invalid periodic advertising sync handle
+#define SL_STATUS_BT_INVALID_MODULE_ACTION                                                               ((sl_status_t)0x040B)        ///< Bluetooth cannot be used on this hardware
+#define SL_STATUS_BT_RADIO                                                                               ((sl_status_t)0x040C)        ///< Error received from radio
+#define SL_STATUS_BT_L2CAP_REMOTE_DISCONNECTED                                                           ((sl_status_t)0x040D)        ///< Returned when remote disconnects the connection-oriented channel by sending disconnection request.
+#define SL_STATUS_BT_L2CAP_LOCAL_DISCONNECTED                                                            ((sl_status_t)0x040E)        ///< Returned when local host disconnect the connection-oriented channel by sending disconnection request.
+#define SL_STATUS_BT_L2CAP_CID_NOT_EXIST                                                                 ((sl_status_t)0x040F)        ///< Returned when local host did not find a connection-oriented channel with given destination CID.
+#define SL_STATUS_BT_L2CAP_LE_DISCONNECTED                                                               ((sl_status_t)0x0410)        ///< Returned when connection-oriented channel disconnected due to LE connection is dropped.
+#define SL_STATUS_BT_L2CAP_FLOW_CONTROL_VIOLATED                                                         ((sl_status_t)0x0412)        ///< Returned when connection-oriented channel disconnected due to remote end send data even without credit.
+#define SL_STATUS_BT_L2CAP_FLOW_CONTROL_CREDIT_OVERFLOWED                                                ((sl_status_t)0x0413)        ///< Returned when connection-oriented channel disconnected due to remote end send flow control credits exceed 65535.
+#define SL_STATUS_BT_L2CAP_NO_FLOW_CONTROL_CREDIT                                                        ((sl_status_t)0x0414)        ///< Returned when connection-oriented channel has run out of flow control credit and local application still trying to send data.
+#define SL_STATUS_BT_L2CAP_CONNECTION_REQUEST_TIMEOUT                                                    ((sl_status_t)0x0415)        ///< Returned when connection-oriented channel has not received connection response message within maximum timeout.
+#define SL_STATUS_BT_L2CAP_INVALID_CID                                                                   ((sl_status_t)0x0416)        ///< Returned when local host received a connection-oriented channel connection response with an invalid destination CID.
+#define SL_STATUS_BT_L2CAP_WRONG_STATE                                                                   ((sl_status_t)0x0417)        ///< Returned when local host application tries to send a command which is not suitable for L2CAP channel's current state.
+#define SL_STATUS_BT_PS_STORE_FULL                                                                       ((sl_status_t)0x041B)        ///< Flash reserved for PS store is full
+#define SL_STATUS_BT_PS_KEY_NOT_FOUND                                                                    ((sl_status_t)0x041C)        ///< PS key not found
+#define SL_STATUS_BT_APPLICATION_MISMATCHED_OR_INSUFFICIENT_SECURITY                                     ((sl_status_t)0x041D)        ///< Mismatched or insufficient security level
+#define SL_STATUS_BT_APPLICATION_ENCRYPTION_DECRYPTION_ERROR                                             ((sl_status_t)0x041E)        ///< Encrypion/decryption operation failed.
+
+// Bluetooth controller status codes
+#define SL_STATUS_BT_CTRL_UNKNOWN_CONNECTION_IDENTIFIER                                                  ((sl_status_t)0x1002)      ///< Connection does not exist, or connection open request was cancelled.
+#define SL_STATUS_BT_CTRL_AUTHENTICATION_FAILURE                                                         ((sl_status_t)0x1005)      ///< Pairing or authentication failed due to incorrect results in the pairing or authentication procedure. This could be due to an incorrect PIN or Link Key
+#define SL_STATUS_BT_CTRL_PIN_OR_KEY_MISSING                                                             ((sl_status_t)0x1006)      ///< Pairing failed because of missing PIN, or authentication failed because of missing Key
+#define SL_STATUS_BT_CTRL_MEMORY_CAPACITY_EXCEEDED                                                       ((sl_status_t)0x1007)      ///< Controller is out of memory.
+#define SL_STATUS_BT_CTRL_CONNECTION_TIMEOUT                                                             ((sl_status_t)0x1008)      ///< Link supervision timeout has expired.
+#define SL_STATUS_BT_CTRL_CONNECTION_LIMIT_EXCEEDED                                                      ((sl_status_t)0x1009)      ///< Controller is at limit of connections it can support.
+#define SL_STATUS_BT_CTRL_SYNCHRONOUS_CONNECTION_LIMIT_EXCEEDED                                          ((sl_status_t)0x100A)     ///< The Synchronous Connection Limit to a Device Exceeded error code indicates that the Controller has reached the limit to the number of synchronous connections that can be achieved to a device.
+#define SL_STATUS_BT_CTRL_ACL_CONNECTION_ALREADY_EXISTS                                                  ((sl_status_t)0x100B)     ///< The ACL Connection Already Exists error code indicates that an attempt to create a new ACL Connection to a device when there is already a connection to this device.
+#define SL_STATUS_BT_CTRL_COMMAND_DISALLOWED                                                             ((sl_status_t)0x100C)     ///< Command requested cannot be executed because the Controller is in a state where it cannot process this command at this time.
+#define SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_LIMITED_RESOURCES                                   ((sl_status_t)0x100D)     ///< The Connection Rejected Due To Limited Resources error code indicates that an incoming connection was rejected due to limited resources.
+#define SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_SECURITY_REASONS                                    ((sl_status_t)0x100E)     ///< The Connection Rejected Due To Security Reasons error code indicates that a connection was rejected due to security requirements not being fulfilled, like authentication or pairing.
+#define SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_UNACCEPTABLE_BD_ADDR                                ((sl_status_t)0x100F)     ///< The Connection was rejected because this device does not accept the BD_ADDR. This may be because the device will only accept connections from specific BD_ADDRs.
+#define SL_STATUS_BT_CTRL_CONNECTION_ACCEPT_TIMEOUT_EXCEEDED                                             ((sl_status_t)0x1010)     ///< The Connection Accept Timeout has been exceeded for this connection attempt.
+#define SL_STATUS_BT_CTRL_UNSUPPORTED_FEATURE_OR_PARAMETER_VALUE                                         ((sl_status_t)0x1011)     ///< A feature or parameter value in the HCI command is not supported.
+#define SL_STATUS_BT_CTRL_INVALID_COMMAND_PARAMETERS                                                     ((sl_status_t)0x1012)     ///< Command contained invalid parameters.
+#define SL_STATUS_BT_CTRL_REMOTE_USER_TERMINATED                                                         ((sl_status_t)0x1013)     ///< User on the remote device terminated the connection.
+#define SL_STATUS_BT_CTRL_REMOTE_DEVICE_TERMINATED_CONNECTION_DUE_TO_LOW_RESOURCES                       ((sl_status_t)0x1014)     ///< The remote device terminated the connection because of low resources
+#define SL_STATUS_BT_CTRL_REMOTE_POWERING_OFF                                                            ((sl_status_t)0x1015)     ///< Remote Device Terminated Connection due to Power Off
+#define SL_STATUS_BT_CTRL_CONNECTION_TERMINATED_BY_LOCAL_HOST                                            ((sl_status_t)0x1016)     ///< Local device terminated the connection.
+#define SL_STATUS_BT_CTRL_REPEATED_ATTEMPTS                                                              ((sl_status_t)0x1017)     ///< The Controller is disallowing an authentication or pairing procedure because too little time has elapsed since the last authentication or pairing attempt failed.
+#define SL_STATUS_BT_CTRL_PAIRING_NOT_ALLOWED                                                            ((sl_status_t)0x1018)     ///< The device does not allow pairing. This can be for example, when a device only allows pairing during a certain time window after some user input allows pairing
+#define SL_STATUS_BT_CTRL_UNSUPPORTED_REMOTE_FEATURE                                                     ((sl_status_t)0x101A)     ///< The remote device does not support the feature associated with the issued command.
+#define SL_STATUS_BT_CTRL_UNSPECIFIED_ERROR                                                              ((sl_status_t)0x101F)     ///< No other error code specified is appropriate to use.
+#define SL_STATUS_BT_CTRL_LL_RESPONSE_TIMEOUT                                                            ((sl_status_t)0x1022)     ///< Connection terminated due to link-layer procedure timeout.
+#define SL_STATUS_BT_CTRL_LL_PROCEDURE_COLLISION                                                         ((sl_status_t)0x1023)     ///< LL procedure has collided with the same transaction or procedure that is already in progress.
+#define SL_STATUS_BT_CTRL_ENCRYPTION_MODE_NOT_ACCEPTABLE                                                 ((sl_status_t)0x1025)     ///< The requested encryption mode is not acceptable at this time.
+#define SL_STATUS_BT_CTRL_LINK_KEY_CANNOT_BE_CHANGED                                                     ((sl_status_t)0x1026)     ///< Link key cannot be changed because a fixed unit key is being used.
+#define SL_STATUS_BT_CTRL_INSTANT_PASSED                                                                 ((sl_status_t)0x1028)     ///< LMP PDU or LL PDU that includes an instant cannot be performed because the instant when this would have occurred has passed.
+#define SL_STATUS_BT_CTRL_PAIRING_WITH_UNIT_KEY_NOT_SUPPORTED                                            ((sl_status_t)0x1029)     ///< It was not possible to pair as a unit key was requested and it is not supported.
+#define SL_STATUS_BT_CTRL_DIFFERENT_TRANSACTION_COLLISION                                                ((sl_status_t)0x102A)     ///< LMP transaction was started that collides with an ongoing transaction.
+#define SL_STATUS_BT_CTRL_CHANNEL_ASSESSMENT_NOT_SUPPORTED                                               ((sl_status_t)0x102E)     ///< The Controller cannot perform channel assessment because it is not supported.
+#define SL_STATUS_BT_CTRL_INSUFFICIENT_SECURITY                                                          ((sl_status_t)0x102F)     ///< The HCI command or LMP PDU sent is only possible on an encrypted link.
+#define SL_STATUS_BT_CTRL_PARAMETER_OUT_OF_MANDATORY_RANGE                                               ((sl_status_t)0x1030)     ///< A parameter value requested is outside the mandatory range of parameters for the given HCI command or LMP PDU.
+#define SL_STATUS_BT_CTRL_SIMPLE_PAIRING_NOT_SUPPORTED_BY_HOST                                           ((sl_status_t)0x1037)     ///< The IO capabilities request or response was rejected because the sending Host does not support Secure Simple Pairing even though the receiving Link Manager does.
+#define SL_STATUS_BT_CTRL_HOST_BUSY_PAIRING                                                              ((sl_status_t)0x1038)     ///< The Host is busy with another pairing operation and unable to support the requested pairing. The receiving device should retry pairing again later.
+#define SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_NO_SUITABLE_CHANNEL_FOUND                           ((sl_status_t)0x1039)     ///< The Controller could not calculate an appropriate value for the Channel selection operation.
+#define SL_STATUS_BT_CTRL_CONTROLLER_BUSY                                                                ((sl_status_t)0x103A)     ///< Operation was rejected because the controller is busy and unable to process the request.
+#define SL_STATUS_BT_CTRL_UNACCEPTABLE_CONNECTION_INTERVAL                                               ((sl_status_t)0x103B)     ///< Remote device terminated the connection because of an unacceptable connection interval.
+#define SL_STATUS_BT_CTRL_ADVERTISING_TIMEOUT                                                            ((sl_status_t)0x103C)     ///< Ddvertising for a fixed duration completed or, for directed advertising, that advertising completed without a connection being created.
+#define SL_STATUS_BT_CTRL_CONNECTION_TERMINATED_DUE_TO_MIC_FAILURE                                       ((sl_status_t)0x103D)     ///< Connection was terminated because the Message Integrity Check (MIC) failed on a received packet.
+#define SL_STATUS_BT_CTRL_CONNECTION_FAILED_TO_BE_ESTABLISHED                                            ((sl_status_t)0x103E)     ///< LL initiated a connection but the connection has failed to be established. Controller did not receive any packets from remote end.
+#define SL_STATUS_BT_CTRL_MAC_CONNECTION_FAILED                                                          ((sl_status_t)0x103F)     ///< The MAC of the 802.11 AMP was requested to connect to a peer, but the connection failed.
+#define SL_STATUS_BT_CTRL_COARSE_CLOCK_ADJUSTMENT_REJECTED_BUT_WILL_TRY_TO_ADJUST_USING_CLOCK_DRAGGING   ((sl_status_t)0x1040)     ///< The master, at this time, is unable to make a coarse adjustment to the piconet clock, using the supplied parameters. Instead the master will attempt to move the clock using clock dragging.
+#define SL_STATUS_BT_CTRL_UNKNOWN_ADVERTISING_IDENTIFIER                                                 ((sl_status_t)0x1042)     ///< A command was sent from the Host that should identify an Advertising or Sync handle, but the Advertising or Sync handle does not exist.
+#define SL_STATUS_BT_CTRL_LIMIT_REACHED                                                                  ((sl_status_t)0x1043)     ///< Number of operations requested has been reached and has indicated the completion of the activity (e.g., advertising or scanning).
+#define SL_STATUS_BT_CTRL_OPERATION_CANCELLED_BY_HOST                                                    ((sl_status_t)0x1044)     ///< A request to the Controller issued by the Host and still pending was successfully canceled.
+#define SL_STATUS_BT_CTRL_PACKET_TOO_LONG                                                                ((sl_status_t)0x1045)     ///< An attempt was made to send or receive a packet that exceeds the maximum allowed packet l
+
+// Bluetooth attribute status codes
+#define SL_STATUS_BT_ATT_INVALID_HANDLE                                                                  ((sl_status_t)0x1101)      ///< The attribute handle given was not valid on this server
+#define SL_STATUS_BT_ATT_READ_NOT_PERMITTED                                                              ((sl_status_t)0x1102)      ///< The attribute cannot be read
+#define SL_STATUS_BT_ATT_WRITE_NOT_PERMITTED                                                             ((sl_status_t)0x1103)      ///< The attribute cannot be written
+#define SL_STATUS_BT_ATT_INVALID_PDU                                                                     ((sl_status_t)0x1104)      ///< The attribute PDU was invalid
+#define SL_STATUS_BT_ATT_INSUFFICIENT_AUTHENTICATION                                                     ((sl_status_t)0x1105)      ///< The attribute requires authentication before it can be read or written.
+#define SL_STATUS_BT_ATT_REQUEST_NOT_SUPPORTED                                                           ((sl_status_t)0x1106)      ///< Attribute Server does not support the request received from the client.
+#define SL_STATUS_BT_ATT_INVALID_OFFSET                                                                  ((sl_status_t)0x1107)      ///< Offset specified was past the end of the attribute
+#define SL_STATUS_BT_ATT_INSUFFICIENT_AUTHORIZATION                                                      ((sl_status_t)0x1108)      ///< The attribute requires authorization before it can be read or written.
+#define SL_STATUS_BT_ATT_PREPARE_QUEUE_FULL                                                              ((sl_status_t)0x1109)      ///< Too many prepare writes have been queueud
+#define SL_STATUS_BT_ATT_ATT_NOT_FOUND                                                                   ((sl_status_t)0x110A)     ///< No attribute found within the given attribute handle range.
+#define SL_STATUS_BT_ATT_ATT_NOT_LONG                                                                    ((sl_status_t)0x110B)     ///< The attribute cannot be read or written using the Read Blob Request
+#define SL_STATUS_BT_ATT_INSUFFICIENT_ENC_KEY_SIZE                                                       ((sl_status_t)0x110C)     ///< The Encryption Key Size used for encrypting this link is insufficient.
+#define SL_STATUS_BT_ATT_INVALID_ATT_LENGTH                                                              ((sl_status_t)0x110D)     ///< The attribute value length is invalid for the operation
+#define SL_STATUS_BT_ATT_UNLIKELY_ERROR                                                                  ((sl_status_t)0x110E)     ///< The attribute request that was requested has encountered an error that was unlikely, and therefore could not be completed as requested.
+#define SL_STATUS_BT_ATT_INSUFFICIENT_ENCRYPTION                                                         ((sl_status_t)0x110F)     ///< The attribute requires encryption before it can be read or written.
+#define SL_STATUS_BT_ATT_UNSUPPORTED_GROUP_TYPE                                                          ((sl_status_t)0x1110)     ///< The attribute type is not a supported grouping attribute as defined by a higher layer specification.
+#define SL_STATUS_BT_ATT_INSUFFICIENT_RESOURCES                                                          ((sl_status_t)0x1111)     ///< Insufficient Resources to complete the request
+#define SL_STATUS_BT_ATT_OUT_OF_SYNC                                                                     ((sl_status_t)0x1112)     ///< The server requests the client to rediscover the database.
+#define SL_STATUS_BT_ATT_VALUE_NOT_ALLOWED                                                               ((sl_status_t)0x1113)     ///< The attribute parameter value was not allowed.
+#define SL_STATUS_BT_ATT_APPLICATION                                                                     ((sl_status_t)0x1180)    ///< When this is returned in a BGAPI response, the application tried to read or write the value of a user attribute from the GATT databa
+#define SL_STATUS_BT_ATT_WRITE_REQUEST_REJECTED                                                          ((sl_status_t)0x11FC)    ///< The requested write operation cannot be fulfilled for reasons other than permissions.
+#define SL_STATUS_BT_ATT_CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR_IMPROPERLY_CONFIGURED            ((sl_status_t)0x11FD)    ///< The Client Characteristic Configuration descriptor is not configured according to the requirements of the profile or service.
+#define SL_STATUS_BT_ATT_PROCEDURE_ALREADY_IN_PROGRESS                                                   ((sl_status_t)0x11FE)    ///< The profile or service request cannot be serviced because an operation that has been previously triggered is still in progress.
+#define SL_STATUS_BT_ATT_OUT_OF_RANGE                                                                    ((sl_status_t)0x11FF)    ///< The attribute value is out of range as defined by a profile or service specification.
+
+// Bluetooth Security Manager Protocol status codes
+#define SL_STATUS_BT_SMP_PASSKEY_ENTRY_FAILED                                                            ((sl_status_t)0x1201)      ///< The user input of passkey failed, for example, the user cancelled the operation
+#define SL_STATUS_BT_SMP_OOB_NOT_AVAILABLE                                                               ((sl_status_t)0x1202)      ///< Out of Band data is not available for authentication
+#define SL_STATUS_BT_SMP_AUTHENTICATION_REQUIREMENTS                                                     ((sl_status_t)0x1203)      ///< The pairing procedure cannot be performed as authentication requirements cannot be met due to IO capabilities of one or both devices
+#define SL_STATUS_BT_SMP_CONFIRM_VALUE_FAILED                                                            ((sl_status_t)0x1204)      ///< The confirm value does not match the calculated compare value
+#define SL_STATUS_BT_SMP_PAIRING_NOT_SUPPORTED                                                           ((sl_status_t)0x1205)      ///< Pairing is not supported by the device
+#define SL_STATUS_BT_SMP_ENCRYPTION_KEY_SIZE                                                             ((sl_status_t)0x1206)      ///< The resultant encryption key size is insufficient for the security requirements of this device
+#define SL_STATUS_BT_SMP_COMMAND_NOT_SUPPORTED                                                           ((sl_status_t)0x1207)      ///< The SMP command received is not supported on this device
+#define SL_STATUS_BT_SMP_UNSPECIFIED_REASON                                                              ((sl_status_t)0x1208)      ///< Pairing failed due to an unspecified reason
+#define SL_STATUS_BT_SMP_REPEATED_ATTEMPTS                                                               ((sl_status_t)0x1209)      ///< Pairing or authentication procedure is disallowed because too little time has elapsed since last pairing request or security request
+#define SL_STATUS_BT_SMP_INVALID_PARAMETERS                                                              ((sl_status_t)0x120A)     ///< The Invalid Parameters error code indicates: the command length is invalid or a parameter is outside of the specified range.
+#define SL_STATUS_BT_SMP_DHKEY_CHECK_FAILED                                                              ((sl_status_t)0x120B)     ///< Indicates to the remote device that the DHKey Check value received doesn't match the one calculated by the local device.
+#define SL_STATUS_BT_SMP_NUMERIC_COMPARISON_FAILED                                                       ((sl_status_t)0x120C)     ///< Indicates that the confirm values in the numeric comparison protocol do not match.
+#define SL_STATUS_BT_SMP_BREDR_PAIRING_IN_PROGRESS                                                       ((sl_status_t)0x120D)     ///< Indicates that the pairing over the LE transport failed due to a Pairing Request sent over the BR/EDR transport in process.
+#define SL_STATUS_BT_SMP_CROSS_TRANSPORT_KEY_DERIVATION_GENERATION_NOT_ALLOWED                           ((sl_status_t)0x120E)     ///< Indicates that the BR/EDR Link Key generated on the BR/EDR transport cannot be used to derive and distribute keys for the LE transport.
+#define SL_STATUS_BT_SMP_KEY_REJECTED                                                                    ((sl_status_t)0x120F)     ///< Indicates that the device chose not to accept a distributed key.
+
+// Bluetooth Mesh status codes
+#define SL_STATUS_BT_MESH_ALREADY_EXISTS                                                                 ((sl_status_t)0x0501)      ///< Returned when trying to add a key or some other unique resource with an ID which already exists
+#define SL_STATUS_BT_MESH_DOES_NOT_EXIST                                                                 ((sl_status_t)0x0502)      ///< Returned when trying to manipulate a key or some other resource with an ID which does not exist
+#define SL_STATUS_BT_MESH_LIMIT_REACHED                                                                  ((sl_status_t)0x0503)      ///< Returned when an operation cannot be executed because a pre-configured limit for keys, key bindings, elements, models, virtual addresses, provisioned devices, or provisioning sessions is reached
+#define SL_STATUS_BT_MESH_INVALID_ADDRESS                                                                ((sl_status_t)0x0504)      ///< Returned when trying to use a reserved address or add a "pre-provisioned" device using an address already used by some other device
+#define SL_STATUS_BT_MESH_MALFORMED_DATA                                                                 ((sl_status_t)0x0505)      ///< In a BGAPI response, the user supplied malformed data; in a BGAPI event, the remote end responded with malformed or unrecognized data
+#define SL_STATUS_BT_MESH_ALREADY_INITIALIZED                                                            ((sl_status_t)0x0506)      ///< An attempt was made to initialize a subsystem that was already initialized.
+#define SL_STATUS_BT_MESH_NOT_INITIALIZED                                                                ((sl_status_t)0x0507)      ///< An attempt was made to use a subsystem that wasn't initialized yet. Call the subsystem's init function first.
+#define SL_STATUS_BT_MESH_NO_FRIEND_OFFER                                                                ((sl_status_t)0x0508)      ///< Returned when trying to establish a friendship as a Low Power Node, but no acceptable friend offer message was received.
+#define SL_STATUS_BT_MESH_PROV_LINK_CLOSED                                                               ((sl_status_t)0x0509)      ///< Provisioning link was unexpectedly closed before provisioning was complete.
+#define SL_STATUS_BT_MESH_PROV_INVALID_PDU                                                               ((sl_status_t)0x050A)     ///< An unrecognized provisioning PDU was received.
+#define SL_STATUS_BT_MESH_PROV_INVALID_PDU_FORMAT                                                        ((sl_status_t)0x050B)     ///< A provisioning PDU with wrong length or containing field values that are out of bounds was received.
+#define SL_STATUS_BT_MESH_PROV_UNEXPECTED_PDU                                                            ((sl_status_t)0x050C)     ///< An unexpected (out of sequence) provisioning PDU was received.
+#define SL_STATUS_BT_MESH_PROV_CONFIRMATION_FAILED                                                       ((sl_status_t)0x050D)     ///< The computed confirmation value did not match the expected value.
+#define SL_STATUS_BT_MESH_PROV_OUT_OF_RESOURCES                                                          ((sl_status_t)0x050E)     ///< Provisioning could not be continued due to insufficient resources.
+#define SL_STATUS_BT_MESH_PROV_DECRYPTION_FAILED                                                         ((sl_status_t)0x050F)     ///< The provisioning data block could not be decrypted.
+#define SL_STATUS_BT_MESH_PROV_UNEXPECTED_ERROR                                                          ((sl_status_t)0x0510)     ///< An unexpected error happened during provisioning.
+#define SL_STATUS_BT_MESH_PROV_CANNOT_ASSIGN_ADDR                                                        ((sl_status_t)0x0511)     ///< Device could not assign unicast addresses to all of its elements.
+#define SL_STATUS_BT_MESH_ADDRESS_TEMPORARILY_UNAVAILABLE                                                ((sl_status_t)0x0512)     ///< Returned when trying to reuse an address of a previously deleted device before an IV Index Update has been executed.
+#define SL_STATUS_BT_MESH_ADDRESS_ALREADY_USED                                                           ((sl_status_t)0x0513)     ///< Returned when trying to assign an address that is used by one of the devices in the Device Database, or by the Provisioner itself.
+#define SL_STATUS_BT_MESH_PUBLISH_NOT_CONFIGURED                                                         ((sl_status_t)0x0514)     ///< Application key or publish address are not set
+#define SL_STATUS_BT_MESH_APP_KEY_NOT_BOUND                                                              ((sl_status_t)0x0515)     ///< Application key is not bound to a model
+
+// Bluetooth Mesh foundation status codes
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_ADDRESS                                                     ((sl_status_t)0x1301)      ///< Returned when address in request was not valid
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_MODEL                                                       ((sl_status_t)0x1302)      ///< Returned when model identified is not found for a given element
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_APP_KEY                                                     ((sl_status_t)0x1303)      ///< Returned when the key identified by AppKeyIndex is not stored in the node
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_NET_KEY                                                     ((sl_status_t)0x1304)      ///< Returned when the key identified by NetKeyIndex is not stored in the node
+#define SL_STATUS_BT_MESH_FOUNDATION_INSUFFICIENT_RESOURCES                                              ((sl_status_t)0x1305)      ///< Returned when The node cannot serve the request due to insufficient resources
+#define SL_STATUS_BT_MESH_FOUNDATION_KEY_INDEX_EXISTS                                                    ((sl_status_t)0x1306)      ///< Returned when the key identified is already stored in the node and the new NetKey value is different
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_PUBLISH_PARAMS                                              ((sl_status_t)0x1307)      ///< Returned when the model does not support the publish mechanism
+#define SL_STATUS_BT_MESH_FOUNDATION_NOT_SUBSCRIBE_MODEL                                                 ((sl_status_t)0x1308)      ///< Returned when  the model does not support the subscribe mechanism
+#define SL_STATUS_BT_MESH_FOUNDATION_STORAGE_FAILURE                                                     ((sl_status_t)0x1309)      ///< Returned when storing of the requested parameters failed
+#define SL_STATUS_BT_MESH_FOUNDATION_NOT_SUPPORTED                                                       ((sl_status_t)0x130A)     ///< Returned when requested setting is not supported
+#define SL_STATUS_BT_MESH_FOUNDATION_CANNOT_UPDATE                                                       ((sl_status_t)0x130B)     ///< Returned when the requested update operation cannot be performed due to general constraints
+#define SL_STATUS_BT_MESH_FOUNDATION_CANNOT_REMOVE                                                       ((sl_status_t)0x130C)     ///< Returned when the requested delete operation cannot be performed due to general constraints
+#define SL_STATUS_BT_MESH_FOUNDATION_CANNOT_BIND                                                         ((sl_status_t)0x130D)     ///< Returned when the requested bind operation cannot be performed due to general constraints
+#define SL_STATUS_BT_MESH_FOUNDATION_TEMPORARILY_UNABLE                                                  ((sl_status_t)0x130E)     ///< Returned when The node cannot start advertising with Node Identity or Proxy since the maximum number of parallel advertising is reached
+#define SL_STATUS_BT_MESH_FOUNDATION_CANNOT_SET                                                          ((sl_status_t)0x130F)     ///< Returned when the requested state cannot be set
+#define SL_STATUS_BT_MESH_FOUNDATION_UNSPECIFIED                                                         ((sl_status_t)0x1310)     ///< Returned when an unspecified error took place
+#define SL_STATUS_BT_MESH_FOUNDATION_INVALID_BINDING                                                     ((sl_status_t)0x1311)     ///< Returned when the NetKeyIndex and AppKeyIndex combination is not valid for a Config AppKey Update
+
+// -----------------------------------------------------------------------------
+// Wi-Fi Errors
+
+#define SL_STATUS_WIFI_INVALID_KEY                         ((sl_status_t)0x0B01)  ///< Invalid firmware keyset
+#define SL_STATUS_WIFI_FIRMWARE_DOWNLOAD_TIMEOUT           ((sl_status_t)0x0B02)  ///< The firmware download took too long
+#define SL_STATUS_WIFI_UNSUPPORTED_MESSAGE_ID              ((sl_status_t)0x0B03)  ///< Unknown request ID or wrong interface ID used
+#define SL_STATUS_WIFI_WARNING                             ((sl_status_t)0x0B04)  ///< The request is successful but some parameters have been ignored
+#define SL_STATUS_WIFI_NO_PACKET_TO_RECEIVE                ((sl_status_t)0x0B05)  ///< No Packets waiting to be received
+#define SL_STATUS_WIFI_SLEEP_GRANTED                       ((sl_status_t)0x0B08)  ///< The sleep mode is granted
+#define SL_STATUS_WIFI_SLEEP_NOT_GRANTED                   ((sl_status_t)0x0B09)  ///< The WFx does not go back to sleep
+#define SL_STATUS_WIFI_SECURE_LINK_MAC_KEY_ERROR           ((sl_status_t)0x0B10)  ///< The SecureLink MAC key was not found
+#define SL_STATUS_WIFI_SECURE_LINK_MAC_KEY_ALREADY_BURNED  ((sl_status_t)0x0B11)  ///< The SecureLink MAC key is already installed in OTP
+#define SL_STATUS_WIFI_SECURE_LINK_RAM_MODE_NOT_ALLOWED    ((sl_status_t)0x0B12)  ///< The SecureLink MAC key cannot be installed in RAM
+#define SL_STATUS_WIFI_SECURE_LINK_FAILED_UNKNOWN_MODE     ((sl_status_t)0x0B13)  ///< The SecureLink MAC key installation failed
+#define SL_STATUS_WIFI_SECURE_LINK_EXCHANGE_FAILED         ((sl_status_t)0x0B14)  ///< SecureLink key (re)negotiation failed
+#define SL_STATUS_WIFI_WRONG_STATE                         ((sl_status_t)0x0B18)  ///< The device is in an inappropriate state to perform the request
+#define SL_STATUS_WIFI_CHANNEL_NOT_ALLOWED                 ((sl_status_t)0x0B19)  ///< The request failed due to regulatory limitations
+#define SL_STATUS_WIFI_NO_MATCHING_AP                      ((sl_status_t)0x0B1A)  ///< The connection request failed because no suitable AP was found
+#define SL_STATUS_WIFI_CONNECTION_ABORTED                  ((sl_status_t)0x0B1B)  ///< The connection request was aborted by host
+#define SL_STATUS_WIFI_CONNECTION_TIMEOUT                  ((sl_status_t)0x0B1C)  ///< The connection request failed because of a timeout
+#define SL_STATUS_WIFI_CONNECTION_REJECTED_BY_AP           ((sl_status_t)0x0B1D)  ///< The connection request failed because the AP rejected the device
+#define SL_STATUS_WIFI_CONNECTION_AUTH_FAILURE             ((sl_status_t)0x0B1E)  ///< The connection request failed because the WPA handshake did not complete successfully
+#define SL_STATUS_WIFI_RETRY_EXCEEDED                      ((sl_status_t)0x0B1F)  ///< The request failed because the retry limit was exceeded
+#define SL_STATUS_WIFI_TX_LIFETIME_EXCEEDED                ((sl_status_t)0x0B20)  ///< The request failed because the MSDU life time was exceeded
+
+// -----------------------------------------------------------------------------
+// MVP Driver and MVP Math status codes
+#define SL_STATUS_COMPUTE_DRIVER_FAULT                      ((sl_status_t)0x1501)   ///< Critical fault
+#define SL_STATUS_COMPUTE_DRIVER_ALU_NAN                    ((sl_status_t)0x1502)   ///< ALU operation output NaN
+#define SL_STATUS_COMPUTE_DRIVER_ALU_OVERFLOW               ((sl_status_t)0x1503)   ///< ALU numeric overflow
+#define SL_STATUS_COMPUTE_DRIVER_ALU_UNDERFLOW              ((sl_status_t)0x1504)   ///< ALU numeric underflow
+#define SL_STATUS_COMPUTE_DRIVER_STORE_CONVERSION_OVERFLOW  ((sl_status_t)0x1505)   ///< Overflow during array store
+#define SL_STATUS_COMPUTE_DRIVER_STORE_CONVERSION_UNDERFLOW ((sl_status_t)0x1506)   ///< Underflow during array store conversion
+#define SL_STATUS_COMPUTE_DRIVER_STORE_CONVERSION_INFINITY  ((sl_status_t)0x1507)   ///< Infinity encountered during array store conversion
+#define SL_STATUS_COMPUTE_DRIVER_STORE_CONVERSION_NAN       ((sl_status_t)0x1508)   ///< NaN encountered during array store conversion
+
+#define SL_STATUS_COMPUTE_MATH_FAULT                        ((sl_status_t)0x1511)   ///< MATH Critical fault
+#define SL_STATUS_COMPUTE_MATH_NAN                          ((sl_status_t)0x1512)   ///< MATH NaN encountered
+#define SL_STATUS_COMPUTE_MATH_INFINITY                     ((sl_status_t)0x1513)   ///< MATH Infinity encountered
+#define SL_STATUS_COMPUTE_MATH_OVERFLOW                     ((sl_status_t)0x1514)   ///< MATH numeric overflow
+#define SL_STATUS_COMPUTE_MATH_UNDERFLOW                    ((sl_status_t)0x1515)   ///< MATH numeric underflow
+
+// -----------------------------------------------------------------------------
+// Data Types
+
+typedef uint32_t sl_status_t;
+
+// -----------------------------------------------------------------------------
+// Functions
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/********************************************************************************************************
+ *                                      sl_status_get_string_n()
+ *
+ * @brief    Get a copy of the status string associated to the status code passed, up to
+ *           'buffer_length' length, if the string associated to the status code is enabled. If not,
+ *           the error code number, in hex, prefixed by "SL_STATUS_" will be copied in the buffer
+ *           instead.
+ *           For example, the buffer would either contain "SL_STATUS_FAIL" if that status string is
+ *           enabled, or "SL_STATUS_0x0001" if the string is disabled, as SL_STATUS_FAIL's
+ *           value is 0x0001.
+ *
+ * @param    status         The status code from which to obtain the status string.
+ *
+ * @param    buffer         Pointer to a buffer in which the status string will be copied. A terminating
+ *                          null-character will be appended after the copied status string.
+ *
+ * @param    buffer_length  Maximum number of characters that can be written in the buffer, including the
+ *                          terminating null-character. If the status string would be longer than the
+ *                          available length, it will be truncated and a null-terminating character will
+ *                          be the last character contained in the buffer.
+ *
+ * @return                  The number of characters that would have been written if the buffer_length had been
+ *                          sufficiently large, not counting the terminating null character.
+ *                          If the status code is invalid, 0 or a negative number is returned.
+ *                          Notice that only when this returned value is strictly positive and less than
+ *                          buffer_length, the status string has been completely written in the buffer.
+ *******************************************************************************************************/
+int32_t sl_status_get_string_n(sl_status_t status, char *buffer, uint32_t buffer_length);
+
+/********************************************************************************************************
+ *                                         sl_status_print()
+ *
+ * @brief    Print, through printf, the string associated to the passed status code. If the string
+ *           associated to the status code is enabled, the status string will be printed, for example
+ *           "SL_STATUS_OK". If the string associated to the status code is disabled, the status number,
+ *           in hex, prefixed by "SL_STATUS_" will be printed instead, for example "SL_STATUS_0x0000",
+ *           as SL_STATUS_OK's value is 0x0000.
+ *
+ * @param    status         The status code of which to print the status string.
+ *******************************************************************************************************/
+void sl_status_print(sl_status_t status);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} (end addtogroup status) */
+
+#endif /* SL_STATUS_H */

--- a/wiseconnect/components/device/silabs/si91x/wireless/ncp_interface/sl_si91x_ncp_driver.c
+++ b/wiseconnect/components/device/silabs/si91x/wireless/ncp_interface/sl_si91x_ncp_driver.c
@@ -1,0 +1,194 @@
+/***************************************************************************/ /**
+ * @file
+ * @brief
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#include <stdint.h>
+#include <stddef.h>
+#include "sl_si91x_status.h"
+#include "sl_si91x_types.h"
+#include "sl_si91x_constants.h"
+#include "sl_si91x_spi_constants.h"
+#include "sl_si91x_host_interface.h"
+#include "sl_status.h"
+#include "sl_additional_status.h"
+#include "sl_wifi_constants.h"
+#include "sl_constants.h"
+#include "sl_rsi_utility.h"
+
+// This macro converts a 32-bit value from host to little-endian byte order
+#define htole32(x) (x)
+
+// This macro converts a 16-bit value from host to little-endian byte order
+#define htole16(x) (x)
+
+void sli_submit_rx_buffer(void);
+
+sl_status_t sli_si91x_bus_set_interrupt_mask(uint32_t mask)
+{
+  sl_status_t status;
+  // Create a buffer to store interrupt configuration data, depending on the system's bit support
+#ifdef SLI_BIT_32_SUPPORT
+  uint8_t buffer[4] = { 0, 0, 0, 0 };
+#else
+  uint8_t buffer[2] = { 0, 0 };
+#endif
+
+  // Read the current interrupt mask configuration from memory
+  status = sl_si91x_bus_read_memory(SLI_INT_MASK_REG_ADDR, sizeof(buffer), buffer);
+  SLI_VERIFY_STATUS(status);
+
+  // Modify the interrupt configuration based on the provided mask
+  buffer[1] = buffer[1] & 0xFC; // Clear lower 2 bits
+  buffer[1] = buffer[1] | mask; // Set the specified interrupt mask
+
+  // Write the updated mask value back to memory
+  status = sl_si91x_bus_write_memory(SLI_INT_MASK_REG_ADDR, sizeof(buffer), buffer);
+  return status;
+}
+
+// Function for clearing an interrupt
+sl_status_t sli_si91x_bus_clear_interrupt(uint32_t interrupt_clear_value)
+{
+#ifdef SLI_BIT_32_SUPPORT
+  // Write the provided interrupt clear value to the specified memory address (32-bit version)
+  return sl_si91x_bus_write_memory(SLI_INT_CLR_REG_ADDR, 4, &interrupt_clear_value);
+#else
+  // Write the provided interrupt clear value to the specified memory address (16-bit version)
+  return sl_si91x_bus_write_memory(SLI_INT_CLR_REG_ADDR, 2, (uint8_t *)&interrupt_clear_value);
+#endif
+}
+
+sl_status_t sli_si91x_bus_enable_high_speed(void)
+{
+  // It writes specific data to a register at address 0x08 with a size of 2 bytes
+  return sli_si91x_bus_write_register(0x08, 2, 0x3);
+}
+
+sl_status_t sli_si91x_req_wakeup(void)
+{
+  // Wake device, if needed
+  sl_si91x_host_set_sleep_indicator();
+  uint32_t timestamp = sl_si91x_host_get_timestamp();
+  do {
+    if (sl_si91x_host_get_wake_indicator()) {
+      sli_si91x_ulp_wakeup_init();
+      break;
+    }
+    if (sl_si91x_host_elapsed_time(timestamp) > 1000) {
+      return SL_STATUS_TIMEOUT;
+    }
+  } while (1);
+  return SL_STATUS_OK;
+}
+void sli_submit_rx_buffer(void)
+{
+}
+
+sl_status_t sli_si91x_boot_instruction(uint8_t type, uint16_t *data)
+{
+  sl_status_t retval            = 0;
+  uint16_t local                = 0;
+  uint32_t cmd                  = 0;
+  uint16_t read_data            = 0;
+  volatile int32_t loop_counter = 0;
+#ifdef RSI_DEBUG_PRINT
+  RSI_DPRINT(RSI_PL3, "\nBootInsn\n");
+#endif
+
+  switch (type) {
+    case SLI_REG_READ:
+      retval = sl_si91x_bus_read_memory(SLI_HOST_INTF_REG_OUT, 2, (uint8_t *)&read_data);
+      *data  = read_data;
+      break;
+
+    case SLI_REG_WRITE:
+      retval = sl_si91x_bus_write_memory(SLI_HOST_INTF_REG_IN, 2, (uint8_t *)data);
+      break;
+
+    case SLI_PING_WRITE:
+#ifdef SLAVE_MODE_TRANSFER
+      // Bootloader expects 4KB of data.
+      retval = sli_si91x_bus_write_slave(SLI_PING_PONG_CHUNK_SIZE, (uint8_t *)data);
+#else
+      for (uint32_t offset = 0; offset < 4096; offset += 1024) {
+        retval = sl_si91x_bus_write_memory(0x51400 + offset, 1024, (uint8_t *)((uint32_t)data + offset));
+        VERIFY_STATUS_AND_RETURN(retval);
+      }
+#endif
+      local  = (SLI_PING_AVAIL | SLI_HOST_INTERACT_REG_VALID);
+      retval = sl_si91x_bus_write_memory(SLI_HOST_INTF_REG_IN, 2, (uint8_t *)&local);
+      break;
+
+    case SLI_PONG_WRITE:
+#ifdef SLAVE_MODE_TRANSFER
+      // Bootloader expects 4KB of data.
+      retval = sli_si91x_bus_write_slave(SLI_PING_PONG_CHUNK_SIZE, (uint8_t *)data);
+#else
+      for (uint32_t offset = 0; offset < 4096; offset += 1024) {
+        retval = sl_si91x_bus_write_memory(0x52400 + offset, 1024, (uint8_t *)((uint32_t)data + offset));
+        VERIFY_STATUS_AND_RETURN(retval);
+      }
+#endif
+
+      // Perform the write operation
+      local  = (SLI_PONG_AVAIL | SLI_HOST_INTERACT_REG_VALID);
+      retval = sl_si91x_bus_write_memory(SLI_HOST_INTF_REG_IN, 2, (uint8_t *)&local);
+      break;
+
+    case BURN_M4_FW:
+    case BURN_NWP_FW:
+      cmd    = type | SLI_HOST_INTERACT_REG_VALID;
+      retval = sl_si91x_bus_write_memory(SLI_HOST_INTF_REG_IN, 2, (uint8_t *)&cmd);
+      VERIFY_STATUS_AND_RETURN(retval);
+
+      SLI_SI91X_RESET_LOOP_COUNTER(loop_counter);
+      SLI_SI91X_WHILE_LOOP(loop_counter, SLI_SI91X_LOOP_COUNT_UPGRADE_IMAGE)
+      {
+        retval = sl_si91x_bus_read_memory(SLI_HOST_INTF_REG_OUT, 2, (uint8_t *)&read_data);
+        VERIFY_STATUS_AND_RETURN(retval);
+        if (read_data == (uint16_t)(SLI_SEND_RPS_FILE | SLI_HOST_INTERACT_REG_VALID)) {
+          break;
+        }
+      }
+      SLI_SI91X_CHECK_LOOP_COUNTER(loop_counter, SLI_SI91X_LOOP_COUNT_UPGRADE_IMAGE);
+      break;
+
+    case LOAD_NWP_FW:
+      cmd    = LOAD_NWP_FW | SLI_HOST_INTERACT_REG_VALID;
+      retval = sl_si91x_bus_write_memory(SLI_HOST_INTF_REG_IN, 2, (uint8_t *)&cmd);
+      break;
+    case LOAD_DEFAULT_NWP_FW_ACTIVE_LOW:
+      cmd    = LOAD_DEFAULT_NWP_FW_ACTIVE_LOW | SLI_HOST_INTERACT_REG_VALID;
+      retval = sl_si91x_bus_write_memory(SLI_HOST_INTF_REG_IN, 2, (uint8_t *)&cmd);
+      break;
+    default:
+      retval = SL_STATUS_OK;
+      break;
+  }
+  return retval;
+}

--- a/wiseconnect/components/device/silabs/si91x/wireless/ncp_interface/spi/sl_si91x_spi.c
+++ b/wiseconnect/components/device/silabs/si91x/wireless/ncp_interface/spi/sl_si91x_spi.c
@@ -1,0 +1,561 @@
+/***************************************************************************/ /**
+ * @file
+ * @brief
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#include "sl_si91x_status.h"
+#include "sl_si91x_types.h"
+#include "sl_si91x_constants.h"
+#include "sl_si91x_spi_constants.h"
+#include "sl_si91x_host_interface.h"
+#include "sl_status.h"
+#include "sl_additional_status.h"
+#include "sl_wifi_constants.h"
+#include "sl_constants.h"
+#include "sl_rsi_utility.h"
+#include <stdint.h>
+#include <stddef.h>
+
+// This macro converts a 32-bit value from host to little-endian byte order
+#define htole32(x) (x)
+
+// This macro converts a 16-bit value from host to little-endian byte order
+#define htole16(x) (x)
+#define SECONDS    (1000)
+
+//! @cond Doxygen_Suppress
+#define SLI_SPI_VERIFY_STATUS(s)       \
+  do {                                 \
+    if (s != SL_STATUS_OK) {           \
+      sl_si91x_host_spi_cs_deassert(); \
+      return s;                        \
+    }                                  \
+  } while (0)
+
+#ifdef SLI_BIT_32_SUPPORT
+#define SLI_C2_READ_WRITE_SIZE SLI_C2RDWR4BYTE
+#else
+#define SLI_C2_READ_WRITE_SIZE SLI_C2RDWR1BYTE
+#endif
+
+// Timeout value for waiting for the start token
+#define SLI_START_TOKEN_TIMEOUT (10 * SECONDS)
+
+#ifndef SL_WIFI_BOARD_READY_WAIT_TIME
+#define SL_WIFI_BOARD_READY_WAIT_TIME \
+  40000 //some scenarios like after firmware upgrade, it will take 40 seconds to boad ready
+#endif
+
+sl_status_t sli_verify_device_boot(uint32_t *rom_version);
+sl_status_t sli_wifi_select_option(const uint8_t configuration);
+
+/************************************************************************************
+ ******************************** Static Functions *********************************
+************************************************************************************/
+static sl_status_t sli_send_c1c2(uint16_t data)
+{
+  sl_status_t status;
+  uint8_t rx_buffer[2] = { 0, 0 };
+
+  const uint32_t timestamp = sl_si91x_host_get_timestamp();
+
+  do {
+    // Send C1/C2 and receive the response in rx_buffer
+    status = sl_si91x_host_spi_transfer(&data, rx_buffer, 2);
+
+    // Check if there was an error or if the response indicates success or idle state
+    if (status != SL_STATUS_OK || rx_buffer[1] == SLI_SPI_FAIL) {
+      return SL_STATUS_FAIL;
+    }
+    if ((rx_buffer[1] == SLI_SPI_SUCCESS) || (rx_buffer[1] == 0x00)) {
+      return SL_STATUS_OK;
+    }
+    osDelay(10);
+    // printf("\r\n C1/C2 RESPONSE %x %x\r\n", rx_buffer[0], rx_buffer[1]);
+    // If a timeout occurs while waiting for a response, return a timeout status
+  } while (sl_si91x_host_elapsed_time(timestamp) < 100000000);
+
+  // printf("\r\n TIMEOUT WHILE WAITING FOR C1/C2 RESPONSE %x %x\r\n", rx_buffer[0], rx_buffer[1]);
+  return SL_STATUS_TIMEOUT;
+}
+
+static sl_status_t sli_wait_start_token(uint32_t timeout)
+{
+  sl_status_t status = SL_STATUS_OK;
+#ifdef SLI_BIT_32_SUPPORT
+  // Char to send/receive data in
+  uint32_t temp = 0;
+#else
+  uint8_t temp = 0;
+#endif
+  // Look for start token
+  // Send a character, could be any character, and check the response for a start token
+  // If not found within the timeout time, error out
+  // Timeout value needs to be passed since context is important
+  const uint32_t timestamp = sl_si91x_host_get_timestamp();
+
+  while (temp != SLI_SPI_START_TOKEN) {
+    if (sl_si91x_host_elapsed_time(timestamp) > timeout) {
+      return SL_STATUS_BUSY;
+    }
+
+    // Continuously send/receive data until the start token is found
+    status = sl_si91x_host_spi_transfer(NULL, &temp, sizeof(temp));
+  }
+  return status;
+}
+
+static sl_status_t sli_basic_data_transfer(uint16_t c1c2, uint16_t length, void *tx_data, void *rx_data)
+{
+  sl_status_t status;
+
+  // Send C1/C2 control information
+  status = sli_send_c1c2(c1c2);
+  SLI_VERIFY_STATUS(status);
+
+  // Send the length of data to be transferred
+  status = sl_si91x_host_spi_transfer(&length, NULL, 2);
+  SLI_VERIFY_STATUS(status);
+
+  // Wait for start token
+  if (rx_data != NULL) {
+    status = sli_wait_start_token(SLI_START_TOKEN_TIMEOUT);
+    SLI_VERIFY_STATUS(status);
+  }
+
+  // Perform the actual SPI data transfer
+  status = sl_si91x_host_spi_transfer(tx_data, rx_data, length);
+  return status;
+}
+
+static sl_status_t sli_packet_read_with_dummy_data(void *rx_data, uint16_t dummy_length, uint16_t total_length)
+{
+  sl_status_t status;
+  uint32_t aligned_len = ((total_length) + 3) & ~3;
+
+  // Send C1/C2 control information for reading with dummy data
+  status = sli_send_c1c2(SLI_C1FRMRD16BIT1BYTE | (SLI_C2SPIADDR1BYTE << 8));
+  SLI_VERIFY_STATUS(status);
+
+  // Send the aligned length of data to be transferred
+  status = sl_si91x_host_spi_transfer(&aligned_len, NULL, 2);
+  SLI_VERIFY_STATUS(status);
+
+  // Wait for start token
+  status = sli_wait_start_token(SLI_START_TOKEN_TIMEOUT);
+  SLI_VERIFY_STATUS(status);
+
+  // Transfer dummy data (if present)
+  status = sl_si91x_host_spi_transfer(NULL, NULL, dummy_length);
+  SLI_VERIFY_STATUS(status);
+
+  // Read the actual data and store it in rx_data.
+  status = sl_si91x_host_spi_transfer(NULL, rx_data, (aligned_len - dummy_length));
+  SLI_VERIFY_STATUS(status);
+
+  return status;
+}
+
+/************************************************************************************
+ ******************************** Public Functions *********************************
+************************************************************************************/
+sl_status_t sl_si91x_bus_init(void)
+{
+  uint32_t temp = htole32(SLI_SI91X_INIT_CMD);
+  // Create a buffer to receive the response
+  uint8_t rx_buffer[4] = { 0, 0, 0, 0 };
+  // Create a timestamp to track elapsed time
+  uint32_t timestamp;
+
+  timestamp = sl_si91x_host_get_timestamp();
+  sl_si91x_host_spi_cs_assert();
+  do {
+    sl_si91x_host_spi_transfer(&temp, rx_buffer, sizeof(uint32_t));
+    // Check if the response indicates success
+    if (rx_buffer[3] == SLI_SPI_SUCCESS) {
+      sl_si91x_host_spi_cs_deassert();
+      return SL_STATUS_OK;
+    }
+    // Keep looping as long as the time remaining is less than 10 milliseconds.
+  } while (sl_si91x_host_elapsed_time(timestamp) < 10);
+  sl_si91x_host_spi_cs_deassert();
+
+  // If the initialization did not succeed within the timeout, return SPI busy status
+  return SL_STATUS_SPI_BUSY;
+}
+
+sl_status_t sl_si91x_bus_write_memory(uint32_t addr, uint16_t length, const uint8_t *buffer)
+{
+  uint32_t temp32;
+  uint32_t temp16;
+  sl_status_t status;
+
+  sl_si91x_host_spi_cs_assert();
+  // Send C1/C2 control information to initiate the memory write operation
+  status = sli_send_c1c2(SLI_C1MEMWR16BIT4BYTE | (SLI_C2_READ_WRITE_SIZE << 8));
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Send C3/C4 control information with the length of data to be written
+  temp16 = htole16(length);
+  status = sl_si91x_host_spi_transfer(&temp16, NULL, sizeof(uint16_t));
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Send the 4-byte memory address
+  temp32 = htole32(addr);
+  status = sl_si91x_host_spi_transfer(&temp32, NULL, sizeof(uint32_t));
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Send the data
+  status = sl_si91x_host_spi_transfer(buffer, NULL, length);
+
+  sl_si91x_host_spi_cs_deassert();
+  return status;
+}
+
+sl_status_t sli_si91x_bus_write_slave(uint32_t data_length, const uint8_t *buffer)
+{
+  uint32_t temp32;
+  uint32_t temp16;
+  sl_status_t status;
+
+  sl_si91x_host_spi_cs_assert();
+  // Send C1/C2 control information to initiate the memory write operation
+  status = sli_send_c1c2(SLI_C1FRMWR16BIT4BYTE | (SLI_C2_READ_WRITE_SIZE << 8));
+  SLI_VERIFY_STATUS(status);
+
+  // Send C3/C4 control information with the length of data to be written. 16 extra bytes are expected by SPI.
+  temp16 = htole16(data_length + 16);
+  status = sl_si91x_host_spi_transfer(&temp16, NULL, sizeof(uint16_t));
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Send the 4-byte actual data length
+  temp32 = htole32(data_length);
+  status = sl_si91x_host_spi_transfer(&temp32, NULL, sizeof(uint32_t));
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Send the data
+  // Si917 Bootloader receives the data in DMA mode with descriptor where the first
+  // descriptor expects dummy 12 bytes
+  status = sl_si91x_host_spi_transfer(buffer, NULL, 12);
+  SLI_SPI_VERIFY_STATUS(status);
+  if (data_length > 1024) {
+    // SPI master cannot send more than 1024 bytes. So, the data is split.
+    for (unsigned int i = 0; i < (data_length / 1024); i++) {
+      status = sl_si91x_host_spi_transfer(&buffer[(i * 1024)], NULL, 1024);
+      SLI_SPI_VERIFY_STATUS(status);
+    }
+  } else {
+    status = sl_si91x_host_spi_transfer(buffer, NULL, 1024);
+    SLI_SPI_VERIFY_STATUS(status);
+  }
+
+  sl_si91x_host_spi_cs_deassert();
+  return status;
+}
+
+sl_status_t sl_si91x_bus_read_memory(uint32_t addr, uint16_t length, uint8_t *buffer)
+{
+  //  uint8_t rx_buffer[4];
+  sl_status_t status;
+  uint32_t temp32;
+  uint16_t temp16;
+
+  sl_si91x_host_spi_cs_assert();
+  // Send C1/C2 control information to initiate the memory read operation
+  status = sli_send_c1c2(SLI_C1MEMRD16BIT4BYTE | (SLI_C2_READ_WRITE_SIZE << 8));
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Send C3/C4 control information with the length of data to be read
+  temp16 = htole16(length);
+  status = sl_si91x_host_spi_transfer(&temp16, NULL, 2);
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Send the 4-byte memory address
+  temp32 = htole32(addr);
+  status = sl_si91x_host_spi_transfer(&temp32, NULL, sizeof(uint32_t));
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Wait for the start token
+  status = sli_wait_start_token(10 * SECONDS);
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Read in the memory data
+  status = sl_si91x_host_spi_transfer(NULL, buffer, length);
+
+  sl_si91x_host_spi_cs_deassert();
+  return status;
+}
+
+// address is 6-bits long, upper two bits must be cleared for byte mode
+sl_status_t sli_si91x_bus_write_register(uint8_t address, uint8_t register_size, uint16_t data)
+{
+  sl_status_t status;
+
+  sl_si91x_host_spi_cs_assert();
+  // Send C1/C2 control information with register address and write operation
+  status = sli_send_c1c2(SLI_C1INTWRITE2BYTES | (address << 8));
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Send the data to be written to the register
+  status = sl_si91x_host_spi_transfer(&data, NULL, register_size);
+
+  sl_si91x_host_spi_cs_deassert();
+  return status;
+}
+
+// Reading data from a specific register address on the SI91x bus
+// register_size must be 1 or 2
+sl_status_t sli_si91x_bus_read_register(uint8_t address, uint8_t register_size, uint16_t *output)
+{
+  sl_status_t status;
+  uint16_t temp16 = (register_size == 1 ? SLI_C1INTREAD1BYTES : SLI_C1INTREAD2BYTES) | (address << 8);
+
+  //  SL_ASSERT(register_size == 1 || register_size == 2);
+
+  sl_si91x_host_spi_cs_assert();
+  // Send C1C2
+  status = sli_send_c1c2(temp16);
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Wait for start token
+  status = sli_wait_start_token(10 * SECONDS);
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Start token found now read the byte/s of data
+  status = sl_si91x_host_spi_transfer(NULL, output, register_size);
+
+  sl_si91x_host_spi_cs_deassert();
+  return status;
+}
+
+sl_status_t sli_si91x_bus_write_frame(sl_wifi_system_packet_t *packet, const uint8_t *payloadparam, uint16_t size_param)
+{
+  UNUSED_PARAMETER(payloadparam); // Unused parameter(to suppress compiler warnings)
+  sl_status_t status;
+
+  sl_si91x_host_spi_cs_assert();
+#ifdef DEBUG_PACKET_EXCHANGE
+  // If debugging is enabled, log debugging information about the frame
+  memset(debug_output, '\0', sizeof(debug_output));
+  sprintf(debug_output, "[WR(%d)]", rsi_hal_gettickcount());
+  for (uint32_t i = 0; i < 16; i++) {
+    sprintf(debug_output, "%s%.2x", debug_output, ((char *)(uFrameDscFrame))[i]);
+  }
+  if (size_param) {
+    sprintf(debug_output, "%s | ", debug_output);
+    // Print max of 8 bytes of payload
+    for (uint32_t i = 0; i < size_param && i < MAX_PRINT_PAYLOAD_LEN; i++) {
+      sprintf(debug_output, "%s%.2x", debug_output, payloadparam[i]);
+    }
+  }
+  LOG_PRINT("%s\r\n", debug_output);
+#endif
+
+#ifdef RSI_CHIP_MFG_EN
+  // If a specific chip manufacturing feature is enabled, adjust the size_param
+  size_param += RSI_HOST_DESC_LENGTH;
+  status = sli_basic_data_transfer(c1c2, size_param, uFrameDscFrame, NULL);
+  sl_si91x_host_spi_cs_deassert();
+  return status;
+#endif
+
+  // Write host descriptor
+  status = sli_basic_data_transfer(SLI_C1FRMWR16BIT4BYTE | (SLI_C2_READ_WRITE_SIZE << 8),
+                                   SLI_FRAME_DESC_LEN,
+                                   &packet->desc,
+                                   NULL);
+  // printf("Wrote frame descriptor, status %d\n", status);
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Write payload if present
+  if (size_param) {
+    // 4 byte align for payload size
+    size_param = (size_param + 3) & ~3;
+    status =
+      sli_basic_data_transfer(SLI_C1FRMWR16BIT4BYTE | (SLI_C2_READ_WRITE_SIZE << 8), size_param, &packet->data, NULL);
+    // printf("Wrote frame payload, status %d\n", status);
+    SLI_SPI_VERIFY_STATUS(status);
+  }
+
+  sl_si91x_host_spi_cs_deassert();
+  return status;
+}
+
+sl_status_t sli_si91x_bus_read_frame(sl_wifi_buffer_t **buffer)
+{
+  sl_status_t status;
+  uint16_t local_buffer[2];
+  uint8_t *data;
+  uint16_t temp;
+
+  sl_si91x_host_spi_cs_assert();
+#ifndef RSI_CHIP_MFG_EN
+  // Read the first 4 bytes to determine the frame size
+  status = sli_basic_data_transfer(SLI_C1FRMRD16BIT4BYTE | (SLI_C2_READ_WRITE_SIZE << 8), 4, NULL, &local_buffer);
+  SLI_SPI_VERIFY_STATUS(status);
+
+  // Round up total size (local_buffer[0]) to 4 bytes
+  local_buffer[0] = (htole16(local_buffer[0]) - 4 + 3) & ~3;
+  local_buffer[1] = htole16(local_buffer[1]) - 4;
+
+  // Allocate a buffer for the frame using sli_si91x_host_allocate_buffer
+  status = sli_si91x_host_allocate_buffer(buffer, SL_WIFI_RX_FRAME_BUFFER, local_buffer[0], 10000);
+  if (status != SL_STATUS_OK) {
+    sl_si91x_host_spi_cs_deassert();
+    // printf("\r\n HEAP EXHAUSTED DURING ALLOCATION \r\n");
+    BREAKPOINT();
+  }
+
+  data = (uint8_t *)sl_si91x_host_get_buffer_data(*buffer, 0, &temp);
+
+  // Read complete RX packet
+  if (local_buffer[1] == 0) {
+    // printf("Reading frame with basic data transfer, length %u\n", local_buffer[0]);
+    status = sli_basic_data_transfer(SLI_C1FRMRD16BIT1BYTE | (SLI_C2SPIADDR1BYTE << 8), local_buffer[0], NULL, data);
+  } else {
+    status = sli_packet_read_with_dummy_data(data, local_buffer[1], local_buffer[0]);
+  }
+  sl_si91x_host_spi_cs_deassert();
+  // printf("Read frame data for RX frame, status %d\n", status);
+  // printf("Allocated buffer for RX frame status %d\n", status);
+  return status;
+
+#else
+  // Read first 4 bytes
+  retval = rsi_spi_pkt_len(&local_buffer[0]);
+  if (retval != 0x00) {
+    sl_si91x_host_spi_cs_deassert();
+    return retval;
+  }
+  retval = rsi_nlink_pkt_rd(pkt_buffer, rsi_bytes2R_to_uint16(&local_buffer[0]) & 0xFFF);
+  if (retval != 0x00) {
+    sl_si91x_host_spi_cs_deassert();
+    return retval;
+  }
+  sl_si91x_host_spi_cs_deassert();
+#endif
+}
+
+// Function for reading the interrupt status
+sl_status_t sli_si91x_bus_read_interrupt_status(uint16_t *interrupt_status)
+{
+  sl_status_t status;
+  uint32_t timestamp = sl_si91x_host_get_timestamp();
+
+  do {
+    // Read the interrupt register
+    status = sli_si91x_bus_read_register(SLI_SPI_INT_REG_ADDR, 1, interrupt_status);
+    if (status != SL_STATUS_BUSY) {
+      return status;
+    }
+    // Keep looping while the elapsed time is less than 1000 milliseconds
+  } while (sl_si91x_host_elapsed_time(timestamp) < 1000);
+
+  // If the interrupt status cannot be read within the timeout, return a timeout
+  printf("\r\n TIMEOUT WHILE READING INTERRUPT STATUS \r\n");
+  return SL_STATUS_TIMEOUT;
+}
+
+sl_status_t sli_si91x_bootup_firmware(const uint8_t select_option, uint8_t image_number)
+{
+  UNUSED_PARAMETER(image_number); // Unused parameter(to suppress compiler warnings)
+  uint32_t rom_version;
+  uint32_t timestamp;
+  sl_status_t status = SL_STATUS_FAIL;
+  // const uint8_t select_option = config->boot_option; //LOAD_NWP_FW;
+  timestamp = sl_si91x_host_get_timestamp();
+  do {
+    if (sl_si91x_host_elapsed_time(timestamp) > SL_WIFI_BOARD_READY_WAIT_TIME) {
+      printf("\r\n TIMEOUT WHILE WAITING FOR BOARD READY \r\n");
+      return SL_STATUS_TIMEOUT;
+    }
+    status = sli_verify_device_boot(&rom_version);
+  } while (status == SL_STATUS_WAITING_FOR_BOARD_READY || status == SL_STATUS_SPI_BUSY);
+  VERIFY_STATUS_AND_RETURN(status);
+
+  // selecting bootloader options
+  if (select_option == LOAD_NWP_FW) {
+    status = sli_si91x_bus_set_interrupt_mask(SLI_ACTIVE_HIGH_INTR);
+  } else if (select_option == LOAD_DEFAULT_NWP_FW_ACTIVE_LOW) {
+    status = sli_si91x_bus_set_interrupt_mask(SLI_ACTIVE_LOW_INTR);
+  }
+  VERIFY_STATUS_AND_RETURN(status);
+
+#if SL_SI91X_FAST_FW_UP
+  status = sl_si91x_set_fast_fw_up();
+  VERIFY_STATUS_AND_RETURN(status);
+#endif
+
+  // Select boot option
+  status = sli_wifi_select_option(select_option);
+  VERIFY_STATUS_AND_RETURN(status);
+  return status;
+}
+
+sl_status_t sli_si91x_bus_rx_irq_handler(void)
+{
+  /* Wake the command engine thread (waits on si91x_bus_events) so it can
+   * read the pending SPI frame and dispatch the appropriate response event.
+   */
+  sl_si91x_host_set_bus_event(SL_SI91X_NCP_HOST_BUS_RX_EVENT);
+  return SL_STATUS_OK;
+}
+
+void sli_si91x_bus_rx_done_handler(void)
+{
+  return;
+}
+
+//! Initialize with modules Slave SPI interface on ulp wakeup.
+void sli_si91x_ulp_wakeup_init(void)
+{
+  uint8_t txCmd[4];
+  uint8_t rxbuff[2];
+
+  // Prepare the initialization command
+  txCmd[0] = (SLI_SI91X_INIT_CMD & 0xFF);
+  txCmd[1] = ((SLI_SI91X_INIT_CMD >> 8) & 0xFF);
+  txCmd[2] = ((SLI_SI91X_INIT_CMD >> 16) & 0xFF);
+  txCmd[3] = ((SLI_SI91X_INIT_CMD >> 24) & 0xFF);
+  sl_si91x_host_spi_cs_assert();
+
+  while (1) {
+    // Transfer the initialization command to the SI91x module and check the response
+    sl_si91x_host_spi_transfer(txCmd, rxbuff, 2);
+
+    if (rxbuff[1] == SLI_SPI_FAIL) {
+      break; // Initialization failed, exit the loop
+    } else if (rxbuff[1] == 0x00) {
+      // If the response indicates success, transfer the remaining part of the command
+      sl_si91x_host_spi_transfer(&txCmd[2], rxbuff, 2);
+      if (rxbuff[1] == SLI_SPI_SUCCESS) {
+        break; // Initialization succeeded, exit the loop
+      }
+    }
+  }
+  sl_si91x_host_spi_cs_deassert();
+}


### PR DESCRIPTION
…les for NCP over SPI

There is an NCP driver available on the newest wiseconnect release as well as an interface for SPI calls. The interface is implemented in the driver within the Zephyr tree. The NCP driver will use the SPI interface which will route to the proper Zephyr SPI driver.

Signed-off-by: Ethan Sisk <ethan@firehud.co>