### PR TITLE
wiseconnect: Don't block all the IRQs

### DIFF
--- a/wiseconnect/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c
+++ b/wiseconnect/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c
@@ -30,6 +30,7 @@
 #if defined(SLI_SI917)
 //! This file should be in RAM
 #include "sl_device.h"
+#include "sl_core.h"
 
 /*==================================================*/
 /**
@@ -40,9 +41,13 @@
  */
 void sli_mv_m4_app_from_flash_to_ram(int option)
 {
+  CORE_DECLARE_IRQ_STATE;
 
-  //! Disable all interrupts
-  __disable_irq();
+  /* Ensure this function is also located in RAM (sl_core_cortexm.c has to be
+   * relocated in the same way the current file is relocated). Otherwise, big
+   * trouble will happen.
+   */
+  CORE_ENTER_ATOMIC();
 
   if (option == UPGRADE_M4_IMAGE_OTA) {
     //! Raise interrupt to NWP
@@ -67,8 +72,7 @@ void sli_mv_m4_app_from_flash_to_ram(int option)
       ;
   }
 
-  //! Enable all interrupts
-  __enable_irq();
+  CORE_EXIT_ATOMIC();
 }
 
 #endif


### PR DESCRIPTION
During erase/write access to the flash, the application CPU (Cortex-M4) can't read the flash. Therefore, the application processor can't execute the instructions located in Flash.

However, it is still possible to run some code if the code is located in RAM and the user can guarantee that it does not access to the flash.

However, sli_mv_m4_app_from_flash_to_ram() is very conservative and does not permit any interruption during the write access to the flash. This patch relax this restriction. Thus it is possible to run the ISR with IRQ_ZERO_LATENCY flag.

Upstream-Status: pending