### PR TITLE
gecko: add sleeptimer service

### DIFF
--- a/gecko/platform/service/sleeptimer/config/sl_sleeptimer_config.h
+++ b/gecko/platform/service/sleeptimer/config/sl_sleeptimer_config.h
@@ -1,0 +1,82 @@
+/***************************************************************************//**
+ * @file
+ * @brief Sleep Timer configuration file.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+#ifndef SL_SLEEPTIMER_CONFIG_H
+#define SL_SLEEPTIMER_CONFIG_H
+
+#define SL_SLEEPTIMER_PERIPHERAL_DEFAULT 0
+#define SL_SLEEPTIMER_PERIPHERAL_RTCC    1
+#define SL_SLEEPTIMER_PERIPHERAL_PRORTC  2
+#define SL_SLEEPTIMER_PERIPHERAL_RTC     3
+#define SL_SLEEPTIMER_PERIPHERAL_SYSRTC  4
+#define SL_SLEEPTIMER_PERIPHERAL_BURTC   5
+#define SL_SLEEPTIMER_PERIPHERAL_WTIMER  6
+#define SL_SLEEPTIMER_PERIPHERAL_TIMER   7
+
+// <o SL_SLEEPTIMER_PERIPHERAL> Timer Peripheral Used by Sleeptimer
+//   <SL_SLEEPTIMER_PERIPHERAL_DEFAULT=> Default (auto select)
+//   <SL_SLEEPTIMER_PERIPHERAL_RTCC=> RTCC
+//   <SL_SLEEPTIMER_PERIPHERAL_PRORTC=> Radio internal RTC (PRORTC)
+//   <SL_SLEEPTIMER_PERIPHERAL_RTC=> RTC
+//   <SL_SLEEPTIMER_PERIPHERAL_SYSRTC=> SYSRTC
+//   <SL_SLEEPTIMER_PERIPHERAL_BURTC=> Back-Up RTC (BURTC)
+//   <SL_SLEEPTIMER_PERIPHERAL_WTIMER=> WTIMER
+//   <SL_SLEEPTIMER_PERIPHERAL_TIMER=> TIMER
+// <i> Selection of the Timer Peripheral Used by the Sleeptimer
+#define SL_SLEEPTIMER_PERIPHERAL  SL_SLEEPTIMER_PERIPHERAL_DEFAULT
+
+// <o SL_SLEEPTIMER_TIMER_INSTANCE> TIMER/WTIMER Instance Used by Sleeptimer (not applicable for other peripherals)
+// <i> Make sure TIMER instance size is 32bits. Check datasheet for 32bits TIMERs.
+// <i> Default: 0
+#define SL_SLEEPTIMER_TIMER_INSTANCE  0
+
+// <q SL_SLEEPTIMER_WALLCLOCK_CONFIG> Enable wallclock functionality
+// <i> Enable or disable wallclock functionalities (get_time, get_date, etc).
+// <i> Default: 0
+#define SL_SLEEPTIMER_WALLCLOCK_CONFIG  0
+
+// <o SL_SLEEPTIMER_FREQ_DIVIDER> Timer frequency divider (not applicable for WTIMER/TIMER)
+// <i> WTIMER/TIMER peripherals are always prescaled to 1024.
+// <i> Default: 1
+#define SL_SLEEPTIMER_FREQ_DIVIDER  1
+
+// <q SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER> If Radio internal RTC (PRORTC) HAL is used, determines if it owns the IRQ handler. Enable, if no wireless stack is used.
+// <i> Default: 0
+#define SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER  0
+
+// <q SL_SLEEPTIMER_DEBUGRUN> Enable DEBUGRUN functionality on hardware RTC.
+// <i> Default: 0
+#define SL_SLEEPTIMER_DEBUGRUN  0
+
+#endif /* SLEEPTIMER_CONFIG_H */
+
+// <<< end of configuration section >>>

--- a/gecko/platform/service/sleeptimer/inc/sl_sleeptimer.h
+++ b/gecko/platform/service/sleeptimer/inc/sl_sleeptimer.h
@@ -1,0 +1,1134 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER API definition.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * @addtogroup sleeptimer Sleep Timer
+ * @{
+ ******************************************************************************/
+
+#ifndef SL_SLEEPTIMER_H
+#define SL_SLEEPTIMER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "sl_status.h"
+#include "sl_common.h"
+
+/// @cond DO_NOT_INCLUDE_WITH_DOXYGEN
+#define SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG (0x01)
+#define SL_SLEEPTIMER_ANY_FLAG                                  (0xFF)
+
+#define SLEEPTIMER_ENUM(name) typedef uint8_t name; enum name##_enum
+
+/// @endcond
+
+/// Timestamp, wall clock time in seconds.
+typedef uint32_t sl_sleeptimer_timestamp_t;
+
+// Timestamp, 64 bits wall clock in seconds.
+typedef uint64_t sl_sleeptimer_timestamp_64_t;     ///< sl sleeptimer timestamp 64 t
+
+/// Time zone offset from UTC(second).
+typedef int32_t sl_sleeptimer_time_zone_offset_t;
+
+// Forward declaration
+typedef struct sl_sleeptimer_timer_handle sl_sleeptimer_timer_handle_t;
+
+/***************************************************************************//**
+ * Typedef for the user supplied callback function which is called when
+ * a timer expires.
+ *
+ * @param handle The timer handle.
+ *
+ * @param data An extra parameter for the user application.
+ ******************************************************************************/
+typedef void (*sl_sleeptimer_timer_callback_t)(sl_sleeptimer_timer_handle_t *handle, void *data);
+
+/// @brief Timer structure for sleeptimer
+struct sl_sleeptimer_timer_handle {
+  void *callback_data;                     ///< User data to pass to callback function.
+  uint8_t priority;                        ///< Priority of timer.
+  uint16_t option_flags;                   ///< Option flags.
+  sl_sleeptimer_timer_handle_t *next;      ///< Pointer to next element in list.
+  sl_sleeptimer_timer_callback_t callback; ///< Function to call when timer expires.
+  uint32_t timeout_periodic;               ///< Periodic timeout.
+  uint32_t delta;                          ///< Delay relative to previous element in list.
+  uint32_t timeout_expected_tc;            ///< Expected tick count of the next timeout (only used for periodic timer).
+  uint16_t conversion_error;               ///< The error when converting ms to ticks (thousandths of ticks)
+  uint16_t accumulated_error;              ///< Accumulated conversion error (thousandths of ticks)
+};
+
+/// @brief Month enum.
+SLEEPTIMER_ENUM(sl_sleeptimer_month_t) {
+  MONTH_JANUARY = 0,
+  MONTH_FEBRUARY = 1,
+  MONTH_MARCH   = 2,
+  MONTH_APRIL = 3,
+  MONTH_MAY = 4,
+  MONTH_JUNE = 5,
+  MONTH_JULY = 6,
+  MONTH_AUGUST = 7,
+  MONTH_SEPTEMBER = 8,
+  MONTH_OCTOBER = 9,
+  MONTH_NOVEMBER = 10,
+  MONTH_DECEMBER = 11,
+};
+
+/// @brief Week Day enum.
+SLEEPTIMER_ENUM(sl_sleeptimer_weekDay_t) {
+  DAY_SUNDAY = 0,
+  DAY_MONDAY = 1,
+  DAY_TUESDAY = 2,
+  DAY_WEDNESDAY = 3,
+  DAY_THURSDAY = 4,
+  DAY_FRIDAY = 5,
+  DAY_SATURDAY = 6,
+};
+
+/// @brief Time and Date structure.
+typedef  struct  time_date {
+  uint8_t sec;                                ///< Second (0-59)
+  uint8_t min;                                ///< Minute of month (0-59)
+  uint8_t hour;                               ///< Hour (0-23)
+  uint8_t month_day;                          ///< Day of month (1-31)
+  sl_sleeptimer_month_t month;                ///< Month (0-11)
+  uint16_t year;                              ///< Year, based on a 1900 Epoch.
+  sl_sleeptimer_weekDay_t day_of_week;        ///< Day of week (0-6)
+  uint16_t day_of_year;                       ///< Day of year (1-366)
+  sl_sleeptimer_time_zone_offset_t time_zone; ///< Offset, in seconds, from UTC
+} sl_sleeptimer_date_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * Initializes the Sleeptimer.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_init(void);
+
+/***************************************************************************//**
+ * Starts a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer timeout, in timer ticks.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_start_timer(sl_sleeptimer_timer_handle_t *handle,
+                                      uint32_t timeout,
+                                      sl_sleeptimer_timer_callback_t callback,
+                                      void *callback_data,
+                                      uint8_t priority,
+                                      uint16_t option_flags);
+
+/***************************************************************************//**
+ * Restarts a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer timeout, in timer ticks.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_restart_timer(sl_sleeptimer_timer_handle_t *handle,
+                                        uint32_t timeout,
+                                        sl_sleeptimer_timer_callback_t callback,
+                                        void *callback_data,
+                                        uint8_t priority,
+                                        uint16_t option_flags);
+
+/***************************************************************************//**
+ * Starts a 32 bits periodic timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer periodic timeout, in timer ticks.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_start_periodic_timer(sl_sleeptimer_timer_handle_t *handle,
+                                               uint32_t timeout,
+                                               sl_sleeptimer_timer_callback_t callback,
+                                               void *callback_data,
+                                               uint8_t priority,
+                                               uint16_t option_flags);
+
+/***************************************************************************//**
+ * Restarts a 32 bits periodic timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer periodic timeout, in timer ticks.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_restart_periodic_timer(sl_sleeptimer_timer_handle_t *handle,
+                                                 uint32_t timeout,
+                                                 sl_sleeptimer_timer_callback_t callback,
+                                                 void *callback_data,
+                                                 uint8_t priority,
+                                                 uint16_t option_flags);
+
+/***************************************************************************//**
+ * Stops a timer.
+ *
+ * @param handle Pointer to handle to timer.
+ *
+ * @return
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_stop_timer(sl_sleeptimer_timer_handle_t *handle);
+
+/***************************************************************************//**
+ * Gets the status of a timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param running Pointer to the status of the timer.
+ *
+ * @note A non periodic timer is considered not running during its callback.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_is_timer_running(sl_sleeptimer_timer_handle_t *handle,
+                                           bool *running);
+
+/***************************************************************************//**
+ * Gets remaining time until timer expires.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param time Time left in timer ticks.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_get_timer_time_remaining(sl_sleeptimer_timer_handle_t *handle,
+                                                   uint32_t *time);
+
+/**************************************************************************//**
+ * Gets the time remaining until the first timer with the matching set of flags
+ * expires.
+ *
+ * @param option_flags Set of flags to match:
+ *          - SL_SLEEPTIMER_ANY_TIMER_FLAG
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *
+ * @param time_remaining Time left in timer ticks.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_get_remaining_time_of_first_timer(uint16_t option_flags,
+                                                            uint32_t *time_remaining);
+
+/***************************************************************************//**
+ * Gets current 32 bits global tick count.
+ *
+ * @return Current tick count.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_tick_count(void);
+
+/***************************************************************************//**
+ * Gets current 64 bits global tick count.
+ *
+ * @return Current tick count.
+ ******************************************************************************/
+uint64_t sl_sleeptimer_get_tick_count64(void);
+
+/***************************************************************************//**
+ * Get timer frequency.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_timer_frequency(void);
+
+/***************************************************************************//**
+ * Converts a Unix timestamp into a date.
+ *
+ * @param time 32 bit Unix timestamp to convert.
+ * @param time_zone Offset from UTC in second.
+ * @param date Pointer to converted date.
+ *
+ * @note Time is in Standard Time.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_time_to_date(sl_sleeptimer_timestamp_t time,
+                                               sl_sleeptimer_time_zone_offset_t time_zone,
+                                               sl_sleeptimer_date_t *date);
+
+/***************************************************************************//**
+ * Converts a 64 bit Unix timestamp into a date.
+ *
+ * @param time 64 bit Unix timestamp to convert.
+ * @param time_zone Offset from UTC in second.
+ * @param date Pointer to converted date.
+ *
+ * @note Time is in Standard Time.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_time_to_date_64(sl_sleeptimer_timestamp_64_t time,
+                                                  sl_sleeptimer_time_zone_offset_t time_zone,
+                                                  sl_sleeptimer_date_t *date);
+
+/***************************************************************************//**
+ * Converts a date into a Unix timestamp.
+ *
+ * @param date Pointer to date to convert.
+ * @param time Pointer to converted 32 bit Unix timestamp.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note Dates are based on the Unix time representation.
+ *       Range of dates supported :
+ *          - January 1, 1970, 00:00:00 to January 19, 2038, 03:14:00
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_date_to_time(sl_sleeptimer_date_t *date,
+                                               sl_sleeptimer_timestamp_t *time);
+
+/***************************************************************************//**
+ * Converts a date into a 64 bit timestamp.
+ *
+ * @param date Pointer to date to convert.
+ * @param time Pointer to converted 64 bit Unix timestamp.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note Dates are based on the 64 bit Unix time representation.
+ *       Range of dates supported :
+ *          - January 1, 1900, 00:00:00 to  December 31, 11899 23:59:59.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_date_to_time_64(sl_sleeptimer_date_t *date,
+                                                  sl_sleeptimer_timestamp_64_t *time);
+
+/***************************************************************************//**
+ * Convert date to string.
+ *
+ * @param str Output string.
+ * @param size Size of the input array.
+ * @param format The format specification character.
+ * @param date Pointer to date structure.
+ *
+ * @return 0 if error. Number of character in the output string.
+ *
+ * @note Refer strftime() from UNIX.
+ *       http://man7.org/linux/man-pages/man3/strftime.3.html
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_convert_date_to_str(char *str,
+                                           size_t size,
+                                           const uint8_t *format,
+                                           sl_sleeptimer_date_t *date);
+
+/***************************************************************************//**
+ * Sets time zone offset.
+ *
+ * @param  offset  Time zone offset, in seconds.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ ******************************************************************************/
+void sl_sleeptimer_set_tz(sl_sleeptimer_time_zone_offset_t offset);
+
+/***************************************************************************//**
+ * Gets time zone offset.
+ *
+ * @return Time zone offset, in seconds.
+ ******************************************************************************/
+sl_sleeptimer_time_zone_offset_t sl_sleeptimer_get_tz(void);
+
+/***************************************************************************//**
+ * Retrieves current 32 bit time.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return Current timestamps in Unix format.
+ ******************************************************************************/
+sl_sleeptimer_timestamp_t sl_sleeptimer_get_time(void);
+
+/***************************************************************************//**
+ * Retrieves current 64 bit time.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return Current timestamps in Unix format.
+ ******************************************************************************/
+sl_sleeptimer_timestamp_64_t sl_sleeptimer_get_time_64(void);
+
+/***************************************************************************//**
+ * Sets current time.
+ *
+ * @param time timestamp structure to set.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_time(sl_sleeptimer_timestamp_t time);
+
+/***************************************************************************//**
+ * Sets current time.
+ *
+ * @param time timestamp structure to set.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_time_64(sl_sleeptimer_timestamp_64_t time);
+
+/***************************************************************************//**
+ * Gets current date.
+ *
+ * @param date Pointer to a sl_sleeptimer_date_t structure.
+ *
+ * @note Time is in Standard Time.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_get_datetime(sl_sleeptimer_date_t *date);
+
+/***************************************************************************//**
+ * Sets current time, in date format.
+ *
+ * @param date Pointer to current date.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_datetime(sl_sleeptimer_date_t *date);
+
+/***************************************************************************//**
+ * Builds a date time structure based on the provided parameters,
+ * where the maximum supported date is 10:14:07 PM 01/18/2038.
+ *
+ * @param date Pointer to the structure to be populated.
+ * @param year Current year. May be provided based on a 0 Epoch or a 1900 Epoch.
+ * @param month Months since January. Expected value: 0-11.
+ * @param month_day Day of the month. Expected value: 1-31.
+ * @param hour Hours since midnight. Expected value: 0-23.
+ * @param min Minutes after the hour. Expected value: 0-59.
+ * @param sec Seconds after the minute. Expected value: 0-59.
+ * @param tzOffset Offset, in seconds, from UTC.
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_build_datetime(sl_sleeptimer_date_t *date,
+                                         uint16_t year,
+                                         sl_sleeptimer_month_t month,
+                                         uint8_t month_day,
+                                         uint8_t hour,
+                                         uint8_t min,
+                                         uint8_t sec,
+                                         sl_sleeptimer_time_zone_offset_t tzOffset);
+
+/***************************************************************************//**
+ * Builds a date time structure based on the provided parameters,
+ * where the maximum supported date is 11:59:59 PM 12/31/11899.
+ *
+ * @param date Pointer to the structure to be populated.
+ * @param year Current year based on 0 Epoch.
+ * @param month Months since January. Expected value: 0-11.
+ * @param month_day Day of the month. Expected value: 1-31.
+ * @param hour Hours since midnight. Expected value: 0-23.
+ * @param min Minutes after the hour. Expected value: 0-59.
+ * @param sec Seconds after the minute. Expected value: 0-59.
+ * @param tzOffset Offset, in seconds, from UTC.
+ *
+ * @note Resulting date structure's year will be based on 1900 epoch
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_build_datetime_64(sl_sleeptimer_date_t *date,
+                                            uint16_t year,
+                                            sl_sleeptimer_month_t month,
+                                            uint8_t month_day,
+                                            uint8_t hour,
+                                            uint8_t min,
+                                            uint8_t sec,
+                                            sl_sleeptimer_time_zone_offset_t tzOffset);
+
+/***************************************************************************//**
+ * Converts Unix timestamp into NTP timestamp.
+ *
+ * @param time Unix timestamp.
+ * @param ntp_time Pointer to NTP Timestamp.
+ *
+ * @note Unix timestamp range supported : 0x0 to 0x7C55 817F
+ *       ie. January 1, 1970, 00:00:00 to February 07, 2036, 06:28:15
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_unix_time_to_ntp(sl_sleeptimer_timestamp_t time,
+                                                   uint32_t *ntp_time);
+
+/***************************************************************************//**
+ * Converts NTP timestamp into Unix timestamp.
+ *
+ * @param ntp_time NTP Timestamp.
+ * @param time Pointer to Unix timestamp.
+ *
+ * @note NTP timestamp range supported : 0x83AA 7E80 to 0xFFFF FFFF
+ *       ie. January 1, 1970, 00:00:00 to February 07, 2036, 06:28:15
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_ntp_time_to_unix(uint32_t ntp_time,
+                                                   sl_sleeptimer_timestamp_t *time);
+
+/***************************************************************************//**
+ * Converts Unix timestamp into Zigbee timestamp.
+ *
+ * @param time Unix timestamp.
+ *
+ * @param zigbee_time Pointer to NTP Timestamp.
+ *
+ * @note Unix timestamp range supported : 0x386D 4380 to 0x7FFF FFFF
+ *       ie. January 1, 2000, 00:00:0 to January 19, 2038, 03:14:00
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_unix_time_to_zigbee(sl_sleeptimer_timestamp_t time,
+                                                      uint32_t *zigbee_time);
+
+/***************************************************************************//**
+ * Converts Zigbee timestamp into Unix timestamp.
+ *
+ * @param zigbee_time NTP Timestamp.
+ * @param time Pointer to Unix timestamp.
+ *
+ * @note ZIGBEE timestamp range supported : 0x0 to 0x4792 BC7F
+ *        ie. January 1, 2000, 00:00:00 to January 19, 2038, 03:14:00
+ *
+ * @note Function definition is accessible only when
+ *       SL_SLEEPTIMER_WALLCLOCK_CONFIG is set to 1.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_zigbee_time_to_unix(uint32_t zigbee_time,
+                                                      sl_sleeptimer_timestamp_t *time);
+
+/***************************************************************************//**
+ * Calculates offset for time zone after UTC-0.
+ *
+ * @param hours Number of hours from UTC-0.
+ * @param minutes Number of minutes from UTC-0.
+ *
+ * @return The time zone offset in seconds.
+ ******************************************************************************/
+__STATIC_INLINE sl_sleeptimer_time_zone_offset_t sl_sleeptimer_set_tz_ahead_utc(uint8_t hours,
+                                                                                uint8_t minutes)
+{
+  return ((hours * 3600u) + (minutes * 60u));
+}
+
+/***************************************************************************//**
+ * Calculates offset for time zone before UTC-0.
+ *
+ * @param hours Number of hours to UTC-0.
+ * @param minutes Number of minutes to UTC-0.
+ *
+ * @return The time zone offset in seconds.
+ ******************************************************************************/
+__STATIC_INLINE sl_sleeptimer_time_zone_offset_t sl_sleeptimer_set_tz_behind_utc(uint8_t hours,
+                                                                                 uint8_t minutes)
+{
+  return -(sl_sleeptimer_time_zone_offset_t)((hours * 3600u) + (minutes * 60u));
+}
+
+/***************************************************************************//**
+ * Active delay.
+ *
+ * @param time_ms Delay duration in milliseconds.
+ ******************************************************************************/
+void sl_sleeptimer_delay_millisecond(uint16_t time_ms);
+
+/***************************************************************************//**
+ * Converts milliseconds in ticks.
+ *
+ * @param time_ms Number of milliseconds.
+ *
+ * @return Corresponding ticks number.
+ *
+ * @note The result is "rounded" to the superior tick number.
+ *       This function is light and cannot fail so it should be privilegied to
+ *       perform a millisecond to tick conversion.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_ms_to_tick(uint16_t time_ms);
+
+/***************************************************************************//**
+ * Converts 32-bits milliseconds in ticks.
+ *
+ * @param time_ms Number of milliseconds.
+ * @param tick Pointer to the converted tick number.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  The result is "rounded" to the superior tick number.
+ *        If possible the sl_sleeptimer_ms_to_tick() function should be used.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'time_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'time_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_ms32_to_tick(uint32_t time_ms,
+                                       uint32_t *tick);
+
+/***************************************************************************//**
+ * Gets the maximum value that can be passed to the functions that have a
+ * 32-bits time or timeout argument expressed in milliseconds.
+ *
+ * @return Maximum time or timeout value in milliseconds.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_max_ms32_conversion(void);
+
+/***************************************************************************//**
+ * Converts ticks in milliseconds.
+ *
+ * @param tick Number of tick.
+ *
+ * @return Corresponding milliseconds number.
+ *
+ * @note The result is rounded to the inferior millisecond.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_tick_to_ms(uint32_t tick);
+
+/***************************************************************************//**
+ * Converts 64-bit ticks in milliseconds.
+ *
+ * @param tick Number of tick.
+ * @param ms Pointer to the converted milliseconds number.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note The result is rounded to the inferior millisecond.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_tick64_to_ms(uint64_t tick,
+                                       uint64_t *ms);
+
+/***************************************************************************//**
+ * Allow sleep after ISR exit.
+ *
+ * @return true if sleep is allowed after ISR exit. False otherwise.
+ ******************************************************************************/
+bool sl_sleeptimer_is_power_manager_early_restore_timer_latest_to_expire(void);
+
+/**************************************************************************//**
+ * Starts a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_ms Timer timeout, in milliseconds.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'timeout_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'timeout_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ *****************************************************************************/
+__STATIC_INLINE sl_status_t sl_sleeptimer_start_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                         uint32_t timeout_ms,
+                                                         sl_sleeptimer_timer_callback_t callback,
+                                                         void *callback_data,
+                                                         uint8_t priority,
+                                                         uint16_t option_flags)
+{
+  sl_status_t status;
+  uint32_t timeout_tick;
+
+  status = sl_sleeptimer_ms32_to_tick(timeout_ms, &timeout_tick);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  return sl_sleeptimer_start_timer(handle, timeout_tick, callback, callback_data, priority, option_flags);
+}
+
+/**************************************************************************//**
+ * Restarts a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_ms Timer timeout, in milliseconds.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'timeout_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'timeout_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ *****************************************************************************/
+__STATIC_INLINE sl_status_t sl_sleeptimer_restart_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                           uint32_t timeout_ms,
+                                                           sl_sleeptimer_timer_callback_t callback,
+                                                           void *callback_data,
+                                                           uint8_t priority,
+                                                           uint16_t option_flags)
+{
+  sl_status_t status;
+  uint32_t timeout_tick;
+
+  status = sl_sleeptimer_ms32_to_tick(timeout_ms, &timeout_tick);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  return sl_sleeptimer_restart_timer(handle, timeout_tick, callback, callback_data, priority, option_flags);
+}
+
+/***************************************************************************//**
+ * Starts a 32 bits periodic timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_ms Timer periodic timeout, in milliseconds.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'timeout_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'timeout_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_start_periodic_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                  uint32_t timeout_ms,
+                                                  sl_sleeptimer_timer_callback_t callback,
+                                                  void *callback_data,
+                                                  uint8_t priority,
+                                                  uint16_t option_flags);
+
+/***************************************************************************//**
+ * Restarts a 32 bits periodic timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_ms Timer periodic timeout, in milliseconds.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ * @param option_flags Bit array of option flags for the timer.
+ *        Valid bit-wise OR of one or more of the following:
+ *          - SL_SLEEPTIMER_NO_HIGH_PRECISION_HF_CLOCKS_REQUIRED_FLAG
+ *        or 0 for not flags.
+ *
+ * @return 0 if successful. Error code otherwise.
+ *
+ * @note  This function converts the delay expressed in milliseconds to timer
+ *        ticks (represented on 32 bits). This means that the value that can
+ *        be passed to the argument 'timeout_ms' is limited. The maximum
+ *        timeout value that can be passed to this function can be retrieved
+ *        by calling sl_sleeptimer_get_max_ms32_conversion().
+ *        If the value passed to 'timeout_ms' is too large,
+ *        SL_STATUS_INVALID_PARAMETER will be returned.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_restart_periodic_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                    uint32_t timeout_ms,
+                                                    sl_sleeptimer_timer_callback_t callback,
+                                                    void *callback_data,
+                                                    uint8_t priority,
+                                                    uint16_t option_flags);
+
+/***************************************************************************//**
+ * @brief
+ *   Gets the precision (in PPM) of the sleeptimer's clock.
+ *
+ * @return
+ *   Clock accuracy, in PPM.
+ ******************************************************************************/
+uint16_t sl_sleeptimer_get_clock_accuracy(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} (end addtogroup sleeptimer) */
+
+/* *INDENT-OFF* */
+/* THE REST OF THE FILE IS DOCUMENTATION ONLY! */
+/// @addtogroup sleeptimer Sleep Timer
+/// @{
+///
+///   @details
+///   Sleep Timer can be used for creating timers which are tightly integrated with power management.
+///   The Power Manager requires precision timing to have all clocks ready on time, so that wakeup
+///   happens a little bit earlier to prepare the system to be ready at the right time.
+///   Sleep Timer uses one Hardware Timer and creates multiple software timer instances. It is important
+///   to note that when sleeptimer is used with WTIMER/TIMER, the MCU cannot go to EM2 energy mode
+///   because WTIMER/TIMER uses a high frequency clock source which is not retained in low energy mode.
+///
+///   The sleeptimer.c and sleeptimer.h source files for the SLEEPTIMER device driver library are in the
+///   service/sleeptimer folder.
+///
+///   @n @section sleeptimer_intro Introduction
+///
+///   The Sleeptimer driver provides software timers, delays, timekeeping and date functionalities using a low-frequency real-time clock peripheral.
+///
+///   All Silicon Labs microcontrollers equipped with the RTC or RTCC peripheral are currently supported. Only one instance of this driver can be initialized by the application.
+///
+///   @n @section sleeptimer_functionalities_overview Functionalities overview
+///
+///   @n @subsection software_timers Software Timers
+///
+///   This functionality allows the user to create periodic and one shot timers. A user callback can be associated with a timer and is called when the timer expires.
+///
+///   Timer structures must be allocated by the user. The function is called from within an interrupt handler with interrupts enabled.
+///
+///   As sleeptimer callback functions are executed in ISR, they should be kept simple and short.
+///   For periodic timers, the sleeptimer's callbacks need to be shorter than the timer's period to allow the application to exit the interrupt context.
+///
+///   @n @subsection timekeeping Timekeeping
+///
+///   A 64-bits tick counter is accessible through the @li uint64_t sl_sleeptimer_get_tick_count64(void) API. It keeps the tick count since the initialization of the driver
+///
+///   The `SL_SLEEPTIMER_WALLCLOCK_CONFIG` configuration enables a UNIX timestamp (seconds count since January 1, 1970, 00:00:00).
+///
+///   This timestamp can be retrieved/modified using the following API:
+///
+///   @li sl_sleeptimer_timestamp_t sl_sleeptimer_get_time(void);
+///   @li sl_status_t sl_sleeptimer_set_time(sl_sleeptimer_timestamp_t time);
+///
+///   Convenience conversion functions are provided to convert UNIX timestamp to/from NTP and Zigbee cluster format :
+///
+///   @li sl_status_t sl_sleeptimer_convert_unix_time_to_ntp(sl_sleeptimer_timestamp_t time, uint32_t *ntp_time);
+///   @li sl_status_t sl_sleeptimer_convert_ntp_time_to_unix(uint32_t ntp_time, sl_sleeptimer_timestamp_t *time);
+///   @li sl_status_t sl_sleeptimer_convert_unix_time_to_zigbee(sl_sleeptimer_timestamp_t time, uint32_t *zigbee_time);
+///   @li sl_status_t sl_sleeptimer_convert_zigbee_time_to_unix(uint32_t zigbee_time, sl_sleeptimer_timestamp_t *time);
+///
+///   @n @subsection date Date
+///
+///   The previously described internal timestamp can also be retrieved/modified in a date format sl_sleeptimer_date_t.
+///
+///   @n <b>API :</b> @n
+///
+///   @li sl_status_t sl_sleeptimer_get_datetime(sl_sleeptimer_date_t *date);
+///   @li sl_status_t sl_sleeptimer_set_datetime(sl_sleeptimer_date_t *date);
+///
+///   @n @subsection frequency_setup Frequency Setup and Tick Count
+///
+///   This driver works with a configurable time unit called tick.
+///
+///   The frequency of the ticks is based on the clock source and the internal frequency divider.
+///
+///   WTIMER/TIMER peripherals uses high frequency oscillator. To have a reasonable tick frequency, divider is set to maximum value (1024).
+///
+///   One of the following clock sources must be enabled before initializing the sleeptimer:
+///
+///   @li LFXO: external crystal oscillator. Typically running at 32.768 kHz.
+///   @li LFRCO: internal oscillator running at 32.768 kHz
+///   @li ULFRCO: Ultra low-frequency oscillator running at 1.000 kHz
+///   @li HFXO: High Frequency Crystal Oscillator at 39 Mhz. HFXO is only needed when Sleeptimer runs on TIMER or WTIMER.
+///
+///   The frequency divider is selected with the `SL_SLEEPTIMER_FREQ_DIVIDER` configuration. Its value must be a power of two within the range of 1 to 32. The number of ticks per second (sleeptimer frequency) is dictated by the following formula:
+///
+///   Tick (seconds) = 1 / (clock_frequency / frequency_divider)
+///
+///   The highest resolution for a tick is 30.5 us. It is achieved with a 32.768 kHz clock and a divider of 1.
+///
+///   @n @section sleeptimer_getting_started Getting Started
+///
+///   @n @subsection  clock_selection Clock Selection
+///
+///   The sleeptimer relies on the hardware timer to operate. The hardware timer peripheral must be properly clocked from the application. Selecting the appropriate timer is crucial for design considerations. Each timer can potentially be used as a sleeptimer and is also available to the user. However, note that if a timer is used by the sleeptimer, it can't be used by the application and vice versa.
+///
+///   For WTIMER/TIMER peripherals, the user must select the appropriate oscillator if it is not the default wanted clock source.
+///
+///   When WTIMER/TIMER is selected, sleeptimer uses channel 0 and it is not possible to use other channels of the same instance for other purposes.
+///
+///   @n @subsection  Clock Selection in a Project without Micrium OS
+///
+///   When RTC, RTCC, or BURTC is selected, the clock source for the peripheral must be configured and enabled in the application before initializing the sleeptimer module or any communication stacks. Most of the time, it consists in enabling the desired oscillators and setting up the clock source for the peripheral, like in the following example:
+///
+///   @code{.c}
+///   CMU_ClockSelectSet(cmuClock_LFE, cmuSelect_LFRCO);
+///   CMU_ClockEnable(cmuClock_RTCC, true);
+///   @endcode
+///
+///   @n @subsection  clock_branch_select Clock Branch Select
+///
+///   | Clock  | Enum                    | Description                       | Frequency |
+///   |--------|-------------------------|-----------------------------------|-----------|
+///   | LFXO   | <b>cmuSelect_LFXO</b>   | Low-frequency crystal oscillator  |32.768 Khz |
+///   | LFRCO  | <b>cmuSelect_LFRCO</b>  | Low-frequency RC oscillator       |32.768 Khz |
+///   | ULFRCO | <b>cmuSelect_ULFRCO</b> | Ultra low-frequency RC oscillator |1 Khz      |
+///
+///   @n @subsection  timer_clock_enable Timer Clock Enable
+///
+///   | Module             | Enum                  | Description                                        |
+///   |--------------------|-----------------------|----------------------------------------------------|
+///   | RTCC               | <b>cmuClock_RTCC</b>  | Real-time counter and calendar clock (LF E branch) |
+///   | RTC                | <b>cmuClock_RTC</b>   | Real time counter clock (LF A branch)              |
+///   | BURTC              | <b>cmuClock_BURTC</b> | BURTC clock (EM4 Group A branch)                   |
+///
+///   When the Radio internal RTC (PRORTC) is selected, it is not necessary to configure the clock source for the peripheral. However, it is important to enable the desired oscillator before initializing the sleeptimer module or any communication stacks. The best oscillator available (LFXO being the first choice) will be used by the sleeptimer at initalization. The following example shows how the desired oscilator should be enabled:
+///
+///   @code{.c}
+///   CMU_OscillatorEnable(cmuSelect_LFXO, true, true);
+///   @endcode
+///
+///   @n @subsection  clock_micrium_os Clock Selection in a Project with Micrium OS
+///
+///   When Micrium OS is used, a BSP (all instances) is provided that sets up some parts of the clock tree. The sleeptimer clock source will be enabled by this bsp. However, the desired oscillator remains configurable from the file <b>bsp_cfg.h</b>.
+///
+///   The configuration `BSP_LF_CLK_SEL` determines which oscillator will be used by the sleeptimer's hardware timer peripheral. It can take the following values:
+///
+///   | Config                   | Description                       | Frequency |
+///   |--------------------------|-----------------------------------|-----------|
+///   | <b>BSP_LF_CLK_LFXO</b>   | Low-frequency crystal oscillator  |32.768 Khz |
+///   | <b>BSP_LF_CLK_LFRCO</b>  | Low-frequency RC oscillator       |32.768 Khz |
+///   | <b>BSP_LF_CLK_ULFRCO</b> | Ultra low-frequency RC oscillator |1 Khz      |
+///
+///   @n @section sleeptimer_conf Configuration Options
+///
+///   `SL_SLEEPTIMER_PERIPHERAL` can be set to one of the following values:
+///
+///   | Config                            | Description                                                                                          |
+///   | --------------------------------- |------------------------------------------------------------------------------------------------------|
+///   | `SL_SLEEPTIMER_PERIPHERAL_DEFAULT`| Selects either RTC or RTCC, depending of what is available on the platform.                          |
+///   | `SL_SLEEPTIMER_PERIPHERAL_RTCC`   | Selects RTCC                                                                                         |
+///   | `SL_SLEEPTIMER_PERIPHERAL_RTC`    | Selects RTC                                                                                          |
+///   | `SL_SLEEPTIMER_PERIPHERAL_PRORTC` | Selects Internal radio RTC. Available only on EFR32XG13, EFR32XG14, EFR32XG21 and EFR32XG22 families.|
+///   | `SL_SLEEPTIMER_PERIPHERAL_BURTC`  | Selects BURTC. Not available on Series 0 devices.                                                    |
+///
+///   `SL_SLEEPTIMER_WALLCLOCK_CONFIG` must be set to 1 to enable timestamp and date functionnalities.
+///
+///   `SL_SLEEPTIMER_FREQ_DIVIDER` must be a power of 2 within the range 1 to 32. When `SL_SLEEPTIMER_PERIPHERAL` is set to `SL_SLEEPTIMER_PERIPHERAL_PRORTC`, `SL_SLEEPTIMER_FREQ_DIVIDER` must be set to 1.
+///
+///   `SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER` is only meaningful when `SL_SLEEPTIMER_PERIPHERAL` is set to `SL_SLEEPTIMER_PERIPHERAL_PRORTC`. Set to 1 if no communication stack is used in your project. Otherwise, must be set to 0.
+///
+///   @n @section sleeptimer_api The API
+///
+///   This section contains brief descriptions of the API functions. For
+///   more information about input and output parameters and return values,
+///   click on the hyperlinked function names. Most functions return an error
+///   code, `SL_STATUS_OK` is returned on success,
+///   see sl_status.h for other error codes.
+///
+///   The application code must include the @em sl_sleeptimer.h header file.
+///
+///   All API functions can be called from within interrupt handlers.
+///
+///   @ref sl_sleeptimer_init() @n
+///    These functions initialize the sleeptimer driver. Typically,
+///     sl_sleeptimer_init() is called once in the startup code.
+///
+///   @ref sl_sleeptimer_start_timer() @n
+///    Start a one shot 32 bits timer. When a timer expires, a user-supplied callback function
+///    is called. A pointer to this function is passed to
+///     sl_sleeptimer_start_timer(). See @ref callback for
+///    details of the callback prototype.
+///
+///   @ref sl_sleeptimer_restart_timer() @n
+///    Restart a one shot 32 bits timer. When a timer expires, a user-supplied callback function
+///    is called. A pointer to this function is passed to
+///     sl_sleeptimer_start_timer(). See @ref callback for
+///    details of the callback prototype.
+///
+///   @ref sl_sleeptimer_start_periodic_timer() @n
+///    Start a periodic 32 bits timer. When a timer expires, a user-supplied callback function
+///    is called. A pointer to this function is passed to
+///     sl_sleeptimer_start_timer(). See @ref callback for
+///    details of the callback prototype.
+///
+///   @ref sl_sleeptimer_restart_periodic_timer() @n
+///    Restart a periodic 32 bits timer. When a timer expires, a user-supplied callback function
+///    is called. A pointer to this function is passed to
+///     sl_sleeptimer_start_timer(). See @ref callback for
+///    details of the callback prototype.
+///
+///   @ref sl_sleeptimer_stop_timer() @n
+///    Stop a timer.
+///
+///   @ref sl_sleeptimer_get_timer_time_remaining() @n
+///    Get the time remaining before the timer expires.
+///
+///   @ref sl_sleeptimer_delay_millisecond() @n
+///    Delay for the given number of milliseconds. This is an "active wait" delay function.
+///
+///   @ref sl_sleeptimer_is_timer_running() @n
+///    Check if a timer is running.
+///
+///   @ref sl_sleeptimer_get_time(), @ref sl_sleeptimer_set_time() @n
+///    Get or set wallclock time.
+///
+///   @ref sl_sleeptimer_ms_to_tick(), @ref sl_sleeptimer_ms32_to_tick(),
+///   @ref sl_sleeptimer_tick_to_ms(), @ref sl_sleeptimer_tick64_to_ms() @n
+///    Convert between milliseconds and RTC/RTCC
+///    counter ticks.
+///
+///   @n @anchor callback <b>The timer expiry callback function:</b> @n
+///   The callback function, prototyped as @ref sl_sleeptimer_timer_callback_t(), is called from
+///   within the RTC peripheral interrupt handler on timer expiration.
+///    sl_sleeptimer_timer_callback_t(sl_sleeptimer_timer_handle_t *handle, void *data)
+///
+///   @n @section sleeptimer_example Example
+///   @code{.c}
+///#include "sl_sleeptimer.h"
+///
+///void my_timer_callback(sl_sleeptimer_timer_handle_t *handle, void *data)
+///{
+///  //Code executed when the timer expire.
+///}
+///
+///int start_timer(void)
+///{
+///  sl_status_t status;
+///  sl_sleeptimer_timer_handle_t my_timer;
+///  uint32_t timer_timeout = 300;
+///
+///  // We assume the sleeptimer is initialized properly
+///
+///  status = sl_sleeptimer_start_timer(&my_timer,
+///                                     timer_timeout,
+///                                     my_timer_callback,
+///                                     (void *)NULL,
+///                                     0,
+///                                     0);
+///  if(status != SL_STATUS_OK) {
+///    return -1;
+///  }
+///  return 1;
+///}
+///   @endcode
+///
+/// @} (end addtogroup sleeptimer)
+
+#endif // SL_SLEEPTIMER_H

--- a/gecko/platform/service/sleeptimer/inc/sli_sleeptimer.h
+++ b/gecko/platform/service/sleeptimer/inc/sli_sleeptimer.h
@@ -1,0 +1,136 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER SDK internal APIs.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SLI_SLEEPTIMER_H
+#define SLI_SLEEPTIMER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "em_device.h"
+#include "sl_sleeptimer_config.h"
+
+#define SLEEPTIMER_EVENT_OF (0x01)
+#define SLEEPTIMER_EVENT_COMP (0x02)
+
+#define SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG 0x02
+#define SLI_SLEEPTIMER_POWER_MANAGER_HF_ACCURACY_CLK_FLAG 0x04
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_DEFAULT
+#if defined(RTCC_PRESENT) && RTCC_COUNT >= 1
+#undef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL SL_SLEEPTIMER_PERIPHERAL_RTCC
+#elif defined(RTC_PRESENT) && RTC_COUNT >= 1
+#undef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL SL_SLEEPTIMER_PERIPHERAL_RTC
+#elif defined(SYSRTC_PRESENT) && SYSRTC_COUNT >= 1
+#undef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL SL_SLEEPTIMER_PERIPHERAL_SYSRTC
+#elif defined(BURTC_PRESENT) && BURTC_COUNT >= 1
+#undef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL SL_SLEEPTIMER_PERIPHERAL_BURTC
+#elif defined(WTIMER_PRESENT) && WTIMER_COUNT >= 1
+#undef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL SL_SLEEPTIMER_PERIPHERAL_WTIMER
+#elif defined(TIMER_PRESENT) && TIMER_COUNT >= 1
+#undef SL_SLEEPTIMER_PERIPHERAL
+#define SL_SLEEPTIMER_PERIPHERAL SL_SLEEPTIMER_PERIPHERAL_TIMER
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to perform initialization related to Power Manager.
+ ******************************************************************************/
+__WEAK void sli_sleeptimer_hal_power_manager_integration_init(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to perform initialization related to HFXO Manager.
+ ******************************************************************************/
+__WEAK void sli_sleeptimer_hal_hfxo_manager_integration_init(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get interrupt status.
+ *
+ * @param local_flag Internal interrupt flag.
+ *
+ * @return Boolean indicating if specified interrupt is set.
+ ******************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag);
+
+/**************************************************************************//**
+ * Determines if next timer to expire has the option flag
+ * "SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG".
+ *
+ * @return true if power manager will expire at next compare match,
+ *         false otherwise.
+ *****************************************************************************/
+bool sli_sleeptimer_is_power_manager_timer_next_to_expire(void);
+
+/***************************************************************************//**
+ * Set lowest energy mode based on a project's configurations and clock source
+ *
+ * @note If power_manager_no_deepsleep component is included in a project, the
+ *       lowest possible energy mode is EM1, else lowest energy mode is
+ *       determined by clock source.
+ ******************************************************************************/
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+void sli_sleeptimer_set_pm_em_requirement(void);
+#endif
+
+/***************************************************************************//**
+ * @brief
+ *   Update sleep_on_isr_exit flag.
+ *
+ * @param flag Boolean value update_sleep_on_isr_exit will be set to.
+ ******************************************************************************/
+void sli_sleeptimer_update_sleep_on_isr_exit(bool flag);
+
+/*******************************************************************************
+ * Gets the associated peripheral capture channel current value.
+ *
+ * @return Capture value
+ *         0 if capture channel is not valid
+ ******************************************************************************/
+uint32_t sli_sleeptimer_get_capture(void);
+
+/*******************************************************************************
+ * Resets the PRS signal triggered by the associated peripheral.
+ ******************************************************************************/
+void sli_sleeptimer_reset_prs_signal(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SLI_SLEEPTIMER_H */

--- a/gecko/platform/service/sleeptimer/src/sl_sleeptimer.c
+++ b/gecko/platform/service/sleeptimer/src/sl_sleeptimer.c
@@ -1,0 +1,1941 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER API implementation.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#include <time.h>
+#include <stdlib.h>
+
+#include "em_device.h"
+#include "em_core_generic.h"
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "sl_atomic.h"
+#include "sl_sleeptimer_config.h"
+
+#if defined(SL_COMPONENT_CATALOG_PRESENT)
+#include "sl_component_catalog.h"
+#endif
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#include "sl_power_manager.h"
+#include "sli_power_manager.h"
+#endif
+
+#define TIME_UNIX_EPOCH                         (1970u)
+#define TIME_NTP_EPOCH                          (1900u)
+#define TIME_ZIGBEE_EPOCH                       (2000u)
+#define TIME_64_EPOCH                           TIME_NTP_EPOCH
+#define TIME_NTP_UNIX_EPOCH_DIFF                (TIME_UNIX_EPOCH - TIME_NTP_EPOCH)
+#define TIME_ZIGBEE_UNIX_EPOCH_DIFF             (TIME_ZIGBEE_EPOCH - TIME_UNIX_EPOCH)
+#define TIME_DAY_COUNT_NTP_TO_UNIX_EPOCH        (TIME_NTP_UNIX_EPOCH_DIFF * 365u + 17u)                  ///< 70 years and 17 leap days
+#define TIME_DAY_COUNT_ZIGBEE_TO_UNIX_EPOCH     (TIME_ZIGBEE_UNIX_EPOCH_DIFF * 365u + 7u)                ///< 30 years and 7 leap days
+#define TIME_SEC_PER_DAY                        (60u * 60u * 24u)
+#define TIME_NTP_EPOCH_OFFSET_SEC               (TIME_DAY_COUNT_NTP_TO_UNIX_EPOCH * TIME_SEC_PER_DAY)
+#define TIME_ZIGBEE_EPOCH_OFFSET_SEC            (TIME_DAY_COUNT_ZIGBEE_TO_UNIX_EPOCH * TIME_SEC_PER_DAY)
+#define TIME_DAY_PER_YEAR                       (365u)
+#define TIME_SEC_PER_YEAR                       (TIME_SEC_PER_DAY * TIME_DAY_PER_YEAR)
+#define TIME_UNIX_TIMESTAMP_MAX                 (0x7FFFFFFF)
+#define TIME_64_BIT_UNIX_TIMESTAMP_MAX          (0x497968BD7F)                                           /// Max 64 bit timestamp supported is 11:59:59 PM 12/31/11899
+#define TIME_UNIX_YEAR_MAX                      (2038u - TIME_NTP_EPOCH)                                 ///< Max UNIX year based from a 1900 epoch
+#define TIME_64_BIT_YEAR_MAX                    (11899u - TIME_NTP_EPOCH)                                ///< Max 64 bit format year based from a 1900 epoch
+#define TIME_64_TO_32_EPOCH_OFFSET_SEC          TIME_NTP_EPOCH_OFFSET_SEC
+#define TIME_UNIX_TO_NTP_MAX                    (0xFFFFFFFF - TIME_NTP_EPOCH_OFFSET_SEC)
+
+// Minimum count difference used when evaluating if a timer expired or not after an interrupt
+// by comparing the current count value and the expected expiration count value.
+// The difference should be null or of few ticks since the counter never stop.
+#define MIN_DIFF_BETWEEN_COUNT_AND_EXPIRATION  2
+
+/// @brief Time Format.
+SLEEPTIMER_ENUM(sl_sleeptimer_time_format_t) {
+  TIME_FORMAT_UNIX = 0,           ///< Number of seconds since January 1, 1970, 00:00. Type is signed, so represented on 31 bit.
+  TIME_FORMAT_NTP = 1,            ///< Number of seconds since January 1, 1900, 00:00. Type is unsigned, so represented on 32 bit.
+  TIME_FORMAT_ZIGBEE_CLUSTER = 2, ///< Number of seconds since January 1, 2000, 00:00. Type is unsigned, so represented on 32 bit.
+  TIME_FORMAT_UNIX_64_BIT = 3,    ///< Number of seconds since January 1, 1900, 00:00. Type is unsigned, so represented on 64 bit.
+};
+
+// tick_count, it can wrap around.
+typedef uint32_t sl_sleeptimer_tick_count_t;
+
+// Overflow counter used to provide 64-bits tick count.
+static volatile uint16_t overflow_counter;
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+// Current time count.
+static sl_sleeptimer_timestamp_64_t second_count;
+// Tick rest when the frequency is not a divider of the timer width.
+static uint32_t overflow_tick_rest = 0;
+// Current time zone offset.
+static sl_sleeptimer_time_zone_offset_t tz_offset = 0;
+// Precalculated tick rest in case of overflow.
+static uint32_t calculated_tick_rest = 0;
+// Precalculated timer overflow duration in seconds.
+static uint32_t calculated_sec_count = 0;
+#endif
+
+// Timer frequency in Hz.
+static uint32_t timer_frequency;
+
+// Head of timer list.
+static sl_sleeptimer_timer_handle_t *timer_head;
+
+// Count at last update of delta of first timer.
+static volatile sl_sleeptimer_tick_count_t last_delta_update_count;
+
+// Initialization flag.
+static bool is_sleeptimer_initialized = false;
+
+// Flag that indicates if power manager's timer will expire at next compare match.
+static bool next_timer_to_expire_is_power_manager = false;
+
+// Precalculated value to avoid millisecond to tick conversion overflow.
+static uint32_t max_millisecond_conversion;
+
+// Sleep on ISR exit flag.
+static bool sleep_on_isr_exit = false;
+
+static void delta_list_insert_timer(sl_sleeptimer_timer_handle_t *handle,
+                                    sl_sleeptimer_tick_count_t timeout);
+
+static sl_status_t delta_list_remove_timer(sl_sleeptimer_timer_handle_t *handle);
+
+static void set_comparator_for_next_timer(void);
+
+static void update_delta_list(void);
+
+__STATIC_INLINE uint32_t div_to_log2(uint32_t div);
+
+__STATIC_INLINE bool is_power_of_2(uint32_t nbr);
+
+static sl_status_t create_timer(sl_sleeptimer_timer_handle_t *handle,
+                                sl_sleeptimer_tick_count_t timeout_initial,
+                                sl_sleeptimer_tick_count_t timeout_periodic,
+                                sl_sleeptimer_timer_callback_t callback,
+                                void *callback_data,
+                                uint8_t priority,
+                                uint16_t option_flags);
+
+static void update_next_timer_to_expire_is_power_manager(void);
+
+static void delay_callback(sl_sleeptimer_timer_handle_t *handle,
+                           void *data);
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+static bool is_leap_year(uint16_t year);
+static uint16_t number_of_leap_days(uint32_t base_year, uint32_t current_year);
+
+static sl_sleeptimer_weekDay_t compute_day_of_week(uint32_t day);
+static sl_sleeptimer_weekDay_t compute_day_of_week_64(uint64_t day);
+static uint16_t compute_day_of_year(sl_sleeptimer_month_t month, uint8_t day, bool isLeapYear);
+
+static bool is_valid_time(sl_sleeptimer_timestamp_t time,
+                          sl_sleeptimer_time_format_t format,
+                          sl_sleeptimer_time_zone_offset_t time_zone);
+
+static bool is_valid_time_64(sl_sleeptimer_timestamp_64_t time,
+                             sl_sleeptimer_time_format_t format,
+                             sl_sleeptimer_time_zone_offset_t time_zone);
+
+static bool is_valid_date(sl_sleeptimer_date_t *date);
+
+static bool is_valid_date_64(sl_sleeptimer_date_t *date);
+
+static const uint8_t days_in_month[2u][12] = {
+  /* Jan  Feb  Mar  Apr  May  Jun  Jul  Aug  Sep  Oct  Nov  Dec */
+  { 31u, 28u, 31u, 30u, 31u, 30u, 31u, 31u, 30u, 31u, 30u, 31u },
+  { 31u, 29u, 31u, 30u, 31u, 30u, 31u, 31u, 30u, 31u, 30u, 31u }
+};
+#endif
+
+/**************************************************************************//**
+ * Initializes sleep timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_init(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  if (!is_sleeptimer_initialized) {
+    timer_head  = NULL;
+    last_delta_update_count = 0u;
+    overflow_counter = 0u;
+    sleeptimer_hal_init_timer();
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_OF);
+    timer_frequency = sleeptimer_hal_get_timer_frequency();
+    if (timer_frequency == 0) {
+      CORE_EXIT_ATOMIC();
+      return SL_STATUS_INVALID_CONFIGURATION;
+    }
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+    second_count = 0;
+    calculated_tick_rest = ((uint64_t)UINT32_MAX + 1) % (uint64_t)timer_frequency;
+    calculated_sec_count = (((uint64_t)UINT32_MAX + 1) / (uint64_t)timer_frequency);
+#endif
+    max_millisecond_conversion = (uint32_t)(((uint64_t)UINT32_MAX * (uint64_t)1000u) / timer_frequency);
+    is_sleeptimer_initialized = true;
+  }
+  CORE_EXIT_ATOMIC();
+
+  return SL_STATUS_OK;
+}
+
+/**************************************************************************//**
+ * Starts a 32 bits timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_start_timer(sl_sleeptimer_timer_handle_t *handle,
+                                      uint32_t timeout,
+                                      sl_sleeptimer_timer_callback_t callback,
+                                      void *callback_data,
+                                      uint8_t priority,
+                                      uint16_t option_flags)
+{
+  bool is_running = false;
+
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  handle->conversion_error = 0;
+  handle->accumulated_error = 0;
+
+  sl_sleeptimer_is_timer_running(handle, &is_running);
+  if (is_running == true) {
+    return SL_STATUS_NOT_READY;
+  }
+
+  return create_timer(handle,
+                      timeout,
+                      0,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Restarts a 32 bits timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_restart_timer(sl_sleeptimer_timer_handle_t *handle,
+                                        uint32_t timeout,
+                                        sl_sleeptimer_timer_callback_t callback,
+                                        void *callback_data,
+                                        uint8_t priority,
+                                        uint16_t option_flags)
+{
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  handle->conversion_error = 0;
+  handle->accumulated_error = 0;
+
+  //Trying to stop the Timer. Failing to do so implies the timer is not running.
+  sl_sleeptimer_stop_timer(handle);
+
+  //Creates the timer in any case.
+  return create_timer(handle,
+                      timeout,
+                      0,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Starts a 32 bits periodic timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_start_periodic_timer(sl_sleeptimer_timer_handle_t *handle,
+                                               uint32_t timeout,
+                                               sl_sleeptimer_timer_callback_t callback,
+                                               void *callback_data,
+                                               uint8_t priority,
+                                               uint16_t option_flags)
+{
+  bool is_running = false;
+
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  handle->conversion_error = 0;
+  handle->accumulated_error = 0;
+
+  sl_sleeptimer_is_timer_running(handle, &is_running);
+  if (is_running == true) {
+    return SL_STATUS_INVALID_STATE;
+  }
+
+  return create_timer(handle,
+                      timeout,
+                      timeout,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Starts a 32 bits periodic timer using milliseconds as the timebase.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_start_periodic_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                  uint32_t timeout_ms,
+                                                  sl_sleeptimer_timer_callback_t callback,
+                                                  void *callback_data,
+                                                  uint8_t priority,
+                                                  uint16_t option_flags)
+{
+  bool is_running = false;
+  sl_status_t status;
+  uint32_t timeout_tick;
+
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  sl_sleeptimer_is_timer_running(handle, &is_running);
+  if (is_running == true) {
+    return SL_STATUS_INVALID_STATE;
+  }
+
+  status = sl_sleeptimer_ms32_to_tick(timeout_ms, &timeout_tick);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  // Calculate ms to ticks conversion error
+  handle->conversion_error = 1000
+                             - (((uint64_t)timeout_ms * sl_sleeptimer_get_timer_frequency())
+                                % 1000);
+  if (handle->conversion_error == 1000) {
+    handle->conversion_error = 0;
+  }
+  // Initialize accumulated error to 0. The calculated conversion error will
+  // be added to this variable each time a timer in the series of periodic timers
+  // expires.
+  handle->accumulated_error = 0;
+
+  return create_timer(handle,
+                      timeout_tick,
+                      timeout_tick,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Restarts a 32 bits periodic timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_restart_periodic_timer(sl_sleeptimer_timer_handle_t *handle,
+                                                 uint32_t timeout,
+                                                 sl_sleeptimer_timer_callback_t callback,
+                                                 void *callback_data,
+                                                 uint8_t priority,
+                                                 uint16_t option_flags)
+{
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  handle->conversion_error = 0;
+  handle->accumulated_error = 0;
+
+  //Trying to stop the Timer. Failing to do so implies the timer has already been stopped.
+  sl_sleeptimer_stop_timer(handle);
+
+  //Creates the timer in any case.
+  return create_timer(handle,
+                      timeout,
+                      timeout,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Restarts a 32 bits periodic timer using milliseconds as the timebase.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_restart_periodic_timer_ms(sl_sleeptimer_timer_handle_t *handle,
+                                                    uint32_t timeout_ms,
+                                                    sl_sleeptimer_timer_callback_t callback,
+                                                    void *callback_data,
+                                                    uint8_t priority,
+                                                    uint16_t option_flags)
+{
+  sl_status_t status;
+  uint32_t timeout_tick;
+
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  status = sl_sleeptimer_ms32_to_tick(timeout_ms, &timeout_tick);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  // Calculate ms to ticks conversion error
+  handle->conversion_error = 1000
+                             - ((uint64_t)(timeout_ms * sl_sleeptimer_get_timer_frequency())
+                                % 1000);
+  if (handle->conversion_error == 1000) {
+    handle->conversion_error = 0;
+  }
+
+  // Initialize accumulated error to 0. The calculated conversion error will
+  // be added to this variable each time a timer in the series of periodic timers
+  // expires.
+  handle->accumulated_error = 0;
+
+  //Trying to stop the Timer. Failing to do so implies the timer has already been stopped.
+  sl_sleeptimer_stop_timer(handle);
+
+  //Creates the timer in any case.
+  return create_timer(handle,
+                      timeout_tick,
+                      timeout_tick,
+                      callback,
+                      callback_data,
+                      priority,
+                      option_flags);
+}
+
+/**************************************************************************//**
+ * Stops a 32 bits timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_stop_timer(sl_sleeptimer_timer_handle_t *handle)
+{
+  CORE_DECLARE_IRQ_STATE;
+  sl_status_t error;
+  bool set_comparator = false;
+
+  if (handle == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+  // Disable PRS compare and capture channel, if configured for early wakeup
+#if ((SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_SYSRTC) \
+  && defined(SL_CATALOG_POWER_MANAGER_PRESENT)                     \
+  && !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT))
+  if (handle->option_flags == (SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG | SLI_SLEEPTIMER_POWER_MANAGER_HF_ACCURACY_CLK_FLAG)) {
+    sleeptimer_hal_disable_prs_compare_and_capture_channel();
+  }
+#endif
+
+  CORE_ENTER_CRITICAL();
+  update_delta_list();
+
+  // If first timer in list, update timer comparator.
+  if (timer_head == handle) {
+    set_comparator = true;
+  }
+
+  error = delta_list_remove_timer(handle);
+  if (error != SL_STATUS_OK) {
+    CORE_EXIT_CRITICAL();
+
+    return error;
+  }
+
+  if (set_comparator && timer_head) {
+    set_comparator_for_next_timer();
+  } else if (!timer_head) {
+    sleeptimer_hal_disable_int(SLEEPTIMER_EVENT_COMP);
+  }
+
+  CORE_EXIT_CRITICAL();
+
+  return SL_STATUS_OK;
+}
+
+/**************************************************************************//**
+ * Gets the status of a timer.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_is_timer_running(sl_sleeptimer_timer_handle_t *handle,
+                                           bool *running)
+{
+  CORE_DECLARE_IRQ_STATE;
+  sl_sleeptimer_timer_handle_t *current;
+
+  if (handle == NULL || running == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  } else {
+    *running = false;
+    CORE_ENTER_ATOMIC();
+    current = timer_head;
+    while (current != NULL && !*running) {
+      if (current == handle) {
+        *running = true;
+      } else {
+        current = current->next;
+      }
+    }
+    CORE_EXIT_ATOMIC();
+  }
+  return SL_STATUS_OK;
+}
+
+/**************************************************************************//**
+ * Gets a 32 bits timer's time remaining.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_get_timer_time_remaining(sl_sleeptimer_timer_handle_t *handle,
+                                                   uint32_t *time)
+{
+  CORE_DECLARE_IRQ_STATE;
+  sl_sleeptimer_timer_handle_t *current;
+
+  if (handle == NULL || time == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  CORE_ENTER_ATOMIC();
+
+  update_delta_list();
+  *time  = handle->delta;
+
+  // Retrieve timer in list and add the deltas.
+  current = timer_head;
+  while (current != handle && current != NULL) {
+    *time += current->delta;
+    current = current->next;
+  }
+
+  if (current != handle) {
+    CORE_EXIT_ATOMIC();
+
+    return SL_STATUS_NOT_READY;
+  }
+
+  // Substract time since last compare match.
+  if (*time > sleeptimer_hal_get_counter() - last_delta_update_count) {
+    *time -= sleeptimer_hal_get_counter() - last_delta_update_count;
+  } else {
+    *time = 0;
+  }
+
+  CORE_EXIT_ATOMIC();
+
+  return SL_STATUS_OK;
+}
+
+/**************************************************************************//**
+ * Gets the time remaining until the first timer with the matching set of flags
+ * expires.
+ *****************************************************************************/
+sl_status_t sl_sleeptimer_get_remaining_time_of_first_timer(uint16_t option_flags,
+                                                            uint32_t *time_remaining)
+{
+  CORE_DECLARE_IRQ_STATE;
+  sl_sleeptimer_timer_handle_t *current;
+  uint32_t time = 0;
+
+  CORE_ENTER_ATOMIC();
+  // parse list and retrieve first timer with option flags requirement.
+  current = timer_head;
+  while (current != NULL) {
+    // save time remaining for timer.
+    time += current->delta;
+    // Check if the current timer has the flags requested
+    if (current->option_flags == option_flags
+        || option_flags == SL_SLEEPTIMER_ANY_FLAG) {
+      // Substract time since last compare match.
+      if (time > (sleeptimer_hal_get_counter() - last_delta_update_count)) {
+        time -= (sleeptimer_hal_get_counter() - last_delta_update_count);
+      } else {
+        time = 0;
+      }
+      *time_remaining = time;
+      CORE_EXIT_ATOMIC();
+
+      return SL_STATUS_OK;
+    }
+    current = current->next;
+  }
+  CORE_EXIT_ATOMIC();
+
+  return SL_STATUS_EMPTY;
+}
+
+/**************************************************************************//**
+ * Determines if next timer to expire has the option flag
+ * "SL_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG".
+ *
+ * @note This function is for internal use only.
+ *
+ * @note A check to validate that the Power Manager Sleeptimer is expired on
+ *       top of being the next timer was added. This is because
+ *       this function is called when coming back from EM2 sleep to validate
+ *       that the system woke up because of this precise timer expiration.
+ *       Some race conditions, seen with FreeRTOS, could create invalid RTC
+ *       interrupt leading to believe that the power manager timer was expired
+ *       when it was not.
+ *****************************************************************************/
+bool sli_sleeptimer_is_power_manager_timer_next_to_expire(void)
+{
+  bool next_timer_is_power_manager;
+
+  sl_atomic_load(next_timer_is_power_manager, next_timer_to_expire_is_power_manager);
+
+  // Make sure that the Power Manager Sleeptimer is actually expired in addition
+  // to being the next timer.
+  if ((next_timer_is_power_manager)
+      && ((sl_sleeptimer_get_tick_count() - timer_head->timeout_expected_tc) > MIN_DIFF_BETWEEN_COUNT_AND_EXPIRATION)) {
+    next_timer_is_power_manager = false;
+  }
+
+  return next_timer_is_power_manager;
+}
+
+/***************************************************************************//**
+* Gets current 32 bits tick count.
+*******************************************************************************/
+uint32_t sl_sleeptimer_get_tick_count(void)
+{
+  uint32_t cnt;
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  cnt = sleeptimer_hal_get_counter();
+  CORE_EXIT_ATOMIC();
+
+  return cnt;
+}
+
+/***************************************************************************//**
+* Gets current 64 bits tick count.
+*******************************************************************************/
+uint64_t sl_sleeptimer_get_tick_count64(void)
+{
+  uint32_t tick_cnt;
+  uint32_t of_cnt;
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  tick_cnt = sleeptimer_hal_get_counter();
+  of_cnt = overflow_counter;
+
+  if (sli_sleeptimer_hal_is_int_status_set(SLEEPTIMER_EVENT_OF)) {
+    tick_cnt = sleeptimer_hal_get_counter();
+    of_cnt++;
+  }
+  CORE_EXIT_ATOMIC();
+
+  return (((uint64_t) of_cnt) << 32) | tick_cnt;
+}
+
+/***************************************************************************//**
+ * Get timer frequency.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_timer_frequency(void)
+{
+  return timer_frequency;
+}
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+/***************************************************************************//**
+ * Retrieves current 32 bit time.
+ ******************************************************************************/
+sl_sleeptimer_timestamp_t sl_sleeptimer_get_time(void)
+{
+  uint64_t temp_time = sl_sleeptimer_get_time_64();
+  // Add offset for 64 to 32 bit time
+  if (temp_time >= TIME_64_TO_32_EPOCH_OFFSET_SEC) {
+    temp_time -= TIME_64_TO_32_EPOCH_OFFSET_SEC;
+  }
+  // Return lower 32 bits of 64 bit time
+  uint32_t time = (temp_time & 0xFFFFFFFF);
+
+  return time;
+}
+
+/***************************************************************************//**
+ * Retrieves current 64 bit time.
+ ******************************************************************************/
+sl_sleeptimer_timestamp_64_t sl_sleeptimer_get_time_64(void)
+{
+  uint32_t cnt = 0u;
+  uint32_t freq = 0u;
+  sl_sleeptimer_timestamp_64_t time;
+  CORE_DECLARE_IRQ_STATE;
+
+  cnt = sleeptimer_hal_get_counter();
+  freq = sl_sleeptimer_get_timer_frequency();
+
+  CORE_ENTER_ATOMIC();
+  time = second_count + cnt / freq;
+
+  if (cnt % freq + overflow_tick_rest >= freq) {
+    time++;
+  }
+  CORE_EXIT_ATOMIC();
+
+  return time;
+}
+
+/***************************************************************************//**
+ * Sets current time from 32 bit variable.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_time(sl_sleeptimer_timestamp_t time)
+{
+  // convert 32 bit time to 64 bit time
+  uint64_t temp_time = time + TIME_64_TO_32_EPOCH_OFFSET_SEC;
+  sl_status_t err_code = sl_sleeptimer_set_time_64(temp_time);
+  return err_code;
+}
+
+/***************************************************************************//**
+ * Sets current time from 64 bit variable.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_time_64(sl_sleeptimer_timestamp_64_t time)
+{
+  uint32_t freq = 0u;
+  uint32_t counter_sec = 0u;
+  uint32_t cnt = 0;
+  CORE_DECLARE_IRQ_STATE;
+
+  // convert 64 bit time to 32 bit time
+  if (!is_valid_time_64(time, TIME_FORMAT_UNIX_64_BIT, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  freq = sl_sleeptimer_get_timer_frequency();
+  cnt = sleeptimer_hal_get_counter();
+
+  CORE_ENTER_ATOMIC();
+  // store 64 bit time as 64 bits's
+  second_count = time;
+
+  // Convert 64 bit time to 32 bit time in order to check for overflow
+  // i.e. if 32 bit time is >=counter_sec
+  uint64_t temp_time = second_count - TIME_64_TO_32_EPOCH_OFFSET_SEC;
+  uint32_t second_time_32 = (temp_time & 0xFFFFFFFF);
+
+  overflow_tick_rest = 0;
+  counter_sec = cnt / freq;
+
+  if (second_time_32 >= counter_sec) {
+    second_count -= counter_sec;
+  } else {
+    CORE_EXIT_ATOMIC();
+
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  CORE_EXIT_ATOMIC();
+
+  return SL_STATUS_OK;
+}
+
+/***************************************************************************//**
+ * Gets current date.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_get_datetime(sl_sleeptimer_date_t *date)
+{
+  sl_sleeptimer_timestamp_64_t time = 0u;
+  sl_sleeptimer_time_zone_offset_t tz;
+  sl_status_t err_code = SL_STATUS_OK;
+
+  // Fetch 64 bit timestamp
+  time = sl_sleeptimer_get_time_64();
+  tz = sl_sleeptimer_get_tz();
+  err_code = sl_sleeptimer_convert_time_to_date_64(time, tz, date);
+
+  return err_code;
+}
+
+/***************************************************************************//**
+ * Sets current time, in date format.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_set_datetime(sl_sleeptimer_date_t *date)
+{
+  sl_sleeptimer_timestamp_64_t time = 0u;
+  sl_status_t err_code = SL_STATUS_OK;
+  CORE_DECLARE_IRQ_STATE;
+
+  if (!is_valid_date_64(date)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  err_code = sl_sleeptimer_convert_date_to_time_64(date, &time);
+  if (err_code != SL_STATUS_OK) {
+    return err_code;
+  }
+
+  CORE_ENTER_ATOMIC();
+  // sets the 64 bit second_time value
+  err_code = sl_sleeptimer_set_time_64(time);
+  if (err_code == SL_STATUS_OK) {
+    sl_sleeptimer_set_tz(date->time_zone);
+  }
+  CORE_EXIT_ATOMIC();
+
+  return err_code;
+}
+
+/***************************************************************************//**
+ * Builds a date time structure based on the provided parameters.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_build_datetime(sl_sleeptimer_date_t *date,
+                                         uint16_t year,
+                                         sl_sleeptimer_month_t month,
+                                         uint8_t month_day,
+                                         uint8_t hour,
+                                         uint8_t min,
+                                         uint8_t sec,
+                                         sl_sleeptimer_time_zone_offset_t tz_offset)
+{
+  if (date == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  // If year is smaller than 1900, assume NTP Epoch is used.
+  date->year = ((year < TIME_NTP_EPOCH) ? year : (year - TIME_NTP_EPOCH));
+  date->month = month;
+  date->month_day = month_day;
+  date->hour = hour;
+  date->min = min;
+  date->sec = sec;
+  date->time_zone = tz_offset;
+
+  // Validate that input parameters are correct before filing the missing fields
+  if (!is_valid_date(date)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  date->day_of_year = compute_day_of_year(date->month, date->month_day, is_leap_year(date->year));
+  date->day_of_week = compute_day_of_week(((date->year - TIME_NTP_UNIX_EPOCH_DIFF)  * TIME_DAY_PER_YEAR)
+                                          + number_of_leap_days(TIME_UNIX_EPOCH, (date->year + TIME_NTP_EPOCH))
+                                          + date->day_of_year - 1);
+
+  return SL_STATUS_OK;
+}
+
+/***************************************************************************//**
+ * Builds a date time structure based on the provided parameters.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_build_datetime_64(sl_sleeptimer_date_t *date,
+                                            uint16_t year,
+                                            sl_sleeptimer_month_t month,
+                                            uint8_t month_day,
+                                            uint8_t hour,
+                                            uint8_t min,
+                                            uint8_t sec,
+                                            sl_sleeptimer_time_zone_offset_t tz_offset)
+{
+  if (date == NULL) {
+    return SL_STATUS_NULL_POINTER;
+  }
+
+  // Ensure that year is greater than 1900 and based on 0 epoch
+  if (year < TIME_NTP_EPOCH) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  // Convert year based on 0 epoch to a valid date->year based on 1900 epoch
+  date->year = (year - TIME_NTP_EPOCH);
+  date->month = month;
+  date->month_day = month_day;
+  date->hour = hour;
+  date->min = min;
+  date->sec = sec;
+  date->time_zone = tz_offset;
+
+  // Validate that input parameters are correct before filing the missing fields
+  if (!is_valid_date_64(date)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  date->day_of_year = compute_day_of_year(date->month, date->month_day, is_leap_year(date->year));
+  date->day_of_week = compute_day_of_week_64((date->year * TIME_DAY_PER_YEAR)
+                                             + number_of_leap_days(TIME_NTP_EPOCH, (date->year + TIME_NTP_EPOCH))
+                                             + date->day_of_year - 1);
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Convert a 32 bit time stamp into a date structure.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_time_to_date(sl_sleeptimer_timestamp_t time,
+                                               sl_sleeptimer_time_zone_offset_t time_zone,
+                                               sl_sleeptimer_date_t *date)
+{
+  // convert 32 bit timestamp to 64 bit
+  sl_sleeptimer_timestamp_64_t temp_time = (uint64_t)time + TIME_64_TO_32_EPOCH_OFFSET_SEC;
+  sl_status_t err_code = sl_sleeptimer_convert_time_to_date_64(temp_time, time_zone, date);
+  return err_code;
+}
+
+/*******************************************************************************
+ * Convert a 64 bit time stamp into a date structure.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_time_to_date_64(sl_sleeptimer_timestamp_64_t time,
+                                                  sl_sleeptimer_time_zone_offset_t time_zone,
+                                                  sl_sleeptimer_date_t *date)
+{
+  uint16_t full_year = 0;
+  uint16_t leap_day = 0;
+  uint8_t leap_year_flag = 0;
+  uint8_t current_month = 0;
+
+  if (!is_valid_time_64(time, TIME_FORMAT_UNIX_64_BIT, time_zone)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  time += time_zone;  // add UTC offset to convert to Standard Time
+  date->sec = time % 60;
+  time /= 60;
+  date->min = time % 60;
+  time /= 60;
+  date->hour = time % 24;
+  time /= 24; // time is now the number of days since 1900
+
+  date->day_of_week = (sl_sleeptimer_weekDay_t)compute_day_of_week_64(time);
+
+  full_year = time / TIME_DAY_PER_YEAR; // Approximates the number of full years
+  uint32_t base_year = 1900u;
+  uint32_t current_year = full_year + base_year;
+
+  if (full_year > 4) { // 1904 is the first leap year since 1900
+    leap_day = number_of_leap_days(base_year, current_year);  // Approximates the number of leap days.
+    full_year = (time - leap_day) / TIME_DAY_PER_YEAR; // Computes the number of year integrating the leap days.
+    current_year = full_year + base_year;
+    leap_day = number_of_leap_days(base_year, current_year); // Computes the actual number of leap days of the previous years.
+  }
+  date->year = full_year; // Year in date struct must be based on a 1900 epoch.
+  if (is_leap_year(date->year)) {
+    leap_year_flag = 1;
+  }
+
+  time = (time - leap_day) - (TIME_DAY_PER_YEAR * full_year);  // Subtracts days of previous year.
+  date->day_of_year = time + 1;
+
+  while (time >= days_in_month[leap_year_flag][current_month]) {
+    time -= days_in_month[leap_year_flag][current_month]; // Subtracts the number of days of the passed month.
+    current_month++;
+  }
+  date->month = (sl_sleeptimer_month_t)current_month;
+  date->month_day = time + 1;
+  date->time_zone = time_zone;
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Convert a date structure into a 32 bit time stamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_date_to_time(sl_sleeptimer_date_t *date,
+                                               sl_sleeptimer_timestamp_t *time)
+{
+  // Create a 64 bit time stamp
+  sl_sleeptimer_timestamp_64_t temp_time =  0;
+  sl_status_t err_code = sl_sleeptimer_convert_date_to_time_64(date, &temp_time);
+
+  if (err_code != SL_STATUS_OK) {
+    return err_code;
+  }
+  // Convert 64 bit time to 32 bit time
+
+  sl_sleeptimer_timestamp_64_t time_32 = temp_time;
+  time_32 -= TIME_64_TO_32_EPOCH_OFFSET_SEC;
+  *time = (time_32 & 0xFFFFFFFF);
+
+  return err_code;
+}
+
+/*******************************************************************************
+ * Convert a date structure into a 64 bit time stamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_date_to_time_64(sl_sleeptimer_date_t *date,
+                                                  sl_sleeptimer_timestamp_64_t *time)
+{
+  uint16_t month_days = 0;
+  uint8_t  month;
+  uint16_t  full_year = 0;
+  uint8_t  leap_year_flag = 0;
+  uint16_t  leap_days = 0;
+
+  if (!is_valid_date_64(date)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  full_year = (date->year);                                  // base year for 64 bits its 1900 not 1970
+  month = date->month;                              // offset to get months value from 1 to 12.
+
+  uint32_t base_year = 1900u;
+  uint32_t current_year = full_year + base_year;
+
+  *time = (full_year * (uint64_t)TIME_SEC_PER_YEAR);
+
+  if (full_year > 4) {                                       // 1904 is the first leap year since 1900
+    leap_days = number_of_leap_days(base_year, current_year);
+    month_days = leap_days;
+  }
+
+  if (is_leap_year(date->year)) {
+    leap_year_flag = 1;
+  }
+
+  for (int i = 0; i < month; i++) {
+    month_days += days_in_month[leap_year_flag][i];         // Add the number of days of the month of the year.
+  }
+
+  month_days += (date->month_day - 1);                       // Add full days of the current month.
+  *time += month_days * TIME_SEC_PER_DAY;
+  *time += (3600 * date->hour) + (60 * date->min) + date->sec;
+  *time -= date->time_zone;
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Convert a date structure to string.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_convert_date_to_str(char *str,
+                                           size_t size,
+                                           const uint8_t *format,
+                                           sl_sleeptimer_date_t *date)
+{
+  uint32_t  return_size = 0u;
+  if (is_valid_date(date)) {
+    struct tm date_struct;
+
+    date_struct.tm_hour = date->hour;
+    date_struct.tm_mday = date->month_day;
+    date_struct.tm_min = date->min;
+    date_struct.tm_mon = date->month;
+    date_struct.tm_sec = date->sec;
+    date_struct.tm_wday = date->day_of_week;
+    date_struct.tm_yday = date->day_of_year;
+    date_struct.tm_year = date->year;
+
+    return_size = strftime(str,
+                           size,
+                           (const char *)format,
+                           &date_struct);
+  }
+
+  return return_size;
+}
+
+/***************************************************************************//**
+ * Sets time zone offset.
+ *
+ * @param  offset  Time zone offset, in seconds.
+ ******************************************************************************/
+void sl_sleeptimer_set_tz(sl_sleeptimer_time_zone_offset_t offset)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  tz_offset = offset;
+  CORE_EXIT_ATOMIC();
+}
+
+/***************************************************************************//**
+ * Gets time zone offset.
+ *
+ * @return Time zone offset, in seconds.
+ ******************************************************************************/
+sl_sleeptimer_time_zone_offset_t sl_sleeptimer_get_tz(void)
+{
+  sl_sleeptimer_time_zone_offset_t offset;
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_ATOMIC();
+  offset = tz_offset;
+  CORE_EXIT_ATOMIC();
+
+  return offset;
+}
+
+/***************************************************************************//**
+ * Converts Unix 32 timestamp into NTP timestamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_unix_time_to_ntp(sl_sleeptimer_timestamp_t time,
+                                                   uint32_t *ntp_time)
+{
+  if (time > TIME_UNIX_TO_NTP_MAX) {
+    // Maximum Unix timestamp that can be converted to NTP is 2085978495
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+
+  uint32_t temp_ntp_time;
+  temp_ntp_time = time + TIME_NTP_EPOCH_OFFSET_SEC;
+  if (!is_valid_time(temp_ntp_time, TIME_FORMAT_NTP, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  } else {
+    *ntp_time = temp_ntp_time;
+    return SL_STATUS_OK;
+  }
+}
+
+/***************************************************************************//**
+ * Converts NTP timestamp into Unix timestamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_ntp_time_to_unix(uint32_t ntp_time,
+                                                   sl_sleeptimer_timestamp_t *time)
+{
+  uint32_t temp_time;
+  temp_time = ntp_time - TIME_NTP_EPOCH_OFFSET_SEC;
+  if (!is_valid_time(temp_time, TIME_FORMAT_UNIX, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  } else {
+    *time = temp_time;
+    return SL_STATUS_OK;
+  }
+}
+
+/***************************************************************************//**
+ * Converts Unix timestamp into Zigbee timestamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_unix_time_to_zigbee(sl_sleeptimer_timestamp_t time,
+                                                      uint32_t *zigbee_time)
+{
+  uint32_t temp_zigbee_time;
+  temp_zigbee_time = time - TIME_ZIGBEE_EPOCH_OFFSET_SEC;
+  if (!is_valid_time(temp_zigbee_time, TIME_FORMAT_ZIGBEE_CLUSTER, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  } else {
+    *zigbee_time = temp_zigbee_time;
+    return SL_STATUS_OK;
+  }
+}
+
+/***************************************************************************//**
+ * Converts Zigbee timestamp into Unix timestamp.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_convert_zigbee_time_to_unix(uint32_t zigbee_time,
+                                                      sl_sleeptimer_timestamp_t *time)
+{
+  uint32_t temp_time;
+  temp_time = zigbee_time + TIME_ZIGBEE_EPOCH_OFFSET_SEC;
+  if (!is_valid_time(temp_time, TIME_FORMAT_UNIX, 0u)) {
+    return SL_STATUS_INVALID_PARAMETER;
+  } else {
+    *time = temp_time;
+    return SL_STATUS_OK;
+  }
+}
+
+#endif // SL_SLEEPTIMER_WALLCLOCK_CONFIG
+
+/*******************************************************************************
+ * Active delay of 'time_ms' milliseconds.
+ ******************************************************************************/
+void sl_sleeptimer_delay_millisecond(uint16_t time_ms)
+{
+  volatile bool wait = true;
+  sl_status_t error_code;
+  sl_sleeptimer_timer_handle_t delay_timer;
+  uint32_t delay = sl_sleeptimer_ms_to_tick(time_ms);
+
+  error_code = sl_sleeptimer_start_timer(&delay_timer,
+                                         delay,
+                                         delay_callback,
+                                         (void *)&wait,
+                                         0,
+                                         0);
+  if (error_code == SL_STATUS_OK) {
+    while (wait) { // Active delay loop.
+    }
+  }
+}
+
+/*******************************************************************************
+ * Converts milliseconds in ticks.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_ms_to_tick(uint16_t time_ms)
+{
+  return (uint32_t)((((uint64_t)time_ms * timer_frequency) + 999) / 1000);
+}
+
+/*******************************************************************************
+ * Converts 32-bits milliseconds in ticks.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_ms32_to_tick(uint32_t time_ms,
+                                       uint32_t *tick)
+{
+  if (time_ms <= max_millisecond_conversion) {
+    *tick = (uint32_t)((((uint64_t)time_ms * timer_frequency) + 999) / 1000u);
+    return SL_STATUS_OK;
+  } else {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+}
+
+/***************************************************************************//**
+ * Gets the maximum value that can be passed to the functions that have a
+ * 32-bits time or timeout argument expressed in milliseconds.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_get_max_ms32_conversion(void)
+{
+  return max_millisecond_conversion;
+}
+
+/*******************************************************************************
+ * Converts ticks in milliseconds.
+ ******************************************************************************/
+uint32_t sl_sleeptimer_tick_to_ms(uint32_t tick)
+{
+  uint32_t time_ms;
+  time_ms = 0;
+
+  if (timer_frequency != 0u) {
+    if (is_power_of_2(timer_frequency)) {
+      time_ms = (uint32_t)(((uint64_t)tick * (uint64_t)1000u) >> div_to_log2(timer_frequency));
+    } else {
+      time_ms = (uint32_t)(((uint64_t)tick * (uint64_t)1000u) / timer_frequency);
+    }
+  }
+
+  return time_ms;
+}
+
+/*******************************************************************************
+ * Converts 64-bits ticks in milliseconds.
+ ******************************************************************************/
+sl_status_t sl_sleeptimer_tick64_to_ms(uint64_t tick,
+                                       uint64_t *ms)
+
+{
+  if ((tick <= UINT64_MAX / 1000)
+      && (timer_frequency != 0u)) {
+    if (is_power_of_2(timer_frequency)) {
+      *ms =  (uint64_t)(((uint64_t)tick * (uint64_t)1000u) >> div_to_log2(timer_frequency));
+      return SL_STATUS_OK;
+    } else {
+      *ms = (uint64_t)(((uint64_t)tick * (uint64_t)1000u) / timer_frequency);
+      return SL_STATUS_OK;
+    }
+  } else {
+    return SL_STATUS_INVALID_PARAMETER;
+  }
+}
+
+/*******************************************************************************
+ * Process timer interrupt.
+ *
+ * @param local_flag Flag indicating the type of timer interrupt.
+ ******************************************************************************/
+void process_timer_irq(uint8_t local_flag)
+{
+  CORE_DECLARE_IRQ_STATE;
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+    uint32_t timer_freq = sl_sleeptimer_get_timer_frequency();
+
+    overflow_tick_rest += calculated_tick_rest;
+    if (overflow_tick_rest >= timer_freq) {
+      second_count++;
+      overflow_tick_rest -= timer_freq;
+    }
+    second_count = second_count + calculated_sec_count;
+#endif
+    overflow_counter++;
+
+    update_delta_list();
+
+    if (timer_head) {
+      set_comparator_for_next_timer();
+    }
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    sl_sleeptimer_timer_handle_t *current = NULL;
+
+    uint32_t nb_timer_expire = 0u;
+    uint16_t option_flags = 0;
+
+    CORE_ENTER_ATOMIC();
+    // Make sure the timers list is up to date with the time elapsed since the last update
+    update_delta_list();
+
+    // Process all timers that have expired.
+    while ((timer_head) && (timer_head->delta == 0)) {
+      sl_sleeptimer_timer_handle_t *temp = timer_head;
+      current = timer_head;
+      int32_t periodic_correction = 0u;
+      int64_t timeout_temp = 0;
+      bool skip_remove = false;
+
+      // Process timers with higher priority first
+      while ((temp != NULL) && (temp->delta == 0)) {
+        if (current->priority > temp->priority) {
+          current = temp;
+        }
+        temp = temp->next;
+      }
+      CORE_EXIT_ATOMIC();
+
+      // Check if current periodic timer was delayed more than its actual timeout value
+      // and keep it at the head of the timers list if it's the case so that the
+      // callback function can be called the number of required time.
+      if (current->timeout_periodic != 0u) {
+        timeout_temp = current->timeout_periodic;
+
+        periodic_correction = sleeptimer_hal_get_counter() - current->timeout_expected_tc;
+        if (periodic_correction >= timeout_temp) {
+          skip_remove = true;
+          current->timeout_expected_tc += current->timeout_periodic;
+        }
+      }
+
+      // Remove current timer from timer list except if the current timer is a periodic timer
+      // that was intentionally kept at the head of the timers list.
+      if (skip_remove != true) {
+        CORE_ENTER_ATOMIC();
+        delta_list_remove_timer(current);
+        CORE_EXIT_ATOMIC();
+      }
+
+      // Re-insert periodic timer that was previsouly removed from the list
+      // and compensate for any deviation from the periodic timer frequency.
+      if (current->timeout_periodic != 0u && skip_remove != true) {
+        timeout_temp -= periodic_correction;
+        EFM_ASSERT(timeout_temp > 0);
+        // Compensate for drift caused by ms to ticks conversion
+        if (current->conversion_error > 0) {
+          // Increment accumulated error by the ms to ticks conversion error
+          current->accumulated_error += current->conversion_error;
+          // If the accumulated error exceeds a tick, subtract that tick from the next
+          // periodic timer's timeout value.
+          if (current->accumulated_error >= 1000) {
+            current->accumulated_error -= 1000;
+            timeout_temp -= 1;
+            current->timeout_expected_tc -= 1;
+          }
+        }
+        CORE_ENTER_ATOMIC();
+        delta_list_insert_timer(current, (sl_sleeptimer_tick_count_t)timeout_temp);
+        current->timeout_expected_tc += current->timeout_periodic;
+        CORE_EXIT_ATOMIC();
+      }
+
+      // Save current option flag and the number of timers that expired.
+      option_flags = current->option_flags;
+      nb_timer_expire++;
+
+      // Call current timer callback function if any.
+      if (current->callback != NULL) {
+        current->callback(current, current->callback_data);
+      }
+
+      CORE_ENTER_ATOMIC();
+
+      // Re-update the list to account for delays during timer's callback.
+      update_delta_list();
+    }
+
+    // If the only timer expired is the internal Power Manager one,
+    // from the Sleeptimer perspective, the system can go back to sleep after the ISR handling.
+    sleep_on_isr_exit = false;
+    if (nb_timer_expire == 1u) {
+      if (option_flags & SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG) {
+        sleep_on_isr_exit = true;
+      }
+    }
+
+    if (timer_head) {
+      set_comparator_for_next_timer();
+    } else {
+      sleeptimer_hal_disable_int(SLEEPTIMER_EVENT_COMP);
+    }
+    CORE_EXIT_ATOMIC();
+  }
+}
+
+/*******************************************************************************
+ * Timer expiration callback for the delay function.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param data Pointer to delay flag.
+ ******************************************************************************/
+static void delay_callback(sl_sleeptimer_timer_handle_t *handle,
+                           void *data)
+{
+  volatile bool *wait_flag = (bool *)data;
+
+  (void)handle;  // Unused parameter.
+
+  *wait_flag = false;
+}
+
+/*******************************************************************************
+ * Inserts a timer in the delta list.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout Timer timeout, in ticks.
+ ******************************************************************************/
+static void delta_list_insert_timer(sl_sleeptimer_timer_handle_t *handle,
+                                    sl_sleeptimer_tick_count_t timeout)
+{
+  sl_sleeptimer_tick_count_t local_handle_delta = timeout;
+
+#ifdef SL_CATALOG_POWER_MANAGER_PRESENT
+  // If Power Manager is present, it's possible that a clock restore is needed right away
+  // if we are in the context of a deepsleep and the timeout value is smaller than the restore time.
+  // If it's the case, the restore will be started and the timeout value will be updated to match
+  // the restore delay.
+  if (handle->option_flags == 0) {
+    uint32_t wakeup_delay = sli_power_manager_get_restore_delay();
+
+    if (local_handle_delta < wakeup_delay) {
+      local_handle_delta = wakeup_delay;
+      sli_power_manager_initiate_restore();
+    }
+  }
+#endif
+
+  handle->delta = local_handle_delta;
+
+  if (timer_head != NULL) {
+    sl_sleeptimer_timer_handle_t *prev = NULL;
+    sl_sleeptimer_timer_handle_t *current = timer_head;
+    // Find timer position taking into accounts the deltas and priority.
+    while (current != NULL
+           && (local_handle_delta >= current->delta || current->delta == 0u
+               || (((local_handle_delta - current->delta) == 0) && (handle->priority > current->priority)))) {
+      local_handle_delta -= current->delta;
+      handle->delta = local_handle_delta;
+      prev = current;
+      current = current->next;
+    }
+
+    // Insert timer in middle of delta list.
+    if (prev != NULL) {
+      prev->next = handle;
+    } else {
+      timer_head = handle;
+    }
+    handle->next = current;
+
+    if (current != NULL) {
+      current->delta -= local_handle_delta;
+    }
+  } else {
+    timer_head = handle;
+    handle->next = NULL;
+  }
+}
+
+/*******************************************************************************
+ * Removes a timer from delta list.
+ *
+ * @param handle Pointer to handle to timer.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+static sl_status_t delta_list_remove_timer(sl_sleeptimer_timer_handle_t *handle)
+{
+  sl_sleeptimer_timer_handle_t *prev = NULL;
+  sl_sleeptimer_timer_handle_t *current = timer_head;
+
+  // Retrieve timer in delta list.
+  while (current != NULL && current != handle) {
+    prev = current;
+    current = current->next;
+  }
+
+  if (current != handle) {
+    return SL_STATUS_INVALID_STATE;
+  }
+
+  if (prev != NULL) {
+    prev->next = handle->next;
+  } else {
+    timer_head = handle->next;
+  }
+
+  // Update delta of next timer
+  if (handle->next != NULL) {
+    handle->next->delta += handle->delta;
+  }
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Sets comparator for next timer.
+ ******************************************************************************/
+static void set_comparator_for_next_timer(void)
+{
+  if (timer_head->delta > 0) {
+    sl_sleeptimer_tick_count_t compare_value;
+
+    compare_value = last_delta_update_count + timer_head->delta;
+
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+    sleeptimer_hal_set_compare(compare_value);
+  } else {
+    // In case timer has already expire, don't attempt to set comparator. Just
+    // trigger compare match interrupt.
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+    sleeptimer_hal_set_int(SLEEPTIMER_EVENT_COMP);
+  }
+
+  update_next_timer_to_expire_is_power_manager();
+}
+
+/*******************************************************************************
+ * Updates timer list's deltas.
+ ******************************************************************************/
+static void update_delta_list(void)
+{
+  sl_sleeptimer_tick_count_t current_cnt = sleeptimer_hal_get_counter();
+  sl_sleeptimer_timer_handle_t *timer_handle = timer_head;
+  sl_sleeptimer_tick_count_t time_diff = current_cnt - last_delta_update_count;
+
+  // Go through the delta timer list and update every necessary deltas
+  // according to the time elapsed since the last update.
+  while (timer_handle != NULL && time_diff > 0) {
+    if (timer_handle->delta >= time_diff) {
+      timer_handle->delta -= time_diff;
+      time_diff = 0;
+    } else {
+      time_diff -= timer_handle->delta;
+      timer_handle->delta = 0;
+    }
+    timer_handle = timer_handle->next;
+  }
+
+  last_delta_update_count = current_cnt;
+}
+
+/*******************************************************************************
+ * Creates and start a 32 bits timer.
+ *
+ * @param handle Pointer to handle to timer.
+ * @param timeout_initial Initial timeout, in timer ticks.
+ * @param timeout_periodic Periodic timeout, in timer ticks. This timeout
+ *        applies once timeoutInitial expires. Can be set to 0 for a one
+ *        shot timer.
+ * @param callback Callback function that will be called when
+ *        initial/periodic timeout expires.
+ * @param callback_data Pointer to user data that will be passed to callback.
+ * @param priority Priority of callback. Useful in case multiple timer expire
+ *        at the same time. 0 = highest priority.
+ *
+ * @return 0 if successful. Error code otherwise.
+ ******************************************************************************/
+static sl_status_t create_timer(sl_sleeptimer_timer_handle_t *handle,
+                                sl_sleeptimer_tick_count_t timeout_initial,
+                                sl_sleeptimer_tick_count_t timeout_periodic,
+                                sl_sleeptimer_timer_callback_t callback,
+                                void *callback_data,
+                                uint8_t priority,
+                                uint16_t option_flags)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  handle->priority = priority;
+  handle->callback_data = callback_data;
+  handle->next = NULL;
+  handle->timeout_periodic = timeout_periodic;
+  handle->callback = callback;
+  handle->option_flags = option_flags;
+  if (timeout_periodic == 0) {
+    handle->timeout_expected_tc = sleeptimer_hal_get_counter() + timeout_initial;
+  } else {
+    handle->timeout_expected_tc = sleeptimer_hal_get_counter() + timeout_periodic;
+  }
+
+  if (timeout_initial == 0) {
+    handle->delta = 0;
+    if (handle->callback != NULL) {
+      handle->callback(handle, handle->callback_data);
+    }
+    if (timeout_periodic != 0) {
+      timeout_initial = timeout_periodic;
+    } else {
+      return SL_STATUS_OK;
+    }
+  }
+
+#if ((SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_SYSRTC) \
+  && defined(SL_CATALOG_POWER_MANAGER_PRESENT)                     \
+  && !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT))
+  if (option_flags == (SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG | SLI_SLEEPTIMER_POWER_MANAGER_HF_ACCURACY_CLK_FLAG)) {
+    HFXO0->CTRL_SET = HFXO_CTRL_EM23ONDEMAND;
+    sleeptimer_hal_set_compare_prs_hfxo_startup(timeout_initial);
+    return SL_STATUS_OK;
+  }
+#endif
+
+  CORE_ENTER_CRITICAL();
+  update_delta_list();
+  delta_list_insert_timer(handle, timeout_initial);
+
+  // If first timer, update timer comparator.
+  if (timer_head == handle) {
+    set_comparator_for_next_timer();
+  }
+
+  CORE_EXIT_CRITICAL();
+
+  return SL_STATUS_OK;
+}
+
+/*******************************************************************************
+ * Updates internal flag that indicates if next timer to expire is the power
+ * manager's one.
+ ******************************************************************************/
+static void update_next_timer_to_expire_is_power_manager(void)
+{
+  sl_sleeptimer_timer_handle_t *current = timer_head;
+  uint32_t delta_diff_with_first = 0;
+
+  next_timer_to_expire_is_power_manager = false;
+
+  while (delta_diff_with_first <= 1) {
+    if (current->option_flags & SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG) {
+      next_timer_to_expire_is_power_manager = true;
+      break;
+    }
+
+    current = current->next;
+    if (current == NULL) {
+      break;
+    }
+
+    delta_diff_with_first += current->delta;
+  }
+}
+
+/**************************************************************************//**
+ * Determines if the power manager's early wakeup expired during the last ISR
+ * and it was the only timer to expire in that period.
+ *
+ * @return true if power manager sleep can return to sleep,
+ *         false otherwise.
+ *****************************************************************************/
+bool sl_sleeptimer_is_power_manager_early_restore_timer_latest_to_expire(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+  bool sleep;
+
+  CORE_ENTER_ATOMIC();
+  sleep = sleep_on_isr_exit;
+  CORE_EXIT_ATOMIC();
+
+  return sleep;
+}
+
+/*******************************************************************************
+ * Convert dividend to logarithmic value. It only works for even
+ * numbers equal to 2^n.
+ *
+ * @param  div An unscaled dividend.
+ *
+ * @return Logarithm of 2.
+ ******************************************************************************/
+__STATIC_INLINE uint32_t div_to_log2(uint32_t div)
+{
+  return 31UL - __CLZ(div);  // Count leading zeroes and "reverse" result.
+}
+
+/*******************************************************************************
+ * Determines if a number is a power of two.
+ *
+ * @param  nbr Input value.
+ *
+ * @return True if the number is a power of two.
+ ******************************************************************************/
+__STATIC_INLINE bool is_power_of_2(uint32_t nbr)
+{
+  if ((((nbr) != 0u) && (((nbr) & ((nbr) - 1u)) == 0u))) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+#if SL_SLEEPTIMER_WALLCLOCK_CONFIG
+/*******************************************************************************
+ * Compute the day of the week.
+ *
+ * @param day Days since January 1st of 1970.
+ *
+ * @return the day of the week.
+ ******************************************************************************/
+static sl_sleeptimer_weekDay_t compute_day_of_week(uint32_t day)
+{
+  return (sl_sleeptimer_weekDay_t)((day + 4) % 7); // January 1st was a Thursday(4) in 1970
+}
+
+/*******************************************************************************
+ * Compute the day of the week.
+ *
+ * @param day Days since January 1st of 1900.
+ *
+ * @return the day of the week.
+ ******************************************************************************/
+static sl_sleeptimer_weekDay_t compute_day_of_week_64(uint64_t day)
+{
+  return (sl_sleeptimer_weekDay_t)((day + 1) % 7);  // January 1st was a Monday(1) in 1900
+}
+
+/*******************************************************************************
+ * Compute the day of the year. This function assumes that the inputs are properly
+ * sanitized.
+ *
+ * @param month Number of months since January.
+ * @param day Day of the month
+ * @param is_leap_year Specifies if the year computed against is a leap year.
+ *
+ * @return the number of days since the beginning of the year
+ ******************************************************************************/
+static uint16_t compute_day_of_year(sl_sleeptimer_month_t month, uint8_t day, bool is_leap_year)
+{
+  uint8_t i;
+  uint16_t dayOfYear = 0;
+
+  for (i = 0; i < month; ++i) {
+    dayOfYear += days_in_month[is_leap_year][i];
+  }
+  dayOfYear += day;
+
+  return dayOfYear;
+}
+
+/*******************************************************************************
+ * Checks if the year is a leap year.
+ *
+ * @param year Year to check.
+ *
+ * @return true if the year is a leap year. False otherwise.
+ ******************************************************************************/
+static bool is_leap_year(uint16_t year)
+{
+  // 1900 is not a leap year but 0 % anything is 0.
+  if (year == 0) {
+    return false;
+  }
+
+  bool leap_year;
+
+  leap_year = (((year %   4u) == 0u)
+               && (((year % 100u) != 0u) || ((year % 400u) == 0u))) ? true : false;
+
+  return (leap_year);
+}
+
+/*******************************************************************************
+ * Checks if the time stamp, format and time zone are
+ *  within the supported range.
+ *
+ * @param base_year Year to start from to compute leap days.
+ * @param current_year Year end at for computing leap days.
+ *
+ * @return leap_days Days number of leap days between base_year and current_year.
+ ******************************************************************************/
+static uint16_t number_of_leap_days(uint32_t base_year, uint32_t current_year)
+{
+  // Regular leap years
+  uint16_t lo_reg = (base_year - 0) / 4;
+  uint16_t hi_reg = (current_year - 1) / 4;
+  uint16_t leap_days = hi_reg - lo_reg;
+
+  // Account for non leap years
+  uint16_t lo_century = (base_year - 0) / 100;
+  uint16_t hi_century = (current_year - 1) / 100;
+  leap_days -= hi_century - lo_century;
+
+  // Account for quad century leap years
+  uint16_t lo_quad = (base_year - 0) / 400;
+  uint16_t hi_quad = (current_year - 1) / 400;
+  leap_days += hi_quad - lo_quad;
+
+  return (leap_days);
+}
+
+/*******************************************************************************
+ * Checks if the time stamp, format and time zone are
+ *  within the supported range.
+ *
+ * @param time Time stamp to check.
+ * @param format Format of the time.
+ * @param time_zone Time zone offset in second.
+ *
+ * @return true if the time is valid. False otherwise.
+ ******************************************************************************/
+static bool is_valid_time(sl_sleeptimer_timestamp_t time,
+                          sl_sleeptimer_time_format_t format,
+                          sl_sleeptimer_time_zone_offset_t time_zone)
+{
+  bool valid_time = false;
+
+  // Check for overflow.
+  if ((time_zone < 0 && time > (uint32_t)abs(time_zone)) \
+      || (time_zone >= 0 && (time <= UINT32_MAX - time_zone))) {
+    valid_time = true;
+  }
+  if (format == TIME_FORMAT_UNIX) {
+    if (time > TIME_UNIX_TIMESTAMP_MAX) { // Check if Unix time stamp is an unsigned 31 bits.
+      valid_time = false;
+    }
+  } else {
+    if ((format == TIME_FORMAT_NTP) && (time >= TIME_NTP_EPOCH_OFFSET_SEC)) {
+      valid_time &= true;
+    } else if ((format == TIME_FORMAT_ZIGBEE_CLUSTER) && (time <= TIME_UNIX_TIMESTAMP_MAX - TIME_ZIGBEE_EPOCH_OFFSET_SEC)) {
+      valid_time &= true;
+    } else {
+      valid_time = false;
+    }
+  }
+  return valid_time;
+}
+
+/*******************************************************************************
+ * Checks if the time stamp, format and time zone are
+ *  within the supported range.
+ *
+ * @param time Time stamp to check.
+ * @param format Format of the time.
+ * @param time_zone Time zone offset in second.
+ *
+ * @return true if the time is valid. False otherwise.
+ ******************************************************************************/
+static bool is_valid_time_64(sl_sleeptimer_timestamp_64_t time,
+                             sl_sleeptimer_time_format_t format,
+                             sl_sleeptimer_time_zone_offset_t time_zone)
+{
+  bool valid_time = false;
+
+  // Check for overflow.
+  if ((time_zone < 0 && time > (uint64_t)abs(time_zone))
+      || (time_zone >= 0 && (time <= UINT64_MAX - time_zone))) {
+    valid_time = true;
+  }
+  if (format == TIME_FORMAT_UNIX_64_BIT) {
+    if (time > TIME_64_BIT_UNIX_TIMESTAMP_MAX) { // Check if time stamp is an unsigned 64 bits.
+      valid_time = false;
+    }
+  }
+  return valid_time;
+}
+
+/*******************************************************************************
+ * Checks if the date is valid.
+ *
+ * @param date Date to check.
+ *
+ * @return true if the date is valid. False otherwise.
+ ******************************************************************************/
+static bool is_valid_date(sl_sleeptimer_date_t *date)
+{
+  if ((date == NULL)
+      || (date->year > TIME_UNIX_YEAR_MAX)
+      || (date->month > MONTH_DECEMBER)
+      || (date->month_day == 0 || date->month_day > days_in_month[is_leap_year(date->year)][date->month])
+      || (date->hour > 23)
+      || (date->min > 59)
+      || (date->sec > 59)) {
+    return false;
+  }
+
+  // Unix is valid until the 19th of January 2038 at 03:14:07
+  if (date->year == TIME_UNIX_YEAR_MAX) {
+    if ((uint8_t)date->month > (uint8_t)MONTH_JANUARY) {
+      return false;
+    } else if (date->month_day > 19) {
+      return false;
+    } else if (date->hour > 3) {
+      return false;
+    } else if (date->min > 14) {
+      return false;
+    } else if (date->sec > 7) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*******************************************************************************
+ * Checks if the date is valid.
+ *
+ * @param date Date to check.
+ *
+ * @return true if the date is valid. False otherwise.
+ ******************************************************************************/
+static bool is_valid_date_64(sl_sleeptimer_date_t *date)
+{
+  if ((date == NULL)
+      || (date->year > TIME_64_BIT_YEAR_MAX)
+      || (date->month > MONTH_DECEMBER)
+      || (date->month_day == 0 || date->month_day > days_in_month[is_leap_year(date->year)][date->month])
+      || (date->hour > 23)
+      || (date->min > 59)
+      || (date->sec > 59)) {
+    return false;
+  }
+  return true;
+}
+#endif
+
+/*******************************************************************************
+ * @brief
+ *   Gets the precision (in PPM) of the sleeptimer's clock.
+ *
+ * @return
+ *   Clock accuracy, in PPM.
+ *
+ ******************************************************************************/
+uint16_t sl_sleeptimer_get_clock_accuracy(void)
+{
+  return sleeptimer_hal_get_clock_accuracy();
+}
+
+/***************************************************************************//**
+ * @brief
+ *   Update sleep_on_isr_exit flag.
+ *
+ * @param flag Value update_sleep_on_isr_exit will be set to.
+ ******************************************************************************/
+void sli_sleeptimer_update_sleep_on_isr_exit(bool flag)
+{
+  sleep_on_isr_exit = flag;
+}
+
+/*******************************************************************************
+ * Gets the associated peripheral capture channel current value.
+ ******************************************************************************/
+uint32_t sli_sleeptimer_get_capture(void)
+{
+  return sleeptimer_hal_get_capture();
+}
+
+/*******************************************************************************
+ * Resets the PRS signal triggered by the associated peripheral.
+ ******************************************************************************/
+void sli_sleeptimer_reset_prs_signal(void)
+{
+  sleeptimer_hal_reset_prs_signal();
+}

--- a/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c
+++ b/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_burtc.c
@@ -1,0 +1,325 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER Hardware abstraction implementation for BURTC.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "em_device.h"
+#if defined(_SILICON_LABS_32B_SERIES_2)
+
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "em_burtc.h"
+#include "em_core.h"
+#include "em_cmu.h"
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#include "sl_power_manager.h"
+#endif
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_BURTC
+
+#if defined(_SILICON_LABS_32B_SERIES_0)
+#error BURTC implementation of the sleeptimer not available on Series 0 chips
+#endif
+
+// Minimum difference between current count value and what the comparator of the timer can be set to.
+// 1 tick is added to the minimum diff for the algorithm of compensation for the IRQ handler that
+// triggers when CNT == compare_value + 1. For more details refer to sleeptimer_hal_set_compare() function's header.
+#if defined(_SILICON_LABS_32B_SERIES_2_CONFIG_8)
+#define SLEEPTIMER_COMPARE_MIN_DIFF  (5 + 1)
+#else
+#define SLEEPTIMER_COMPARE_MIN_DIFF  (4 + 1)
+#endif
+
+#define SLEEPTIMER_TMR_WIDTH (_BURTC_CNT_MASK)
+
+static uint32_t get_time_diff(uint32_t a, uint32_t b);
+
+/******************************************************************************
+ * Convert HAL interrupt flag BURTC-interrupt-enable bitmask
+ *****************************************************************************/
+static uint32_t irqien_hal2burtc(uint8_t hal_flag)
+{
+  uint32_t burtc_if = 0u;
+
+  if (hal_flag & SLEEPTIMER_EVENT_OF) {
+    burtc_if |= BURTC_IEN_OF;
+  }
+
+  if (hal_flag & SLEEPTIMER_EVENT_COMP) {
+    burtc_if |= BURTC_IEN_COMP;
+  }
+
+  return burtc_if;
+}
+
+/******************************************************************************
+ * Convert BURTC interrupt flags to HAL events
+ *****************************************************************************/
+static uint8_t irqflags_burtc2hal(uint32_t burtc_flag)
+{
+  uint8_t hal_if = 0u;
+
+  if (burtc_flag & BURTC_IF_OF) {
+    hal_if |= SLEEPTIMER_EVENT_OF;
+  }
+
+  if (burtc_flag & BURTC_IF_COMP) {
+    hal_if |= SLEEPTIMER_EVENT_COMP;
+  }
+
+  return hal_if;
+}
+
+/******************************************************************************
+ * Initializes BURTC sleep timer.
+ *****************************************************************************/
+void sleeptimer_hal_init_timer()
+{
+  BURTC_Init_TypeDef burtc_init = BURTC_INIT_DEFAULT;
+
+  CMU_ClockEnable(cmuClock_BURTC, true);
+
+  burtc_init.start  = false;
+  burtc_init.clkDiv = SL_SLEEPTIMER_FREQ_DIVIDER;
+#if (SL_SLEEPTIMER_DEBUGRUN == 1)
+  burtc_init.debugRun = true;
+#endif
+
+  BURTC_Init(&burtc_init);
+  BURTC_IntDisable(_BURTC_IEN_MASK);
+  BURTC_IntClear(_BURTC_IF_MASK);
+  BURTC_CounterReset();
+
+  BURTC_Start();
+  BURTC_SyncWait();
+
+  // Setup BURTC interrupt
+  NVIC_ClearPendingIRQ(BURTC_IRQn);
+  NVIC_EnableIRQ(BURTC_IRQn);
+}
+
+/******************************************************************************
+ * Gets BURTC counter.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void)
+{
+  return BURTC_CounterGet();
+}
+
+/******************************************************************************
+ * Gets BURTC compare value
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void)
+{
+  return BURTC_CompareGet(0U);
+}
+
+/******************************************************************************
+ * Sets BURTC compare value
+ *
+ * @note Compare match value is set to the requested value - 1. This is done
+ * to compensate for the fact that the BURTC compare match interrupt always
+ * triggers at the end of the requested ticks and that the IRQ handler is
+ * executed when current tick count == compare_value + 1.
+ *****************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint32_t counter;
+  uint32_t compare_current;
+  uint32_t compare_new = value;
+
+  CORE_ENTER_CRITICAL();
+  counter = sleeptimer_hal_get_counter();
+  compare_current = sleeptimer_hal_get_compare();
+
+  if (((BURTC_IntGet() & _BURTC_IF_COMP_MASK) != 0)
+      || get_time_diff(compare_current, counter) > SLEEPTIMER_COMPARE_MIN_DIFF
+      || compare_current == counter) {
+    // Add margin if necessary
+    if (get_time_diff(compare_new, counter) < SLEEPTIMER_COMPARE_MIN_DIFF) {
+      compare_new = counter + SLEEPTIMER_COMPARE_MIN_DIFF;
+    }
+
+    // wrap around if necessary
+    compare_new %= SLEEPTIMER_TMR_WIDTH;
+
+    BURTC_CompareSet(0U, compare_new - 1);
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+  }
+  CORE_EXIT_CRITICAL();
+}
+
+/******************************************************************************
+ * Enables BURTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag)
+{
+  BURTC_IntEnable(irqien_hal2burtc(local_flag));
+}
+
+/******************************************************************************
+ * Disables BURTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag)
+{
+  BURTC_IntDisable(irqien_hal2burtc(local_flag));
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to set timer interrupts.
+ ******************************************************************************/
+void sleeptimer_hal_set_int(uint8_t local_flag)
+{
+  BURTC_IntSet(irqien_hal2burtc(local_flag));
+}
+
+/******************************************************************************
+ * Gets status of specified interrupt.
+ *
+ * Note: This function must be called with interrupts disabled.
+ *****************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag)
+{
+  bool int_is_set = false;
+  uint32_t irq_flag = BURTC_IntGet();
+
+  switch (local_flag) {
+    case SLEEPTIMER_EVENT_COMP:
+      int_is_set = (irq_flag & BURTC_IF_COMP);
+      break;
+
+    case SLEEPTIMER_EVENT_OF:
+      int_is_set = (irq_flag & BURTC_IF_OF);
+      break;
+
+    default:
+      break;
+  }
+
+  return int_is_set;
+}
+
+/*******************************************************************************
+ * Gets BURTC timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void)
+{
+  return (CMU_ClockFreqGet(cmuClock_BURTC) >> (CMU_PrescToLog2(SL_SLEEPTIMER_FREQ_DIVIDER - 1)));
+}
+
+/*******************************************************************************
+ * BURTC interrupt handler.
+ ******************************************************************************/
+void BURTC_IRQHandler(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint8_t local_flag = 0;
+  uint32_t irq_flag;
+
+  CORE_ENTER_ATOMIC();
+  irq_flag = BURTC_IntGet();
+  local_flag = irqflags_burtc2hal(irq_flag);
+
+  BURTC_IntClear(irq_flag & (BURTC_IF_OF | BURTC_IF_COMP));
+
+  process_timer_irq(local_flag);
+
+  CORE_EXIT_ATOMIC();
+}
+
+/*******************************************************************************
+ * Computes difference between two times taking into account timer wrap-around.
+ *
+ * @param a Time.
+ * @param b Time to substract from a.
+ *
+ * @return Time difference.
+ ******************************************************************************/
+static uint32_t get_time_diff(uint32_t a, uint32_t b)
+{
+  return (a - b);
+}
+
+/*******************************************************************************
+ * @brief
+ *   Gets the precision (in PPM) of the sleeptimer's clock.
+ *
+ * @return
+ *   Clock accuracy, in PPM.
+ *
+ ******************************************************************************/
+uint16_t sleeptimer_hal_get_clock_accuracy(void)
+{
+  return CMU_LF_ClockPrecisionGet(cmuClock_BURTC);
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the capture channel value.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_capture(void)
+{
+  // Invalid for BURTC peripheral
+  EFM_ASSERT(0);
+  return 0;
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to reset PRS signal triggered by the associated
+ * peripheral.
+ ******************************************************************************/
+void sleeptimer_hal_reset_prs_signal(void)
+{
+  // Invalid for BURTC peripheral
+  EFM_ASSERT(0);
+}
+
+/***************************************************************************//**
+ * Set lowest energy mode based on a project's configurations and clock source
+ *
+ * @note If power_manager_no_deepsleep component is included in a project, the
+ *       lowest possible energy mode is EM1, else lowest energy mode is
+ *       determined by clock source.
+ ******************************************************************************/
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+void sli_sleeptimer_set_pm_em_requirement(void)
+{
+  switch (CMU->EM4GRPACLKCTRL & _CMU_EM4GRPACLKCTRL_CLKSEL_MASK) {
+    case CMU_EM4GRPACLKCTRL_CLKSEL_LFRCO:
+    case CMU_EM4GRPACLKCTRL_CLKSEL_LFXO:
+      sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM2);
+      break;
+    default:
+      break;
+  }
+}
+#endif
+#endif
+
+#endif

--- a/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c
+++ b/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_prortc.c
@@ -1,0 +1,534 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER hardware abstraction implementation for PRORTC.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "em_core.h"
+#include "em_cmu.h"
+#include "em_bus.h"
+
+#if defined(SL_COMPONENT_CATALOG_PRESENT)
+#include  <sl_component_catalog.h>
+#endif
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#include "sl_power_manager.h"
+#endif
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT) && defined(_SILICON_LABS_32B_SERIES_2_CONFIG) \
+  && (_SILICON_LABS_32B_SERIES_2_CONFIG == 1)
+#include "sli_power_manager.h"
+#endif
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_PRORTC
+
+// Minimum difference between current count value and what the comparator of the timer can be set to.
+// 1 tick is added to the minimum diff for the algorithm of compensation for the IRQ handler that
+// triggers when CNT == compare_value + 1. For more details refer to sleeptimer_hal_set_compare() function's header.
+#define SLEEPTIMER_COMPARE_MIN_DIFF  (2 + 1)
+#define PRORTC_CNT_MASK              0xFFFFFFFFUL
+
+#define SLEEPTIMER_TMR_WIDTH (PRORTC_CNT_MASK)
+
+#define TIMER_COMP_REQ                   0U
+
+#define _PRORTC_IF_COMP_SHIFT              1                             /**< Shift value for RTC_COMP */
+#define PRORTC_IF_OF                      (0x1UL << 0)                   /**< Overflow Interrupt Flag */
+
+#if (TIMER_COMP_REQ == 0)
+#define PRORTC_IF_COMP_BIT RTCC_IF_CC0
+#elif  (TIMER_COMP_REQ == 1)
+#define PRORTC_IF_COMP_BIT RTCC_IF_CC1
+#endif
+
+#ifndef SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER
+#define SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER 0
+#endif
+
+#if SL_SLEEPTIMER_FREQ_DIVIDER != 1
+#warning A value other than 1 for SL_SLEEPTIMER_FREQ_DIVIDER is not supported on Radio Internal RTC (PRORTC)
+#endif
+
+static uint32_t get_time_diff(uint32_t a, uint32_t b);
+
+static bool cc_disabled = true;
+
+/******************************************************************************
+ * Initializes PRORTC sleep timer.
+ *****************************************************************************/
+void sleeptimer_hal_init_timer(void)
+{
+#if defined(_SILICON_LABS_32B_SERIES_1)
+  uint32_t cmu_status = CMU->STATUS;
+  uint32_t lfr_clk_sel = CMU_LFRCLKSEL_LFR_DEFAULT;
+
+  if ((cmu_status & _CMU_STATUS_LFXORDY_MASK) == CMU_STATUS_LFXORDY) {
+    lfr_clk_sel = CMU_LFRCLKSEL_LFR_LFXO;
+#ifdef PLFRCO_PRESENT
+  } else if ((cmu_status & _CMU_STATUS_PLFRCORDY_MASK) == CMU_STATUS_PLFRCORDY) {
+    lfr_clk_sel = CMU_LFRCLKSEL_LFR_PLFRCO;
+#endif
+  } else {
+    lfr_clk_sel = CMU_LFRCLKSEL_LFR_LFRCO;
+  }
+
+  // Set the Low Frequency R Clock Select Register
+  CMU->LFRCLKSEL = (CMU->LFRCLKSEL & ~_CMU_LFRCLKSEL_LFR_MASK)
+                   | (lfr_clk_sel << _CMU_LFRCLKSEL_LFR_SHIFT);
+
+  // Enable the PRORTC module
+  CMU->LFRCLKEN0 |= 1 << _CMU_LFRCLKEN0_PRORTC_SHIFT;
+
+  PRORTC->IFC = _PRORTC_IF_MASK;
+
+#if (SL_SLEEPTIMER_DEBUGRUN == 1)
+  PRORTC->CTRL = _PRORTC_CTRL_EN_MASK | _PRORTC_CTRL_DEBUGRUN_MASK;
+#else
+  PRORTC->CTRL = _PRORTC_CTRL_EN_MASK;
+#endif
+#else
+  bool use_clk_lfxo  = true;
+
+  // Must enable radio clock branch to clock the radio bus as PRORTC is on this bus.
+  CMU->RADIOCLKCTRL = CMU_RADIOCLKCTRL_EN;
+
+#if defined(CMU_CLKEN1_PRORTC)
+  CMU->CLKEN1_SET = CMU_CLKEN1_PRORTC;
+#endif
+
+#if _SILICON_LABS_32B_SERIES_2_CONFIG > 1
+  uint32_t enabled_clocks = CMU->CLKEN0;
+  use_clk_lfxo = ((enabled_clocks & _CMU_CLKEN0_LFXO_MASK) == _CMU_CLKEN0_LFXO_MASK);
+#endif //_SILICON_LABS_32B_SERIES_2_CONFIG == 2
+
+  // On demand clocking for series 2 chips, make sure that the clock is
+  // not force disabled i.e. FORCEEN = 0, DISONDEMAND = 1
+  // Cannot rely on ENS bit of STATUS register since that is only set
+  // when a module uses the LF clock otherwise the ENS bit will be set to 0.
+  use_clk_lfxo = use_clk_lfxo
+                 && ((LFXO->CTRL
+                      & (_LFXO_CTRL_FORCEEN_MASK | _LFXO_CTRL_DISONDEMAND_MASK))
+                     != _LFXO_CTRL_DISONDEMAND_MASK);
+
+  if (use_clk_lfxo) {
+    CMU->PRORTCCLKCTRL = CMU_PRORTCCLKCTRL_CLKSEL_LFXO;
+  } else {
+    CMU->PRORTCCLKCTRL = CMU_PRORTCCLKCTRL_CLKSEL_LFRCO;
+  }
+
+#if (SL_SLEEPTIMER_DEBUGRUN == 1)
+  PRORTC->CFG |= _RTCC_CFG_DEBUGRUN_MASK;
+#endif
+
+  PRORTC->EN_SET = RTCC_EN_EN;
+
+  PRORTC->CC[TIMER_COMP_REQ].CTRL = (_RTCC_CC_CTRL_MODE_OFF << _RTCC_CC_CTRL_MODE_SHIFT)
+                                    | (_RTCC_CC_CTRL_CMOA_PULSE << _RTCC_CC_CTRL_CMOA_SHIFT)
+                                    | (_RTCC_CC_CTRL_ICEDGE_NONE << _RTCC_CC_CTRL_ICEDGE_SHIFT)
+                                    | (_RTCC_CC_CTRL_COMPBASE_CNT << _RTCC_CC_CTRL_COMPBASE_SHIFT);
+
+  // Write the start bit until it syncs to the low frequency domain
+  do {
+    PRORTC->CMD = RTCC_CMD_START;
+    while ((PRORTC->SYNCBUSY & _RTCC_SYNCBUSY_MASK) != 0U) ;
+  } while ((PRORTC->STATUS & _RTCC_STATUS_RUNNING_MASK) != RTCC_STATUS_RUNNING);
+
+#if defined (RTCC_HAS_SET_CLEAR)
+  // Disable ALL PRORTC interrupts
+  PRORTC->IEN_CLR = _RTCC_IEN_MASK;
+  // Clear any pending interrupts
+  PRORTC->IF_CLR = _RTCC_IF_MASK;
+#else
+  PRORTC->IEN &= ~_RTCC_IEN_MASK;
+  PRORTC->IFC = _RTCC_IF_MASK;
+#endif
+#endif
+
+  NVIC_ClearPendingIRQ(PRORTC_IRQn);
+  NVIC_EnableIRQ(PRORTC_IRQn);
+}
+
+/******************************************************************************
+ * Gets PRORTC counter value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void)
+{
+  return PRORTC->CNT;
+}
+
+/******************************************************************************
+ * Gets PRORTC compare value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void)
+{
+#if defined(_SILICON_LABS_32B_SERIES_1)
+  return PRORTC->COMP[TIMER_COMP_REQ].COMP;
+#else
+  return PRORTC->CC[TIMER_COMP_REQ].OCVALUE;
+#endif
+}
+
+/******************************************************************************
+ * Sets PRORTC compare value.
+ *
+ * @note Compare match value is set to the requested value - 1. This is done
+ * to compensate for the fact that the PRORTC compare match interrupt always
+ * triggers at the end of the requested ticks and that the IRQ handler is
+ * executed when current tick count == compare_value + 1.
+ *****************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint32_t counter;
+  uint32_t compare;
+  uint32_t compare_value = value;
+
+  CORE_ENTER_CRITICAL();
+  counter = sleeptimer_hal_get_counter();
+  compare = sleeptimer_hal_get_compare();
+
+  if (((PRORTC->IF & PRORTC_IF_COMP_BIT) != 0)
+      || get_time_diff(compare, counter) > SLEEPTIMER_COMPARE_MIN_DIFF
+      || compare == counter) {
+    // Add margin if necessary
+    if (get_time_diff(compare_value, counter) < SLEEPTIMER_COMPARE_MIN_DIFF) {
+      compare_value = counter + SLEEPTIMER_COMPARE_MIN_DIFF;
+    }
+    compare_value %= SLEEPTIMER_TMR_WIDTH;
+
+#if defined(_SILICON_LABS_32B_SERIES_1)
+    PRORTC->COMP[TIMER_COMP_REQ].COMP = compare_value - 1;
+#else
+    PRORTC->CC[TIMER_COMP_REQ].OCVALUE = compare_value - 1;
+#endif
+
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+  }
+  CORE_EXIT_CRITICAL();
+
+#if defined(_SILICON_LABS_32B_SERIES_2)
+  if (cc_disabled) {
+    PRORTC->CC[TIMER_COMP_REQ].CTRL |= RTCC_CC_CTRL_MODE_OUTPUTCOMPARE;
+    cc_disabled = false;
+  }
+#endif
+}
+
+/******************************************************************************
+ * Enables PRORTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag)
+{
+  uint32_t prortc_ien = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    prortc_ien |= PRORTC_IF_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+#if defined(_SILICON_LABS_32B_SERIES_1)
+    if (cc_disabled == true) {
+#if defined (RTCC_HAS_SET_CLEAR)
+      PRORTC->IF_CLR = PRORTC_IF_COMP_BIT;
+#else
+      PRORTC->IFC = PRORTC_IF_COMP_BIT;
+#endif
+
+      cc_disabled = false;
+    }
+#endif
+
+    prortc_ien |= PRORTC_IF_COMP_BIT;
+  }
+
+  BUS_RegMaskedSet(&PRORTC->IEN, prortc_ien);
+}
+
+/******************************************************************************
+ * Disables PRORTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag)
+{
+  uint32_t prortc_int_dis = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    prortc_int_dis |= PRORTC_IF_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    prortc_int_dis |= PRORTC_IF_COMP_BIT;
+    cc_disabled = true;
+
+#if defined(_SILICON_LABS_32B_SERIES_2)
+    PRORTC->CC[TIMER_COMP_REQ].CTRL &= ~_RTCC_CC_CTRL_MODE_MASK;
+#endif
+  }
+
+  BUS_RegMaskedClear(&PRORTC->IEN, prortc_int_dis);
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to set timer interrupts.
+ ******************************************************************************/
+void sleeptimer_hal_set_int(uint8_t local_flag)
+{
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+#if defined (RTCC_HAS_SET_CLEAR)
+    PRORTC->IF_SET = PRORTC_IF_COMP_BIT;
+#else
+    PRORTC->IFS = PRORTC_IF_COMP_BIT;
+#endif
+  }
+}
+
+/******************************************************************************
+ * Gets status of specified interrupt.
+ *
+ * Note: This function must be called with interrupts disabled.
+ *****************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag)
+{
+  bool int_is_set = false;
+  uint32_t irq_flag = PRORTC->IF;;
+
+  switch (local_flag) {
+    case SLEEPTIMER_EVENT_COMP:
+      int_is_set = ((irq_flag & PRORTC_IF_COMP_BIT) == PRORTC_IF_COMP_BIT);
+      break;
+
+    case SLEEPTIMER_EVENT_OF:
+      int_is_set = ((irq_flag & PRORTC_IF_OF) == PRORTC_IF_OF);
+      break;
+
+    default:
+      break;
+  }
+
+  return int_is_set;
+}
+
+/*******************************************************************************
+ * PRORTC interrupt handler.
+ ******************************************************************************/
+#if (SL_SLEEPTIMER_PRORTC_HAL_OWNS_IRQ_HANDLER == 1)
+void PRORTC_IRQHandler(void)
+#else
+void PRORTC_IRQHandlerOverride(void)
+#endif
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint8_t local_flag = 0;
+  uint32_t irq_flag;
+
+  CORE_ENTER_ATOMIC();
+  irq_flag = PRORTC->IF;
+
+  if (irq_flag & PRORTC_IF_OF) {
+    local_flag |= SLEEPTIMER_EVENT_OF;
+  }
+  if (irq_flag & PRORTC_IF_COMP_BIT) {
+    local_flag |= SLEEPTIMER_EVENT_COMP;
+  }
+
+  /* Clear interrupt source. */
+#if defined (RTCC_HAS_SET_CLEAR)
+  PRORTC->IF_CLR = irq_flag;
+#else
+  PRORTC->IFC = irq_flag;
+#endif
+
+  process_timer_irq(local_flag);
+  CORE_EXIT_ATOMIC();
+}
+
+/*******************************************************************************
+ * Gets PRORTC timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void)
+{
+#if defined(_SILICON_LABS_32B_SERIES_1)
+  uint32_t lfr_clk_sel;
+#endif
+  uint32_t freq;
+
+#if defined(_SILICON_LABS_32B_SERIES_1)
+  lfr_clk_sel = (CMU->LFRCLKSEL & _CMU_LFRCLKSEL_LFR_MASK) << _CMU_LFRCLKSEL_LFR_SHIFT;
+
+  switch (lfr_clk_sel) {
+    case _CMU_LFRCLKSEL_LFR_LFXO:
+      freq = SystemLFXOClockGet();
+      break;
+
+#if defined(PLFRCO_PRESENT)
+    case _CMU_LFRCLKSEL_LFR_PLFRCO:
+      freq = SystemLFRCOClockGet();
+      break;
+#endif
+
+    case _CMU_LFRCLKSEL_LFR_LFRCO:
+    default:
+      freq = SystemLFRCOClockGet();
+      break;
+  }
+
+  freq >>= (CMU->LFRPRESC0 & _CMU_LFRPRESC0_PRORTC_MASK)
+           >> _CMU_LFRPRESC0_PRORTC_SHIFT;
+#elif defined(_SILICON_LABS_32B_SERIES_2)
+  if (CMU->PRORTCCLKCTRL == CMU_PRORTCCLKCTRL_CLKSEL_LFXO) {
+    freq = SystemLFXOClockGet();
+  } else {
+    freq = SystemLFRCOClockGet();
+  }
+#endif
+
+  return freq;
+}
+
+/*******************************************************************************
+ * Computes difference between two times taking into account timer wrap-around.
+ *
+ * @param a Time.
+ * @param b Time to substract from a.
+ *
+ * @return Time difference.
+ ******************************************************************************/
+static uint32_t get_time_diff(uint32_t a, uint32_t b)
+{
+  return (a - b);
+}
+
+/*******************************************************************************
+ * @brief
+ *   Gets the precision (in PPM) of the sleeptimer's clock.
+ *
+ * @return
+ *   Clock accuracy, in PPM.
+ *
+ * @note
+ *  The CMU_LF_ClockPrecisionGet function usally used to retrieve
+ *  the clock accuracy can't be used for PRORTC as it isn't public,
+ *  so this function works in the same way.
+ ******************************************************************************/
+uint16_t sleeptimer_hal_get_clock_accuracy(void)
+{
+  uint16_t precision = 0xFFFF;
+
+#if defined(_SILICON_LABS_32B_SERIES_2)
+  if (CMU->PRORTCCLKCTRL == CMU_PRORTCCLKCTRL_CLKSEL_LFXO) {
+    precision = CMU_LFXOPrecisionGet();
+
+#if defined(LFRCO_CFG_HIGHPRECEN) && defined(PLFRCO_PRESENT)
+  } else {
+    CMU->CLKEN0_SET = CMU_CLKEN0_LFRCO;
+
+    if (LFRCO->CFG & _LFRCO_CFG_HIGHPRECEN_MASK) {
+      precision = 500;
+    } else {
+      precision = 0xFFFF;
+    }
+#endif
+  }
+
+#else
+  uint32_t lfr_clk_sel = (CMU->LFRCLKSEL & _CMU_LFRCLKSEL_LFR_MASK) << _CMU_LFRCLKSEL_LFR_SHIFT;
+
+  switch (lfr_clk_sel) {
+    case _CMU_LFRCLKSEL_LFR_LFXO:
+      precision = CMU_LFXOPrecisionGet();
+      break;
+
+#if defined(_SILICON_LABS_32B_SERIES_1) && defined(PLFRCO_PRESENT)
+    case _CMU_LFRCLKSEL_LFR_PLFRCO:
+      precision = 500;
+      break;
+#endif
+
+    default:
+      precision = 0xFFFF;
+      break;
+  }
+
+#endif
+
+  return precision;
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the capture channel value.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_capture(void)
+{
+  // Invalid for PRORTC peripheral
+  EFM_ASSERT(0);
+  return 0;
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to reset PRS signal triggered by the associated
+ * peripheral.
+ ******************************************************************************/
+void sleeptimer_hal_reset_prs_signal(void)
+{
+  // Invalid for PRORTC peripheral
+  EFM_ASSERT(0);
+}
+
+/***************************************************************************//**
+ * Set lowest energy mode based on a project's configurations and clock source
+ *
+ * @note If power_manager_no_deepsleep component is included in a project, the
+ *       lowest possible energy mode is EM1, else lowest energy mode is
+ *       determined by clock source.
+ ******************************************************************************/
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+void sli_sleeptimer_set_pm_em_requirement(void)
+{
+#if defined(_SILICON_LABS_32B_SERIES_1)
+  switch (CMU->LFRCLKSEL & _CMU_LFRCLKSEL_LFR_MASK) {
+    case CMU_LFRCLKSEL_LFR_LFRCO:
+    case CMU_LFRCLKSEL_LFR_LFXO:
+      sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM2);
+      break;
+    default:
+      break;
+  }
+#else
+  switch (CMU->PRORTCCLKCTRL & _CMU_PRORTCCLKCTRL_CLKSEL_MASK) {
+    case CMU_PRORTCCLKCTRL_CLKSEL_LFRCO:
+    case CMU_PRORTCCLKCTRL_CLKSEL_LFXO:
+      sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM2);
+      break;
+    default:
+      break;
+  }
+#endif
+}
+#endif
+#endif

--- a/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtc.c
+++ b/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtc.c
@@ -1,0 +1,359 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER Hardware abstraction implementation for RTC.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "em_rtc.h"
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "em_core.h"
+#include "em_cmu.h"
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#include "sl_power_manager.h"
+#endif
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_RTC
+
+// Use RTC compare channel B.
+#define SLEEPTIMER_RTC_COMP_SHIFT (2u)
+#define SLEEPTIMER_RTC_COMP       (1 << SLEEPTIMER_RTC_COMP_SHIFT)
+
+// Minimum difference between current count value and what the comparator of the timer can be set to.
+// Almost always current count + 1. However, the RTC on legacy gecko (EFM32G) requires the comparator to be set to at least current cnt + 4.
+// 1 tick is added to the minimum diff for the algorithm of compensation for the IRQ handler that
+// triggers when CNT == compare_value + 1. For more details refer to sleeptimer_hal_set_compare() function's header.
+#ifdef _EFM32_GECKO_FAMILY
+#define SLEEPTIMER_COMPARE_MIN_DIFF  (5 + 1)
+#else
+#define SLEEPTIMER_COMPARE_MIN_DIFF  (2 + 1)
+#endif
+
+#define SLEEPTIMER_TMR_WIDTH (_RTC_CNT_MASK)
+#define SLEEPTIMER_TMR_BIT_WIDTH 24u
+
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b);
+
+static volatile uint8_t rtc_overflow_count = 0;
+static volatile uint32_t compare_value_32 = 0;
+static bool comp_int_disabled = true;
+
+/******************************************************************************
+ * Initializes RTC sleep timer.
+ *****************************************************************************/
+void sleeptimer_hal_init_timer()
+{
+  RTC_Init_TypeDef rtc_init = RTC_INIT_DEFAULT;
+
+  CMU_ClockDivSet(cmuClock_RTC, SL_SLEEPTIMER_FREQ_DIVIDER);
+  CMU_ClockEnable(cmuClock_RTC, true);
+
+  // Initialize RTC.
+  rtc_init.comp0Top = false;
+  rtc_init.enable = true;
+#if (SL_SLEEPTIMER_DEBUGRUN == 1)
+  rtc_init.debugRun = true;
+#endif
+
+  RTC_Init(&rtc_init);
+  RTC_IntDisable(_RTC_IEN_MASK);
+  RTC_IntClear(_RTC_IFC_MASK);
+#if !defined(_EFM32_GECKO_FAMILY)
+  RTC_CounterSet(0u);
+#endif
+
+  // Setup RTC interrupt
+  NVIC_ClearPendingIRQ(RTC_IRQn);
+  NVIC_EnableIRQ(RTC_IRQn);
+}
+
+/******************************************************************************
+ * Gets RTC counter.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void)
+{
+  uint32_t tick_cnt;
+  uint16_t of_cnt;
+
+  tick_cnt = RTC_CounterGet();
+  of_cnt = rtc_overflow_count;
+
+  if (RTC_IntGet() & RTC_IF_OF) {
+    tick_cnt = RTC_CounterGet();
+    of_cnt++;
+  }
+
+  return tick_cnt | ((uint32_t)of_cnt << SLEEPTIMER_TMR_BIT_WIDTH);
+}
+
+/******************************************************************************
+ * Gets RTC compare value
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void)
+{
+  return compare_value_32;
+}
+
+/******************************************************************************
+ * Sets RTC compare value
+ *
+ * @note Compare match value is set to the requested value - 1. This is done
+ * to compensate for the fact that the RTC compare match interrupt always
+ * triggers at the end of the requested ticks and that the IRQ handler is
+ * executed when current tick count == compare_value + 1.
+ *****************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint32_t counter;
+  uint32_t compare_value = value;
+
+  CORE_ENTER_CRITICAL();
+  counter = sleeptimer_hal_get_counter();
+  if (((RTC_IntGet() & SLEEPTIMER_RTC_COMP) != 0)
+      || get_time_diff(compare_value_32, counter) > SLEEPTIMER_COMPARE_MIN_DIFF
+      || compare_value_32 == counter) {
+    // Add margin if necessary
+    if (get_time_diff(compare_value, counter) < SLEEPTIMER_COMPARE_MIN_DIFF) {
+      compare_value = counter + SLEEPTIMER_COMPARE_MIN_DIFF;
+    }
+
+    compare_value_32 = compare_value - 1;
+    if (compare_value_32 - counter <= SLEEPTIMER_TMR_WIDTH) {
+      RTC_CompareSet(1, compare_value_32 % (SLEEPTIMER_TMR_WIDTH + 1));
+      sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+    } else {
+      sleeptimer_hal_disable_int(SLEEPTIMER_EVENT_COMP);
+    }
+  }
+  CORE_EXIT_CRITICAL();
+}
+
+/******************************************************************************
+ * Enables RTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag)
+{
+  uint32_t rtc_ien = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    rtc_ien |= RTC_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    if (comp_int_disabled == true) {
+      RTC_IntClear(SLEEPTIMER_RTC_COMP);
+      comp_int_disabled = false;
+    }
+
+    rtc_ien |= SLEEPTIMER_RTC_COMP;
+  }
+
+  RTC_IntEnable(rtc_ien);
+}
+
+/******************************************************************************
+ * Disables RTC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag)
+{
+  uint32_t rtc_int_clr = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    rtc_int_clr |= RTC_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    rtc_int_clr |= SLEEPTIMER_RTC_COMP;
+    comp_int_disabled = true;
+  }
+
+  RTC_IntDisable(rtc_int_clr);
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to set timer interrupts.
+ ******************************************************************************/
+void sleeptimer_hal_set_int(uint8_t local_flag)
+{
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    RTC_IntSet(SLEEPTIMER_RTC_COMP);
+  }
+}
+
+/******************************************************************************
+ * Gets status of specified interrupt.
+ *
+ * Note: This function must be called with interrupts disabled.
+ *****************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag)
+{
+  bool int_is_set = false;
+  uint32_t irq_flag = RTC_IntGet();
+
+  switch (local_flag) {
+    case SLEEPTIMER_EVENT_COMP:
+      int_is_set = ((irq_flag & SLEEPTIMER_RTC_COMP) == SLEEPTIMER_RTC_COMP);
+      break;
+
+    case SLEEPTIMER_EVENT_OF:
+      int_is_set = ((irq_flag & RTC_IF_OF) == RTC_IF_OF)
+                   && (((rtc_overflow_count << SLEEPTIMER_TMR_BIT_WIDTH) + SLEEPTIMER_TMR_WIDTH) == UINT32_MAX);
+      break;
+
+    default:
+      break;
+  }
+
+  return int_is_set;
+}
+
+/*******************************************************************************
+ * Gets RTC timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void)
+{
+  return CMU_ClockFreqGet(cmuClock_RTC);
+}
+
+/*******************************************************************************
+ * RTC interrupt handler.
+ ******************************************************************************/
+void RTC_IRQHandler(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint8_t local_flag = 0;
+  uint32_t irq_flag;
+  uint32_t compare_value_24 = 0;
+
+  CORE_ENTER_ATOMIC();
+  irq_flag = RTC_IntGet();
+
+  if (irq_flag & RTC_IF_OF) {
+    if (((rtc_overflow_count << SLEEPTIMER_TMR_BIT_WIDTH) + SLEEPTIMER_TMR_WIDTH) == UINT32_MAX) {
+      local_flag |= SLEEPTIMER_EVENT_OF;
+    }
+    rtc_overflow_count++;
+    compare_value_24 = compare_value_32;
+    compare_value_24 -= (rtc_overflow_count << SLEEPTIMER_TMR_BIT_WIDTH);
+    if (compare_value_24 <= SLEEPTIMER_TMR_WIDTH) {
+      RTC_CompareSet(1, compare_value_24);
+      sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+    }
+  }
+  if (irq_flag & SLEEPTIMER_RTC_COMP) {
+    local_flag |= SLEEPTIMER_EVENT_COMP;
+  }
+  RTC_IntClear(irq_flag & (RTC_IFC_OF | SLEEPTIMER_RTC_COMP));
+
+  if (local_flag != 0) {
+    process_timer_irq(local_flag);
+  }
+  CORE_EXIT_ATOMIC();
+}
+
+/*******************************************************************************
+ * Computes difference between two times taking into account timer wrap-around.
+ *
+ * @param a Time.
+ * @param b Time to substract from a.
+ *
+ * @return Time difference.
+ ******************************************************************************/
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b)
+{
+  return (a - b);
+}
+
+/*******************************************************************************
+ * @brief
+ *   Gets the precision (in PPM) of the sleeptimer's clock.
+ *
+ * @return
+ *   Clock accuracy, in PPM.
+ *
+ ******************************************************************************/
+uint16_t sleeptimer_hal_get_clock_accuracy(void)
+{
+  return CMU_LF_ClockPrecisionGet(cmuClock_LFA);
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the capture channel value.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_capture(void)
+{
+  // Invalid for RTC peripheral
+  EFM_ASSERT(0);
+  return 0;
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to reset PRS signal triggered by the associated
+ * peripheral.
+ ******************************************************************************/
+void sleeptimer_hal_reset_prs_signal(void)
+{
+  // Invalid for RTC peripheral
+  EFM_ASSERT(0);
+}
+
+/***************************************************************************//**
+ * Set lowest energy mode based on a project's configurations and clock source
+ *
+ * @note If power_manager_no_deepsleep component is included in a project, the
+ *       lowest possible energy mode is EM1, else lowest energy mode is
+ *       determined by clock source.
+ ******************************************************************************/
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+void sli_sleeptimer_set_pm_em_requirement(void)
+{
+#if defined(_CMU_LFCLKSEL_MASK)
+  switch ((CMU->LFCLKSEL & _CMU_LFCLKSEL_LFA_MASK) >> _CMU_LFCLKSEL_LFA_SHIFT) {
+    case CMU_LFCLKSEL_LFA_LFRCO:
+    case CMU_LFCLKSEL_LFA_LFXO:
+      sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM2);
+      break;
+    default:
+      break;
+  }
+#else
+  switch ((CMU->LFACLKSEL & _CMU_LFACLKSEL_LFA_MASK) >> _CMU_LFACLKSEL_LFA_SHIFT) {
+    case CMU_LFACLKSEL_LFA_LFRCO:
+    case CMU_LFACLKSEL_LFA_LFXO:
+      sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM2);
+      break;
+    default:
+      break;
+  }
+#endif
+}
+#endif
+#endif

--- a/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c
+++ b/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c
@@ -1,0 +1,341 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER hardware abstraction implementation for RTCC.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "em_rtcc.h"
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "em_core.h"
+#include "em_cmu.h"
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#include "sl_power_manager.h"
+#endif
+
+#if SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_RTCC
+
+// Minimum difference between current count value and what the comparator of the timer can be set to.
+// 1 tick is added to the minimum diff for the algorithm of compensation for the IRQ handler that
+// triggers when CNT == compare_value + 1. For more details refer to sleeptimer_hal_set_compare() function's header.
+#define SLEEPTIMER_COMPARE_MIN_DIFF  (2 + 1)
+
+#define SLEEPTIMER_TMR_WIDTH (_RTCC_CNT_MASK)
+
+static bool cc_disabled = true;
+
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b);
+
+/******************************************************************************
+ * Initializes RTCC sleep timer.
+ *****************************************************************************/
+void sleeptimer_hal_init_timer(void)
+{
+  RTCC_Init_TypeDef rtcc_init   = RTCC_INIT_DEFAULT;
+  RTCC_CCChConf_TypeDef channel = RTCC_CH_INIT_COMPARE_DEFAULT;
+
+  CMU_ClockEnable(cmuClock_RTCC, true);
+
+  rtcc_init.enable = false;
+  rtcc_init.presc = (RTCC_CntPresc_TypeDef)(CMU_PrescToLog2(SL_SLEEPTIMER_FREQ_DIVIDER - 1));
+#if (SL_SLEEPTIMER_DEBUGRUN == 1)
+  rtcc_init.debugRun = true;
+#endif
+
+  RTCC_Init(&rtcc_init);
+
+  // Compare channel starts disabled and is enabled only when compare match interrupt is enabled.
+  channel.chMode = rtccCapComChModeOff;
+  RTCC_ChannelInit(1u, &channel);
+
+  RTCC_IntDisable(_RTCC_IEN_MASK);
+  RTCC_IntClear(_RTCC_IF_MASK);
+  RTCC_CounterSet(0u);
+
+  RTCC_Enable(true);
+
+  NVIC_ClearPendingIRQ(RTCC_IRQn);
+  NVIC_EnableIRQ(RTCC_IRQn);
+}
+
+/******************************************************************************
+ * Gets RTCC counter value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void)
+{
+  return RTCC_CounterGet();
+}
+
+/******************************************************************************
+ * Gets RTCC compare value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void)
+{
+  return RTCC_ChannelCCVGet(1u);
+}
+
+/******************************************************************************
+ * Sets RTCC compare value.
+ *
+ * @note Compare match value is set to the requested value - 1. This is done
+ * to compensate for the fact that the RTCC compare match interrupt always
+ * triggers at the end of the requested ticks and that the IRQ handler is
+ * executed when current tick count == compare_value + 1.
+ *****************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint32_t counter;
+  uint32_t compare;
+  uint32_t compare_value = value;
+
+  CORE_ENTER_CRITICAL();
+  counter = sleeptimer_hal_get_counter();
+  compare = sleeptimer_hal_get_compare();
+  if (((RTCC_IntGet() & RTCC_IEN_CC1) != 0)
+      || get_time_diff(compare, counter) > SLEEPTIMER_COMPARE_MIN_DIFF
+      || compare == counter) {
+    // Add margin if necessary
+    if (get_time_diff(compare_value, counter) < SLEEPTIMER_COMPARE_MIN_DIFF) {
+      compare_value = counter + SLEEPTIMER_COMPARE_MIN_DIFF;
+    }
+    compare_value %= SLEEPTIMER_TMR_WIDTH;
+
+    RTCC_ChannelCCVSet(1u, compare_value - 1u);
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+  }
+  CORE_EXIT_CRITICAL();
+
+  if (cc_disabled) {
+    RTCC->CC[1].CTRL |= RTCC_CC_CTRL_MODE_OUTPUTCOMPARE;
+    cc_disabled = false;
+  }
+}
+
+/******************************************************************************
+ * Enables RTCC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag)
+{
+  uint32_t rtcc_ien = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    rtcc_ien |= RTCC_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    rtcc_ien |= RTCC_IEN_CC1;
+  }
+
+  RTCC_IntEnable(rtcc_ien);
+}
+
+/******************************************************************************
+ * Disables RTCC interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag)
+{
+  uint32_t rtcc_int_dis = 0u;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    rtcc_int_dis |= RTCC_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    rtcc_int_dis |= RTCC_IEN_CC1;
+
+    cc_disabled = true;
+    RTCC->CC[1].CTRL &= ~_RTCC_CC_CTRL_MODE_MASK;
+  }
+
+  RTCC_IntDisable(rtcc_int_dis);
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to set timer interrupts.
+ ******************************************************************************/
+void sleeptimer_hal_set_int(uint8_t local_flag)
+{
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    RTCC_IntSet(RTCC_IF_CC1);
+  }
+}
+
+/******************************************************************************
+ * Gets status of specified interrupt.
+ *
+ * Note: This function must be called with interrupts disabled.
+ *****************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag)
+{
+  bool int_is_set = false;
+  uint32_t irq_flag = RTCC_IntGet();
+
+  switch (local_flag) {
+    case SLEEPTIMER_EVENT_COMP:
+      int_is_set = ((irq_flag & RTCC_IF_CC1) == RTCC_IF_CC1);
+      break;
+
+    case SLEEPTIMER_EVENT_OF:
+      int_is_set = ((irq_flag & RTCC_IF_OF) == RTCC_IF_OF);
+      break;
+
+    default:
+      break;
+  }
+
+  return int_is_set;
+}
+
+/*******************************************************************************
+ * RTCC interrupt handler.
+ ******************************************************************************/
+void RTCC_IRQHandler(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint8_t local_flag = 0;
+  uint32_t irq_flag;
+
+  CORE_ENTER_ATOMIC();
+  irq_flag = RTCC_IntGet();
+
+  if (irq_flag & RTCC_IF_OF) {
+    local_flag |= SLEEPTIMER_EVENT_OF;
+  }
+  if (irq_flag & RTCC_IF_CC1) {
+    local_flag |= SLEEPTIMER_EVENT_COMP;
+  }
+  RTCC_IntClear(irq_flag & (RTCC_IF_OF | RTCC_IF_CC1 | RTCC_IF_CC0));
+
+  process_timer_irq(local_flag);
+
+  CORE_EXIT_ATOMIC();
+}
+
+/*******************************************************************************
+ * Gets RTCC timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void)
+{
+  return (CMU_ClockFreqGet(cmuClock_RTCC) >> (CMU_PrescToLog2(SL_SLEEPTIMER_FREQ_DIVIDER - 1)));
+}
+
+/*******************************************************************************
+ * Computes difference between two times taking into account timer wrap-around.
+ *
+ * @param a Time.
+ * @param b Time to substract from a.
+ *
+ * @return Time difference.
+ ******************************************************************************/
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b)
+{
+  return (a - b);
+}
+
+/*******************************************************************************
+ * @brief
+ *   Gets the precision (in PPM) of the sleeptimer's clock.
+ *
+ * @return
+ *   Clock accuracy, in PPM.
+ *
+ ******************************************************************************/
+uint16_t sleeptimer_hal_get_clock_accuracy(void)
+{
+#if defined(_SILICON_LABS_32B_SERIES_2)
+  return CMU_LF_ClockPrecisionGet(cmuClock_RTCC);
+
+#else
+  return CMU_LF_ClockPrecisionGet(cmuClock_LFE);
+#endif
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the capture channel value.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_capture(void)
+{
+  // Invalid for RTCC peripheral
+  EFM_ASSERT(0);
+  return 0;
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to reset PRS signal triggered by the associated
+ * peripheral.
+ ******************************************************************************/
+void sleeptimer_hal_reset_prs_signal(void)
+{
+  // Invalid for RTCC peripheral
+  EFM_ASSERT(0);
+}
+
+/***************************************************************************//**
+ * Set lowest energy mode based on a project's configurations and clock source
+ *
+ * @note If power_manager_no_deepsleep component is included in a project, the
+ *       lowest possible energy mode is EM1, else lowest energy mode is
+ *       determined by clock source.
+ ******************************************************************************/
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+void sli_sleeptimer_set_pm_em_requirement(void)
+{
+#if defined(_CMU_RTCCCLKCTRL_CLKSEL_MASK)
+  switch (CMU->RTCCCLKCTRL & _CMU_RTCCCLKCTRL_CLKSEL_MASK) {
+    case CMU_RTCCCLKCTRL_CLKSEL_LFRCO:
+    case CMU_RTCCCLKCTRL_CLKSEL_LFXO:
+      sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM2);
+      break;
+    default:
+      break;
+  }
+#elif defined(_CMU_LFECLKEN0_RTCC_MASK)
+  switch ((CMU->LFECLKSEL & _CMU_LFECLKSEL_LFE_MASK) >> _CMU_LFECLKSEL_LFE_SHIFT) {
+    case CMU_LFECLKSEL_LFE_LFRCO:
+    case CMU_LFECLKSEL_LFE_LFXO:
+      sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM2);
+      break;
+    default:
+      break;
+  }
+#elif defined(_CMU_LFACLKEN0_RTCC_MASK)
+  switch ((CMU->LFACLKSEL & _CMU_LFACLKSEL_LFA_MASK) >> _CMU_LFACLKSEL_LFA_SHIFT) {
+    case CMU_LFACLKSEL_LFA_LFRCO:
+    case CMU_LFACLKSEL_LFA_LFXO:
+      sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM2);
+      break;
+    default:
+      break;
+  }
+#endif
+}
+#endif
+#endif

--- a/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c
+++ b/gecko/platform/service/sleeptimer/src/sl_sleeptimer_hal_timer.c
@@ -1,0 +1,363 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER hardware abstraction implementation for WTIMER/TIMER.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "em_timer.h"
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer_hal.h"
+#include "em_core.h"
+#include "em_cmu.h"
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#include "sl_power_manager.h"
+#endif
+
+#if (SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_TIMER) \
+  || (SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_WTIMER)
+
+// Minimum difference between current count value and what the comparator of the timer can be set to.
+// 1 tick is added to the minimum diff for the algorithm of compensation for the IRQ handler that
+// triggers when CNT == compare_value + 1. For more details refer to sleeptimer_hal_set_compare() function's header.
+#define SLEEPTIMER_COMPARE_MIN_DIFF  (1 + 1)
+
+// Macros used to constructs WTIMER/TIMER instance
+#define _CONCAT_TWO_TOKENS(token_1, token_2)                     token_1 ## token_2
+#define _CONCAT_THREE_TOKENS(token_1, token_2, token_3)          token_1 ## token_2 ## token_3
+#define CONCAT_TWO_TOKENS(token_1, token_2)                      _CONCAT_TWO_TOKENS(token_1, token_2)
+#define CONCAT_THREE_TOKENS(token_1, token_2, token_3)           _CONCAT_THREE_TOKENS(token_1, token_2, token_3)
+
+#if (SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_WTIMER)
+#if defined(WTIMER_PRESENT)                        \
+  && (SL_SLEEPTIMER_TIMER_INSTANCE < WTIMER_COUNT) \
+  && (_WTIMER_CNT_MASK == 0xFFFFFFFFUL)
+  #define SLEEPTIMER_TIMER_INSTANCE    CONCAT_TWO_TOKENS(WTIMER, SL_SLEEPTIMER_TIMER_INSTANCE)
+  #define SLEEPTIMER_TIMER_CHANNEL     0
+  #define SLEEPTIMER_TIMER_IRQ         CONCAT_THREE_TOKENS(WTIMER, SL_SLEEPTIMER_TIMER_INSTANCE, _IRQn)
+  #define SLEEPTIMER_TIMER_IRQHandler  CONCAT_THREE_TOKENS(WTIMER, SL_SLEEPTIMER_TIMER_INSTANCE, _IRQHandler)
+  #define SLEEPTIMER_TIMER_IEN_COMPARE WTIMER_IEN_CC0
+  #define SLEEPTIMER_TIMER_CLK         CONCAT_TWO_TOKENS(cmuClock_WTIMER, SL_SLEEPTIMER_TIMER_INSTANCE)
+  #define SLEEPTIMER_TIMER_TOP_MAX     _WTIMER_TOP_MASK
+  #define SLEEPTIMER_TMR_WIDTH         _WTIMER_CNT_MASK
+#else
+  #define TIMER_UNSUPORTED
+#endif
+
+#elif (SL_SLEEPTIMER_PERIPHERAL == SL_SLEEPTIMER_PERIPHERAL_TIMER) \
+  && (_SILICON_LABS_32B_SERIES > 1)
+#if defined(TIMER_PRESENT)                        \
+  && (SL_SLEEPTIMER_TIMER_INSTANCE < TIMER_COUNT) \
+  && (TIMER_CNTWIDTH(SL_SLEEPTIMER_TIMER_INSTANCE) == 0x20)
+  #define SLEEPTIMER_TIMER_INSTANCE    TIMER(SL_SLEEPTIMER_TIMER_INSTANCE)
+  #define SLEEPTIMER_TIMER_CHANNEL     0
+  #define SLEEPTIMER_TIMER_IRQ         CONCAT_THREE_TOKENS(TIMER, SL_SLEEPTIMER_TIMER_INSTANCE, _IRQn)
+  #define SLEEPTIMER_TIMER_IRQHandler  CONCAT_THREE_TOKENS(TIMER, SL_SLEEPTIMER_TIMER_INSTANCE, _IRQHandler)
+  #define SLEEPTIMER_TIMER_IEN_COMPARE TIMER_IEN_CC0
+  #define SLEEPTIMER_TIMER_CLK         CONCAT_TWO_TOKENS(cmuClock_TIMER, SL_SLEEPTIMER_TIMER_INSTANCE)
+  #define SLEEPTIMER_TIMER_TOP_MAX     _TIMER_TOP_MASK
+  #define SLEEPTIMER_TMR_WIDTH         _TIMER_CNT_MASK
+#else
+  #define TIMER_UNSUPORTED
+#endif
+
+#else
+  #define TIMER_UNSUPORTED
+#endif
+
+#if defined(TIMER_UNSUPORTED)
+#error "The WTIMER/TIMER peripheral instance or channel is not supported. It must be a valid 32-bits size instance."
+#endif
+static bool comp_int_disabled = true;
+
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b);
+
+/******************************************************************************
+ * Initializes TIMER sleep timer.
+ *****************************************************************************/
+void sleeptimer_hal_init_timer(void)
+{
+  TIMER_Init_TypeDef init_config = TIMER_INIT_DEFAULT;
+  TIMER_InitCC_TypeDef init_config_cc = TIMER_INITCC_DEFAULT;
+
+  CMU_ClockEnable(SLEEPTIMER_TIMER_CLK, true);
+
+  init_config_cc.mode = timerCCModeCompare;
+  TIMER_InitCC(SLEEPTIMER_TIMER_INSTANCE, SLEEPTIMER_TIMER_CHANNEL, &init_config_cc);
+  TIMER_TopSet(SLEEPTIMER_TIMER_INSTANCE, SLEEPTIMER_TIMER_TOP_MAX);
+
+#if (SL_SLEEPTIMER_DEBUGRUN == 1)
+  init_config.debugRun = true;
+#endif
+
+  //
+  init_config.prescale = timerPrescale1024;
+
+  TIMER_Init(SLEEPTIMER_TIMER_INSTANCE, &init_config);
+#if defined(TIMER_STATUS_SYNCBUSY)
+  TIMER_SyncWait(SLEEPTIMER_TIMER_INSTANCE);
+#endif
+
+  TIMER_IntDisable(SLEEPTIMER_TIMER_INSTANCE, _TIMER_IEN_MASK);
+  TIMER_IntClear(SLEEPTIMER_TIMER_INSTANCE, _TIMER_IEN_MASK);
+
+  TIMER_CompareSet(SLEEPTIMER_TIMER_INSTANCE, SLEEPTIMER_TIMER_CHANNEL, 0UL);
+
+  NVIC_ClearPendingIRQ(SLEEPTIMER_TIMER_IRQ);
+  NVIC_EnableIRQ(SLEEPTIMER_TIMER_IRQ);
+}
+
+/******************************************************************************
+ * Gets TIMER counter value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void)
+{
+  return TIMER_CounterGet(SLEEPTIMER_TIMER_INSTANCE);
+}
+
+/******************************************************************************
+ * Gets TIMER compare value.
+ *****************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void)
+{
+  return TIMER_CaptureGet(SLEEPTIMER_TIMER_INSTANCE, SLEEPTIMER_TIMER_CHANNEL);
+}
+
+/******************************************************************************
+ * Sets TIMER compare value.
+ *
+ * @note Compare match value is set to the requested value - 1. This is done
+ * to compensate for the fact that the TIMER compare match interrupt always
+ * triggers at the end of the requested ticks and that the IRQ handler is
+ * executed when current tick count == compare_value + 1.
+ *****************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint32_t counter;
+  uint32_t compare;
+  uint32_t compare_value = value;
+
+  CORE_ENTER_CRITICAL();
+  counter = sleeptimer_hal_get_counter();
+  compare = sleeptimer_hal_get_compare();
+
+  if (((TIMER_IntGet(SLEEPTIMER_TIMER_INSTANCE) & SLEEPTIMER_TIMER_IEN_COMPARE) != 0)
+      || get_time_diff(compare, counter) > SLEEPTIMER_COMPARE_MIN_DIFF
+      || compare == counter) {
+    // Add margin if necessary
+    if (get_time_diff(compare_value, counter) < SLEEPTIMER_COMPARE_MIN_DIFF) {
+      compare_value = counter + SLEEPTIMER_COMPARE_MIN_DIFF;
+    }
+    compare_value %= SLEEPTIMER_TMR_WIDTH;
+
+    TIMER_CompareSet(SLEEPTIMER_TIMER_INSTANCE, SLEEPTIMER_TIMER_CHANNEL, compare_value - 1);
+    sleeptimer_hal_enable_int(SLEEPTIMER_EVENT_COMP);
+    comp_int_disabled = false;
+  }
+  CORE_EXIT_CRITICAL();
+}
+
+/******************************************************************************
+ * Enables TIMER interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag)
+{
+  uint32_t timer_ien = 0UL;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    timer_ien |= TIMER_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    if (comp_int_disabled == true) {
+      TIMER_IntClear(SLEEPTIMER_TIMER_INSTANCE, SLEEPTIMER_TIMER_IEN_COMPARE);
+      comp_int_disabled = false;
+    }
+    timer_ien |= SLEEPTIMER_TIMER_IEN_COMPARE;
+  }
+
+  TIMER_IntEnable(SLEEPTIMER_TIMER_INSTANCE, timer_ien);
+}
+
+/******************************************************************************
+ * Disables TIMER interrupts.
+ *****************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag)
+{
+  uint32_t timer_int_dis = 0UL;
+
+  if (local_flag & SLEEPTIMER_EVENT_OF) {
+    timer_int_dis |= TIMER_IEN_OF;
+  }
+
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    timer_int_dis |= SLEEPTIMER_TIMER_IEN_COMPARE;
+
+    comp_int_disabled = true;
+  }
+
+  TIMER_IntDisable(SLEEPTIMER_TIMER_INSTANCE, timer_int_dis);
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to set timer interrupts.
+ ******************************************************************************/
+void sleeptimer_hal_set_int(uint8_t local_flag)
+{
+  if (local_flag & SLEEPTIMER_EVENT_COMP) {
+    TIMER_IntSet(SLEEPTIMER_TIMER_INSTANCE, SLEEPTIMER_TIMER_IEN_COMPARE);
+  }
+}
+
+/******************************************************************************
+ * Gets status of specified interrupt.
+ *
+ * Note: This function must be called with interrupts disabled.
+ *****************************************************************************/
+bool sli_sleeptimer_hal_is_int_status_set(uint8_t local_flag)
+{
+  bool int_is_set = false;
+  uint32_t irq_flag = TIMER_IntGet(SLEEPTIMER_TIMER_INSTANCE);
+
+  switch (local_flag) {
+    case SLEEPTIMER_EVENT_COMP:
+      int_is_set = ((irq_flag & SLEEPTIMER_TIMER_IEN_COMPARE) == SLEEPTIMER_TIMER_IEN_COMPARE);
+      break;
+
+    case SLEEPTIMER_EVENT_OF:
+      int_is_set = ((irq_flag & TIMER_IEN_OF) == TIMER_IEN_OF);
+      break;
+
+    default:
+      break;
+  }
+
+  return int_is_set;
+}
+
+/*******************************************************************************
+ * TIMER interrupt handler.
+ ******************************************************************************/
+void SLEEPTIMER_TIMER_IRQHandler(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+  uint8_t local_flag = 0;
+  uint32_t irq_flag;
+
+  CORE_ENTER_ATOMIC();
+  irq_flag = TIMER_IntGet(SLEEPTIMER_TIMER_INSTANCE);
+
+  if (irq_flag & TIMER_IEN_OF) {
+    local_flag |= SLEEPTIMER_EVENT_OF;
+  }
+
+  if (irq_flag & SLEEPTIMER_TIMER_IEN_COMPARE) {
+    local_flag |= SLEEPTIMER_EVENT_COMP;
+  }
+  TIMER_IntClear(SLEEPTIMER_TIMER_INSTANCE, irq_flag & (TIMER_IEN_OF | SLEEPTIMER_TIMER_IEN_COMPARE));
+
+  process_timer_irq(local_flag);
+
+  CORE_EXIT_ATOMIC();
+}
+
+/*******************************************************************************
+ * Gets TIMER timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void)
+{
+  // Returns source frequency divided by max prescaler value 1024.
+  return (CMU_ClockFreqGet(SLEEPTIMER_TIMER_CLK) >> 10UL);
+}
+
+/*******************************************************************************
+ * Computes difference between two times taking into account timer wrap-around.
+ *
+ * @param a Time.
+ * @param b Time to substract from a.
+ *
+ * @return Time difference.
+ ******************************************************************************/
+__STATIC_INLINE uint32_t get_time_diff(uint32_t a,
+                                       uint32_t b)
+{
+  return (a - b);
+}
+
+/*******************************************************************************
+ * @brief
+ *   Gets the precision (in PPM) of the sleeptimer's clock.
+ *
+ * @return
+ *   Clock accuracy, in PPM.
+ *
+ ******************************************************************************/
+uint16_t sleeptimer_hal_get_clock_accuracy(void)
+{
+#if defined(WTIMER_PRESENT)
+  return CMU_HF_ClockPrecisionGet(cmuClock_HF);
+#else
+  return CMU_HF_ClockPrecisionGet(SLEEPTIMER_TIMER_CLK);
+#endif
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the capture channel value.
+ *
+ * @return Capture value.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_capture(void)
+{
+  // Invalid for TIMER peripheral
+  EFM_ASSERT(0);
+  return 0;
+}
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to reset PRS signal triggered by the associated
+ * peripheral.
+ ******************************************************************************/
+void sleeptimer_hal_reset_prs_signal(void)
+{
+  // Invalid for TIMER peripheral
+  EFM_ASSERT(0);
+}
+
+/***************************************************************************//**
+ * Set lowest energy mode based on a project's configurations and clock source
+ *
+ * @note Lowest possible energy mode for WTIMER and TIMER peripheral is EM1.
+ ******************************************************************************/
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+void sli_sleeptimer_set_pm_em_requirement(void)
+{
+  sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);
+}
+#endif
+#endif

--- a/gecko/platform/service/sleeptimer/src/sli_sleeptimer_hal.h
+++ b/gecko/platform/service/sleeptimer/src/sli_sleeptimer_hal.h
@@ -1,0 +1,146 @@
+/***************************************************************************//**
+ * @file
+ * @brief SLEEPTIMER hardware abstraction layer definition.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_SLEEPTIMER_HAL_H
+#define SL_SLEEPTIMER_HAL_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "em_device.h"
+#include "sli_sleeptimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*******************************************************************************
+ * Hardware Abstraction Layer of the sleep timer init.
+ ******************************************************************************/
+void sleeptimer_hal_init_timer(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the current timer count.
+ *
+ * @return Value in ticks of the timer counter.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_counter(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get a timer comparator value.
+ *
+ * @return Value in ticks of the timer comparator.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_compare(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to set a timer comparator value.
+ *
+ * @param value Number of ticks to set.
+ ******************************************************************************/
+void sleeptimer_hal_set_compare(uint32_t value);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to set a comparator value to trigger a
+ * peripheral request signal to initialize.
+ *
+ * @param value Number of ticks to set.
+ ******************************************************************************/
+void sleeptimer_hal_set_compare_prs_hfxo_startup(int32_t value);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the timer frequency.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_timer_frequency(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to enable timer interrupts.
+ *
+ * @param local_flag Internal interrupt flag.
+ ******************************************************************************/
+void sleeptimer_hal_enable_int(uint8_t local_flag);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to disable timer interrupts.
+ *
+ * @param local_flag Internal interrupt flag.
+ ******************************************************************************/
+void sleeptimer_hal_disable_int(uint8_t local_flag);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to set timer interrupts.
+ *
+ * @param local_flag Internal interrupt flag.
+ ******************************************************************************/
+void sleeptimer_hal_set_int(uint8_t local_flag);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the sleeptimer's clock accuracy.
+ *
+ * @return Clock accuracy in PPM.
+ ******************************************************************************/
+uint16_t sleeptimer_hal_get_clock_accuracy(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to get the capture channel value.
+ *
+ * @note Not supported by all peripherals Sleeptimer can use.
+ *
+ * @return Capture value.
+ ******************************************************************************/
+uint32_t sleeptimer_hal_get_capture(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to reset PRS signal triggered by the associated
+ * peripheral.
+ *
+ * @note Not supported by all peripherals Sleeptimer can use.
+ ******************************************************************************/
+void sleeptimer_hal_reset_prs_signal(void);
+
+/*******************************************************************************
+ * Hardware Abstraction Layer to disable PRS compare and capture channel.
+ *
+ * @note Not supported by all peripherals Sleeptimer can use.
+ ******************************************************************************/
+void sleeptimer_hal_disable_prs_compare_and_capture_channel(void);
+
+/*******************************************************************************
+ * Process the timer interrupt.
+ *
+ * @param flags Internal interrupt flag.
+ ******************************************************************************/
+void process_timer_irq(uint8_t local_flag);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SL_SLEEPTIMER_HAL_H */


### PR DESCRIPTION
Origin: Silicon Labs Gecko SDK
URL: https://github.com/SiliconLabs/Gecko_SDK
Version: v4.5.0 (SHA: 90fc93e1f95a10c981f0e49ca6787192e82fd8f2)
Purpose: Add support for Zephyr sleeptimer driver.
License: Zlib
Maintained-by: External

Required by: https://github.com/zephyrproject-rtos/zephyr/pull/112116