### PR TITLE
gecko: add power_manager service

### DIFF
--- a/gecko/platform/service/power_manager/config/sl_power_manager_config.h
+++ b/gecko/platform/service/power_manager/config/sl_power_manager_config.h
@@ -1,0 +1,64 @@
+/***************************************************************************//**
+ * @file
+ * @brief Power Manager configuration file.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+#ifndef SL_POWER_MANAGER_CONFIG_H
+#define SL_POWER_MANAGER_CONFIG_H
+
+// <h>Power Manager Configuration
+
+// <q SL_POWER_MANAGER_CUSTOM_HF_OSCILLATOR_IRQ_HANDLER> Enable custom IRQ handler for external HF oscillator.
+// <i> Enable if CMU_IRQHandler/HFXO0_IRQHandler is needed from your application.
+// <i> The function sl_power_manager_irq_handler() will have to be called from you custom handler if this is enabled.
+// <i> Default: 0
+#define SL_POWER_MANAGER_CUSTOM_HF_OSCILLATOR_IRQ_HANDLER  0
+
+// <q SL_POWER_MANAGER_CONFIG_VOLTAGE_SCALING_FAST_WAKEUP> Enable fast wakeup (disable voltage scaling in EM2/3 mode)
+// <i> Enable or disable voltage scaling in EM2/3 modes (when available). This decreases wakeup time by about 30 us.
+// <i> Deprecated. It is replaced by the function sl_power_manager_em23_voltage_scaling_enable_fast_wakeup()
+// <i> Default: 0
+#define SL_POWER_MANAGER_CONFIG_VOLTAGE_SCALING_FAST_WAKEUP   0
+
+// <e SL_POWER_MANAGER_DEBUG> Enable debugging feature
+// <i> Enable or disable debugging features (trace the different modules that have requirements).
+// <i> Default: 0
+#define SL_POWER_MANAGER_DEBUG  0
+
+// <o SL_POWER_MANAGER_DEBUG_POOL_SIZE> Maximum numbers of requirements that can be logged
+// <i> Default: 10
+#define SL_POWER_MANAGER_DEBUG_POOL_SIZE  10
+// </e>
+
+// </h>
+
+#endif /* SL_POWER_MANAGER_CONFIG_H */
+
+// <<< end of configuration section >>>

--- a/gecko/platform/service/power_manager/inc/sl_power_manager.h
+++ b/gecko/platform/service/power_manager/inc/sl_power_manager.h
@@ -1,0 +1,535 @@
+/***************************************************************************//**
+ * @file
+ * @brief Power Manager API definition.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_POWER_MANAGER_H
+#define SL_POWER_MANAGER_H
+
+#ifndef SL_POWER_MANAGER_DEBUG
+#include "sl_power_manager_config.h"
+#endif
+#include "sl_slist.h"
+#include "sl_status.h"
+#include "sl_sleeptimer.h"
+#include "sl_enum.h"
+
+#include "em_core_generic.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup power_manager Power Manager
+ *
+ * @details Power manager is a platform level software module that manages
+ * the system's energy modes. Its main purpose is to transition the system to a
+ * low energy mode when the processor has nothing to execute. The energy mode the
+ * system will transition to is determined each time the system goes to sleep
+ * using requirements. These requirements are set by the different software modules
+ * (drivers, stacks, application code, etc...). Power manager also ensures a
+ * strict control of some power hungry resources such as the high frequency
+ * external oscillator (normally called HFXO). Power manager also
+ * offers a notification mechanism through which any piece of software module can be
+ * notified of energy mode transitions through callbacks.
+ *
+ * @note Sleep Driver is deprecated. Use Power Manager for all sleep-related
+ *       operations. See <a href="https://www.silabs.com/documents/
+ *       public/application-notes/
+ *       an1358-migrating-from-sleep-driver-to-power-manager.pdf">AN1358:
+ *       Migrating from Sleep Driver to Power Manager</a> for information on how
+ *       to migrate from Sleep Driver to Power Manager.
+ * @note Emlib EMU functions EMU_EnterEM1()/EMU_EnterEM2()/EMU_EnterEM3() must not
+ *       be used when the Power Manager is present. The Power Manager module must be
+ *       the one deciding at which EM level the device sleeps to ensure the application
+ *       properly works. Using both at the same time could lead to undefined behavior
+ *       in the application.
+ *
+ * @details
+ * ## Initialization
+ *
+ *   Power manager must be initialized prior to any call to power manager API.
+ *   If sl_system is used, only sl_system_init() must be called, otherwise
+ *   sl_power_manager_init() must be called manually. Note that power manager
+ *   must be initialized after the clock(s), when initialized manually, as the
+ *   power manager check which oscillators are used during the initialization phase.
+ *
+ * ## Add and remove requirements
+ *
+ *   The drivers should add and remove energy mode requirements, at runtime, on the
+ *   lowest energy mode for them depending on their state. When calling
+ *   sl_power_manager_sleep(), the lowest possible Energy mode will be automatically
+ *   selected.
+ *
+ *   It is possible to add and remove requirements from ISR. If a specific energy mode
+ *   is required in the ISR, but not required to generate the interrupt, a requirement
+ *   on the energy mode can be added from the ISR. It is guaranteed that the associated
+ *   clock will be active once sl_power_manager_add_requirement() returns. The EM
+ *   requirement can be also be removed from an ISR.
+ *
+ * ## Subscribe to events
+ *
+ *   It possible to get notified when the system transition from a power level to
+ *   another power level. This can allow to do some operations depending on which level
+ *   the system goes, such as saving/restoring context.
+ *
+ * ## Sleep
+ *
+ *   When the software has no more operation and only need to wait for an event, the
+ *   software must call sl_power_manager_sleep(). This is automatically done when the
+ *   kernel is present, but it needs to be called from the super loop in a baremetal
+ *   project.
+ *
+ * ## Query callback functions
+ *
+ * ### Is OK to sleep
+ *
+ *   Between the time `sl_power_manager_sleep` is called and the MCU is really put
+ *   in a lower Energy mode, it is possible that an ISR occur and require the system
+ *   to resume at that time instead of sleeping. So a callback is called in a critical
+ *   section to validate that the MCU can go to sleep.
+ *
+ *   In case of an application that runs on an RTOS, the RTOS will take care of determining
+ *   if it is ok to sleep. In case of a baremetal application, the function `sl_power_manager_is_ok_to_sleep()`
+ *   will be generated automatically by Simplicity Studio's wizard.
+ *   The function will look at multiple software modules from the SDK to take a decision.
+ *   The application can contribute to the decision by defining the function `app_is_ok_to_sleep()`.
+ *   If any of the software modules (including the application via `app_is_ok_to_sleep()`) return false,
+ *   the process of entering in sleep will be aborted.
+ *
+ * ### Sleep on ISR exit
+ *
+ *   When the system enters sleep, the only way to wake it up is via an interrupt or
+ *   exception. By default, power manager will assume that when an interrupt
+ *   occurs and the corresponding ISR has been executed, the system must not go back
+ *   to sleep. However, in the case where all the processing related to this interrupt
+ *   is performed in the ISR, it is possible to go back to sleep by using this hook.
+ *
+ *   In case of an application that runs on an RTOS, the RTOS will take care of determining
+ *   if the system can go back to sleep on ISR exit. Power manager will ensure the system resumes
+ *   its operations as soon as a task is resumed, posted or that its delay expires.
+ *   In case of a baremetal application, the function `sl_power_manager_sleep_on_isr_exit()` will be generated
+ *   automatically by Simplicity Studio's wizard. The function will look at multiple software modules from the SDK
+ *   to take a decision. The application can contribute to the decision by defining the
+ *   function `app_sleep_on_isr_exit()`.
+ *   The generated function will take a decision based on the value returned by the different software modules
+ *   (including the application via `app_sleep_on_isr_exit()`):
+ *
+ *   `SL_POWER_MANAGER_IGNORE`: if the software module did not cause the system wakeup and/or doesn't want to contribute to the decision.
+ *   `SL_POWER_MANAGER_SLEEP`: if the software module did cause the system wakeup, but the system should go back to sleep.
+ *   `SL_POWER_MANAGER_WAKEUP`: if the software module did cause the system wakeup, and the system should not go back to sleep.
+ *
+ *   If any software module returned `SL_POWER_MANAGER_SLEEP` and none returned `SL_POWER_MANAGER_WAKEUP`,
+ *   the system will go back to sleep. Any other combination will cause the system not to go back to sleep.
+ *
+ * ### Debugging feature
+ *
+ *   By setting the configuration define SL_POWER_MANAGER_DEBUG to 1, it is possible
+ *   to record the requirements currently set and their owner. It is possible to print
+ *   at any time a table that lists all the added requirements and their owner. This
+ *   table can be printed by caling the function
+ *   sl_power_manager_debug_print_em_requirements().
+ *   Make sure to add the following define
+ *   ```
+ *   #define CURRENT_MODULE_NAME "<Module printable name here>"
+ *   ```
+ *   to any application code source file that adds and removes requirements.
+ *
+ * ## Usage Example
+ *
+ * ```
+ * #define EM_EVENT_MASK_ALL  (SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM0   \
+ *                             | SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM0  \
+ *                             | SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM1 \
+ *                             | SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM1  \
+ *                             | SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM2 \
+ *                             | SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM2  \
+ *                             | SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM3 \
+ *                             | SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM3)
+ *
+ * sl_power_manager_em_transition_event_handle_t event_handle;
+ * sl_power_manager_em_transition_event_info_t event_info = {
+ *   .event_mask = EM_EVENT_MASK_ALL,
+ *   .on_event = my_events_callback,
+ * }
+ *
+ * void main(void)
+ * {
+ *   // Initialize power manager; not needed if sl_system_init() is used.
+ *   sl_power_manager_init();
+ *
+ *   // Limit sleep level to EM1
+ *   sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);
+ *
+ *   // Subscribe to all event types; get notified for every power transition.
+ *   sl_power_manager_subscribe_em_transition_event(&event_handle, &event_info);
+ *   while (1) {
+ *     // Actions
+ *     [...]
+ *     if (completed) {
+ *        // Remove energy mode requirement, can go to EM2 or EM3 now, depending on the configuration
+ *        sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
+ *     }
+ *
+ *     // Sleep to lowest possible energy mode; This call is not needed when using the kernel.
+ *     sl_power_manager_sleep();
+ *     // Will resume after an interrupt or exception
+ *   }
+ * }
+ *
+ * void my_events_callback(sl_power_manager_em_t from,
+ *                         sl_power_manager_em_t to)
+ * {
+ *   printf("Event:%s-%s\r\n", string_lookup_table[from], string_lookup_table[to]);
+ * }
+ * ```
+ *
+ * @{
+ ******************************************************************************/
+
+// -----------------------------------------------------------------------------
+// Defines
+
+// Current module name for debugging features
+#ifndef CURRENT_MODULE_NAME
+#define CURRENT_MODULE_NAME "Anonymous"            ///< current module name
+#endif
+
+// Power transition events
+#define SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM0     (1 << 0)                                  ///< sl power manager event transition entering em0
+#define SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM0      (1 << 1)                                  ///< sl power manager event transition leaving em0
+#define SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM1     (1 << 2)                                  ///< sl power manager event transition entering em1
+#define SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM1      (1 << 3)                                  ///< sl power manager event transition leaving em1
+#define SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM2     (1 << 4)                                  ///< sl power manager event transition entering em2
+#define SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM2      (1 << 5)                                  ///< sl power manager event transition leaving em2
+#define SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM3     (1 << 6)                                  ///< sl power manager event transition entering em3
+#define SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM3      (1 << 7)                                  ///< sl power manager event transition leaving em3
+
+// -----------------------------------------------------------------------------
+// Data Types
+
+/// @brief Energy modes
+typedef  enum  {
+  SL_POWER_MANAGER_EM0 = 0,   ///< Run Mode (Energy Mode 0)
+  SL_POWER_MANAGER_EM1,       ///< Sleep Mode (Energy Mode 1)
+  SL_POWER_MANAGER_EM2,       ///< Deep Sleep Mode (Energy Mode 2)
+  SL_POWER_MANAGER_EM3,       ///< Stop Mode (Energy Mode 3)
+  SL_POWER_MANAGER_EM4,       ///< Shutoff Mode (Energy Mode 4)
+} sl_power_manager_em_t;
+
+/// @brief Mask of all the event(s) to listen to.
+typedef uint32_t sl_power_manager_em_transition_event_t;
+
+/***************************************************************************//**
+ * Typedef for the user supplied callback function which is called when
+ * an energy mode transition occurs.
+ *
+ * @param from Energy mode we are leaving.
+ * @param to   Energy mode we are entering.
+ ******************************************************************************/
+typedef void (*sl_power_manager_em_transition_on_event_t)(sl_power_manager_em_t from,
+                                                          sl_power_manager_em_t to);
+
+/// @brief Struct representing energy mode transition event information
+typedef struct {
+  const sl_power_manager_em_transition_event_t event_mask;  ///< Mask of the transitions on which the callback should be called.
+  const sl_power_manager_em_transition_on_event_t on_event; ///< Function that must be called when the event occurs.
+} sl_power_manager_em_transition_event_info_t;
+
+/// @brief Struct representing energy mode transition event handle
+typedef struct {
+  sl_slist_node_t node;                               ///< List node.
+  sl_power_manager_em_transition_event_info_t *info;  ///< Handle event info.
+} sl_power_manager_em_transition_event_handle_t;
+
+/// On ISR Exit Hook answer
+SL_ENUM(sl_power_manager_on_isr_exit_t) {
+  SL_POWER_MANAGER_IGNORE = (1UL << 0UL),     ///< The module did not trigger an ISR and it doesn't want to contribute to the decision
+  SL_POWER_MANAGER_SLEEP  = (1UL << 1UL),     ///< The module was the one that caused the system wakeup and the system SHOULD go back to sleep
+  SL_POWER_MANAGER_WAKEUP = (1UL << 2UL),     ///< The module was the one that caused the system wakeup and the system MUST NOT go back to sleep
+};
+
+// -----------------------------------------------------------------------------
+// Internal Prototypes only to be used by Power Manager module
+void sli_power_manager_update_em_requirement(sl_power_manager_em_t em,
+                                             bool  add);
+
+// To make sure that we are able to optimize out the string argument when the
+// debug feature is disable, we use a pre-processor macro resulting in a no-op.
+// We also make sure to always have a definition for the function regardless if
+// the debug feature is enable or not for binary compatibility.
+#if (SL_POWER_MANAGER_DEBUG == 1)
+void sli_power_manager_debug_log_em_requirement(sl_power_manager_em_t em,
+                                                bool                  add,
+                                                const char            *name);
+#else
+#define sli_power_manager_debug_log_em_requirement(em, add, name) /* no-op */
+#endif
+
+// -----------------------------------------------------------------------------
+// Prototypes
+
+/***************************************************************************//**
+ * Initialize Power Manager module.
+ * @return Status code
+ ******************************************************************************/
+sl_status_t sl_power_manager_init(void);
+
+/***************************************************************************//**
+ * Sleep at the lowest allowed energy mode.
+ *
+ * @note Must not be called from ISR
+ * @par
+ * @note This function will expect and call a callback with the following
+ *       signature: `bool sl_power_manager_is_ok_to_sleep(void)`.
+ *
+ * @note This function can be used to cancel a sleep action and handle the
+ *       possible race condition where an ISR that would cause a wakeup is
+ *       triggered right after the decision to call sl_power_manager_sleep()
+ *       has been made.
+ *
+ * @note This function must not be called with interrupts disabled.
+ *
+ * Usage example:
+ *
+ * ```c
+ * void main(void)
+ * {
+ *   sl_power_manager_init();
+ *   while (1) {
+ *     tick();
+ *     sl_power_manager_sleep();
+ *   }
+ * }
+ * ```
+ ******************************************************************************/
+void sl_power_manager_sleep(void);
+
+/***************************************************************************//**
+ * Adds requirement on given energy mode.
+ *
+ * @param em  Energy mode to add the requirement to:
+ *            - ::SL_POWER_MANAGER_EM1
+ *            - ::SL_POWER_MANAGER_EM2
+ ******************************************************************************/
+__STATIC_INLINE void sl_power_manager_add_em_requirement(sl_power_manager_em_t em)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+  sli_power_manager_update_em_requirement(em, true);
+
+  sli_power_manager_debug_log_em_requirement(em, true, (const char *)CURRENT_MODULE_NAME);
+  CORE_EXIT_CRITICAL();
+}
+
+/***************************************************************************//**
+ * Removes requirement on given energy mode.
+ *
+ * @param em  Energy mode to remove the requirement to:
+ *            - ::SL_POWER_MANAGER_EM1
+ *            - ::SL_POWER_MANAGER_EM2
+ ******************************************************************************/
+__STATIC_INLINE void sl_power_manager_remove_em_requirement(sl_power_manager_em_t em)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+  sli_power_manager_update_em_requirement(em, false);
+
+  sli_power_manager_debug_log_em_requirement(em, false, (const char *)CURRENT_MODULE_NAME);
+  CORE_EXIT_CRITICAL();
+}
+
+/***************************************************************************//**
+ * Registers a callback to be called on given Energy Mode transition(s).
+ *
+ * @param event_handle  Event handle (no initialization needed).
+ *
+ * @param event_info    Event info structure that contains the event mask and the
+ *                      callback that must be called.
+ *
+ * @note Adding and removing requirement(s) from a callback on a transition event
+ *       is not supported.
+ *
+ * @note The parameters passed must be persistent, meaning that they need to survive
+ *       until the callback fires.
+ *
+ * Usage example:
+ *
+ * ```c
+ * #define EM_EVENT_MASK_ALL      (  SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM0 \
+ *                                 | SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM0  \
+ *                                 | SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM1 \
+ *                                 | SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM1  \
+ *                                 | SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM2 \
+ *                                 | SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM2  \
+ *                                 | SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM3 \
+ *                                 | SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM3)
+ *
+ * sl_power_manager_em_transition_event_handle_t event_handle;
+ * sl_power_manager_em_transition_event_info_t event_info = {
+ *   .event_mask = EM_EVENT_MASK_ALL,
+ *   .on_event = my_callback,
+ * };
+ *
+ * void my_callback(sl_power_manager_em_t from,
+ *                  sl_power_manager_em_t to)
+ * {
+ *   [...]
+ * }
+ *
+ * void main(void)
+ * {
+ *   sl_power_manager_init();
+ *   sl_power_manager_subscribe_em_transition_event(&event_handle, &event_info);
+ * }
+ * ```
+ ******************************************************************************/
+void sl_power_manager_subscribe_em_transition_event(sl_power_manager_em_transition_event_handle_t     *event_handle,
+                                                    const sl_power_manager_em_transition_event_info_t *event_info);
+
+/***************************************************************************//**
+ * Unregisters an event callback handle on Energy mode transition.
+ *
+ * @param event_handle  Event handle which must be unregistered (must have been
+ *                      registered previously).
+ *
+ * @note  An EFM_ASSERT is thrown if the handle is not found.
+ ******************************************************************************/
+void sl_power_manager_unsubscribe_em_transition_event(sl_power_manager_em_transition_event_handle_t *event_handle);
+
+/***************************************************************************//**
+ * Get configurable overhead value for early restore time in Sleeptimer ticks
+ * when a schedule wake-up is set.
+ *
+ * @return  Current overhead value for early restore time.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+int32_t sl_power_manager_schedule_wakeup_get_restore_overhead_tick(void);
+
+/***************************************************************************//**
+ * Set configurable overhead value for early restore time in Sleeptimer ticks
+ * used for schedule wake-up.
+ * Must be called after initialization else the value will be overwritten.
+ *
+ * @param overhead_tick Overhead value to set for early restore time.
+ *
+ * @note The overhead value can also be negative to remove time from the restore
+ *       process.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+void sl_power_manager_schedule_wakeup_set_restore_overhead_tick(int32_t overhead_tick);
+
+/***************************************************************************//**
+ * Get configurable minimum off-time value for schedule wake-up in Sleeptimer
+ * ticks.
+ *
+ * @return  Current minimum off-time value for schedule wake-up.
+ *
+ * @note  Turning on external high frequency clock, such as HFXO, requires more
+ *        energy since we must supply higher current for the wake-up.
+ *        Therefore, when an 'external high frequency clock enable' is scheduled
+ *        in 'x' time, there is a threshold 'x' value where turning off the clock
+ *        is not worthwhile since the energy consumed by taking into account the
+ *        wake-up will be greater than if we just keep the clock on until the next
+ *        scheduled clock enabled. This threshold value is what we refer as the
+ *        minimum off-time.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+uint32_t sl_power_manager_schedule_wakeup_get_minimum_offtime_tick(void);
+
+/***************************************************************************//**
+ * Set configurable minimum off-time value for schedule wake-up in Sleeptimer
+ * ticks.
+ *
+ * @param minimum_offtime_tick  minimum off-time value to set for schedule
+ *                              wake-up.
+ *
+ * @note  Turning on external high frequency clock, such as HFXO, requires more
+ *        energy since we must supply higher current for the wake-up.
+ *        Therefore, when an 'external high frequency clock enable' is scheduled
+ *        in 'x' time, there is a threshold 'x' value where turning off the clock
+ *        is not worthwhile since the energy consumed by taking into account the
+ *        wake-up will be greater than if we just keep the clock on until the next
+ *        scheduled clock enabled. This threshold value is what we refer as the
+ *        minimum off-time.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+void sl_power_manager_schedule_wakeup_set_minimum_offtime_tick(uint32_t minimum_offtime_tick);
+
+/***************************************************************************//**
+ * Enable or disable fast wake-up in EM2 and EM3
+ *
+ * @param enable True False variable act as a switch for this api
+ *
+ * @note Will also update the wake up time from EM2 to EM0.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+void sl_power_manager_em23_voltage_scaling_enable_fast_wakeup(bool enable);
+
+/**************************************************************************//**
+ * Determines if the HFXO interrupt was part of the last wake-up and/or if
+ * the HFXO early wakeup expired during the last ISR
+ * and if it was the only timer to expire in that period.
+ *
+ * @return true if power manager sleep can return to sleep,
+ *         false otherwise.
+ *
+ * @note This function will always return false in case a requirement
+ *       is added on SL_POWER_MANAGER_EM1, since we will
+ *       never sleep at a lower level than EM1.
+ *****************************************************************************/
+bool sl_power_manager_is_latest_wakeup_internal(void);
+
+/** @} (end addtogroup power_manager) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SL_POWER_MANAGER_H

--- a/gecko/platform/service/power_manager/inc/sl_power_manager_debug.h
+++ b/gecko/platform/service/power_manager/inc/sl_power_manager_debug.h
@@ -1,0 +1,60 @@
+/***************************************************************************//**
+ * @file
+ * @brief Power Manager API definition.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_POWER_MANAGER_DEBUG_H
+#define SL_POWER_MANAGER_DEBUG_H
+
+#include "sl_power_manager.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @addtogroup power_manager
+ * @{
+ ******************************************************************************/
+
+// -----------------------------------------------------------------------------
+// Prototypes
+
+/***************************************************************************//**
+ * Print a table that describes the current requirements on each energy
+ * mode and their owner.
+ ******************************************************************************/
+void sl_power_manager_debug_print_em_requirements(void);
+
+/** @} (end addtogroup power_manager) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/gecko/platform/service/power_manager/inc/sli_power_manager.h
+++ b/gecko/platform/service/power_manager/inc/sli_power_manager.h
@@ -1,0 +1,97 @@
+/***************************************************************************//**
+ * @file
+ * @brief Power Manager Private API definition.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SLI_POWER_MANAGER_H
+#define SLI_POWER_MANAGER_H
+
+#include "sl_power_manager.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*******************************************************************************
+ *****************************   PROTOTYPES   **********************************
+ ******************************************************************************/
+
+void sli_power_manager_update_hf_clock_settings_preservation_requirement(bool add);
+
+/***************************************************************************//**
+ * Adds requirement on the preservation of the High Frequency Clocks settings.
+ *
+ * @note FOR INTERNAL USE ONLY.
+ *
+ * @note Must be used together with adding an EM2 requirement.
+ ******************************************************************************/
+void sli_power_manager_add_hf_clock_settings_preservation_requirement(void);
+
+/***************************************************************************//**
+ * Removes requirement on the preservation of the High Frequency Clocks settings.
+ *
+ * @note FOR INTERNAL USE ONLY.
+ *
+ * @note Must be used together with removing an EM2 requirement.
+ ******************************************************************************/
+void sli_power_manager_remove_hf_clock_settings_preservation_requirement(void);
+
+/***************************************************************************//**
+ * Informs the power manager module that the high accuracy/high frequency clock
+ * is used.
+ *
+ * @note FOR INTERNAL USE ONLY.
+ *
+ * @note Must be called by RAIL initialization in case radio clock settings
+ *       are not set before the Power Manager initialization.
+ ******************************************************************************/
+__WEAK void sli_power_manager_set_high_accuracy_hf_clock_as_used(void);
+
+/***************************************************************************//**
+ * Gets the wake-up restore process time.
+ * If we are not in the context of a deepsleep and therefore don't need to
+ * do a restore, the return value is 0.
+ *
+ *
+ * @return   Wake-up restore process time.
+ ******************************************************************************/
+uint32_t sli_power_manager_get_restore_delay(void);
+
+/***************************************************************************//**
+ * Initiates the wake-up restore process.
+ ******************************************************************************/
+void sli_power_manager_initiate_restore(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SLI_POWER_MANAGER_H */

--- a/gecko/platform/service/power_manager/src/sl_power_manager.c
+++ b/gecko/platform/service/power_manager/src/sl_power_manager.c
@@ -1,0 +1,1180 @@
+/***************************************************************************//**
+ * @file
+ * @brief Power Manager API implementation.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "sl_power_manager.h"
+#include "sl_power_manager_config.h"
+#include "sli_power_manager_private.h"
+#include "sli_power_manager.h"
+#include "sli_sleeptimer.h"
+#include "sl_assert.h"
+#include "sl_atomic.h"
+
+#include "em_device.h"
+#if !defined(_SILICON_LABS_32B_SERIES_3)
+#include "em_emu.h"
+#endif
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+/*******************************************************************************
+ *********************************   DEFINES   *********************************
+ ******************************************************************************/
+
+// Default overhead value for the wake-up time used for the schedule wake-up
+// functionality.
+#define SCHEDULE_WAKEUP_DEFAULT_RESTORE_TIME_OVERHEAD_TICK  0
+
+// Determine if the device supports EM1P
+#if !defined(SLI_DEVICE_SUPPORTS_EM1P) && defined(_SILICON_LABS_32B_SERIES_2_CONFIG) && _SILICON_LABS_32B_SERIES_2_CONFIG >= 2
+#define SLI_DEVICE_SUPPORTS_EM1P
+#endif
+
+/*******************************************************************************
+ ***************************  LOCAL VARIABLES   ********************************
+ ******************************************************************************/
+
+// Initialization flag.
+static bool is_initialized = false;
+
+// Current active energy mode.
+static sl_power_manager_em_t current_em = SL_POWER_MANAGER_EM0;
+
+// Events subscribers lists
+static sl_slist_node_t *power_manager_em_transition_event_list = NULL;
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+// Store the sleeptimer module clock frequency for conversion calculation
+static uint32_t sleeptimer_frequency;
+
+// Table of energy modes counters. Each counter indicates the presence (not zero)
+// or absence (zero) of requirements on a given energy mode. The table doesn't
+// contain requirement on EM0.
+static uint8_t requirement_em_table[SLI_POWER_MANAGER_EM_TABLE_SIZE] = {
+  0,  // EM1 requirement counter
+  0,  // EM2 requirement counter
+};
+
+// Counter variable to save the number of High Accuracy HF clock requirements requested.
+uint8_t requirement_high_accuracy_hf_clock_counter = 0;
+
+#ifdef SLI_DEVICE_SUPPORTS_EM1P
+// Variable to indicate if the High Accuracy HF clock requirements count is back to zero.
+bool requirement_high_accuracy_hf_clock_back_to_zero = false;
+#endif
+
+// Saved energy mode we are coming from when waiting for HFXO ready.
+static sl_power_manager_em_t waiting_clock_restore_from_em = SL_POWER_MANAGER_EM0;
+
+// Flag indicating if we are sleeping, waiting for the HF clock restore
+static bool is_sleeping_waiting_for_clock_restore = false;
+
+// Flag indicating if the system states (clocks) are saved and should be restored
+static bool is_states_saved = false;
+
+// Timer that it is used for enabling the clock for the scheduled wakeup
+static sl_sleeptimer_timer_handle_t clock_wakeup_timer_handle = { 0 };
+
+// Store if requirement on EM1 has been added before sleeping;
+// i.e. only possible if sleeping for less than minimum off time
+static bool requirement_on_em1_added = false;
+
+// Threshold delay in sleeptimer ticks indicating the minimum time required
+// to make the shut down of external high frequency oscillator worthwhile before
+// the next synchronous high frequency oscillator requirement. Shorter than this
+// delay, the power gain of shutting down is invalidated.
+uint32_t high_frequency_min_offtime_tick = 0;
+
+// Store the configuration overhead value in sleeptimer tick to add/remove to the wake-up time.
+int32_t wakeup_time_config_overhead_tick = 0;
+
+static bool is_hf_x_oscillator_not_preserved;
+
+// Store if we are currently waiting for HF clock restoration to finish
+static bool is_actively_waiting_for_clock_restore = false;
+
+// Indicates if the clock restore was completed from the HFXO ISR
+static bool is_restored_from_hfxo_isr = false;
+static bool is_restored_from_hfxo_isr_internal = false;
+#endif
+
+/*
+ *********************************************************************************************************
+ *                                           HOOK REFERENCES
+ *********************************************************************************************************
+ */
+
+bool sl_power_manager_sleep_on_isr_exit(void);
+
+// Callback to application after wakeup but before restoring interrupts.
+// For internal Silicon Labs use only
+__WEAK void sli_power_manager_on_wakeup(void);
+
+// Hook that can be used by the log outputer to suspend transmission of logs
+// in case it would require energy mode changes while in the sleep loop.
+__WEAK void sli_power_manager_suspend_log_transmission(void);
+
+// Hook that can be used by the log outputer to resume transmission of logs.
+__WEAK void sli_power_manager_resume_log_transmission(void);
+
+// Callback to notify possible transition from EM1P to EM2.
+// For internal Silicon Labs use only
+#ifdef SLI_DEVICE_SUPPORTS_EM1P
+__WEAK void sli_power_manager_em1p_to_em2_notification(void);
+#endif
+
+/***************************************************************************//**
+ * Mandatory callback that allows to cancel sleeping action.
+ ******************************************************************************/
+bool sl_power_manager_is_ok_to_sleep(void);
+
+/*******************************************************************************
+ **************************   LOCAL FUNCTIONS   ********************************
+ ******************************************************************************/
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+static sl_power_manager_em_t get_lowest_em(void);
+
+static void evaluate_wakeup(sl_power_manager_em_t to);
+
+static void update_em1_requirement(bool add);
+
+static void on_clock_wakeup_timeout(sl_sleeptimer_timer_handle_t *handle,
+                                    void *data);
+
+static void clock_restore_and_wait(void);
+
+static void clock_restore(void);
+#endif
+
+static void power_manager_notify_em_transition(sl_power_manager_em_t from,
+                                               sl_power_manager_em_t to);
+
+// Use PriMask to enter critical section by disabling interrupts.
+static CORE_irqState_t enter_critical_with_primask();
+
+// Exit critical section by re-enabling interrupts in PriMask.
+static void exit_critical_with_primask(CORE_irqState_t primask_state);
+
+/*******************************************************************************
+ **************************   GLOBAL FUNCTIONS   *******************************
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * Initialize Power Manager module.
+ ******************************************************************************/
+sl_status_t sl_power_manager_init(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+  if (!is_initialized) {
+    sl_status_t status = SL_STATUS_OK;
+
+    // Initialize Sleeptimer module in case not already done.
+    status = sl_sleeptimer_init();
+    if (status != SL_STATUS_OK) {
+      CORE_EXIT_CRITICAL();
+      return status;
+    }
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT) \
+    && !defined(SL_CATALOG_POWER_MANAGER_DEEPSLEEP_BLOCKING_HFXO_RESTORE_PRESENT)
+    // Additional Sleeptimer HW configuration if the "power_manager_deepsleep" component is used
+    sli_sleeptimer_hal_power_manager_integration_init();
+#endif
+
+  #if (SL_POWER_MANAGER_DEBUG == 1)
+    sli_power_manager_debug_init();
+  #endif
+    sl_slist_init(&power_manager_em_transition_event_list);
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+    // If lowest energy mode is not restricted to EM1, determine and set lowest energy mode
+    sli_sleeptimer_set_pm_em_requirement();
+    // Set the default wake-up overhead value
+    wakeup_time_config_overhead_tick = SCHEDULE_WAKEUP_DEFAULT_RESTORE_TIME_OVERHEAD_TICK;
+
+    // Get the sleeptimer frequency
+    sleeptimer_frequency = sl_sleeptimer_get_timer_frequency();
+#endif
+  }
+
+  // Do all necessary hardware initialization.
+  sli_power_manager_init_hardware();
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  // Set the HF minimum offtime in sleeptimer ticks
+  high_frequency_min_offtime_tick = sli_power_manager_get_default_high_frequency_minimum_offtime();
+#endif
+
+  is_initialized = true;
+  CORE_EXIT_CRITICAL();
+
+  return SL_STATUS_OK;
+}
+
+/***************************************************************************//**
+ * Sleep at the lowest allowed energy mode.
+ ******************************************************************************/
+void sl_power_manager_sleep(void)
+{
+  CORE_irqState_t primask_state;
+
+  primask_state = enter_critical_with_primask();
+
+  sli_power_manager_suspend_log_transmission();
+
+  if (sl_power_manager_is_ok_to_sleep() != true) {
+    sli_power_manager_resume_log_transmission();
+    exit_critical_with_primask(primask_state);
+    return;
+  }
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  sl_power_manager_em_t lowest_em;
+
+  // Go to another energy mode (same, higher to lower or lower to higher)
+  do {
+    // Remove any previous EM1 requirement added internally by the power manager itself
+    if (requirement_on_em1_added) {
+      update_em1_requirement(false);
+      requirement_on_em1_added = false;
+    }
+
+    lowest_em = get_lowest_em();
+    evaluate_wakeup(lowest_em);
+    lowest_em = get_lowest_em();  // Reevaluate as a requirement can be added from evaluate_wakeup()
+
+    if ((lowest_em >= SL_POWER_MANAGER_EM2)
+        && (is_states_saved == false)) {
+      sli_power_manager_save_states();
+    }
+
+    // Notify listeners if transition to another energy mode
+    if (lowest_em != current_em) {
+#ifdef SLI_DEVICE_SUPPORTS_EM1P
+      requirement_high_accuracy_hf_clock_back_to_zero = false;
+#endif
+      if (is_sleeping_waiting_for_clock_restore == false) {
+        // But only notify if we are not in the process of waiting for the HF oscillators restore.
+        power_manager_notify_em_transition(current_em, lowest_em);
+      }
+      current_em = lowest_em;           // Keep new active energy mode
+    }
+
+#ifdef SLI_DEVICE_SUPPORTS_EM1P
+    // Notification for possible transition from EM1P to EM2
+    // For internal Silicon Labs use only
+    if (requirement_high_accuracy_hf_clock_back_to_zero
+        && current_em == SL_POWER_MANAGER_EM2) {
+      requirement_high_accuracy_hf_clock_back_to_zero = false;
+      sli_power_manager_em1p_to_em2_notification();
+    }
+#endif
+
+    // Pre-sleep operations if any are necessary
+    if ((lowest_em >= SL_POWER_MANAGER_EM2)
+        && (is_states_saved == false)) {
+      // Only do pre-sleep operations if there is no requirement on High Accuracy Clock.
+      // Else we must not touch the clock tree.
+      if (requirement_high_accuracy_hf_clock_counter == 0) {
+        sli_power_manager_handle_pre_deepsleep_operations();
+        is_hf_x_oscillator_not_preserved = true;
+      }
+      is_states_saved = true;
+    }
+
+    // Apply lowest reachable energy mode
+    sli_power_manager_apply_em(current_em);
+
+    // In case we are waiting for the restore from an early wake-up,
+    // we put back the current EM to the one before the early wake-up to do the next notification correctly.
+    if (is_sleeping_waiting_for_clock_restore == true) {
+      current_em = waiting_clock_restore_from_em;
+    }
+
+    // Notify consumer of wakeup while interrupts are still off
+    // For internal Silicon Labs use only
+    sli_power_manager_on_wakeup();
+
+    exit_critical_with_primask(primask_state);
+    primask_state = enter_critical_with_primask();
+
+    // In case the HF restore was completed from the HFXO ISR,
+    // and notification not done elsewhere, do it here
+    if (is_restored_from_hfxo_isr_internal == true) {
+      is_restored_from_hfxo_isr_internal = false;
+      if (current_em == waiting_clock_restore_from_em) {
+        current_em = SL_POWER_MANAGER_EM1;
+        power_manager_notify_em_transition(waiting_clock_restore_from_em, SL_POWER_MANAGER_EM1);
+      }
+    }
+
+    // Stop the internal power manager sleeptimer.
+    sl_sleeptimer_stop_timer(&clock_wakeup_timer_handle);
+  } while (sl_power_manager_sleep_on_isr_exit() == true);
+
+#ifdef SLI_DEVICE_SUPPORTS_EM1P
+  requirement_high_accuracy_hf_clock_back_to_zero = false;
+#endif
+
+  if (is_states_saved == true) {
+    is_sleeping_waiting_for_clock_restore = false;
+    // Restore clocks
+    if (is_hf_x_oscillator_not_preserved) {
+      sli_power_manager_restore_high_freq_accuracy_clk();
+      is_hf_x_oscillator_not_preserved = false;
+    }
+    // If possible, go back to sleep in EM1 while waiting for HF accuracy restore
+    while (!sli_power_manager_is_high_freq_accuracy_clk_ready(false)) {
+      sli_power_manager_apply_em(SL_POWER_MANAGER_EM1);
+      exit_critical_with_primask(primask_state);
+      primask_state = enter_critical_with_primask();
+    }
+    sli_power_manager_restore_states();
+    is_states_saved = false;
+  }
+
+  evaluate_wakeup(SL_POWER_MANAGER_EM0);
+#else
+  current_em = SL_POWER_MANAGER_EM1;
+
+  // Notify listeners of transition to EM1
+  power_manager_notify_em_transition(SL_POWER_MANAGER_EM0, SL_POWER_MANAGER_EM1);
+  do {
+    // Apply EM1 energy mode
+    sli_power_manager_apply_em(SL_POWER_MANAGER_EM1);
+
+    exit_critical_with_primask(primask_state);
+    primask_state = enter_critical_with_primask();
+  } while (sl_power_manager_sleep_on_isr_exit() == true);
+#endif
+
+  // Indicate back to EM0
+  power_manager_notify_em_transition(current_em, SL_POWER_MANAGER_EM0);
+  current_em = SL_POWER_MANAGER_EM0;
+
+  sli_power_manager_resume_log_transmission();
+
+  exit_critical_with_primask(primask_state);
+}
+
+/***************************************************************************//**
+ * Updates requirement on the given energy mode.
+ *
+ * @param   em    Energy mode. Possible values are:
+ *                SL_POWER_MANAGER_EM1
+ *                SL_POWER_MANAGER_EM2
+ *
+ * @param   add   Flag indicating if requirement is added (true) or removed
+ *                (false).
+ *
+ * @note Need to be call inside a critical section.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+void sli_power_manager_update_em_requirement(sl_power_manager_em_t em,
+                                             bool add)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  // EM0 is not allowed
+  EFM_ASSERT((em > SL_POWER_MANAGER_EM0) && (em < SL_POWER_MANAGER_EM3));
+
+  // Cannot increment above 255 (wraparound not allowed)
+  EFM_ASSERT(!((requirement_em_table[em - 1] == UINT8_MAX) && (add == true)));
+  // Cannot decrement below 0 (wraparound not allowed)
+  EFM_ASSERT(!((requirement_em_table[em - 1] == 0) && (add == false)));
+
+  // Increment (add) or decrement (remove) energy mode counter.
+  requirement_em_table[em - 1] += (add) ? 1 : -1;
+
+  if (add == true
+      && current_em >= SL_POWER_MANAGER_EM2) {  // if currently sleeping at a level that can require a clock restore; i.e. called from ISR
+    sl_power_manager_em_t lowest_em;
+    // If requirement added when sleeping, restore the clock before continuing the processing.
+    // Retrieve lowest reachable energy mode
+    lowest_em = get_lowest_em();
+
+    if (lowest_em <= SL_POWER_MANAGER_EM1) {
+      // If new lowest requirement is greater than the current
+      // Restore clock; Everything is restored (HF and LF Clocks), the sleep loop will
+      // shutdown the clocks when returning sleeping
+      clock_restore_and_wait();
+    } else if (current_em == SL_POWER_MANAGER_EM3
+               && lowest_em == SL_POWER_MANAGER_EM2) {
+      // Restore LF clocks if we are transitioning from EM3 to EM2
+      sli_power_manager_low_frequency_restore();
+    }
+
+    if (current_em != lowest_em) {
+      power_manager_notify_em_transition(current_em, lowest_em);
+      current_em = lowest_em;           // Keep new active energy mode
+    }
+  }
+#else
+  (void)em;
+  (void)add;
+#endif
+}
+
+/***************************************************************************//**
+ * Updates requirement on preservation of High Frequency Clocks settings.
+ *
+ * @param   add   Flag indicating if requirement is added (true) or removed
+ *                (false).
+ ******************************************************************************/
+void sli_power_manager_update_hf_clock_settings_preservation_requirement(bool add)
+{
+#if (defined(SLI_DEVICE_SUPPORTS_EM1P) && !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT))
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+  // Cannot increment above 255 (wraparound not allowed)
+  EFM_ASSERT(!((requirement_high_accuracy_hf_clock_counter == UINT8_MAX) && (add == true)));
+  // Cannot decrement below 0 (wraparound not allowed)
+  EFM_ASSERT(!((requirement_high_accuracy_hf_clock_counter == 0) && (add == false)));
+
+  // Cannot add requirement if the "normal" clock settings are not currently applied
+  EFM_ASSERT(!((current_em > SL_POWER_MANAGER_EM2) && (add == true)));
+
+  // Increment (add) or decrement (remove) energy mode counter.
+  requirement_high_accuracy_hf_clock_counter += (add) ? 1 : -1;
+
+  // Save if the requirement is back to zero.
+  requirement_high_accuracy_hf_clock_back_to_zero = (requirement_high_accuracy_hf_clock_counter == 0) ? true : false;
+
+  CORE_EXIT_CRITICAL();
+#else
+  (void)add;
+#endif
+}
+
+/***************************************************************************//**
+ * Adds requirement on the preservation of the High Frequency Clocks settings.
+ *
+ * @note FOR INTERNAL USE ONLY.
+ *
+ * @note Must be used together with adding an EM2 requirement.
+ ******************************************************************************/
+void sli_power_manager_add_hf_clock_settings_preservation_requirement(void)
+{
+#if defined(SLI_DEVICE_SUPPORTS_EM1P)
+  sli_power_manager_update_hf_clock_settings_preservation_requirement(true);
+#else
+  sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);
+#endif
+}
+
+/***************************************************************************//**
+ * Removes requirement on the preservation of the High Frequency Clocks settings.
+ *
+ * @note FOR INTERNAL USE ONLY.
+ *
+ * @note Must be used together with removing an EM2 requirement.
+ ******************************************************************************/
+void sli_power_manager_remove_hf_clock_settings_preservation_requirement(void)
+{
+#if defined(SLI_DEVICE_SUPPORTS_EM1P)
+  sli_power_manager_update_hf_clock_settings_preservation_requirement(false);
+#else
+  sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
+#endif
+}
+
+/***************************************************************************//**
+ * Gets the wake-up restore process time.
+ * If we are not in the context of a deepsleep and therefore don't need to
+ * do a restore, the return value is 0.
+ *
+ * @return   Wake-up restore process time.
+ ******************************************************************************/
+uint32_t sli_power_manager_get_restore_delay(void)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  uint32_t wakeup_delay = 0;
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+
+  // If we are not currently in deepsleep, not need for any clock restore
+  if (current_em <= SL_POWER_MANAGER_EM1) {
+    CORE_EXIT_CRITICAL();
+    return wakeup_delay;
+  }
+
+  // Get the clock restore delay
+  wakeup_delay = sl_power_manager_schedule_wakeup_get_restore_overhead_tick();
+  wakeup_delay += sli_power_manager_get_wakeup_process_time_overhead();
+
+  CORE_EXIT_CRITICAL();
+
+  return wakeup_delay;
+#else
+  return 0;
+#endif
+}
+
+/***************************************************************************//**
+ * Initiates the wake-up restore process.
+ ******************************************************************************/
+void sli_power_manager_initiate_restore(void)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+
+  // Start restore process
+  clock_restore();
+
+  CORE_EXIT_CRITICAL();
+#endif
+}
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/*******************************************************************************
+ * Gets the status of power manager variable is_sleeping_waiting_for_clock_restore.
+ ******************************************************************************/
+bool sli_power_manager_get_clock_restore_status(void)
+{
+  return is_sleeping_waiting_for_clock_restore;
+}
+#endif
+
+/***************************************************************************//**
+ * Registers a callback to be called on given Energy Mode transition(s).
+ *
+ * @note Adding/Removing requirement(s) from the callback is not supported.
+ ******************************************************************************/
+void sl_power_manager_subscribe_em_transition_event(sl_power_manager_em_transition_event_handle_t *event_handle,
+                                                    const sl_power_manager_em_transition_event_info_t *event_info)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  event_handle->info = (sl_power_manager_em_transition_event_info_t *)event_info;
+  CORE_ENTER_CRITICAL();
+  sl_slist_push(&power_manager_em_transition_event_list, &event_handle->node);
+  CORE_EXIT_CRITICAL();
+}
+
+/***************************************************************************//**
+ * Unregisters an event callback handle on Energy mode transition.
+ ******************************************************************************/
+void sl_power_manager_unsubscribe_em_transition_event(sl_power_manager_em_transition_event_handle_t *event_handle)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+  sl_slist_remove(&power_manager_em_transition_event_list, &event_handle->node);
+  CORE_EXIT_CRITICAL();
+}
+
+/***************************************************************************//**
+ * Get configurable overhead value for early restore time in Sleeptimer ticks
+ * when a schedule wake-up is set.
+ *
+ * @return  Current overhead value for early wake-up time.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+int32_t sl_power_manager_schedule_wakeup_get_restore_overhead_tick(void)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  int32_t overhead_tick;
+
+  sl_atomic_load(overhead_tick, wakeup_time_config_overhead_tick);
+  return overhead_tick;
+#else
+  return 0;
+#endif
+}
+
+/***************************************************************************//**
+ * Set configurable overhead value for early restore time in Sleeptimer ticks
+ * used for schedule wake-up.
+ * Must be called after initialization else the value will be overwritten.
+ *
+ * @param overhead_tick Overhead value to set for early restore time.
+ *
+ * @note The overhead value can also be negative to remove time from the restore
+ *       process.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+void sl_power_manager_schedule_wakeup_set_restore_overhead_tick(int32_t overhead_tick)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  sl_atomic_store(wakeup_time_config_overhead_tick, overhead_tick);
+#else
+  (void)overhead_tick;
+#endif
+}
+
+/***************************************************************************//**
+ * Get configurable minimum off-time value for schedule wake-up in Sleeptimer
+ * ticks.
+ *
+ * @return  Current minimum off-time value for schedule wake-up.
+ *
+ * @note  Turning on external high frequency oscillator, such as HFXO, requires
+ *        more energy since we must supply higher current for the wake-up.
+ *        Therefore, when an 'external high frequency oscillator enable' is
+ *        scheduled in 'x' time, there is a threshold 'x' value where turning
+ *        off the oscillator is not worthwhile since the energy consumed by
+ *        taking into account the wake-up will be greater than if we just keep
+ *        the oscillator on until the next scheduled oscillator enabled. This
+ *        threshold value is what we refer as the minimum off-time.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+uint32_t sl_power_manager_schedule_wakeup_get_minimum_offtime_tick(void)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  uint32_t offtime_tick;
+
+  sl_atomic_load(offtime_tick, high_frequency_min_offtime_tick);
+  return offtime_tick;
+#else
+  return 0;
+#endif
+}
+
+/***************************************************************************//**
+ * Set configurable minimum off-time value for schedule wake-up in Sleeptimer
+ * ticks.
+ *
+ * @param minimum_offtime_tick  minimum off-time value to set for schedule
+ *                              wake-up.
+ *
+ * @note  Turning on external high frequency oscillator, such as HFXO, requires
+ *        more energy since we must supply higher current for the wake-up.
+ *        Therefore, when an 'external high frequency oscillator enable' is
+ *        scheduled in 'x' time, there is a threshold 'x' value where turning
+ *        off the oscillator is not worthwhile since the energy consumed by
+ *        taking into account the wake-up will be greater than if we just keep
+ *        the oscillator on until the next scheduled oscillator enabled. This
+ *        threshold value is what we refer as the minimum off-time.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+void sl_power_manager_schedule_wakeup_set_minimum_offtime_tick(uint32_t minimum_offtime_tick)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  sl_atomic_store(high_frequency_min_offtime_tick, minimum_offtime_tick);
+#else
+  (void)minimum_offtime_tick;
+#endif
+}
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/*******************************************************************************
+ * Converts microseconds time in sleeptimer ticks.
+ ******************************************************************************/
+uint32_t sli_power_manager_convert_delay_us_to_tick(uint32_t time_us)
+{
+  return (((time_us * sleeptimer_frequency) + (1000000 - 1)) / 1000000);
+}
+#endif
+
+/***************************************************************************//**
+ * Last-chance check before sleep.
+ *
+ * @return  True, if the system should actually sleep.
+ *          False, if not.
+ *
+ * @note This is the fallback implementation of the callback, it can be
+ *       overridden by the application or other components.
+ ******************************************************************************/
+__WEAK bool sl_power_manager_is_ok_to_sleep(void)
+{
+  return true;
+}
+
+/***************************************************************************//**
+ * Check if the MCU can sleep after an interrupt.
+ *
+ * @return  True, if the system can sleep after the interrupt.
+ *          False, otherwise.
+ *
+ * @note This is the fallback implementation of the callback, it can be
+ *       overridden by the application or other components.
+ ******************************************************************************/
+__WEAK bool sl_power_manager_sleep_on_isr_exit(void)
+{
+  return false;
+}
+
+/**************************************************************************//**
+ * Determines if the HFXO interrupt was part of the last wake-up and/or if
+ * the HFXO early wakeup expired during the last ISR
+ * and if it was the only timer to expire in that period.
+ *
+ * @return true if power manager sleep can return to sleep,
+ *         false otherwise.
+ *
+ * @note This function will always return false in case
+ *       a requirement is added on  SL_POWER_MANAGER_EM1,
+ *       since we will never sleep at a lower level than EM1.
+ *****************************************************************************/
+bool sl_power_manager_is_latest_wakeup_internal(void)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  CORE_DECLARE_IRQ_STATE;
+  bool sleep;
+
+  CORE_ENTER_CRITICAL();
+  sleep = is_restored_from_hfxo_isr;
+  is_restored_from_hfxo_isr = false;
+  CORE_EXIT_CRITICAL();
+
+  sleep |= sl_sleeptimer_is_power_manager_early_restore_timer_latest_to_expire();
+  return sleep;
+#else
+  return false;
+#endif
+}
+
+/*******************************************************************************
+ **************************   LOCAL FUNCTIONS   ********************************
+ ******************************************************************************/
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Get lowest energy mode to apply given the requirements on the different
+ * energy modes.
+ *
+ * @return  Lowest energy mode: EM1, EM2 or EM3.
+ *
+ * @note If no requirement for any energy mode (EM1 and EM2), lowest energy mode
+ * is EM3.
+ ******************************************************************************/
+static sl_power_manager_em_t get_lowest_em(void)
+{
+  uint32_t em_ix;
+  sl_power_manager_em_t em;
+
+  // Retrieve lowest Energy mode allowed given the requirements
+  for (em_ix = 1; (em_ix < 3) && (requirement_em_table[em_ix - 1] == 0); em_ix++) {
+    ;
+  }
+
+  em = (sl_power_manager_em_t)em_ix;
+
+  return em;
+}
+#endif
+
+/***************************************************************************//**
+ * Notify subscribers about energy mode transition.
+ *
+ * @param  from  Energy mode from which CPU comes from.
+ *
+ * @param  to    Energy mode to which CPU is going to.
+ ******************************************************************************/
+static void power_manager_notify_em_transition(sl_power_manager_em_t from,
+                                               sl_power_manager_em_t to)
+{
+  sl_power_manager_em_transition_event_handle_t *handle;
+  sl_power_manager_em_transition_event_t transition = 0;
+
+  switch (to) {
+    case SL_POWER_MANAGER_EM0:
+      transition = SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM0;
+      break;
+
+    case SL_POWER_MANAGER_EM1:
+      transition = SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM1;
+      break;
+
+    case SL_POWER_MANAGER_EM2:
+      transition = SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM2;
+      break;
+
+    case SL_POWER_MANAGER_EM3:
+      transition = SL_POWER_MANAGER_EVENT_TRANSITION_ENTERING_EM3;
+      break;
+
+    default:
+      EFM_ASSERT(0);
+  }
+
+  switch (from) {
+    case SL_POWER_MANAGER_EM0:
+      transition |= SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM0;
+      break;
+
+    case SL_POWER_MANAGER_EM1:
+      transition |= SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM1;
+      break;
+
+    case SL_POWER_MANAGER_EM2:
+      transition |= SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM2;
+      break;
+
+    case SL_POWER_MANAGER_EM3:
+      transition |= SL_POWER_MANAGER_EVENT_TRANSITION_LEAVING_EM3;
+      break;
+
+    default:
+      EFM_ASSERT(0);
+  }
+
+  SL_SLIST_FOR_EACH_ENTRY(power_manager_em_transition_event_list, handle, sl_power_manager_em_transition_event_handle_t, node) {
+    if ((handle->info->event_mask & transition) > 0) {
+      handle->info->on_event(from, to);
+    }
+  }
+}
+
+/***************************************************************************//**
+ * Enter critical section by disabling interrupts using PriMask.
+ *
+ * @return primask Initial primask state.
+ *
+ * @note @ref sl_power_manager_sleep() function should use PriMask to disable
+ *       interrupts.
+ ******************************************************************************/
+static CORE_irqState_t enter_critical_with_primask(void)
+{
+  CORE_irqState_t irqState = __get_PRIMASK();
+  __disable_irq();
+
+  return irqState;
+}
+
+/***************************************************************************//**
+ * Exit critical section by re-enabling interrupts using PriMask.
+ *
+ * @param  primask_state  Initial primask state.
+ ******************************************************************************/
+static void exit_critical_with_primask(CORE_irqState_t primask_state)
+{
+  if (primask_state == 0U) {
+    __enable_irq();
+  }
+}
+/***************************************************************************//**
+ * Evaluates scheduled wakeup and restart timer based on the wakeup time.
+ * If the remaining time is shorter than the wakeup time then add a requirement
+ * on EM1 for avoiding the wakeup delay time.
+ *
+ * @note Must be called in a critical section.
+ ******************************************************************************/
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+static void evaluate_wakeup(sl_power_manager_em_t to)
+{
+  sl_status_t status;
+  uint32_t tick_remaining;
+
+  switch (to) {
+    case SL_POWER_MANAGER_EM0:
+      // Coming back from Sleep.
+      if (requirement_on_em1_added) {
+        update_em1_requirement(false);
+        requirement_on_em1_added = false;
+      }
+      break;
+
+    case SL_POWER_MANAGER_EM1:
+      // External high frequency clock, such as HFXO, already enabled; No wakeup delay
+      break;
+
+    case SL_POWER_MANAGER_EM2:
+    case SL_POWER_MANAGER_EM3:
+      // Get the time remaining until the next sleeptimer requiring early wake-up
+      status = sl_sleeptimer_get_remaining_time_of_first_timer(0, &tick_remaining);
+      if (status == SL_STATUS_OK) {
+        if (tick_remaining <= high_frequency_min_offtime_tick) {
+          // Add EM1 requirement if time remaining is to short to be energy efficient
+          // if going back to deepsleep.
+          update_em1_requirement(true);
+          requirement_on_em1_added = true;
+        } else {
+          int32_t wakeup_delay = 0;
+          int32_t cfg_overhead_tick = 0;
+
+          // Calculate overall wake-up delay.
+          sl_atomic_load(cfg_overhead_tick, wakeup_time_config_overhead_tick);
+          wakeup_delay += cfg_overhead_tick;
+          wakeup_delay += sli_power_manager_get_wakeup_process_time_overhead();
+          EFM_ASSERT(wakeup_delay >= 0);
+          if (tick_remaining <= (uint32_t)wakeup_delay) {
+            // Add EM1 requirement if time remaining is smaller than wake-up delay.
+            update_em1_requirement(true);
+            requirement_on_em1_added = true;
+          } else {
+            uint16_t hf_accuracy_clk_flag = 0;
+            if (sli_power_manager_is_high_freq_accuracy_clk_used()) {
+              hf_accuracy_clk_flag = SLI_SLEEPTIMER_POWER_MANAGER_HF_ACCURACY_CLK_FLAG;
+            }
+            // Start internal sleeptimer to do the early wake-up.
+            sl_sleeptimer_restart_timer(&clock_wakeup_timer_handle,
+                                        (tick_remaining - (uint32_t)wakeup_delay),
+                                        on_clock_wakeup_timeout,
+                                        NULL,
+                                        0,
+                                        (SLI_SLEEPTIMER_POWER_MANAGER_EARLY_WAKEUP_TIMER_FLAG | hf_accuracy_clk_flag));
+          }
+        }
+      }
+      break;
+
+    default:
+      EFM_ASSERT(false);
+  }
+}
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Updates internal EM1 requirement.
+ * We add an internal EM1 requirement when we would usually go into EM2/EM3
+ * but there is not enough time before the next schedule event requiring a
+ * clock restore. So we just go to sleep in EM1.
+ * We remove this internal EM1 requirement next time we wake-up.
+ *
+ * @param   add  true, to add EM1 requirement,
+ *               false, to remove EM1 requirement.
+ *
+ * @note For internal use only.
+ *
+ * @note Need to be call inside a critical section.
+ ******************************************************************************/
+static void update_em1_requirement(bool add)
+{
+  // Cannot increment above 255 (wraparound not allowed)
+  EFM_ASSERT(!((requirement_em_table[SL_POWER_MANAGER_EM1 - 1] == UINT8_MAX) && (add == true)));
+  // Cannot decrement below 0 (wraparound not allowed)
+  EFM_ASSERT(!((requirement_em_table[SL_POWER_MANAGER_EM1 - 1] == 0) && (add == false)));
+
+#if (SL_POWER_MANAGER_DEBUG == 1)
+  sli_power_manager_debug_log_em_requirement(SL_POWER_MANAGER_EM1, add, "PM_INTERNAL_EM1_REQUIREMENT");
+#endif
+
+  // Increment (add) or decrement (remove) energy mode counter.
+  requirement_em_table[SL_POWER_MANAGER_EM1 - 1] += (add) ? 1 : -1;
+
+  // In rare occasions a clock restore must be started here:
+  // - An asynchronous event wake-up the system from deepsleep very near the early wake-up event,
+  //   When we re-enter the sleep loop, we delete the internal early wake-up timer, but during
+  //   the evaluation before sleep, it is calculated that not enough time is remains to go to
+  //   deepsleep. In that case, since we deleted the early wake-up timer we must start the
+  //   restore process here.
+  // - A synchronous event is added during an ISR, when we evaluate if the timeout is bigger
+  //   than the clock restore time, it's barely bigger, so no clock restore process is started
+  //   at that time. But when we do the evaluate before sleep, the remaining time is now smaller
+  //   than the clock restore delay. So me must start the restore process here.
+  if (add == true
+      && current_em >= SL_POWER_MANAGER_EM2
+      && is_sleeping_waiting_for_clock_restore == false) {
+    clock_restore();
+  }
+}
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Do clock restore process and wait for it to be completed.
+ ******************************************************************************/
+static void clock_restore_and_wait(void)
+{
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+  if (is_states_saved == true) {
+    if (is_actively_waiting_for_clock_restore == false) {
+      is_actively_waiting_for_clock_restore = true;
+
+      // Since we will actively wait for clock restore, we cancel any current non-active wait.
+      is_sleeping_waiting_for_clock_restore = false;
+    }
+
+    if (is_hf_x_oscillator_not_preserved) {
+      sli_power_manager_restore_high_freq_accuracy_clk();
+      is_hf_x_oscillator_not_preserved = false;
+    }
+
+    CORE_EXIT_CRITICAL();
+    // We remove the critical section in case HFXO fails to startup and the HFXO Interrupt needs to run to handle the error.
+    sli_power_manager_is_high_freq_accuracy_clk_ready(true);
+    CORE_ENTER_CRITICAL();
+    if (is_actively_waiting_for_clock_restore) {
+      sli_power_manager_restore_states();
+      is_actively_waiting_for_clock_restore = false;
+    }
+
+    is_states_saved = false;
+  }
+  CORE_EXIT_CRITICAL();
+}
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Start clock restore process.
+ *
+ * @note Need to be call inside a critical section.
+ ******************************************************************************/
+static void clock_restore(void)
+{
+  // Check if we need to start the clock restore process
+  if (is_states_saved == true) {
+    if (is_hf_x_oscillator_not_preserved) {
+      sli_power_manager_restore_high_freq_accuracy_clk();
+      is_hf_x_oscillator_not_preserved = false;
+    }
+    if (sli_power_manager_is_high_freq_accuracy_clk_ready(false)) {
+      // Do the clock restore if the HF oscillator is already ready
+      sli_power_manager_restore_states();
+      is_states_saved = false;
+
+      // We do the notification only when the restore is completed.
+      power_manager_notify_em_transition(current_em, SL_POWER_MANAGER_EM1);
+      current_em = SL_POWER_MANAGER_EM1; // Keep new active energy mode
+    } else {
+      // If the HF oscillator is not yet ready, we will go back to sleep while waiting
+      is_sleeping_waiting_for_clock_restore = true;
+
+      // Save current EM to do the right notification later
+      waiting_clock_restore_from_em = current_em;
+    }
+  }
+}
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Callback for clock enable timer.
+ *
+ * @param   handle  Pointer to sleeptimer handle
+ *
+ * @param   data    Pointer to callback data
+ *
+ * @note We restore the HF clocks and go to EM1 here to be ready in time for the
+ *       Application sleeptimer callback. But no EM1 requirement is added
+ *       here. Since the time until the Application sleeptimer times out is <=
+ *       than the wake-up delay, it protects us from going back to sleep lower
+ *       than EM1. After that, it's up to the Application sleeptimer callback to
+ *       put a EM1 requirement if still needed.
+ ******************************************************************************/
+static void on_clock_wakeup_timeout(sl_sleeptimer_timer_handle_t *handle,
+                                    void *data)
+{
+  (void)handle;
+  (void)data;
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+
+  if (is_actively_waiting_for_clock_restore) {
+    // In case we are already actively waiting for HFXO ready in another ISR, just exit
+    CORE_EXIT_CRITICAL();
+    return;
+  }
+
+  // If needed start the clock restore process
+  clock_restore();
+
+  CORE_EXIT_CRITICAL();
+}
+#endif
+
+/***************************************************************************//**
+ * HFXO ready notification callback for internal use with power manager
+ *
+ * @note Will only be used on series 2 devices when HFXO Manager is present.
+ ******************************************************************************/
+void sli_hfxo_manager_notify_ready_for_power_manager(void)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  // Complete HF restore and change current Energy mode
+  // The notification will be done once back in the sleep loop
+  if (current_em != SL_POWER_MANAGER_EM0
+      && (is_sleeping_waiting_for_clock_restore == true)) {
+    sli_power_manager_restore_states();
+    is_sleeping_waiting_for_clock_restore = false;
+    is_states_saved = false;
+    is_restored_from_hfxo_isr = true;
+    is_restored_from_hfxo_isr_internal = true;
+  }
+#endif
+}
+
+/***************************************************************************//**
+ * HFXO PRS ready notification callback for internal use with power manager
+ *
+ * @note Will only be used on series 2 devices when HFXO Manager and SYSRTC
+ * is present.
+ ******************************************************************************/
+void sli_hfxo_notify_ready_for_power_manager_from_prs(void)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  // Set clock restore to true to indicate that HFXO has been restored from a
+  // PRS interrupt unless already in EM0 indicating HFXO didn't need to be restored.
+  if (current_em != SL_POWER_MANAGER_EM0) {
+    is_sleeping_waiting_for_clock_restore = true;
+  }
+#endif
+}
+
+/***************************************************************************//**
+ * Enable or disable fast wake-up in EM2 and EM3
+ *
+ * @note Will also update the wake up time from EM2 to EM0.
+ *
+ * @note This function will do nothing when a project contains the
+ *       power_manager_no_deepsleep component, which configures the
+ *       lowest energy mode as EM1.
+ ******************************************************************************/
+void sl_power_manager_em23_voltage_scaling_enable_fast_wakeup(bool enable)
+{
+#if (defined(EMU_VSCALE_PRESENT) && !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT))
+  CORE_DECLARE_IRQ_STATE;
+
+  CORE_ENTER_CRITICAL();
+
+  sli_power_manager_em23_voltage_scaling_enable_fast_wakeup(enable);
+
+  CORE_EXIT_CRITICAL();
+#else
+  (void)enable;
+#endif
+}

--- a/gecko/platform/service/power_manager/src/sl_power_manager_debug.c
+++ b/gecko/platform/service/power_manager/src/sl_power_manager_debug.c
@@ -1,0 +1,169 @@
+/***************************************************************************//**
+ * @file
+ * @brief Power Manager Debug API implementation.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "sl_power_manager.h"
+#include "sl_power_manager_config.h"
+#include "sl_power_manager_debug.h"
+#include "sli_power_manager_private.h"
+
+#if (SL_POWER_MANAGER_DEBUG == 1)
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+static sl_slist_node_t *power_manager_debug_requirement_em_table[SLI_POWER_MANAGER_EM_TABLE_SIZE];
+static sli_power_debug_requirement_entry_t  power_debug_entry_table[SL_POWER_MANAGER_DEBUG_POOL_SIZE];
+static sl_slist_node_t *power_debug_free_entry_list = NULL;
+static bool power_debug_ran_out_of_entry = false;
+
+#if (!defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT))
+static void power_manager_log_add_requirement(sl_slist_node_t **p_list,
+                                              bool            add,
+                                              const char      *name);
+#endif // !(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+
+/***************************************************************************//**
+ * Print a fancy table that describes the current requirements on each energy
+ * mode and their owner.
+ ******************************************************************************/
+void sl_power_manager_debug_print_em_requirements(void)
+{
+  uint8_t i;
+  sli_power_debug_requirement_entry_t *entry;
+
+  if (power_debug_ran_out_of_entry) {
+    printf("WARNING: The system ran out of Debug Entry; This report is likely to be incomplete. Increase SL_POWER_MANAGER_DEBUG_POOL_SIZE\n\n");
+  }
+  printf("------------------------------------------\n");
+  printf("| EM requirements\n");
+  printf("------------------------------------------\n");
+  for (i = 0; i < SLI_POWER_MANAGER_EM_TABLE_SIZE; i++) {
+    if (power_manager_debug_requirement_em_table[i] != NULL) {
+      printf("| EM%d requirement module owners:\n", i + 1);
+    }
+    SL_SLIST_FOR_EACH_ENTRY(power_manager_debug_requirement_em_table[i], entry, sli_power_debug_requirement_entry_t, node) {
+      printf("|     %s\n", entry->module_name);
+    }
+    if (power_manager_debug_requirement_em_table[i] != NULL) {
+      printf("------------------------------------------\n");
+    }
+  }
+}
+
+/***************************************************************************//**
+ * Initialize debugging feature.
+ ******************************************************************************/
+void sli_power_manager_debug_init(void)
+{
+  uint32_t i;
+
+  for (i = 0; i < SL_POWER_MANAGER_DEBUG_POOL_SIZE; i++) {
+    sli_power_debug_requirement_entry_t  *entry = &power_debug_entry_table[i];
+    sl_slist_push(&power_debug_free_entry_list, &entry->node);
+  }
+}
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Log requirement to a list
+ *
+ * @param p_list  List where to push or remove the requirement.
+ *
+ * @param add     Add (true) or remove (false) the requirement.
+ *
+ * @param name    Module name that acquired or remove the requirement.
+ ******************************************************************************/
+static void power_manager_log_add_requirement(sl_slist_node_t **p_list,
+                                              bool            add,
+                                              const char      *name)
+{
+  sl_slist_node_t *node;
+  sli_power_debug_requirement_entry_t  *entry;
+
+  if (add == true) {
+    // Get entry from free list
+    node = sl_slist_pop(&power_debug_free_entry_list);
+    if (node == NULL) {
+      power_debug_ran_out_of_entry = true;
+      return;
+    }
+
+    // Push entry to the EMx requirement debug list
+    entry = SL_SLIST_ENTRY(node, sli_power_debug_requirement_entry_t, node);
+    entry->module_name = name;
+    sl_slist_push(p_list, &entry->node);
+  } else {
+    sli_power_debug_requirement_entry_t  *entry_remove = NULL;
+
+    // Search in the EMx requirement debug list
+    SL_SLIST_FOR_EACH_ENTRY(*p_list, entry, sli_power_debug_requirement_entry_t, node) {
+      // Current module name and entry module name
+      if (strcmp(entry->module_name, name) == 0) {
+        entry_remove = entry;
+        break;
+      }
+    }
+
+    if (entry_remove == NULL) {
+      return;
+    }
+
+    sl_slist_remove(p_list, &entry_remove->node);
+    sl_slist_push(&power_debug_free_entry_list, &entry_remove->node);
+  }
+}
+#endif // !(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+#endif // SL_POWER_MANAGER_DEBUG
+
+#undef sli_power_manager_debug_log_em_requirement
+/***************************************************************************//**
+ * Log energy mode (EM) requirement
+ *
+ * @param em    Energy mode added or removed.
+ *
+ * @param add   Add (true) or remove (false) the requirement.
+ *
+ * @param name  Module name that adds or removes the requirement.
+ ******************************************************************************/
+void sli_power_manager_debug_log_em_requirement(sl_power_manager_em_t em,
+                                                bool                  add,
+                                                const char            *name)
+{
+#if (!defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT) && (SL_POWER_MANAGER_DEBUG == 1))
+  if (em != SL_POWER_MANAGER_EM0) {
+    power_manager_log_add_requirement(&power_manager_debug_requirement_em_table[em - 1], add, name);
+  }
+#else
+  (void)em;
+  (void)add;
+  (void)name;
+#endif
+}

--- a/gecko/platform/service/power_manager/src/sl_power_manager_hal_s0_s1.c
+++ b/gecko/platform/service/power_manager/src/sl_power_manager_hal_s0_s1.c
@@ -1,0 +1,469 @@
+/***************************************************************************//**
+ * @file
+ * @brief Power Manager HAL API implementation.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#include "em_device.h"
+#if (defined(_SILICON_LABS_32B_SERIES_0) || defined(_SILICON_LABS_32B_SERIES_1))
+#include "em_emu.h"
+#include "em_cmu.h"
+#include "sl_assert.h"
+#include "sl_power_manager_config.h"
+#include "sl_power_manager.h"
+#include "sli_power_manager_private.h"
+#include "sl_sleeptimer.h"
+#include "sli_sleeptimer.h"
+
+#include <stdbool.h>
+
+/*******************************************************************************
+ *********************************   DEFINES   *********************************
+ ******************************************************************************/
+
+#if defined(_SILICON_LABS_32B_SERIES_1)
+#if !defined(PRORTC_PRESENT)
+// RTCC prescaler affects the wakeup overhead
+#define EM2_PRESCALER_TIMING (5 * (1 - (1 << ((RTCC->CTRL & _RTCC_CTRL_CNTPRESC_MASK) >> _RTCC_CTRL_CNTPRESC_SHIFT))))
+#else
+#define EM2_PRESCALER_TIMING (0)
+#endif
+#else
+#define EM2_PRESCALER_TIMING (0)
+#endif
+
+// Time required by the hardware to come out of EM2 in microseconds.
+// This value includes HW startup, emlib and sleepdrv execution time.
+// Voltage scaling, HFXO startup and HFXO steady times are excluded from
+// this because they are handled separately. RTCCSYNC time is also
+// excluded and it is handled by RTCCSYNC code itself.
+//TODO need to validate this value. how?
+#define EM2_WAKEUP_PROCESS_TIME_OVERHEAD_US (100 + EM2_PRESCALER_TIMING) //(215 + EM2_PRESCALER_TIMING)
+
+// Time it takes to upscale voltage after EM2 in microseconds.
+#define EM2_WAKEUP_VSCALE_OVERHEAD_US (30)
+
+// DPLL Locking delay
+#define DPLL_COARSECOUNT_VALUE  (5u)
+
+// Default time value in microseconds required to start-up the hfxo oscillator.
+#define HFXO_START_UP_TIME_DEFAULT_VALUE_US  (600u)
+
+// high frequency oscillator wake-up time margin for possible variation
+// A shift by 3 will be like a division by 8, so a percentage of 12.5%.
+#define HFXO_START_UP_TIME_OVERHEAD_LOG2   3
+
+// Default time value in microseconds for the HFXO minimum off time.
+#if defined(_SILICON_LABS_32B_SERIES_1) \
+  && (_SILICON_LABS_GECKO_INTERNAL_SDID >= 100)
+// Default value for series 1 EFM devices.
+#define HFXO_MINIMUM_OFFTIME_DEFAULT_VALUE_US  1000u
+#elif defined(_CMU_HFXOCTRL_MASK)
+// Default value for series 1 EFR devices.
+#define HFXO_MINIMUM_OFFTIME_DEFAULT_VALUE_US  600u
+#else
+// Default value for series 0 devices.
+#define HFXO_MINIMUM_OFFTIME_DEFAULT_VALUE_US  1200u
+#endif
+
+/*******************************************************************************
+ *******************************  MACROS   *************************************
+ ******************************************************************************/
+
+/*******************************************************************************
+* DPLL lock time can be approximately calculated by the equation:
+*   COARSECOUNT * (N + 1) * Thfrco
+* Where
+*   - COARSECOUNT is calibration value in a hidden register. Its default value
+*     is 5 and should not change with calibration.
+*   - N is one the DPLL configuration parameter.
+*   - Thfrco is the targeted HFRCO period.
+*******************************************************************************/
+#define DPLL_LOCKING_DELAY_US_FUNCTION(N, freq_hfrco) \
+  ((uint64_t)(DPLL_COARSECOUNT_VALUE * ((N) +1)) * 1000000 + ((freq_hfrco) - 1)) / (freq_hfrco)
+
+/*******************************************************************************
+ ***************************  LOCAL VARIABLES   ********************************
+ ******************************************************************************/
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+// Time in ticks required for HFXO start-up after wake-up from sleep.
+static uint32_t hfxo_wakeup_time_tick = 0;
+static bool is_hf_x_oscillator_used = false;
+
+static bool is_hf_x_oscillator_already_started = false;
+static uint32_t hf_x_oscillator_wakeup_time_tc_inital = 0;
+
+#if defined(_CMU_DPLLCTRL_MASK)
+static bool is_dpll_used = false;
+#endif
+
+// Time in ticks required for the general wake-up process.
+static uint32_t process_wakeup_overhead_tick = 0;
+
+#if defined(EMU_VSCALE_PRESENT)
+static bool is_fast_wakeup_enabled = true;
+#endif
+
+static uint32_t cmu_status;
+#endif
+
+/***************************************************************************//**
+ * Do some hardware initialization if necessary.
+ ******************************************************************************/
+void sli_power_manager_init_hardware(void)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  // Validate that HFXO auto-start and auto-select feature is disabled
+  // since they are not compatible with Power Manager
+#if defined(_CMU_HFXOCTRL_AUTOSTARTEM0EM1_MASK)
+  EFM_ASSERT((CMU->HFXOCTRL & _CMU_HFXOCTRL_AUTOSTARTEM0EM1_MASK) == 0);
+#endif
+#if defined(_CMU_HFXOCTRL_AUTOSTARTSELEM0EM1_MASK)
+  EFM_ASSERT((CMU->HFXOCTRL & _CMU_HFXOCTRL_AUTOSTARTSELEM0EM1_MASK) == 0);
+#endif
+#endif
+
+  // Initializes EMU (voltage scaling in EM2/3)
+#if defined(EMU_VSCALE_PRESENT)
+  EMU_EM01Init_TypeDef em01_init = EMU_EM01INIT_DEFAULT;
+
+  EMU_EM01Init(&em01_init);
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+#if defined(SL_POWER_MANAGER_CONFIG_VOLTAGE_SCALING_FAST_WAKEUP)
+#if (SL_POWER_MANAGER_CONFIG_VOLTAGE_SCALING_FAST_WAKEUP == 0)
+  sli_power_manager_em23_voltage_scaling_enable_fast_wakeup(false);
+#else
+  sli_power_manager_em23_voltage_scaling_enable_fast_wakeup(true);
+#endif
+#else
+  sli_power_manager_em23_voltage_scaling_enable_fast_wakeup(false);
+#endif
+#endif
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  is_hf_x_oscillator_used = (CMU->STATUS & _CMU_STATUS_HFXOENS_MASK) == _CMU_STATUS_HFXOENS_MASK;
+#if defined(_CMU_DPLLCTRL_MASK)
+  is_dpll_used = (CMU->STATUS & CMU_STATUS_DPLLENS) == CMU_STATUS_DPLLENS;
+#endif
+
+  // Enable HFXO Interrupt if HFXO is used
+  if (is_hf_x_oscillator_used) {
+    // Initialize default values for HFXO start-up time
+    hfxo_wakeup_time_tick = sli_power_manager_convert_delay_us_to_tick(HFXO_START_UP_TIME_DEFAULT_VALUE_US);
+  }
+
+  // Calculate DPLL locking delay from its configuration
+#if defined(_CMU_DPLLCTRL_MASK)
+  if (is_dpll_used) {
+    uint32_t freq = CMU_ClockFreqGet(cmuClock_HF);
+    freq = freq * (((CMU->HFPRESC & _CMU_HFPRESC_PRESC_MASK) >> _CMU_HFPRESC_PRESC_SHIFT) + 1);
+    if (freq > 0) { // Avoid division by 0
+      // Add DPLL Locking delay
+      process_wakeup_overhead_tick += sli_power_manager_convert_delay_us_to_tick(DPLL_LOCKING_DELAY_US_FUNCTION((CMU->DPLLCTRL1 & _CMU_DPLLCTRL1_N_MASK) >> _CMU_DPLLCTRL1_N_SHIFT, freq));
+    }
+  }
+#endif
+
+  process_wakeup_overhead_tick += sli_power_manager_convert_delay_us_to_tick(EM2_WAKEUP_PROCESS_TIME_OVERHEAD_US);
+
+  // Save CMU register to handle the LF clock tree restore without the HF restore.
+  cmu_status = CMU->STATUS;
+#endif
+}
+
+/***************************************************************************//**
+ * Enable or disable fast wake-up in EM2 and EM3.
+ ******************************************************************************/
+void sli_power_manager_em23_voltage_scaling_enable_fast_wakeup(bool enable)
+{
+#if (defined(EMU_VSCALE_PRESENT) && !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT))
+
+  if (enable == is_fast_wakeup_enabled) {
+    return;
+  }
+
+  EMU_EM23Init_TypeDef em23_init = EMU_EM23INIT_DEFAULT;
+
+  // Enable/disable EMU voltage scaling in EM2/3
+  if (enable) {
+    em23_init.vScaleEM23Voltage = emuVScaleEM23_FastWakeup;
+  } else {
+    em23_init.vScaleEM23Voltage = emuVScaleEM23_LowPower;
+  }
+
+  EMU_EM23Init(&em23_init);
+
+  // Calculate and add voltage scaling wake-up delays in ticks
+  if (enable) {
+    // Remove voltage scaling delay if it was added before
+    process_wakeup_overhead_tick -= sli_power_manager_convert_delay_us_to_tick(EM2_WAKEUP_VSCALE_OVERHEAD_US);
+  } else {
+    // Add voltage scaling delay if it was not added before
+    process_wakeup_overhead_tick += sli_power_manager_convert_delay_us_to_tick(EM2_WAKEUP_VSCALE_OVERHEAD_US);
+  }
+
+  is_fast_wakeup_enabled = enable;
+#else
+  (void)enable;
+#endif
+}
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Save the CMU HF clock select state, oscillator enable, and voltage scaling.
+ ******************************************************************************/
+void sli_power_manager_save_states(void)
+{
+  EMU_Save();
+}
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Handle post-sleep operations. The idea is to start HFXO ASAP when we know we
+ * will need it.
+ ******************************************************************************/
+void EMU_EM23PostsleepHook(void)
+{
+  // Poke sleeptimer to determine if power manager's timer expired before the
+  // ISR handler executes.
+  if (is_hf_x_oscillator_used
+      && sli_sleeptimer_hal_is_int_status_set(SLEEPTIMER_EVENT_COMP)
+      && sli_sleeptimer_is_power_manager_timer_next_to_expire()) {
+    CMU_OscillatorEnable(cmuOsc_HFXO, true, false);
+
+    hf_x_oscillator_wakeup_time_tc_inital = sl_sleeptimer_get_tick_count();
+    is_hf_x_oscillator_already_started = true;
+  }
+}
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Handle pre-deepsleep operations if any are necessary, like manually disabling
+ * oscillators, change clock settings, etc.
+ ******************************************************************************/
+void sli_power_manager_handle_pre_deepsleep_operations(void)
+{
+}
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Handle post-sleep operations if any are necessary, like manually enabling
+ * oscillators, change clock settings, etc.
+ ******************************************************************************/
+void sli_power_manager_restore_high_freq_accuracy_clk(void)
+{
+}
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Checks if HF accuracy clocks is fully restored and, if needed, waits for it.
+ *
+ * @param wait  True, to wait for HF accuracy clocks to be ready
+ *              False, otherwise.
+ *
+ * @return True, if HFXO ready.
+ *         False, otherwise.
+ ******************************************************************************/
+bool sli_power_manager_is_high_freq_accuracy_clk_ready(bool wait)
+{
+  (void)wait;
+
+  return true;
+}
+#endif
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/***************************************************************************//**
+ * Restore CMU HF clock select state, oscillator enable, and voltage scaling.
+ *
+ * @return True, if restore is complete
+ *         False, otherwise.
+ ******************************************************************************/
+void sli_power_manager_restore_states(void)
+{
+  // For the cases where it's not started from an early wake up
+  if (!is_hf_x_oscillator_already_started
+      && is_hf_x_oscillator_used) {
+    hf_x_oscillator_wakeup_time_tc_inital = sl_sleeptimer_get_tick_count();
+  }
+
+  EMU_Restore();
+
+  if (is_hf_x_oscillator_used) {
+    // If HFXO is needed but somehow doesn't clock the cpu, wait for it to be ready.
+    while (!(CMU->STATUS & _CMU_STATUS_HFXORDY_MASK)) {
+    }
+
+    hfxo_wakeup_time_tick = sl_sleeptimer_get_tick_count() - hf_x_oscillator_wakeup_time_tc_inital;
+    is_hf_x_oscillator_already_started = false;
+  }
+
+#if 0 // TODO PLATFORM_MTL-8499
+#if defined(_CMU_DPLLCTRL_MASK)
+  if (is_dpll_used) {
+    // If DPLL is used, wait for it to be ready.
+    while (!(CMU->STATUS & _CMU_STATUS_DPLLRDY_MASK)) {
+    }
+  }
+#endif
+#endif
+}
+#endif
+
+/***************************************************************************//**
+ * Applies energy mode.
+ *
+ * @param em  Energy mode to apply:
+ *            SL_POWER_MANAGER_EM0
+ *            SL_POWER_MANAGER_EM1
+ *            SL_POWER_MANAGER_EM2
+ *
+ * @note EMU_EnterEM2() and EMU_EnterEM3() has the parameter 'restore' set to
+ *       true in the Power Manager. When set to true, the parameter 'restore'
+ *       allows the EMU driver to save and restore oscillators, clocks and
+ *       voltage scaling. When the processor returns from EM2 or EM3, its
+ *       execution resumes in a clean and stable state.
+ ******************************************************************************/
+void sli_power_manager_apply_em(sl_power_manager_em_t em)
+{
+  // Perform required actions according to energy mode
+  switch (em) {
+    case SL_POWER_MANAGER_EM1:
+#if (SL_EMLIB_CORE_ENABLE_INTERRUPT_DISABLED_TIMING == 1)
+      // when measuring interrupt disabled time, we don't
+      // want to count the time spent in sleep
+      sl_cycle_counter_pause();
+#endif
+      EMU_EnterEM1();
+#if (SL_EMLIB_CORE_ENABLE_INTERRUPT_DISABLED_TIMING == 1)
+      sl_cycle_counter_resume();
+#endif
+      break;
+
+    case SL_POWER_MANAGER_EM2:
+      EMU_EnterEM2(false);
+      break;
+
+    case SL_POWER_MANAGER_EM3:
+      EMU_EnterEM3(false);
+      break;
+
+    case SL_POWER_MANAGER_EM0:
+    default:
+      EFM_ASSERT(false);
+      break;
+  }
+}
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/*******************************************************************************
+ * Returns the default minimum offtime for HFXO.
+ ******************************************************************************/
+uint32_t sli_power_manager_get_default_high_frequency_minimum_offtime(void)
+{
+  return sli_power_manager_convert_delay_us_to_tick(HFXO_MINIMUM_OFFTIME_DEFAULT_VALUE_US);
+}
+#endif
+
+/*******************************************************************************
+ * Gets the delay associated the wake-up process from EM23.
+ *
+ * @return Delay for the complete wake-up process with full restore.
+ ******************************************************************************/
+uint32_t sli_power_manager_get_wakeup_process_time_overhead(void)
+{
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+  uint32_t delay = 0;
+  uint32_t delay_temp = 0;
+
+  // Add HFXO start-up delay if applicable
+  if (hfxo_wakeup_time_tick != 0) {
+    delay_temp = hfxo_wakeup_time_tick;
+    delay_temp += delay_temp >> HFXO_START_UP_TIME_OVERHEAD_LOG2;
+    delay += delay_temp;
+  }
+
+  // Add all additional overhead wake-up delays (DPLL, VSCALE, general wake-up process)
+  delay += process_wakeup_overhead_tick;
+
+  return delay;
+#else
+  return 0;
+#endif
+}
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/*******************************************************************************
+ * Restores the Low Frequency clocks according to which LF oscillators are used.
+ ******************************************************************************/
+void sli_power_manager_low_frequency_restore(void)
+{
+  uint32_t cmu_locked;
+  uint32_t osc_en_cmd;
+
+  // CMU registers may be locked.
+  cmu_locked = CMU->LOCK & CMU_LOCK_LOCKKEY_LOCKED;
+  CMU_Unlock();
+
+#if defined(_CMU_OSCENCMD_MASK)
+  /* AUXHFRCO are automatically disabled (except if using debugger). */
+  /* HFRCO, USHFRCO and HFXO are automatically disabled. */
+  /* LFRCO/LFXO may be disabled by SW in EM3. */
+  /* Restore according to status prior to entering energy mode. */
+  osc_en_cmd = 0;
+  osc_en_cmd |= (cmu_status & CMU_STATUS_LFRCOENS) != 0U
+                ? CMU_OSCENCMD_LFRCOEN : 0U;
+  osc_en_cmd |= (cmu_status & CMU_STATUS_LFXOENS) != 0U
+                ? CMU_OSCENCMD_LFXOEN : 0U;
+
+  CMU->OSCENCMD = osc_en_cmd;
+#endif
+
+  // Restore CMU register locking
+  if (cmu_locked != 0U) {
+    CMU_Lock();
+  }
+}
+
+/***************************************************************************//**
+ * Informs the power manager if the high accuracy/high frequency clock
+ * is used, prior to scheduling an early clock restore.
+ *
+ * @return true if HFXO is used, else false.
+ ******************************************************************************/
+bool sli_power_manager_is_high_freq_accuracy_clk_used(void)
+{
+  return is_hf_x_oscillator_used;
+}
+#endif
+#endif

--- a/gecko/platform/service/power_manager/src/sli_power_manager_private.h
+++ b/gecko/platform/service/power_manager/src/sli_power_manager_private.h
@@ -1,0 +1,142 @@
+/***************************************************************************//**
+ * @file
+ * @brief Power Manager Internal API definition.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2019 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "sl_power_manager.h"
+#include "sl_slist.h"
+
+#if defined(SL_COMPONENT_CATALOG_PRESENT)
+#include "sl_component_catalog.h"
+#endif
+
+#if defined(SL_CATALOG_EMLIB_CORE_DEBUG_CONFIG_PRESENT)
+#include "emlib_core_debug_config.h"
+#endif
+
+#if !defined(SL_EMLIB_CORE_ENABLE_INTERRUPT_DISABLED_TIMING)
+#define SL_EMLIB_CORE_ENABLE_INTERRUPT_DISABLED_TIMING   0
+#endif
+
+#if (SL_EMLIB_CORE_ENABLE_INTERRUPT_DISABLED_TIMING == 1)
+#include "sl_cycle_counter.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*******************************************************************************
+ *******************************   DEFINES   ***********************************
+ ******************************************************************************/
+
+#define SLI_POWER_MANAGER_EM_TABLE_SIZE  2
+
+/*******************************************************************************
+ *****************************   DATA TYPES   *********************************
+ ******************************************************************************/
+
+// Debug entry
+typedef struct {
+  sl_slist_node_t node;
+  const char *module_name;
+} sli_power_debug_requirement_entry_t;
+
+/*******************************************************************************
+ *****************************   PROTOTYPES   **********************************
+ ******************************************************************************/
+
+void sli_power_manager_init_hardware(void);
+
+void sli_power_manager_apply_em(sl_power_manager_em_t em);
+
+void sli_power_manager_debug_init(void);
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+void sli_power_manager_save_states(void);
+
+void sli_power_manager_handle_pre_deepsleep_operations(void);
+
+void sli_power_manager_restore_high_freq_accuracy_clk(void);
+
+bool sli_power_manager_is_high_freq_accuracy_clk_ready(bool wait);
+
+void sli_power_manager_restore_states(void);
+
+/*******************************************************************************
+ * Converts microseconds time in sleeptimer ticks.
+ ******************************************************************************/
+uint32_t sli_power_manager_convert_delay_us_to_tick(uint32_t time_us);
+
+/*******************************************************************************
+ * Returns the default minimum offtime for xtal high frequency oscillator.
+ ******************************************************************************/
+uint32_t sli_power_manager_get_default_high_frequency_minimum_offtime(void);
+
+/*******************************************************************************
+ * Restores the Low Frequency clocks according to which LF oscillators are used.
+ ******************************************************************************/
+void sli_power_manager_low_frequency_restore(void);
+
+/***************************************************************************//**
+ * Informs the power manager if the high accuracy/high frequency clock
+ * is used, prior to scheduling an early clock restore.
+ *
+ * @return true if HFXO is used, else false.
+ ******************************************************************************/
+bool sli_power_manager_is_high_freq_accuracy_clk_used(void);
+#endif
+
+/***************************************************************************//**
+ * Enable or disable fast wake-up in EM2 and EM3
+ *
+ * @note Will also update the wake up time from EM2 to EM0.
+ ******************************************************************************/
+void sli_power_manager_em23_voltage_scaling_enable_fast_wakeup(bool enable);
+
+/*******************************************************************************
+ * Gets the delay associated the wake-up process from EM23.
+ *
+ * @return Delay for the complete wake-up process with full restore.
+ ******************************************************************************/
+uint32_t sli_power_manager_get_wakeup_process_time_overhead(void);
+
+#if !defined(SL_CATALOG_POWER_MANAGER_NO_DEEPSLEEP_PRESENT)
+/*******************************************************************************
+ * Gets the status of power manager variable is_sleeping_waiting_for_clock_restore.
+ *
+ * @return true if Power Manager is sleeping waiting for clock restore, else false.
+ *
+ * @note FOR INTERNAL USE ONLY.
+ ******************************************************************************/
+bool sli_power_manager_get_clock_restore_status(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Origin: Silicon Labs Gecko SDK
URL: https://github.com/SiliconLabs/Gecko_SDK
Version: v4.5.0 (SHA: 90fc93e1f95a10c981f0e49ca6787192e82fd8f2)
Purpose: Add support for Zephyr power management, integrated with librail.
License: Zlib
Maintained-by: External

Required by: https://github.com/zephyrproject-rtos/zephyr/pull/112796