### PR TITLE
Used a minimal wait time in host buffer allocation

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/wireless/memory/mem_pool_buffer_quota.c
+++ b/wiseconnect/components/device/silabs/si91x/wireless/memory/mem_pool_buffer_quota.c
@@ -123,7 +123,7 @@ sl_status_t sli_si91x_host_allocate_buffer(sl_wifi_buffer_t **buffer,
     return SL_STATUS_INVALID_PARAMETER;
   }
   uint32_t start_time = osKernelGetTickCount();
-  uint32_t delay      = 2;
+  uint32_t delay      = 150;
   *buffer             = NULL;
   do {
     CORE_DECLARE_IRQ_STATE;
@@ -142,8 +142,8 @@ sl_status_t sli_si91x_host_allocate_buffer(sl_wifi_buffer_t **buffer,
       }
     }
     CORE_EXIT_CRITICAL();
-    osDelay(SLI_SYSTEM_MS_TO_TICKS(delay));
-    delay = (delay < 50) ? delay * 2 : 50;
+    osDelay(SLI_SYSTEM_US_TO_TICKS(delay));
+    delay = (delay < 2000) ? (delay * 3) / 2 : 2000;
   } while (sl_si91x_host_elapsed_time(start_time) <= wait_duration_ms);
   if (*buffer == NULL) {
     return SL_STATUS_ALLOCATION_FAILED;


### PR DESCRIPTION
The function starts with a 2 ms delay when no WiseConnect buffers are available, and the delay increases exponentially up to a maximum of 50 ms even though a buffer could become available within a few microseconds. Based on our measurements, a 150 µs delay is generally sufficient, as the command engine thread typically takes less than 150 µs to process a packet and free a buffer.