### PR TITLE
gecko: add everything needed for Bluetooth

### DIFF
--- a/gecko/platform/radio/rail_lib/chip/efr32/efr32xg1x/rail_chip_specific.h
+++ b/gecko/platform/radio/rail_lib/chip/efr32/efr32xg1x/rail_chip_specific.h
@@ -29,6 +29,12 @@
  *
  ******************************************************************************/
 
+#ifdef  SLI_LIBRARY_BUILD
+
+// This file should not be included when doing SLI_LIBRARY_BUILDs
+
+#else//!SLI_LIBRARY_BUILD
+
 #ifndef __RAIL_CHIP_SPECIFIC_H_
 #if !defined(__RAIL_TYPES_H__) && !defined(DOXYGEN_SHOULD_SKIP_THIS)
 #warning rail_chip_specific.h should only be included by rail_types.h
@@ -64,15 +70,6 @@ extern "C" {
  * @ingroup General
  */
 
-/**
- * A placeholder for a chip-specific RAIL handle. Using NULL as a RAIL handle is
- * not recommended. As a result, another value that can't be de-referenced is used.
- *
- * This generic handle can and should be used for RAIL APIs that are called
- * prior to RAIL initialization.
- */
-#define RAIL_EFR32_HANDLE ((RAIL_Handle_t)0xFFFFFFFFUL)
-
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 /**
@@ -80,21 +77,21 @@ extern "C" {
  * @brief The EFR32XG1 series size needed for
  *   \ref RAIL_StateBufferEntry_t::bufferBytes.
  */
-#define RAIL_EFR32XG1_STATE_BUFFER_BYTES 456
+#define RAIL_EFR32XG1_STATE_BUFFER_BYTES 480
 
 /**
  * @def RAIL_EFR32XG12_STATE_BUFFER_BYTES
  * @brief The EFR32XG12 series size needed for
  *   \ref RAIL_StateBufferEntry_t::bufferBytes.
  */
-#define RAIL_EFR32XG12_STATE_BUFFER_BYTES 480
+#define RAIL_EFR32XG12_STATE_BUFFER_BYTES 488
 
 /**
  * @def RAIL_EFR32XG13_STATE_BUFFER_BYTES
  * @brief The EFR32XG13 series size needed for
  *   \ref RAIL_StateBufferEntry_t::bufferBytes.
  */
-#define RAIL_EFR32XG13_STATE_BUFFER_BYTES 488
+#define RAIL_EFR32XG13_STATE_BUFFER_BYTES 496
 
 /**
  * @def RAIL_EFR32XG14_STATE_BUFFER_BYTES
@@ -122,97 +119,57 @@ extern "C" {
 #error "Unsupported platform!"
 #endif
 
-#endif//DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * @def RAIL_SEQ_IMAGE_1
+ * @brief A macro for the first sequencer image.
+ */
+#define RAIL_SEQ_IMAGE_1                  1
 
 /**
- * @struct RAILSched_Config_t
- * @brief Provided for backwards compatibility.
+ * @def RAIL_SEQ_IMAGE_2
+ * @brief A macro for the second sequencer image.
  */
-typedef struct RAILSched_Config {
-  uint8_t buffer[1]; /**< Dummy buffer no longer used. */
-} RAILSched_Config_t;
+#define RAIL_SEQ_IMAGE_2                  2
+
+#if (_SILICON_LABS_32B_SERIES_1_CONFIG == 3)
+/**
+ * @def RAIL_SEQ_IMAGE_ZWAVE
+ * @brief A chip-specific macro for the sequencer image used on EFR32XG13 OPNs
+ *   with ZWave.
+ */
+#define RAIL_SEQ_IMAGE_ZWAVE          RAIL_SEQ_IMAGE_1
 
 /**
- * @typedef RAIL_StateBuffer_t
- * @brief Provided for backwards compatibility.
+ * @def RAIL_SEQ_IMAGE_HIGH_BW_PHY
+ * @brief A chip-specific macro for the sequencer image used on EFR32XG13 OPNs
+ *   with High BW PHYs supported.
  */
-typedef uint8_t RAIL_StateBuffer_t[1];
+#define RAIL_SEQ_IMAGE_HIGH_BW_PHY         RAIL_SEQ_IMAGE_2
 
 /**
- * @struct RAIL_Config_t
- * @brief RAIL configuration structure.
+ * @def RAIL_SEQ_IMAGE_COUNT
+ * @brief A macro for the total number of sequencer images supported on the
+ *   platform.
  */
-typedef struct RAIL_Config {
-  /**
-   * A pointer to a function, which is called whenever a RAIL event occurs.
-   *
-   * @param[in] railHandle A handle for a RAIL instance.
-   * @param[in] events A bit mask of RAIL events.
-   *
-   * See the \ref RAIL_Events_t documentation for the list of RAIL events.
-   */
-  void (*eventsCallback)(RAIL_Handle_t railHandle, RAIL_Events_t events);
-  /**
-   * Provided for backwards compatibility. Ignored.
-   */
-  void *protocol;
-  /**
-   * Provided for backwards compatibility. Ignored.
-   */
-  RAILSched_Config_t *scheduler;
-  /**
-   * Provided for backwards compatibility. Ignored.
-   */
-  RAIL_StateBuffer_t buffer;
-} RAIL_Config_t;
+#define RAIL_SEQ_IMAGE_COUNT              2
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
+#else //(_SILICON_LABS_32B_SERIES_1_CONFIG != 3)
+
 /**
- * @enum RAIL_RadioStateEfr32_t
- * @brief Radio state machine statuses.
+ * @def RAIL_SEQ_IMAGE_DEFAULT
+ * @brief A chip-specific macro for the default sequencer image on platforms
+ *   that support only one sequencer image.
  */
-RAIL_ENUM(RAIL_RadioStateEfr32_t) {
-  RAIL_RAC_STATE_OFF,         /**< Radio is off. */
-  RAIL_RAC_STATE_RXWARM,      /**< Radio is enabling the receiver. */
-  RAIL_RAC_STATE_RXSEARCH,    /**< Radio is listening for incoming frames. */
-  RAIL_RAC_STATE_RXFRAME,     /**< Radio is receiving a frame. */
-  RAIL_RAC_STATE_RXPD,        /**< Radio is powering down receiver and going to
-                                   OFF state. */
-  RAIL_RAC_STATE_RX2RX,       /**< Radio is going back to receive mode after
-                                   receiving a frame. */
-  RAIL_RAC_STATE_RXOVERFLOW,  /**< Received data was lost due to full receive
-                                   buffer. */
-  RAIL_RAC_STATE_RX2TX,       /**< Radio is disabling receiver and enabling
-                                   transmitter. */
-  RAIL_RAC_STATE_TXWARM,      /**< Radio is enabling transmitter. */
-  RAIL_RAC_STATE_TX,          /**< Radio is transmitting data. */
-  RAIL_RAC_STATE_TXPD,        /**< Radio is powering down transmitter and going
-                                   to OFF state. */
-  RAIL_RAC_STATE_TX2RX,       /**< Radio is disabling transmitter and enabling
-                                   reception. */
-  RAIL_RAC_STATE_TX2TX,       /**< Radio is preparing a transmission after the
-                                   previous transmission was ended. */
-  RAIL_RAC_STATE_SHUTDOWN,    /**< Radio is powering down receiver and going to
-                                   OFF state. */
-  RAIL_RAC_STATE_NONE         /**< Invalid Radio state, must be the last entry. */
-};
+#define RAIL_SEQ_IMAGE_DEFAULT            RAIL_SEQ_IMAGE_1
 
-// Self-referencing defines minimize compiler complaints when using RAIL_ENUM
-#define RAIL_RAC_STATE_OFF          ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_OFF)
-#define RAIL_RAC_STATE_RXWARM       ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXWARM)
-#define RAIL_RAC_STATE_RXSEARCH     ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXSEARCH)
-#define RAIL_RAC_STATE_RXFRAME      ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXFRAME)
-#define RAIL_RAC_STATE_RXPD         ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXPD)
-#define RAIL_RAC_STATE_RX2RX        ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RX2RX)
-#define RAIL_RAC_STATE_RXOVERFLOW   ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXOVERFLOW)
-#define RAIL_RAC_STATE_RX2TX        ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RX2TX)
-#define RAIL_RAC_STATE_TXWARM       ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TXWARM)
-#define RAIL_RAC_STATE_TX           ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TX)
-#define RAIL_RAC_STATE_TXPD         ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TXPD)
-#define RAIL_RAC_STATE_TX2RX        ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TX2RX)
-#define RAIL_RAC_STATE_TX2TX        ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TX2TX)
-#define RAIL_RAC_STATE_SHUTDOWN     ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_SHUTDOWN)
-#define RAIL_RAC_STATE_NONE         ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_NONE)
+/**
+ * @def RAIL_SEQ_IMAGE_COUNT
+ * @brief A macro for the total number of sequencer images supported on the
+ *   platform.
+ */
+#define RAIL_SEQ_IMAGE_COUNT              1
+#endif //(_SILICON_LABS_32B_SERIES_1_CONFIG == 3)
+
 #endif//DOXYGEN_SHOULD_SKIP_THIS
 
 /** @} */ // end of group General_EFR32XG1
@@ -236,68 +193,6 @@ RAIL_ENUM(RAIL_RadioStateEfr32_t) {
 /** @} */ // end of group Multiprotocol_EFR32
 
 // -----------------------------------------------------------------------------
-// Antenna Control
-// -----------------------------------------------------------------------------
-/**
- * @addtogroup Antenna_Control_EFR32 EFR32
- * @{
- * @brief EFR32 Antenna Control Functionality
- * @ingroup Antenna_Control
- *
- * These enumerations and structures are used with RAIL Antenna Control API. EFR32 supports
- * up to two antennas with configurable pin locations.
- */
-
-/** Antenna path Selection enumeration. */
-RAIL_ENUM(RAIL_AntennaSel_t) {
-  /** Enum for antenna path 0. */
-  RAIL_ANTENNA_0 = 0,
-  /** Enum for antenna path 1. */
-  RAIL_ANTENNA_1 = 1,
-  /** Enum for antenna path auto. */
-  RAIL_ANTENNA_AUTO = 255,
-};
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Self-referencing defines minimize compiler complaints when using RAIL_ENUM
-#define RAIL_ANTENNA_0    ((RAIL_AntennaSel_t) RAIL_ANTENNA_0)
-#define RAIL_ANTENNA_1    ((RAIL_AntennaSel_t) RAIL_ANTENNA_1)
-#define RAIL_ANTENNA_AUTO ((RAIL_AntennaSel_t) RAIL_ANTENNA_AUTO)
-#endif//DOXYGEN_SHOULD_SKIP_THIS
-
-/**
- * @struct RAIL_AntennaConfig_t
- * @brief A configuration for antenna selection.
- */
-typedef struct RAIL_AntennaConfig {
-  /** Antenna 0 Pin Enable */
-  bool ant0PinEn;
-  /** Antenna 1 Pin Enable */
-  bool ant1PinEn;
-  /** Antenna 0 location for pin/port (EFR32 series 1)
-   *  On EFR32 series 2 this field is called defaultPath and
-   *  specifies the internal default RF path.  It is ignored
-   *  on EFR32 series 2 parts that have only one RF path bonded
-   *  out and on EFR32xG27 dual-band OPNs where the appropriate
-   *  RF path is automatically set by RAIL to 0 for 2.4GHZ band
-   *  and 1 for SubGHz band PHYs.
-   */
-  uint8_t ant0Loc;
-  /** Antenna 0 output GPIO port */
-  uint8_t ant0Port;
-  /** Antenna 0 output GPIO pin */
-  uint8_t ant0Pin;
-  /** Antenna 1 location for pin/port (EFR32 series 1 only) */
-  uint8_t ant1Loc;
-  /** Antenna 1 output GPIO port */
-  uint8_t ant1Port;
-  /** Antenna 1 output GPIO pin */
-  uint8_t ant1Pin;
-} RAIL_AntennaConfig_t;
-
-/** @} */ // end of group Antenna_Control_EFR32
-
-// -----------------------------------------------------------------------------
 // Calibration
 // -----------------------------------------------------------------------------
 /**
@@ -305,49 +200,7 @@ typedef struct RAIL_AntennaConfig {
  * @{
  * @brief EFR32-specific Calibrations
  * @ingroup Calibration
- *
- * The EFR32 supports the Image Rejection (IR)
- * calibration and a temperature-dependent calibration. The IR calibration
- * can be computed once and stored off or computed each time at
- * startup. Because it is PHY-specific and provides sensitivity improvements,
- * it is highly recommended. The IR calibration should only be run when the
- * radio is IDLE.
- *
- * The temperature-dependent calibrations are used to recalibrate the synth if
- * the temperature crosses 0C or the temperature delta since the last
- * calibration exceeds 70C while in receive. RAIL will run the VCO calibration
- * automatically upon entering receive or transmit states, so the application
- * can omit this calibration if the stack re-enters receive or transmit with
- * enough frequency to avoid reaching the temperature delta. If the application
- * does not calibrate for temperature, it's possible to miss receive packets due
- * to a drift in the carrier frequency.
  */
-
-/** EFR32-specific temperature calibration bit */
-#define RAIL_CAL_TEMP_VCO         (0x00000001U)
-/** EFR32-specific HFXO temperature check bit */
-#define RAIL_CAL_TEMP_HFXO        (0U)
-/** EFR32-specific HFXO compensation bit */
-#define RAIL_CAL_COMPENSATE_HFXO  (0U)
-/** EFR32-specific IR calibration bit */
-#define RAIL_CAL_RX_IRCAL         (0x00010000U)
-/** EFR32-specific IR calibration bit */
-#define RAIL_CAL_ONETIME_IRCAL    (RAIL_CAL_RX_IRCAL)
-
-/** A mask to run temperature-dependent calibrations */
-#define RAIL_CAL_TEMP             (RAIL_CAL_TEMP_VCO)
-/** A mask to run one-time calibrations */
-#define RAIL_CAL_ONETIME          (RAIL_CAL_ONETIME_IRCAL)
-/** A mask to run optional performance calibrations */
-#define RAIL_CAL_PERF             (0)
-/** A mask for calibrations that require the radio to be off */
-#define RAIL_CAL_OFFLINE          (RAIL_CAL_ONETIME_IRCAL)
-/** A mask to run all possible calibrations for this chip */
-#define RAIL_CAL_ALL              (RAIL_CAL_TEMP | RAIL_CAL_ONETIME)
-/** A mask to run all pending calibrations */
-#define RAIL_CAL_ALL_PENDING      (0x00000000U)
-/** An invalid calibration value */
-#define RAIL_CAL_INVALID_VALUE    (0xFFFFFFFFU)
 
 /**
  * @def RAIL_RF_PATHS
@@ -355,33 +208,9 @@ typedef struct RAIL_AntennaConfig {
  */
 #define RAIL_RF_PATHS 1
 
-/**
- * RAIL_IrCalValues_t
- * @brief An IR calibration value structure.
- *
- * This definition contains the set of persistent calibration values for
- * EFR32. You can set these beforehand and apply them at startup to save the
- * time required to compute them. Any of these values may be set to
- * RAIL_IRCAL_INVALID_VALUE to force the code to compute that calibration value.
- */
-typedef uint32_t RAIL_IrCalValues_t[RAIL_RF_PATHS];
-
-/**
- * A define to set all RAIL_IrCalValues_t values to uninitialized.
- *
- * This define can be used when you have no data to pass to the calibration
- * routines but wish to compute and save all possible calibrations.
- */
-#define RAIL_IRCALVALUES_UNINIT { \
-    RAIL_CAL_INVALID_VALUE,       \
-}
-
-/**
- * A define allowing Rx calibration value access compatibility
- * between series 1 and series 2.
- */
-#define RAIL_IRCALVAL(irCalStruct, rfPath) \
-  ((irCalStruct)[(rfPath)])
+#if     (RAIL_RF_PATHS > RAIL_MAX_RF_PATHS)
+#error "Update rail_types.h RAIL_MAX_RF_PATHS"
+#endif
 
 /**
  * @struct RAIL_ChannelConfigEntryAttr
@@ -389,314 +218,11 @@ typedef uint32_t RAIL_IrCalValues_t[RAIL_RF_PATHS];
  *  are designed to be altered and updated during run-time.
  */
 struct RAIL_ChannelConfigEntryAttr {
-  RAIL_IrCalValues_t calValues; /**< IR calibration attributes specific to
-                                       each channel configuration entry. */
+  /** IR calibration attributes specific to each channel configuration entry. */
+  RAIL_RxIrCalValues_t calValues;
 };
 
-/**
- * Apply a given image rejection calibration value.
- *
- * @param[in] railHandle A RAIL instance handle.
- * @param[in] imageRejection The image rejection value to apply.
- * @return A status code indicating success of the function call.
- *
- * Take an image rejection calibration value and apply it. This value should be
- * determined from a previous run of \ref RAIL_CalibrateIr on the same
- * physical device with the same radio configuration. The imageRejection value
- * will also be stored to the \ref RAIL_ChannelConfigEntry_t::attr, if possible.
- *
- * If multiple protocols are used, this function will return
- * \ref RAIL_STATUS_INVALID_STATE if it is called and the given railHandle is
- * not active. In that case, the caller must attempt to re-call this function later.
- *
- * @deprecated Please use \ref RAIL_ApplyIrCalibrationAlt instead.
- */
-RAIL_Status_t RAIL_ApplyIrCalibration(RAIL_Handle_t railHandle,
-                                      uint32_t imageRejection);
-
-/**
- * Apply a given image rejection calibration value.
- *
- * @param[in] railHandle A RAIL instance handle.
- * @param[in] imageRejection Pointer to the image rejection value to apply.
- * @param[in] rfPath RF path to calibrate.
- * @return A status code indicating success of the function call.
- *
- * Take an image rejection calibration value and apply it. This value should be
- * determined from a previous run of \ref RAIL_CalibrateIrAlt on the same
- * physical device with the same radio configuration. The imageRejection value
- * will also be stored to the \ref RAIL_ChannelConfigEntry_t::attr, if possible.
- * @note: To make sure the imageRejection value is stored/configured correctly,
- * \ref RAIL_ConfigAntenna should be called before calling this API.
- *
- * If multiple protocols are used, this function will return
- * \ref RAIL_STATUS_INVALID_STATE if it is called and the given railHandle is
- * not active. In that case, the caller must attempt to re-call this function later.
- */
-RAIL_Status_t RAIL_ApplyIrCalibrationAlt(RAIL_Handle_t railHandle,
-                                         RAIL_IrCalValues_t *imageRejection,
-                                         RAIL_AntennaSel_t rfPath);
-
-/**
- * Run the image rejection calibration.
- *
- * @param[in] railHandle A RAIL instance handle.
- * @param[out] imageRejection The result of the image rejection calibration.
- * @return A status code indicating success of the function call.
- *
- * Run the image rejection calibration and apply the resulting value. If the
- * imageRejection parameter is not NULL, store the value at that
- * location. The imageRejection value will also be stored to the
- * \ref RAIL_ChannelConfigEntry_t::attr, if possible. This is a long-running
- * calibration that adds significant code space when run and can be run with a
- * separate firmware image on each device to save code space in the
- * final image.
- *
- * If multiple protocols are used, this function will make the given railHandle
- * active, if not already, and perform calibration. If called during a protocol
- * switch, it will return \ref RAIL_STATUS_INVALID_STATE. In this case,
- * \ref RAIL_ApplyIrCalibration may be called to apply a previously determined
- * IR calibration value, or the app must defer calibration until the
- * protocol switch is complete. Silicon Labs recommends calling this function
- * from the application main loop.
- *
- * @deprecated Please use \ref RAIL_CalibrateIrAlt instead.
- */
-RAIL_Status_t RAIL_CalibrateIr(RAIL_Handle_t railHandle,
-                               uint32_t *imageRejection);
-
-/**
- * Run the image rejection calibration.
- *
- * @param[in] railHandle A RAIL instance handle.
- * @param[out] imageRejection Pointer to the image rejection result.
- * @param[in] rfPath RF path to calibrate.
- * @return A status code indicating success of the function call.
- *
- * Run the image rejection calibration and apply the resulting value. If the
- * imageRejection parameter is not NULL, store the value at that
- * location. The imageRejection value will also be stored to the
- * \ref RAIL_ChannelConfigEntry_t::attr, if possible. This is a long-running
- * calibration that adds significant code space when run and can be run with a
- * separate firmware image on each device to save code space in the
- * final image.
- * @note: To make sure the imageRejection value is stored/configured correctly,
- * \ref RAIL_ConfigAntenna should be called before calling this API.
- *
- * If multiple protocols are used, this function will return
- * \ref RAIL_STATUS_INVALID_STATE if it is called and the given railHandle is
- * not active. In that case, the caller must attempt to re-call this function later.
- */
-RAIL_Status_t RAIL_CalibrateIrAlt(RAIL_Handle_t railHandle,
-                                  RAIL_IrCalValues_t *imageRejection,
-                                  RAIL_AntennaSel_t rfPath);
-
-/**
- * Calibrate image rejection for IEEE 802.15.4 2.4 GHz.
- *
- * @param[in] railHandle A RAIL instance handle.
- * @param[out] imageRejection The result of the image rejection calibration.
- * @return A status code indicating success of the function call.
- *
- * Some chips have protocol-specific image rejection calibrations programmed
- * into their flash. This function will either get the value from flash and
- * apply it, or run the image rejection algorithm to find the value.
- */
-RAIL_Status_t RAIL_IEEE802154_CalibrateIr2p4Ghz(RAIL_Handle_t railHandle,
-                                                uint32_t *imageRejection);
-
-/**
- * Calibrate image rejection for IEEE 802.15.4 915 MHz and 868 MHz.
- *
- * @param[in] railHandle A RAIL instance handle.
- * @param[out] imageRejection The result of the image rejection calibration.
- * @return A status code indicating success of the function call.
- *
- * Some chips have protocol-specific image rejection calibrations programmed
- * into their flash. This function will either get the value from flash and
- * apply it, or run the image rejection algorithm to find the value.
- */
-RAIL_Status_t RAIL_IEEE802154_CalibrateIrSubGhz(RAIL_Handle_t railHandle,
-                                                uint32_t *imageRejection);
-
-/**
- * Calibrate image rejection for Bluetooth Low Energy.
- *
- * @param[in] railHandle A RAIL instance handle.
- * @param[out] imageRejection The result of the image rejection calibration.
- * @return A status code indicating success of the function call.
- *
- * Some chips have protocol-specific image rejection calibrations programmed
- * into their flash. This function will either get the value from flash and
- * apply it, or run the image rejection algorithm to find the value.
- */
-RAIL_Status_t RAIL_BLE_CalibrateIr(RAIL_Handle_t railHandle,
-                                   uint32_t *imageRejection);
-
-/**
- * Run the temperature calibration.
- *
- * @param[in] railHandle A RAIL instance handle.
- * @return A status code indicating success of the function call.
- *
- * Run the temperature calibration, which needs to recalibrate the synth if
- * the temperature crosses 0C or the temperature delta since the last
- * calibration exceeds 70C while in receive. RAIL will run the VCO calibration
- * automatically upon entering receive or transmit states, so the application
- * can omit this calibration if the stack re-enters receive or transmit with
- * enough frequency to avoid reaching the temperature delta. If the application
- * does not calibrate for temperature, it's possible to miss receive packets due
- * to a drift in the carrier frequency.
- *
- * If multiple protocols are used, this function will return
- * \ref RAIL_STATUS_INVALID_STATE if it is called and the given railHandle is
- * not active. In that case, the calibration will be automatically performed
- * next time the radio enters receive.
- */
-RAIL_Status_t RAIL_CalibrateTemp(RAIL_Handle_t railHandle);
-
-/**
- * Performs HFXO compensation.
- *
- * @param[in] railHandle A RAIL instance handle.
- * @param[out] crystalPPMError Current deviation that has been corrected,
- *   measured in PPM. May be NULL.
- * @return A status code indicating the result of the function call.
- *
- * Compute the PPM correction using the thermistor value available when
- * \ref RAIL_EVENT_THERMISTOR_DONE occurs, after
- * \ref RAIL_StartThermistorMeasurement() call.
- * Then correct the RF frequency as well as Tx and Rx sampling.
- *
- * This function calls the following RAIL functions in sequence saving having
- * to call them individually:
- *   - \ref RAIL_ConvertThermistorImpedance()
- *   - \ref RAIL_ComputeHFXOPPMError()
- *   - \ref RAIL_CompensateHFXO()
- *
- * @note This function makes the radio idle.
- */
-RAIL_Status_t RAIL_CalibrateHFXO(RAIL_Handle_t railHandle, int8_t *crystalPPMError);
-
-/**
- * @typedef RAIL_CalValues_t
- * @brief A calibration value structure.
- *
- * This structure contains the set of persistent calibration values for
- * EFR32. You can set these beforehand and apply them at startup to save the
- * time required to compute them. Any of these values may be set to
- * RAIL_CAL_INVALID_VALUE to force the code to compute that calibration value.
- */
-typedef RAIL_IrCalValues_t RAIL_CalValues_t;
-
-/**
- * A define to set all RAIL_CalValues_t values to uninitialized.
- *
- * This define can be used when you have no data to pass to the calibration
- * routines but wish to compute and save all possible calibrations.
- */
-#define RAIL_CALVALUES_UNINIT RAIL_IRCALVALUES_UNINIT
-
 /** @} */ // end of group Calibration_EFR32
-
-// -----------------------------------------------------------------------------
-// Diagnostic
-// -----------------------------------------------------------------------------
-/**
- * @addtogroup Diagnostic_EFR32 EFR32
- * @{
- * @brief Types specific to the EFR32 for the diagnostic routines.
- * @ingroup Diagnostic
- */
-
-/**
- * @typedef RAIL_FrequencyOffset_t
- * @brief Chip-specific type that represents the number of Frequency Offset
- *   units. It is used with \ref RAIL_GetRxFreqOffset() and
- *   \ref RAIL_SetFreqOffset().
- *
- * The units on this chip are radio synthesizer resolution steps (synthTicks).
- * On EFR32 (at least for now), the frequency offset is limited to 15 bits
- * (size of SYNTH_CALOFFSET). A value of \ref RAIL_FREQUENCY_OFFSET_INVALID
- * means that this value is invalid.
- */
-typedef int16_t RAIL_FrequencyOffset_t;
-
-/**
- * The maximum frequency offset value supported by this radio.
- */
-#define RAIL_FREQUENCY_OFFSET_MAX ((RAIL_FrequencyOffset_t) 0x3FFF)
-
-/**
- * The minimum frequency offset value supported by this radio.
- */
-#define RAIL_FREQUENCY_OFFSET_MIN ((RAIL_FrequencyOffset_t) -RAIL_FREQUENCY_OFFSET_MAX)
-
-/**
- * Specify an invalid frequency offset value. This will be returned if you
- * call \ref RAIL_GetRxFreqOffset() at an invalid time.
- */
-#define RAIL_FREQUENCY_OFFSET_INVALID ((RAIL_FrequencyOffset_t) 0x8000)
-
-/**
- * @struct RAIL_DirectModeConfig_t
- * @brief Chip-specific type that allows the user to specify direct mode
- *   parameters using \ref RAIL_ConfigDirectMode().
- */
-typedef struct RAIL_DirectModeConfig {
-  /** Enable synchronous RX DOUT using DCLK vs. asynchronous RX DOUT. */
-  bool syncRx;
-  /** Enable synchronous TX DIN using DCLK vs. asynchronous TX DIN. */
-  bool syncTx;
-
-  /** Only used with directRx */
-  /** Data output (DOUT) GPIO port */
-  uint8_t doutPort;
-  /** Data output (DOUT) GPIO pin */
-  uint8_t doutPin;
-
-  /** Only used in synchronous mode */
-  /** Data clock (DCLK) GPIO port. Only used in synchronous mode */
-  uint8_t dclkPort;
-  /** Data clock (DCLK) GPIO pin. Only used in synchronous mode */
-  uint8_t dclkPin;
-
-  /** Only used with directTx */
-  /** Data frame (DIN) GPIO port */
-  uint8_t dinPort;
-  /** Data frame (DIN) GPIO pin */
-  uint8_t dinPin;
-
-  /** Data output (DOUT) location for pin/port. */
-  uint8_t doutLoc;
-  /** Data clock (DCLK) location for pin/port. */
-  uint8_t dclkLoc;
-  /** Data frame (DIN) location for pin/port. */
-  uint8_t dinLoc;
-} RAIL_DirectModeConfig_t;
-
-/** @} */ // end of group Diagnostic_EFR32
-
-// -----------------------------------------------------------------------------
-// Radio Configuration
-// -----------------------------------------------------------------------------
-/**
- * @addtogroup Radio_Configuration_EFR32 EFR32
- * @{
- * @ingroup Radio_Configuration
- * @brief Types specific to the EFR32 for radio configuration.
- */
-
-/**
- * @brief The radio configuration structure.
- *
- * The radio configuration properly configures the
- * radio for operation on a protocol. These configurations should not be
- * created or edited by hand.
- */
-typedef const uint32_t *RAIL_RadioConfig_t;
-
-/** @} */ // end of group Radio_Configuration_EFR32
 
 // -----------------------------------------------------------------------------
 // Transmit
@@ -707,31 +233,6 @@ typedef const uint32_t *RAIL_RadioConfig_t;
  * @ingroup PA
  * @brief Types specific to the EFR32 for dealing with the on-chip PAs.
  */
-
-/**
- * Raw power levels used directly by the RAIL_Get/SetTxPower API where a higher
- * numerical value corresponds to a higher output power. These are referred to
- * as 'raw (values/units)'. On EFR32, they can range from one of \ref
- * RAIL_TX_POWER_LEVEL_2P4_LP_MIN, \ref RAIL_TX_POWER_LEVEL_2P4_HP_MIN, or
- * \ref RAIL_TX_POWER_LEVEL_SUBGIG_HP_MIN to one of \ref
- * RAIL_TX_POWER_LEVEL_2P4_LP_MAX, \ref RAIL_TX_POWER_LEVEL_2P4_HP_MAX, and \ref
- * RAIL_TX_POWER_LEVEL_SUBGIG_HP_MAX, respectively, depending on the selected \ref
- * RAIL_TxPowerMode_t.
- */
-typedef uint8_t RAIL_TxPowerLevel_t;
-
-/**
- * PA power setting used directly by the \ref RAIL_GetPaPowerSetting() and
- * \ref RAIL_SetPaPowerSetting() APIs which is decoded to the actual
- * hardware register value(s).
- */
-typedef uint32_t RAIL_PaPowerSetting_t;
-
-/**
- * Returned by \ref RAIL_SetPaPowerSetting when the current PA does
- * not support the dBm to power setting mapping table.
- */
-#define RAIL_TX_PA_POWER_SETTING_UNSUPPORTED     (0U)
 
 /**
  * The maximum valid value for the \ref RAIL_TxPowerLevel_t when in \ref
@@ -763,17 +264,6 @@ typedef uint32_t RAIL_PaPowerSetting_t;
  * RAIL_TX_POWER_MODE_SUBGIG mode.
  */
 #define RAIL_TX_POWER_LEVEL_SUBGIG_HP_MIN (0U)
-/**
- * Invalid RAIL_TxPowerLevel_t value returned when an error occurs
- * with RAIL_GetTxPower.
- */
-#define RAIL_TX_POWER_LEVEL_INVALID (255U)
-/**
- * Sentinel value that can be passed to RAIL_SetTxPower to set
- * the highest power level available on the current PA, regardless
- * of which one is selected.
- */
-#define RAIL_TX_POWER_LEVEL_MAX (254U)
 
 /** Backwards compatibility define */
 #define RAIL_TX_POWER_LEVEL_LP_MAX      RAIL_TX_POWER_LEVEL_2P4_LP_MAX
@@ -789,242 +279,23 @@ typedef uint32_t RAIL_PaPowerSetting_t;
 #define RAIL_TX_POWER_LEVEL_SUBGIG_MIN  RAIL_TX_POWER_LEVEL_SUBGIG_HP_MIN
 
 /**
- * @enum RAIL_TxPowerMode_t
- * @brief An enumeration of the EFR32 power modes.
- *
- * The power modes on the EFR32 correspond to the different on-chip PAs that
- * are available. For more information about the power and performance
- * characteristics of a given amplifier, see the data sheet.
- */
-RAIL_ENUM(RAIL_TxPowerMode_t) {
-  /** High-power amplifier, up to 20 dBm, raw values: 0-252 */
-  RAIL_TX_POWER_MODE_2P4GIG_HP,
-  /** Low-power amplifier, up to 0 dBm, raw values: 1-7 */
-  RAIL_TX_POWER_MODE_2P4GIG_LP,
-  /** SubGig amplifier, up to 20 dBm, raw values: 0-248 */
-  RAIL_TX_POWER_MODE_SUBGIG,
-  /** Invalid amplifier Selection */
-  RAIL_TX_POWER_MODE_NONE,
-};
-
-/** @deprecated Please use \ref RAIL_TX_POWER_MODE_2P4GIG_HP instead. */
-#define RAIL_TX_POWER_MODE_2P4_HP RAIL_TX_POWER_MODE_2P4GIG_HP
-/** @deprecated Please use \ref RAIL_TX_POWER_MODE_2P4GIG_LP instead. */
-#define RAIL_TX_POWER_MODE_2P4_LP RAIL_TX_POWER_MODE_2P4GIG_LP
-
-/**
  * The number of PA's on this chip. (Including Virtual PAs)
  */
 #define RAIL_NUM_PA (3U)
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 // Self-referencing defines minimize compiler complaints when using RAIL_ENUM
+// Only those supported per-platform are defined, for use with #ifdef in
+// apps or librail code.
 #define RAIL_TX_POWER_MODE_2P4GIG_HP ((RAIL_TxPowerMode_t) RAIL_TX_POWER_MODE_2P4GIG_HP)
+#define RAIL_TX_POWER_MODE_2P4_HP ((RAIL_TxPowerMode_t) RAIL_TX_POWER_MODE_2P4_HP)
 #define RAIL_TX_POWER_MODE_2P4GIG_LP ((RAIL_TxPowerMode_t) RAIL_TX_POWER_MODE_2P4GIG_LP)
+#define RAIL_TX_POWER_MODE_2P4_LP ((RAIL_TxPowerMode_t) RAIL_TX_POWER_MODE_2P4_LP)
+#define RAIL_TX_POWER_MODE_SUBGIG_HP ((RAIL_TxPowerMode_t) RAIL_TX_POWER_MODE_SUBGIG_HP)
 #define RAIL_TX_POWER_MODE_SUBGIG ((RAIL_TxPowerMode_t) RAIL_TX_POWER_MODE_SUBGIG)
-#define RAIL_TX_POWER_MODE_NONE   ((RAIL_TxPowerMode_t) RAIL_TX_POWER_MODE_NONE)
 #endif//DOXYGEN_SHOULD_SKIP_THIS
-
-/**
- * @def RAIL_TX_POWER_MODE_NAMES
- * @brief The names of the TX power modes
- *
- * A list of the names for the TX power modes on the EFR32 series 1 parts. This
- * macro is useful for test applications and debugging output.
- */
-#define RAIL_TX_POWER_MODE_NAMES {  \
-    "RAIL_TX_POWER_MODE_2P4GIG_HP", \
-    "RAIL_TX_POWER_MODE_2P4GIG_LP", \
-    "RAIL_TX_POWER_MODE_SUBGIG",    \
-    "RAIL_TX_POWER_MODE_NONE"       \
-}
-
-/**
- * @struct RAIL_TxPowerConfig_t
- *
- * @brief A structure containing values used to initialize the power amplifiers.
- */
-typedef struct RAIL_TxPowerConfig {
-  /** TX power mode */
-  RAIL_TxPowerMode_t mode;
-  /** Power amplifier supply voltage in mV, generally:
-   *  DCDC supply ~ 1800 mV (1.8 V)
-   *  Battery supply ~ 3300 mV (3.3 V)
-   */
-  uint16_t voltage;
-  /** The amount of time to spend ramping for TX in uS. */
-  uint16_t rampTime;
-} RAIL_TxPowerConfig_t;
 
 /** @} */ // end of group PA_EFR32
-
-// -----------------------------------------------------------------------------
-// PTI
-// -----------------------------------------------------------------------------
-/**
- * @addtogroup PTI_EFR32 EFR32
- * @{
- * @brief EFR32 PTI functionality
- * @ingroup PTI
- *
- * These enumerations and structures are used with RAIL PTI API. EFR32 supports
- * SPI and UART PTI and is configurable in terms of baud rates and pin PTI
- * pin locations.
- */
-
-/** A channel type enumeration. */
-RAIL_ENUM(RAIL_PtiMode_t) {
-  /** Turn PTI off entirely. */
-  RAIL_PTI_MODE_DISABLED,
-  /** SPI mode. */
-  RAIL_PTI_MODE_SPI,
-  /** UART mode. */
-  RAIL_PTI_MODE_UART,
-  /** 9-bit UART mode. */
-  RAIL_PTI_MODE_UART_ONEWIRE,
-};
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-// Self-referencing defines minimize compiler complaints when using RAIL_ENUM
-#define RAIL_PTI_MODE_DISABLED     ((RAIL_PtiMode_t) RAIL_PTI_MODE_DISABLED)
-#define RAIL_PTI_MODE_SPI          ((RAIL_PtiMode_t) RAIL_PTI_MODE_SPI)
-#define RAIL_PTI_MODE_UART         ((RAIL_PtiMode_t) RAIL_PTI_MODE_UART)
-#define RAIL_PTI_MODE_UART_ONEWIRE ((RAIL_PtiMode_t) RAIL_PTI_MODE_UART_ONEWIRE)
-#endif//DOXYGEN_SHOULD_SKIP_THIS
-
-/**
- * @struct RAIL_PtiConfig_t
- * @brief A configuration for PTI.
- */
-typedef struct RAIL_PtiConfig {
-  /** Packet Trace mode (UART or SPI) */
-  RAIL_PtiMode_t mode;
-  /** Output baudrate for PTI in Hz */
-  uint32_t baud;
-  /** Data output (DOUT) location for pin/port */
-  uint8_t doutLoc;
-  /** Data output (DOUT) GPIO port */
-  uint8_t doutPort;
-  /** Data output (DOUT) GPIO pin */
-  uint8_t doutPin;
-  /** Data clock (DCLK) location for pin/port. Only used in SPI mode */
-  uint8_t dclkLoc;
-  /** Data clock (DCLK) GPIO port. Only used in SPI mode */
-  uint8_t dclkPort;
-  /** Data clock (DCLK) GPIO pin. Only used in SPI mode */
-  uint8_t dclkPin;
-  /** Data frame (DFRAME) location for pin/port */
-  uint8_t dframeLoc;
-  /** Data frame (DFRAME) GPIO port */
-  uint8_t dframePort;
-  /** Data frame (DFRAME) GPIO pin */
-  uint8_t dframePin;
-} RAIL_PtiConfig_t;
-
-/** @} */ // end of group PTI_EFR32
-
-/******************************************************************************
- * Calibration Structures
- *****************************************************************************/
-/**
- * @addtogroup Calibration
- * @{
- */
-
-/// Use this value with either TX or RX values in RAIL_SetPaCTune
-/// to use whatever value is already set and do no update.
-#define RAIL_PACTUNE_IGNORE (255U)
-
-/** @} */ // end of group Calibration
-
-// -----------------------------------------------------------------------------
-// Retiming
-// -----------------------------------------------------------------------------
-/**
- * @addtogroup Retiming_EFR32 Retiming
- * @{
- * @brief EFR32-specific retiming capability.
- * @ingroup RAIL_API
- *
- * The EFR product families have many digital and analog modules that can run
- * in parallel with a radio. These combinations can cause interference and
- * degradation on the radio RX sensitivity. Retiming can
- * modify the clocking of the digital modules to reduce the interference.
- */
-
-/**
- * @enum RAIL_RetimeOptions_t
- * @brief Retiming options bit shifts.
- */
-RAIL_ENUM(RAIL_RetimeOptions_t) {
-  /** Shift position of \ref RAIL_RETIME_OPTION_HFXO bit */
-  RAIL_RETIME_OPTION_HFXO_SHIFT = 0,
-  /** Shift position of \ref RAIL_RETIME_OPTION_HFRCO bit */
-  RAIL_RETIME_OPTION_HFRCO_SHIFT,
-  /** Shift position of \ref RAIL_RETIME_OPTION_DCDC bit */
-  RAIL_RETIME_OPTION_DCDC_SHIFT,
-};
-
-// RAIL_RetimeOptions_t bitmasks
-/**
- * An option to configure HFXO retiming
- */
-#define RAIL_RETIME_OPTION_HFXO \
-  (1U << RAIL_RETIME_OPTION_HFXO_SHIFT)
-
-/**
- * An option to configure HFRCO retiming
- */
-#define RAIL_RETIME_OPTION_HFRCO \
-  (1U << RAIL_RETIME_OPTION_HFRCO_SHIFT)
-
-/**
- * An option to configure DCDC retiming
- */
-#define RAIL_RETIME_OPTION_DCDC \
-  (1U << RAIL_RETIME_OPTION_DCDC_SHIFT)
-
-/** A value representing no retiming options */
-#define RAIL_RETIME_OPTIONS_NONE 0x0U
-
-/** A value representing all retiming options */
-#define RAIL_RETIME_OPTIONS_ALL 0xFFU
-
-/**
- * Configure retiming options.
- *
- * @param[in] railHandle A handle of RAIL instance.
- * @param[in] mask A bitmask containing which options should be modified.
- * @param[in] options A bitmask containing desired configuration settings.
- *   Bit positions for each option are found in the \ref RAIL_RetimeOptions_t.
- * @return Status code indicating success of the function call.
- */
-RAIL_Status_t RAIL_ConfigRetimeOptions(RAIL_Handle_t railHandle,
-                                       RAIL_RetimeOptions_t mask,
-                                       RAIL_RetimeOptions_t options);
-
-/**
- * Get the currently configured retiming option.
- *
- * @param[in] railHandle A handle of RAIL instance.
- * @param[out] pOptions A pointer to configured retiming options
-                        bitmask indicating which are enabled.
- * @return Status code indicating success of the function call.
- */
-RAIL_Status_t RAIL_GetRetimeOptions(RAIL_Handle_t railHandle,
-                                    RAIL_RetimeOptions_t *pOptions);
-
-/**
- * Indicate that the DCDC peripheral bus clock enable has changed allowing
- * RAIL to react accordingly.
- *
- * @note This should be called after DCDC has been enabled or disabled.
- *
- * @return Status code indicating success of the function call.
- */
-RAIL_Status_t RAIL_ChangedDcdc(void);
-
-/** @} */ // end of group Retiming_EFR32
 
 /******************************************************************************
  * RX Channel Hopping
@@ -1036,7 +307,12 @@ RAIL_Status_t RAIL_ChangedDcdc(void);
 
 /// The static amount of memory needed per channel for channel hopping, measured
 /// in 32 bit words, regardless of the size of radio configuration structures.
-#define RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL (53U)
+#define RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL (55U)
+
+#if     (RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL \
+         > RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL_WORST_CASE)
+#error "Update rail_types.h RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL_WORST_CASE"
+#endif
 
 /** @} */  // end of group Rx_Channel_Hopping
 
@@ -1066,22 +342,6 @@ RAIL_Status_t RAIL_ChangedDcdc(void);
 /** @} */ // end of group Sleep
 
 /**
- * @addtogroup Data_Management_EFR32 EFR32
- * @{
- * @ingroup Data_Management
- */
-
-/// Fixed-width type indicating the needed alignment for RX and TX FIFOs. Note
-/// that docs.silabs.com will incorrectly indicate that this is always a
-/// uint8_t, but it does vary across RAIL platforms.
-#define RAIL_FIFO_ALIGNMENT_TYPE uint8_t
-
-/// Alignment that is needed for the RX and TX FIFOs.
-#define RAIL_FIFO_ALIGNMENT (sizeof(RAIL_FIFO_ALIGNMENT_TYPE))
-
-/** @} */ // end of group Data_Management_EFR32
-
-/**
  * @addtogroup State_Transitions_EFR32 EFR32
  * @{
  * @ingroup State_Transitions
@@ -1105,16 +365,6 @@ RAIL_Status_t RAIL_ChangedDcdc(void);
 #define RAIL_MAXIMUM_TRANSITION_US (1000000U)
 #endif//(_SILICON_LABS_32B_SERIES_1_CONFIG == 1)
 
-/**
- * @typedef RAIL_TransitionTime_t
- * @brief Suitable type for the supported transition time range.
- */
-#if     (_SILICON_LABS_32B_SERIES_1_CONFIG == 1)
-typedef uint16_t RAIL_TransitionTime_t;
-#else//!(_SILICON_LABS_32B_SERIES_1_CONFIG == 1)
-typedef uint32_t RAIL_TransitionTime_t;
-#endif//(_SILICON_LABS_32B_SERIES_1_CONFIG == 1)
-
 /** @} */ // end of group State_Transitions_EFR32
 
 #ifdef __cplusplus
@@ -1124,3 +374,5 @@ typedef uint32_t RAIL_TransitionTime_t;
 #endif // __RAIL_TYPES_H__
 
 #endif // __RAIL_CHIP_SPECIFIC_H_
+
+#endif // SLI_LIBRARY_BUILD

--- a/gecko/platform/radio/rail_lib/common/rail.h
+++ b/gecko/platform/radio/rail_lib/common/rail.h
@@ -176,6 +176,125 @@ RAIL_Status_t RAIL_AddStateBuffer4(RAIL_Handle_t genericRailHandle);
  */
 RAIL_Status_t RAIL_UseDma(uint8_t channel);
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * Load the first image \ref RAIL_SEQ_IMAGE_1 into the radio sequencer during
+ * RAIL initialization.
+ *
+ * @param[in] genericRailHandle A generic RAIL instance handle.
+ * @return Status code indicating success of the function call.
+ *
+ * This function must only be called from within the RAIL callback context of
+ * \ref RAILCb_RadioSequencerImageLoad. Otherwise, the function returns \ref
+ * RAIL_STATUS_INVALID_STATE.
+ */
+RAIL_Status_t RAIL_LoadSequencerImage1(RAIL_Handle_t genericRailHandle);
+
+/**
+ * Load the second image \ref RAIL_SEQ_IMAGE_2 into the radio sequencer during
+ * RAIL initialization.
+ *
+ * @param[in] genericRailHandle A generic RAIL instance handle.
+ * @return Status code indicating success of the function call.
+ *
+ * This function must only be called from within the RAIL callback context of
+ * \ref RAILCb_RadioSequencerImageLoad. Otherwise, the function returns \ref
+ * RAIL_STATUS_INVALID_STATE. On platforms where \ref RAIL_SEQ_IMAGE_COUNT < 2,
+ * the function returns with \ref RAIL_STATUS_INVALID_CALL.
+ */
+RAIL_Status_t RAIL_LoadSequencerImage2(RAIL_Handle_t genericRailHandle);
+
+/**
+ * Callback used to load the radio sequencer image during RAIL initialization.
+ * This function is optional to implement.
+ *
+ * @return Status code indicating success of the function call.
+ *
+ * This callback is used by RAIL to load a radio sequencer image during \ref
+ * RAIL_Init via an API such as \ref RAIL_LoadSequencerImage1. If this
+ * function is not implemented, a default image will be loaded. On some
+ * platforms, (in particular EFR32XG24), not implementing this function may
+ * result in a larger overall code size due to unused sequencer images not
+ * being dead stripped.
+ *
+ * @note If this function is implemented without a call to an image loading API
+ *   such as \ref RAIL_LoadSequencerImage1, an assert will occur during
+ *   RAIL initialization. Similarly, if an image is loaded that is
+ *   unsupported by the platform, an assert will occur.
+ */
+RAIL_Status_t RAILCb_RadioSequencerImageLoad(void);
+
+/**
+ * Load the FSK, OFDM and OQPSK image into the software modem (SFM) sequencer
+ * during RAIL initialization.
+ *
+ * @param[in] genericRailHandle A generic RAIL instance handle.
+ * @return Status code indicating success of the function call.
+ *
+ * This function must only be called from within the RAIL callback context of
+ * \ref RAILCb_LoadSfmSequencer. Otherwise, the function returns \ref
+ * RAIL_STATUS_INVALID_STATE.
+ */
+RAIL_Status_t RAIL_LoadSfmSunFskOfdmOqpsk(RAIL_Handle_t genericRailHandle);
+
+/**
+ * Load the OFDM and OQPSK image into the software modem (SFM) sequencer during
+ * RAIL initialization.
+ *
+ * @param[in] genericRailHandle A generic RAIL instance handle.
+ * @return Status code indicating success of the function call.
+ *
+ * This function must only be called from within the RAIL callback context of
+ * \ref RAILCb_LoadSfmSequencer. Otherwise, the function returns \ref
+ * RAIL_STATUS_INVALID_STATE.
+ */
+RAIL_Status_t RAIL_LoadSfmSunOfdmOqpsk(RAIL_Handle_t genericRailHandle);
+
+/**
+ * Load the OFDM image into the software modem (SFM) sequencer during
+ * RAIL initialization.
+ *
+ * @param[in] genericRailHandle A generic RAIL instance handle.
+ * @return Status code indicating success of the function call.
+ *
+ * This function must only be called from within the RAIL callback context of
+ * \ref RAILCb_LoadSfmSequencer. Otherwise, the function returns \ref
+ * RAIL_STATUS_INVALID_STATE.
+ */
+RAIL_Status_t RAIL_LoadSfmSunOfdm(RAIL_Handle_t genericRailHandle);
+
+/**
+ * Load the empty image into the software modem (SFM) sequencer during
+ * RAIL initialization.
+ *
+ * @param[in] genericRailHandle A generic RAIL instance handle.
+ * @return Status code indicating success of the function call.
+ *
+ * This function must only be called from within the RAIL callback context of
+ * \ref RAILCb_LoadSfmSequencer. Otherwise, the function returns \ref
+ * RAIL_STATUS_INVALID_STATE.
+ */
+RAIL_Status_t RAIL_LoadSfmEmpty(RAIL_Handle_t genericRailHandle);
+
+/**
+ * Callback used to load the software modem (SFM) sequencer image during RAIL
+ * initialization. This function is optional to implement.
+ *
+ * @return Status code indicating success of the function call.
+ *
+ * This callback is used by RAIL to load a software modem sequencer image during \ref
+ * RAIL_Init via an API such as \ref RAIL_LoadSfmSunFskOfdmOqpsk. If this
+ * function is not implemented, a default image including FSK, OFDM andd OQPSK
+ * modulations will be loaded.
+ *
+ * @note If this function is implemented without a call to an image loading API
+ *   such as \ref RAIL_LoadSfmSunFskOfdmOqpsk, an assert will occur during
+ *   RAIL initialization. Similiarly, if an image is loaded that is
+ *   unsupported by the platform, an assert will occur.
+ */
+RAIL_Status_t RAILCb_LoadSfmSequencer(void);
+#endif //DOXYGEN_SHOULD_SKIP_THIS
+
 /**
  * Initialize RAIL.
  *
@@ -683,9 +802,97 @@ RAIL_Status_t RAIL_GetSyncWords(RAIL_Handle_t railHandle,
  * This function will return \ref RAIL_STATUS_INVALID_STATE if called when BLE
  * has been enabled for this railHandle. When changing sync words in BLE mode,
  * use \ref RAIL_BLE_ConfigChannelRadioParams instead.
+ *
+ * @note If multiple protocols share the same radio configuration, the user
+ *   should not set custom sync words in any of those protocols as these
+ *   sync words could leak into the other protocol sharing the same radio
+ *   configuration.
  **/
 RAIL_Status_t RAIL_ConfigSyncWords(RAIL_Handle_t railHandle,
                                    const RAIL_SyncWordConfig_t *syncWordConfig);
+
+/**
+ * Sets the whitening initialization value.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return The whitening initialization value currently being used.
+ */
+uint16_t RAIL_GetWhiteningInitVal(RAIL_Handle_t railHandle);
+
+/**
+ * Returns the CRC initialization value.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return The CRC initialization value currently being used.
+ */
+uint32_t RAIL_GetCrcInitVal(RAIL_Handle_t railHandle);
+
+/**
+ * Sets the whitening initialization value.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in] whiteInit A whitening initialization value.
+ * @return Status code indicating success of the function call.
+ *
+ * Use this function to override the whitening initialization value
+ * defined by the current PHY's radio configuration. The new value
+ * will persist until this function is called again, \ref
+ * RAIL_ResetWhiteningInitVal() is called, or the PHY is
+ * changed.
+ *
+ * @note Overriding a PHY's whitening initialization value
+ *   will break communication with peers unless they effect
+ *   a similar change.
+ *
+ * @warning This API must not be used when either 802.15.4
+ *   or BLE modes are enabled.
+ */
+RAIL_Status_t RAIL_SetWhiteningInitVal(RAIL_Handle_t railHandle,
+                                       uint16_t whiteInit);
+
+/**
+ * Sets the CRC initialization value.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in] crcInit A CRC initialization value.
+ * @return Status code indicating success of the function call.
+ *
+ * Use this function to override the CRC initialization value
+ * defined by the current PHY's radio configuration. The new value
+ * will persist until this function is called again, \ref
+ * RAIL_ResetCrcInitVal() is called, or the PHY is changed.
+ *
+ * @note Overriding a PHY's CRC initialization value
+ *   will break communication with peers unless they effect
+ *   a similar change.
+ *
+ * @warning This API must not be used when either 802.15.4
+ *   or BLE modes are enabled.
+ */
+RAIL_Status_t RAIL_SetCrcInitVal(RAIL_Handle_t railHandle,
+                                 uint32_t crcInit);
+
+/**
+ * Restores the whitening initialization value to its initial setting
+ * from the Radio Configurator.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return Status code indicating success of the function call.
+ *
+ * Can use this function after using \ref RAIL_SetWhiteningInitVal().
+ */
+RAIL_Status_t RAIL_ResetWhiteningInitVal(RAIL_Handle_t railHandle);
+
+/**
+ * Restores the CRC initialization value to its initial setting from
+ * the Radio Configurator.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return Status code indicating success of the function call.
+ *
+ * Can use this function after using \ref RAIL_SetCrcInitVal().
+ */
+RAIL_Status_t RAIL_ResetCrcInitVal(RAIL_Handle_t railHandle);
 
 /** @} */ // end of group Radio_Configuration
 
@@ -1342,13 +1549,15 @@ RAIL_Status_t RAIL_Wake(RAIL_Time_t elapsedTime);
  *
  * @return Status code indicating success of the function call.
  *
- * @note Call this function only when the application is built
- * and initialized with Power Manager plugin.
- * RAIL will perform timer synchronization, upon transitioning from EM2 or lower
- * to EM1 or higher energy mode or vice-versa, in the Power Manager EM
- * transition callback. Since EM transition callbacks are not called in a
- * deterministic order, it is suggested to not call any RAIL time dependent APIs
- * in an EM transition callback.
+ * @note This function must be called only when the application is built
+ *   and initialized with Power Manager plugin and when the radio is idle.
+ *   RAIL will perform timer synchronization, upon transitioning from EM2 or
+ *   lower to EM1 or higher energy mode or vice-versa, in the Power Manager EM
+ *   transition callback.
+ *
+ * @warning Since EM transition callbacks are not called in a deterministic
+ *   order, it is suggested to not call any RAIL time dependent APIs
+ *   in an EM transition callback.
  */
 RAIL_Status_t RAIL_InitPowerManager(void);
 
@@ -1736,15 +1945,15 @@ uint16_t RAIL_WriteTxFifo(RAIL_Handle_t railHandle,
  * Set the address of the transmit FIFO, a circular buffer used for TX data.
  *
  * @param[in] railHandle A RAIL instance handle.
- * @param[in,out] addr A pointer to a read-write memory location in RAM
- *   used as the transmit FIFO. This memory must persist until the next call to
- *   this function.
+ * @param[in,out] addr An appropriately-aligned (see below) pointer to a read-write memory
+ *   location in RAM used as the transmit FIFO. This memory must persist until the next
+ *   call to this function or \ref RAIL_SetTxFifoAlt.
  * @param[in] initLength A number of initial bytes already in the transmit FIFO.
  * @param[in] size A desired size of the transmit FIFO in bytes.
  * @return Returns the FIFO size in bytes, 0 if an error occurs.
  *
- * This function sets the memory location for the transmit FIFO. It
- * must be called at least once before any transmit operations occur.
+ * This function sets the memory location for the transmit FIFO. \ref RAIL_SetTxFifo or
+ * \ref RAIL_SetTxFifoAlt must be called at least once before any transmit operations occur.
  *
  * FIFO size can be determined by the return value of this function. The
  * chosen size is determined based on the available FIFO sizes supported by the
@@ -1753,9 +1962,9 @@ uint16_t RAIL_WriteTxFifo(RAIL_Handle_t railHandle,
  * For more on supported FIFO sizes and alignments, see chip-specific
  * documentation, such as \ref efr32_main. The returned FIFO size will be the
  * closest allowed size less than or equal to the passed in size parameter,
- * unless the size parameter is smaller than the minimum FIFO size. If the
- * initLength parameter is larger than the returned size, the FIFO will be
- * filled up to its size.
+ * unless the size parameter is smaller than the minimum FIFO size, in that case
+ * 0 is returned. If the initLength parameter is larger than the returned
+ * size, the FIFO will be filled up to its size.
  *
  * A user may write to the custom memory location directly before calling this
  * function, or use \ref RAIL_WriteTxFifo to write to the memory location after
@@ -1786,6 +1995,39 @@ uint16_t RAIL_SetTxFifo(RAIL_Handle_t railHandle,
                         uint16_t initLength,
                         uint16_t size);
 
+/**
+ * Set the address of the transmit FIFO, a circular buffer used for TX data which
+ * can start at offset distance from the FIFO base address.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in,out] addr An appropriately-aligned (see \ref RAIL_SetTxFifo description)
+ *   pointer to a read-write memory location in RAM used as the transmit FIFO. This memory
+ *   must persist until the next call to this function or \ref RAIL_SetTxFifo.
+ * @param[in] startOffset A number of bytes defining the start position of the TX data
+ *   from the transmit FIFO base address, only valid if initLength is not 0.
+ * @param[in] initLength The number of valid bytes already in the transmit FIFO after startOffset.
+ * @param[in] size A desired size of the transmit FIFO in bytes.
+ * @return Returns the FIFO size in bytes, 0 if an error occurs.
+ *
+ * This function is similar to \ref RAIL_SetTxFifo except a startOffset can be specified
+ * to indicate where the transmit packet data starts. This allows an application to
+ * place unaligned initial packet data within the aligned transmit FIFO (initLength > 0).
+ * Specifying a startOffset will not reduce the FIFO threshold or affect
+ * \ref RAIL_GetTxFifoSpaceAvailable().
+ * \ref RAIL_SetTxFifo or \ref RAIL_SetTxFifoAlt must be called at least once before any transmit
+ * operations occur.
+ * FIFO size handling is quite same as \ref RAIL_SetTxFifo. Only difference is that if the
+ * initLength plus startOffset parameters are larger than the returned size, the FIFO
+ * will be filled up to its size from startOffset.
+ * Note that the startOffset is essentially forgotten after the next transmit --
+ * i.e. it applies onto to the next transmit operation, and is not re-established when
+ * the transmit FIFO is reset.
+ */
+uint16_t RAIL_SetTxFifoAlt(RAIL_Handle_t railHandle,
+                           uint8_t *addr,
+                           uint16_t startOffset,
+                           uint16_t initLength,
+                           uint16_t size);
 /**
  * Set the address of the receive FIFO, a circular buffer used for RX data.
  *
@@ -1933,13 +2175,21 @@ uint16_t RAIL_SetTxFifoThreshold(RAIL_Handle_t railHandle,
  * @return Configured receive FIFO threshold value.
  *
  * This function configures the threshold for the receive FIFO. When the
- * number of bytes of packet data in the receive FIFO exceeds the configured
- * threshold, \ref RAIL_Config_t::eventsCallback will fire with \ref
- * RAIL_EVENT_RX_FIFO_ALMOST_FULL set.
- * The rxThreshold value should be smaller than the receive FIFO size;
- * anything else, including a
- * value of \ref RAIL_FIFO_THRESHOLD_DISABLED, will disable the threshold,
+ * number of bytes of packet data in the receive FIFO exceeds the
+ * configured threshold, \ref RAIL_Config_t::eventsCallback will keep
+ * firing with \ref RAIL_EVENT_RX_FIFO_ALMOST_FULL set as long as the
+ * number of bytes in the receive FIFO exceeds the configured threshold
+ * value. The rxThreshold value should be smaller than the receive FIFO
+ * size; anything else, including a value of
+ * \ref RAIL_FIFO_THRESHOLD_DISABLED, will disable the threshold,
  * returning \ref RAIL_FIFO_THRESHOLD_DISABLED.
+ *
+ * @note To avoid sticking in the event handler (even in idle state):
+ * 1. Disable the event (via the config events API or the
+ *    \ref RAIL_FIFO_THRESHOLD_DISABLED parameter)
+ * 2. Increase FIFO threshold
+ * 3. Read the FIFO (that's not an option in
+ *    \ref RAIL_DataMethod_t::PACKET_MODE) in the event handler
  */
 uint16_t RAIL_SetRxFifoThreshold(RAIL_Handle_t railHandle,
                                  uint16_t rxThreshold);
@@ -2102,11 +2352,15 @@ RAIL_Status_t RAIL_GetTxTransitions(RAIL_Handle_t railHandle,
  *
  * Any call to \ref RAIL_Idle or \ref RAIL_StopTx will clear the pending
  * repeated transmits. The state will also be cleared by another call to this
- * function. To clear the repeated transmits before they've started without
- * stopping other radio actions, call this function with a \ref
- * RAIL_TxRepeatConfig_t::iterations count of 0. A DMP switch will clear this
+ * function. A DMP switch will clear this
  * state only if the initial transmit triggering the repeated transmits has
  * started.
+ *
+ * One can change the repeated transmit configuration by re-calling
+ * this function with new parameters as long as that occurs prior to
+ * calling a \ref Packet_TX API. Passing a \ref
+ * RAIL_TxRepeatConfig_t::iterations count of 0 will prevent the next
+ * transmit from repeating.
  *
  * The application is responsible for populating the transmit data to be used
  * by the repeated transmits via \ref RAIL_SetTxFifo or \ref RAIL_WriteTxFifo.
@@ -2117,9 +2371,10 @@ RAIL_Status_t RAIL_GetTxTransitions(RAIL_Handle_t railHandle,
  * Consider using \ref RAIL_TX_OPTION_RESEND if the same packet data is to
  * be repeated: then the Transmit FIFO only needs to be set/written once.
  *
- * Do not call this function after starting a transmit operation or before
- * processing the final transmit completion event of a prior transmit.
- * This function will fail to configure the repetition if a transmit of any
+ * Do not call this function after starting a transmit operation via a \ref
+ * Packet_TX API call or
+ * before processing the final transmit completion event of a prior transmit.
+ * This function will fail to (re)configure the repetition if a transmit of any
  * kind is ongoing, including during the time between an initial transmit and
  * the end of a previously-configured repetition.
  *
@@ -2282,6 +2537,35 @@ RAIL_RadioState_t RAIL_GetRadioState(RAIL_Handle_t railHandle);
  */
 RAIL_RadioStateDetail_t RAIL_GetRadioStateDetail(RAIL_Handle_t railHandle);
 
+/**
+ * Enable/disable caching of synth calibration value.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in] enable A booloean to enable or disable caching of synth calibration.
+ * @return Status code indicating success of the function call.
+ *
+ * Once enabled, the sequencer will start caching synth calibration values for
+ * channels and apply them instead of performing calibration on every state
+ * transition and channel change.
+ * This will increase the transition time for the first time calibration is
+ * performed. Subsequent state transitions will be faster. The cache size is 2.
+ * \ref RAIL_IEEE802154_SUPPORTS_RX_CHANNEL_SWITCHING internally uses this feature
+ * and there is no need to enable/disable it. This function returns
+ * \ref RAIL_STATUS_INVALID_STATE if we try to disable it while
+ * \ref RAIL_IEEE802154_SUPPORTS_RX_CHANNEL_SWITCHING is enabled.
+ *
+ * @note This function will improve the minimum timings that can be achieved in
+ * \ref RAIL_StateTiming_t::idleToRx, \ref RAIL_StateTiming_t::idleToTx,
+ * \ref RAIL_StateTiming_t::rxToTx, \ref RAIL_StateTiming_t::txToRx and
+ * \ref RAIL_StateTiming_t::txToTx. A call to \ref RAIL_SetStateTiming()
+ * is needed to achieve lower transition times.
+ *
+ * @note On a protocol switch the cache is cleared, so it is not suitable for
+ * applications where a protocol switch happens frequently, like with
+ * Dynamic Multiprotocol.
+ */
+RAIL_Status_t RAIL_EnableCacheSynthCal(RAIL_Handle_t railHandle, bool enable);
+
 /** @} */ // end of group State_Transitions
 
 /******************************************************************************
@@ -2329,8 +2613,8 @@ RAIL_RadioStateDetail_t RAIL_GetRadioStateDetail(RAIL_Handle_t railHandle);
 /// \ref RAIL_ConvertRawToDbm and \ref RAIL_ConvertDbmToRaw,
 /// which convert between the dBm power and the raw power levels,
 /// provide a solution that fits all these applications.
-/// The levels of customizability are outlined below:
-///  1) No customizability needed: for a given dBm value, the result
+/// The levels of customization are outlined below:
+///  1) No customization needed: for a given dBm value, the result
 ///     of RAIL_ConvertDbmToRaw provides an appropriate
 ///     raw power level that, when written to the registers via
 ///     RAIL_SetPowerLevel, causes the chip to output at that
@@ -2660,12 +2944,12 @@ const RAIL_PaPowerSetting_t *RAIL_GetPowerSettingTable(RAIL_Handle_t railHandle,
  * power determined by \ref RAIL_SetTxPowerDbm().
  *
  * @param[in] railHandle A RAIL instance handle.
- * @param[in] paPowerSetting The desired pa power setting.
+ * @param[in] paPowerSetting The desired PA power setting.
  * @param[in] minPowerDbm The minimum power in dBm that the PA can output.
  * @param[in] maxPowerDbm The maximum power in dBm that the PA can output.
  * @param[in] currentPowerDbm The corresponding output power in dBm for this power setting.
  * @return RAIL Status variable indicate whether setting the
- *   pa power setting was successful.
+ *   PA power setting was successful.
  */
 RAIL_Status_t RAIL_SetPaPowerSetting(RAIL_Handle_t railHandle,
                                      RAIL_PaPowerSetting_t paPowerSetting,
@@ -2674,11 +2958,11 @@ RAIL_Status_t RAIL_SetPaPowerSetting(RAIL_Handle_t railHandle,
                                      RAIL_TxPower_t currentPowerDbm);
 
 /**
- * Get the TX pa power setting, which is used to configure power configurations
+ * Get the TX PA power setting, which is used to configure power configurations
  * when the dBm to paPowerSetting mapping table mode is used.
  *
  * @param[in] railHandle A RAIL instance handle.
- * @return The current pa power setting.
+ * @return The current PA power setting.
  */
 RAIL_PaPowerSetting_t RAIL_GetPaPowerSetting(RAIL_Handle_t railHandle);
 
@@ -2699,7 +2983,7 @@ RAIL_PaPowerSetting_t RAIL_GetPaPowerSetting(RAIL_Handle_t railHandle);
  * able to operate properly to ensure that PA Auto Mode functions correctly.
  * See the PA Conversions plugin or AN1127 for more details.
  *
- * @param[in] railHandle A RAIL instance handle.
+ * @param[in] railHandle A real (not generic) RAIL instance handle.
  * @param[in] enable Enable or disable PA Auto Mode.
  * @return Status parameter indicating success of function call.
  */
@@ -2708,7 +2992,8 @@ RAIL_Status_t RAIL_EnablePaAutoMode(RAIL_Handle_t railHandle, bool enable);
 /**
  * Query status of PA Auto Mode.
  *
- * @param[in] railHandle A RAIL instance handle on which to query PA Auto Mode status.
+ * @param[in] railHandle A real (not generic) RAIL instance handle on which to
+ * query PA Auto Mode status.
  * @return Indicator of whether Auto Mode is enabled (true) or not (false).
  */
 bool RAIL_IsPaAutoModeEnabled(RAIL_Handle_t railHandle);
@@ -3033,11 +3318,15 @@ RAIL_Status_t RAIL_StartScheduledCcaLbtTx(RAIL_Handle_t railHandle,
  * @param[in] railHandle A RAIL instance handle.
  * @param[in] mode Configure the types of transmits to stop.
  * @return \ref RAIL_STATUS_NO_ERROR if the transmit was successfully
- *   canceled.
- *   Returns \ref RAIL_STATUS_INVALID_STATE if the requested
- *                transmit mode cannot be stopped.
+ *   stopped or \ref RAIL_STATUS_INVALID_STATE if there is no transmit
+ *   operation to stop.
  *
- * @note This function will stop an auto-ACK in active transmit.
+ * @note When mode includes \ref RAIL_STOP_MODE_ACTIVE, this can also stop
+ *   an active auto-ACK transmit. When an active transmit is stopped, \ref
+ *   RAIL_EVENT_TX_ABORTED or \ref RAIL_EVENT_TXACK_ABORTED should occur.
+ *   When mode includes \ref RAIL_STOP_MODE_PENDING this can also stop
+ *   a \ref RAIL_TX_OPTION_CCA_ONLY transmit operation. When a pending
+ *   transmit is stopped, \ref RAIL_EVENT_TX_BLOCKED should occur.
  */
 RAIL_Status_t RAIL_StopTx(RAIL_Handle_t railHandle, RAIL_StopMode_t mode);
 
@@ -3344,6 +3633,10 @@ bool RAIL_IsTxHoldOffEnabled(RAIL_Handle_t railHandle);
  * @param[in] railHandle A RAIL instance handle.
  * @param[in] length The desired preamble length, in bits.
  * @return Status code indicating success of the function call.
+ *
+ * To cause a transmission to use this alternate preamble length,
+ * specify \ref RAIL_TX_OPTION_ALT_PREAMBLE_LEN in the txOptions
+ * parameter passed to the respective RAIL transmit API.
  *
  * @note Attempting to set a preamble length of 0xFFFF bits will result in
  * \ref RAIL_STATUS_INVALID_PARAMETER.
@@ -4508,14 +4801,43 @@ bool RAIL_IsAutoAckEnabled(RAIL_Handle_t railHandle);
  *
  * @param[in] railHandle A RAIL instance handle.
  * @param[in] ackData A pointer to ACK data to transmit.
+ *   This may be NULL, in which case it's assumed the data has already
+ *   been emplaced into the ACK buffer and RAIL just needs to be told
+ *   how many bytes are there.  Use \ref RAIL_GetAutoAckFifo() to get
+ *   the address of RAIL's AutoACK buffer in RAM and its size.
  * @param[in] ackDataLen The number of bytes in ACK data.
  * @return Status code indicating success of the function call.
  *
  * If the ACK buffer is available for updates, load the ACK buffer with data.
+ * If it is not available, \ref RAIL_STATUS_INVALID_STATE is returned.
+ * If ackDataLen exceeds \ref RAIL_AUTOACK_MAX_LENGTH then
+ * \ref RAIL_STATUS_INVALID_PARAMETER will be returned and nothing is
+ * written to the ACK buffer (unless ackData is NULL in which case this
+ * indicates the application has already likely corrupted RAM).
  */
 RAIL_Status_t RAIL_WriteAutoAckFifo(RAIL_Handle_t railHandle,
                                     const uint8_t *ackData,
                                     uint8_t ackDataLen);
+
+/**
+ * Get the address and size of the auto-ACK buffer for direct access.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in,out] ackBuffer A pointer to a uint8_t pointer that will be
+ *    updated to the RAM base address of the TXACK buffer.
+ * @param[in,out] ackBufferBytes A pointer to a uint16_t that will be
+ *    updated to the size of the TXACK buffer, in bytes, which is
+ *    currently \ref RAIL_AUTOACK_MAX_LENGTH.
+ * @return Status code indicating success of the function call.
+ *
+ * Applications can use this to more flexibly write AutoAck data into
+ * the buffer directly and in pieces, passing NULL ackData parameter to
+ * \ref RAIL_WriteAutoAckFifo() or \ref RAIL_IEEE802154_WriteEnhAck()
+ * to inform RAIL of its final length.
+ */
+RAIL_Status_t RAIL_GetAutoAckFifo(RAIL_Handle_t railHandle,
+                                  uint8_t **ackBuffer,
+                                  uint16_t *ackBufferBytes);
 
 /**
  * Pause/resume RX auto-ACK functionality.
@@ -4741,6 +5063,149 @@ RAIL_Status_t RAIL_Calibrate(RAIL_Handle_t railHandle,
 RAIL_CalMask_t RAIL_GetPendingCal(RAIL_Handle_t railHandle);
 
 /**
+ * Apply a given image rejection calibration value.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in] imageRejection The image rejection value to apply.
+ * @return A status code indicating success of the function call.
+ *
+ * Take an image rejection calibration value and apply it. This value should be
+ * determined from a previous run of \ref RAIL_CalibrateIr on the same
+ * physical device with the same radio configuration. The imageRejection value
+ * will also be stored to the \ref RAIL_ChannelConfigEntry_t::attr, if possible.
+ *
+ * If multiple protocols are used, this function will return
+ * \ref RAIL_STATUS_INVALID_STATE if it is called and the given railHandle is
+ * not active. In that case, the caller must attempt to re-call this function later.
+ *
+ * @deprecated Please use \ref RAIL_ApplyIrCalibrationAlt instead.
+ */
+RAIL_Status_t RAIL_ApplyIrCalibration(RAIL_Handle_t railHandle,
+                                      uint32_t imageRejection);
+
+/**
+ * Apply a given image rejection calibration value.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in] imageRejection Pointer to the image rejection value to apply.
+ * @param[in] rfPath RF path to calibrate.
+ * @return A status code indicating success of the function call.
+ *
+ * Take an image rejection calibration value and apply it. This value should be
+ * determined from a previous run of \ref RAIL_CalibrateIrAlt on the same
+ * physical device with the same radio configuration. The imageRejection value
+ * will also be stored to the \ref RAIL_ChannelConfigEntry_t::attr, if possible.
+ * @note: To make sure the imageRejection value is stored/configured correctly,
+ * \ref RAIL_ConfigAntenna should be called before calling this API.
+ *
+ * If multiple protocols are used, this function will return
+ * \ref RAIL_STATUS_INVALID_STATE if it is called and the given railHandle is
+ * not active. In that case, the caller must attempt to re-call this function later.
+ */
+RAIL_Status_t RAIL_ApplyIrCalibrationAlt(RAIL_Handle_t railHandle,
+                                         RAIL_IrCalValues_t *imageRejection,
+                                         RAIL_AntennaSel_t rfPath);
+
+/**
+ * Run the image rejection calibration.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[out] imageRejection The result of the image rejection calibration.
+ * @return A status code indicating success of the function call.
+ *
+ * Run the image rejection calibration and apply the resulting value. If the
+ * imageRejection parameter is not NULL, store the value at that
+ * location. The imageRejection value will also be stored to the
+ * \ref RAIL_ChannelConfigEntry_t::attr, if possible. This is a long-running
+ * calibration that adds significant code space when run and can be run with a
+ * separate firmware image on each device to save code space in the
+ * final image.
+ *
+ * If multiple protocols are used, this function will make the given railHandle
+ * active, if not already, and perform calibration. If called during a protocol
+ * switch, it will return \ref RAIL_STATUS_INVALID_STATE. In this case,
+ * \ref RAIL_ApplyIrCalibration may be called to apply a previously determined
+ * IR calibration value, or the app must defer calibration until the
+ * protocol switch is complete. Silicon Labs recommends calling this function
+ * from the application main loop.
+ *
+ * @deprecated Please use \ref RAIL_CalibrateIrAlt instead.
+ */
+RAIL_Status_t RAIL_CalibrateIr(RAIL_Handle_t railHandle,
+                               uint32_t *imageRejection);
+
+/**
+ * Run the image rejection calibration.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[out] imageRejection Pointer to the image rejection result.
+ * @param[in] rfPath RF path to calibrate.
+ * @return A status code indicating success of the function call.
+ *
+ * Run the image rejection calibration and apply the resulting value. If the
+ * imageRejection parameter is not NULL, store the value at that
+ * location. The imageRejection value will also be stored to the
+ * \ref RAIL_ChannelConfigEntry_t::attr, if possible. This is a long-running
+ * calibration that adds significant code space when run and can be run with a
+ * separate firmware image on each device to save code space in the
+ * final image.
+ * @note: To make sure the imageRejection value is stored/configured correctly,
+ * \ref RAIL_ConfigAntenna should be called before calling this API.
+ *
+ * If multiple protocols are used, this function will return
+ * \ref RAIL_STATUS_INVALID_STATE if it is called and the given railHandle is
+ * not active. In that case, the caller must attempt to re-call this function later.
+ */
+RAIL_Status_t RAIL_CalibrateIrAlt(RAIL_Handle_t railHandle,
+                                  RAIL_IrCalValues_t *imageRejection,
+                                  RAIL_AntennaSel_t rfPath);
+
+/**
+ * Run the temperature calibration.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return A status code indicating success of the function call.
+ *
+ * Run the temperature calibration, which needs to recalibrate the synth if
+ * the temperature crosses 0C or the temperature delta since the last
+ * calibration exceeds 70C while in receive. RAIL will run the VCO calibration
+ * automatically upon entering receive or transmit states, so the application
+ * can omit this calibration if the stack re-enters receive or transmit with
+ * enough frequency to avoid reaching the temperature delta. If the application
+ * does not calibrate for temperature, it's possible to miss receive packets due
+ * to a drift in the carrier frequency.
+ *
+ * If multiple protocols are used, this function will return
+ * \ref RAIL_STATUS_INVALID_STATE if it is called and the given railHandle is
+ * not active. In that case, the calibration will be automatically performed
+ * next time the radio enters receive.
+ */
+RAIL_Status_t RAIL_CalibrateTemp(RAIL_Handle_t railHandle);
+
+/**
+ * Performs HFXO compensation.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[out] crystalPPMError Current deviation that has been corrected,
+ *   measured in PPM. May be NULL.
+ * @return A status code indicating the result of the function call.
+ *
+ * Compute the PPM correction using the thermistor value available when
+ * \ref RAIL_EVENT_THERMISTOR_DONE occurs, after
+ * \ref RAIL_StartThermistorMeasurement() call.
+ * Then correct the RF frequency as well as TX and RX sampling.
+ *
+ * This function calls the following RAIL functions in sequence saving having
+ * to call them individually:
+ *   - \ref RAIL_ConvertThermistorImpedance()
+ *   - \ref RAIL_ComputeHFXOPPMError()
+ *   - \ref RAIL_CompensateHFXO()
+ *
+ * @note This function makes the radio idle.
+ */
+RAIL_Status_t RAIL_CalibrateHFXO(RAIL_Handle_t railHandle, int8_t *crystalPPMError);
+
+/**
  * Enable/disable the PA calibration.
  *
  * @param[in] enable Enables/disables the PA calibration.
@@ -4932,6 +5397,8 @@ bool RAIL_IsRfSensed(RAIL_Handle_t railHandle);
  * as channel changes will be done implicitly, without requiring numerous calls
  * to \ref RAIL_StartRx. Currently, while this feature is enabled, the radio
  * will hop channels in the given sequence each time it enters RX.
+ * Note that RX Channel hopping and EFR32xG25's concurrent mode / collision
+ * detection are mutually exclusive.
  *
  * The channel hopping buffer requires RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL
  * number of 32-bit words of overhead per channel, plus 3 words overall plus the
@@ -4976,13 +5443,13 @@ bool RAIL_IsRfSensed(RAIL_Handle_t railHandle);
  */
 
 /**
- * Configure RX Channel Hopping.
+ * Configure RX channel hopping.
  *
  * @param[in] railHandle A RAIL instance handle.
  * @param[in] config Configuration parameters for RX Channel Hopping.
  * @return Status code indicating success of the function call.
  *
- * Configure Channel Hopping channels, conditions, and parameters. This
+ * Configure channel hopping channels, conditions, and parameters. This
  * API must be called before \ref RAIL_EnableRxChannelHopping(). This API must
  * never be called while the radio is on with RX Duty Cycle or Channel
  * Hopping enabled.
@@ -5398,6 +5865,8 @@ uint32_t RAIL_GetRadioClockFreqHz(RAIL_Handle_t railHandle);
  *
  * @note This function proportionally affects the entire chip's timing
  *   across all its peripherals, including radio tuning and channel spacing.
+ *   It is recommended to call this function only when HFXO is not being used,
+ *   as it can cause disturbance on the HFXO frequency.
  *   A separate function, \ref RAIL_SetFreqOffset(), can be used to adjust
  *   just the radio tuner without disturbing channel spacing or other chip
  *   peripheral timing.
@@ -5572,7 +6041,7 @@ RAIL_Status_t RAIL_StopInfinitePreambleTx(RAIL_Handle_t railHandle);
  */
 RAIL_Status_t RAIL_ConfigVerification(RAIL_Handle_t railHandle,
                                       RAIL_VerifyConfig_t *configVerify,
-                                      const uint32_t *radioConfig,
+                                      RAIL_RadioConfig_t radioConfig,
                                       RAIL_VerifyCallbackPtr_t cb);
 
 /**
@@ -5654,7 +6123,7 @@ RAIL_Time_t RAIL_TimerTicksToUs(RAIL_TimerTick_t startTick,
 RAIL_TimerTick_t RAIL_UsToTimerTicks(RAIL_Time_t microseconds);
 
 /**
- * Enable Radio state change interrupt.
+ * Enable radio state change interrupt.
  *
  * @param[in] railHandle A RAIL instance handle.
  * @param[in] enable Enable/disable Radio state change interrupt.
@@ -5761,7 +6230,7 @@ RAIL_Status_t RAIL_GetTemperature(RAIL_Handle_t railHandle,
                                   int16_t tempBuffer[RAIL_TEMP_MEASURE_COUNT],
                                   bool reset);
 
-/** Number of bytes provided by \ref RAIL_GetSetEffControl(). */
+/** Number of bytes provided by \ref RAIL_GetSetEffClpcControl(). */
 #define RAIL_EFF_CONTROL_SIZE (52U)
 
 /**
@@ -5773,9 +6242,9 @@ RAIL_Status_t RAIL_GetTemperature(RAIL_Handle_t railHandle,
  * @param[in] reset Reset the EFF Control measurements.
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetEffControl(RAIL_Handle_t railHandle,
-                                    uint16_t tempBuffer[RAIL_EFF_CONTROL_SIZE / sizeof(uint16_t)],
-                                    bool reset);
+RAIL_Status_t RAIL_GetSetEffClpcControl(RAIL_Handle_t railHandle,
+                                        uint16_t tempBuffer[RAIL_EFF_CONTROL_SIZE / sizeof(uint16_t)],
+                                        bool reset);
 
 /**
  * Copy the current FEM_DATA pin values into newMode. If changeMode is true,
@@ -5786,9 +6255,9 @@ RAIL_Status_t RAIL_GetSetEffControl(RAIL_Handle_t railHandle,
  * @param[in] changeMode If true, use newMode to update FEM_DATA pin values
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetEffMode(RAIL_Handle_t railHandle,
-                                 uint8_t *newMode,
-                                 bool changeMode);
+RAIL_Status_t RAIL_GetSetEffClpcFemdata(RAIL_Handle_t railHandle,
+                                        uint8_t *newMode,
+                                        bool changeMode);
 
 /**
  * Copy the current Rural to Urban trip voltage into newTrip. If changeTrip is true,
@@ -5799,9 +6268,9 @@ RAIL_Status_t RAIL_GetSetEffMode(RAIL_Handle_t railHandle,
  * @param[in] changeTrip If true, use newTrip to update current Rural to Urban trip voltage
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetEffRuralUrbanMv(RAIL_Handle_t railHandle,
-                                         uint16_t *newTrip,
-                                         bool changeTrip);
+RAIL_Status_t RAIL_GetSetEffLnaRuralUrbanMv(RAIL_Handle_t railHandle,
+                                            uint16_t *newTrip,
+                                            bool changeTrip);
 
 /**
  * Copy the current Urban to Bypass trip voltage into newTrip. If changeTrip is true,
@@ -5812,9 +6281,9 @@ RAIL_Status_t RAIL_GetSetEffRuralUrbanMv(RAIL_Handle_t railHandle,
  * @param[in] changeTrip If true, use newTrip to update current Urban to Bypass trip voltage
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetEffUrbanBypassMv(RAIL_Handle_t railHandle,
-                                          uint16_t *newTrip,
-                                          bool changeTrip);
+RAIL_Status_t RAIL_GetSetEffLnaUrbanBypassMv(RAIL_Handle_t railHandle,
+                                             uint16_t *newTrip,
+                                             bool changeTrip);
 
 /**
  * Copy the current Urban dwell time into newDwellTime. If changeDwellTime is true,
@@ -5826,9 +6295,9 @@ RAIL_Status_t RAIL_GetSetEffUrbanBypassMv(RAIL_Handle_t railHandle,
  * @param[in] changeDwellTime If true, use newDwellTime to update current Urban dwell time
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetEffUrbanDwellTimeMs(RAIL_Handle_t railHandle,
-                                             uint32_t *newDwellTime,
-                                             bool changeDwellTime);
+RAIL_Status_t RAIL_GetSetEffLnaUrbanDwellTimeMs(RAIL_Handle_t railHandle,
+                                                uint32_t *newDwellTime,
+                                                bool changeDwellTime);
 
 /**
  * Copy the current Bypass dwell time into newDwellTime. If changeDwellTime is true,
@@ -5840,9 +6309,9 @@ RAIL_Status_t RAIL_GetSetEffUrbanDwellTimeMs(RAIL_Handle_t railHandle,
  * @param[in] changeDwellTime If true, use newDwellTime to update current Bypass dwell time
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetEffBypassDwellTimeMs(RAIL_Handle_t railHandle,
-                                              uint32_t *newDwellTime,
-                                              bool changeDwellTime);
+RAIL_Status_t RAIL_GetSetEffLnaBypassDwellTimeMs(RAIL_Handle_t railHandle,
+                                                 uint32_t *newDwellTime,
+                                                 bool changeDwellTime);
 
 /**
  * If changeValues is true, update current CLPC Fast Loop calibration
@@ -5855,10 +6324,10 @@ RAIL_Status_t RAIL_GetSetEffBypassDwellTimeMs(RAIL_Handle_t railHandle,
  * @param[in] changeValues If true, use new values to update the CLPC fast loop calibration
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetClpcFastLoopCal(RAIL_Handle_t railHandle,
-                                         RAIL_EffModeSensor_t modeSensorIndex,
-                                         RAIL_EffCalConfig_t *calibrationEntry,
-                                         bool changeValues);
+RAIL_Status_t RAIL_GetSetEffClpcFastLoopCal(RAIL_Handle_t railHandle,
+                                            RAIL_EffModeSensor_t modeSensorIndex,
+                                            RAIL_EffCalConfig_t *calibrationEntry,
+                                            bool changeValues);
 
 /**
  * If changeValues is true, update current CLPC Fast Loop calibration
@@ -5872,11 +6341,11 @@ RAIL_Status_t RAIL_GetSetClpcFastLoopCal(RAIL_Handle_t railHandle,
  * @param[in] changeValues If true, use new values to update the CLPC fast loop calibration equations
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetClpcFastLoopCalSlp(RAIL_Handle_t railHandle,
-                                            RAIL_EffModeSensor_t modeSensorIndex,
-                                            int16_t *newSlope1e1MvPerDdbm,
-                                            int16_t *newoffset290Ddbm,
-                                            bool changeValues);
+RAIL_Status_t RAIL_GetSetEffClpcFastLoopCalSlp(RAIL_Handle_t railHandle,
+                                               RAIL_EffModeSensor_t modeSensorIndex,
+                                               int16_t *newSlope1e1MvPerDdbm,
+                                               int16_t *newoffset290Ddbm,
+                                               bool changeValues);
 
 /**
  * If changeValues is true, update current CLPC Fast Loop Target and
@@ -5890,11 +6359,11 @@ RAIL_Status_t RAIL_GetSetClpcFastLoopCalSlp(RAIL_Handle_t railHandle,
  * @param[in] changeValues If true, use newTargetMv and newSlopeMvPerPaLevel to update the CLPC Fast Loop values
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetClpcFastLoop(RAIL_Handle_t railHandle,
-                                      RAIL_EffModeSensor_t modeSensorIndex,
-                                      uint16_t *newTargetMv,
-                                      uint16_t *newSlopeMvPerPaLevel,
-                                      bool changeValues);
+RAIL_Status_t RAIL_GetSetEffClpcFastLoop(RAIL_Handle_t railHandle,
+                                         RAIL_EffModeSensor_t modeSensorIndex,
+                                         uint16_t *newTargetMv,
+                                         uint16_t *newSlopeMvPerPaLevel,
+                                         bool changeValues);
 
 /**
  * Copy the current CLPC Enable in to newClpcEnable. If changeClpcEnable is true,
@@ -5905,9 +6374,9 @@ RAIL_Status_t RAIL_GetSetClpcFastLoop(RAIL_Handle_t railHandle,
  * @param[in] changeClpcEnable If true, use newClpcEnable to update the current CLPC Enable
  * @return Status code indicating success of the function call.
  */
-RAIL_Status_t RAIL_GetSetClpcEnable(RAIL_Handle_t railHandle,
-                                    uint8_t *newClpcEnable,
-                                    bool changeClpcEnable);
+RAIL_Status_t RAIL_GetSetEffClpcEnable(RAIL_Handle_t railHandle,
+                                       uint8_t *newClpcEnable,
+                                       bool changeClpcEnable);
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 /**
@@ -6097,7 +6566,7 @@ void RAILCb_AssertFailed(RAIL_Handle_t railHandle,
  */
 
 /**
- * Start a Thermistor measurement. To get the Thermistor impedance, call the
+ * Start a thermistor measurement. To get the thermistor impedance, call the
  * function \ref RAIL_GetThermistorImpedance. On platforms having
  * \ref RAIL_SUPPORTS_EXTERNAL_THERMISTOR, this function reconfigures
  * GPIO_THMSW_EN_PIN located in GPIO_THMSW_EN_PORT.
@@ -6118,7 +6587,7 @@ void RAILCb_AssertFailed(RAIL_Handle_t railHandle,
 RAIL_Status_t RAIL_StartThermistorMeasurement(RAIL_Handle_t railHandle);
 
 /**
- * Get the thermistor impedance measurement and returns \ref
+ * Get the thermistor impedance measurement and return \ref
  * RAIL_INVALID_THERMISTOR_VALUE if the thermistor is not properly
  * configured or the thermistor measurement is not ready.
  *
@@ -6143,9 +6612,10 @@ RAIL_Status_t RAIL_GetThermistorImpedance(RAIL_Handle_t railHandle,
  *   in eighth of Celsius degree
  * @return Status code indicating success of the function call.
  *
- * This function is provided in the rail_util_thermistor plugin to get
- * accurate values from our boards thermistors. For a custom board, this
- * function could be modified and re-implemented for other needs.
+ * A version of this function is provided in the \ref rail_util_thermistor
+ * plugin for Silicon Labs radio boards. For custom boards this function can be
+ * modified and re-implemented as needed.
+ *
  * The variable railHandle is only used to indicate to the user from where the
  * function was called, so it is okay to use either a real protocol handle,
  * or one of the chip-specific ones, such as \ref RAIL_EFR32_HANDLE.
@@ -6279,7 +6749,7 @@ bool RAIL_SupportsSubGHzBand(RAIL_Handle_t railHandle);
 bool RAIL_SupportsDualBand(RAIL_Handle_t railHandle);
 
 /**
- * Indicate whether this chip supports bit masked address filtering
+ * Indicate whether this chip supports bit masked address filtering.
  *
  * @param[in] railHandle A RAIL instance handle.
  * @return true if bit masked address filtering is supported; false otherwise.
@@ -6370,6 +6840,17 @@ bool RAIL_SupportsDirectMode(RAIL_Handle_t railHandle);
  *   if the chip in general claims to support it.
  */
 bool RAIL_SupportsDualSyncWords(RAIL_Handle_t railHandle);
+
+/**
+ * Indicate whether this chip supports start to start TX repeats.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return true if start to start TX repeats are supported; false otherwise.
+ *
+ * Runtime refinement of compile-time \ref
+ * RAIL_SUPPORTS_TX_REPEAT_START_TO_START.
+ */
+bool RAIL_SupportsTxRepeatStartToStart(RAIL_Handle_t railHandle);
 
 /**
  * Indicate whether this chip supports EFF.
@@ -6530,15 +7011,15 @@ bool RAIL_SupportsTxPowerMode(RAIL_Handle_t railHandle,
  *
  * @param[in] railHandle A RAIL instance handle.
  * @param[in,out] powerMode A pointer to PA power mode to check if supported.
- *   In case of  RAIL_TX_POWER_MODE_2P4_HIGHEST or
- *   RAIL_TX_POWER_MODE_SUBGIG_HIGHEST is used as input
- *   then the highest selected PA on the chip is updated here.
+ *   For platforms that support \ref RAIL_TX_POWER_MODE_2P4_HIGHEST or
+ *   \ref RAIL_TX_POWER_MODE_SUBGIG_HIGHEST the powerMode is updated
+ *   to the highest corresponding PA available on the chip.
  * @param[out] maxPowerLevel A pointer to a \ref RAIL_TxPowerLevel_t that
  *   if non-NULL will be filled in with the power mode's highest power level
- *   allowed if this function returns \ref RAIL_STATUS_NO_ERROR.
+ *   allowed if this function returns true.
  * @param[out] minPowerLevel A pointer to a \ref RAIL_TxPowerLevel_t that
  *   if non-NULL will be filled in with the power mode's lowest power level
- *   allowed if this function returns \ref RAIL_STATUS_NO_ERROR.
+ *   allowed if this function returns true.
  * @return true if powerMode is supported; false otherwise.
  */
 bool RAIL_SupportsTxPowerModeAlt(RAIL_Handle_t railHandle,
@@ -6669,6 +7150,18 @@ bool RAIL_BLE_SupportsCodedPhy(RAIL_Handle_t railHandle);
  */
 bool RAIL_BLE_SupportsCte(RAIL_Handle_t railHandle);
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * Indicate whether this chip supports BLE HADM.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return true if BLE HADM is supported; false otherwise.
+ *
+ * Runtime refinement of compile-time \ref RAIL_BLE_SUPPORTS_HADM.
+ */
+bool RAIL_BLE_SupportsHadm(RAIL_Handle_t railHandle);
+#endif
+
 /**
  * Indicate whether this chip supports BLE IQ Sampling needed for
  * Angle-of-Arrival/Departure receives.
@@ -6730,6 +7223,18 @@ bool RAIL_BLE_SupportsSimulscanPhy(RAIL_Handle_t railHandle);
  * Runtime refinement of compile-time \ref RAIL_SUPPORTS_PROTOCOL_IEEE802154.
  */
 bool RAIL_SupportsProtocolIEEE802154(RAIL_Handle_t railHandle);
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * Indicate whether this chip supports the IEEE 802.15.4 2Mbps PHY.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return true if the 802.15.4 2Mbps PHY is supported; false otherwise.
+ *
+ * Runtime refinement of compile-time \ref RAIL_IEEE802154_SUPPORTS_2MBPS_PHY.
+ */
+bool RAIL_IEEE802154_Supports2MbpsPhy(RAIL_Handle_t railHandle);
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * Indicate whether this chip supports the IEEE 802.15.4 Wi-Fi Coexistence PHY.
@@ -6880,7 +7385,7 @@ bool RAIL_IEEE802154_SupportsESubsetGB868(RAIL_Handle_t railHandle);
 bool RAIL_IEEE802154_SupportsG4ByteCrc(RAIL_Handle_t railHandle);
 
 /**
- * Indicate whether this chip supports IEEE 802.15.4G dynamic FEC
+ * Indicate whether this chip supports IEEE 802.15.4G dynamic FEC.
  *
  * @param[in] railHandle A RAIL instance handle.
  * @return true if dynamic FEC is supported; false otherwise.
@@ -6891,7 +7396,18 @@ bool RAIL_IEEE802154_SupportsG4ByteCrc(RAIL_Handle_t railHandle);
 bool RAIL_IEEE802154_SupportsGDynFec(RAIL_Handle_t railHandle);
 
 /**
- * Indicate whether this chip supports Wi-SUN mode switching
+ * Indicate whether this chip supports Wi-SUN.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return true if Wi-SUN is supported; false otherwise.
+ *
+ * Runtime refinement of compile-time \ref
+ * RAIL_SUPPORTS_PROTOCOL_WI_SUN.
+ */
+bool RAIL_SupportsProtocolWiSUN(RAIL_Handle_t railHandle);
+
+/**
+ * Indicate whether this chip supports Wi-SUN mode switching.
  *
  * @param[in] railHandle A RAIL instance handle.
  * @return true if Wi-SUN mode switching is supported; false otherwise.
@@ -6940,6 +7456,16 @@ bool RAIL_IEEE802154_SupportsGUnwhitenedRx(RAIL_Handle_t railHandle);
 bool RAIL_IEEE802154_SupportsGUnwhitenedTx(RAIL_Handle_t railHandle);
 
 /**
+ * Indicate whether this chip supports WMBUS simultaneous M2O RX of T and C modes.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return true if the WMBUS simultaneous M2O RX of T and C modes is supported; false otherwise.
+ *
+ * Runtime refinement of compile-time \ref RAIL_WMBUS_SUPPORTS_SIMULTANEOUS_T_C_RX.
+ */
+bool RAIL_WMBUS_SupportsSimultaneousTCRx(RAIL_Handle_t railHandle);
+
+/**
  * Indicate whether this chip supports the Z-Wave protocol.
  *
  * @param[in] railHandle A RAIL instance handle.
@@ -6986,6 +7512,36 @@ bool RAIL_ZWAVE_SupportsRegionPti(RAIL_Handle_t railHandle);
  * @return true if signal identifier is supported; false otherwise.
  */
 bool RAIL_IEEE802154_SupportsSignalIdentifier(RAIL_Handle_t railHandle);
+
+/**
+ * Indicate whether this chip supports fast RX2RX.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return true if fast RX2RX is supported; false otherwise.
+ *
+ * Runtime refinement of compile-time \ref RAIL_SUPPORTS_FAST_RX2RX.
+ */
+bool RAIL_SupportsFastRx2Rx(RAIL_Handle_t railHandle);
+
+/**
+ * Indicate whether this chip supports collision detection.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return true if collision detection is supported; false otherwise.
+ *
+ * Runtime refinement of compile-time \ref RAIL_SUPPORTS_COLLISION_DETECTION.
+ */
+bool RAIL_SupportsCollisionDetection(RAIL_Handle_t railHandle);
+
+/**
+ * Indicate whether this chip supports Sidewalk protocol.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @return true if Sidewalk protocol is supported; false otherwise.
+ *
+ * Runtime refinement of compile-time \ref RAIL_SUPPORTS_PROTOCOL_SIDEWALK.
+ */
+bool RAIL_SupportsProtocolSidewalk(RAIL_Handle_t railHandle);
 
 /** @} */ // end of group Features
 

--- a/gecko/platform/radio/rail_lib/common/rail_assert_error_codes.h
+++ b/gecko/platform/radio/rail_lib/common/rail_assert_error_codes.h
@@ -49,32 +49,32 @@ extern "C" {
  */
 RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
 {
-  /** Appended info missing from Rx packet. */
+  /** Appended info missing from RX packet. */
   RAIL_ASSERT_FAILED_APPENDED_INFO_MISSING = 0,
   /** Receive FIFO too small for IR calibration. */
   RAIL_ASSERT_FAILED_RX_FIFO_BYTES = 1,
-  /** Error reading back packet payload. */
-  RAIL_ASSERT_FAILED_RX_FIFO_ZERO_BYTES_READ = 2,
-  /** Receive fifo entry has invalid status. */
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_2 = 2,
+  /** Receive FIFO entry has invalid status. */
   RAIL_ASSERT_FAILED_ILLEGAL_RXLEN_ENTRY_STATUS = 3,
-  /** Receive fifo entry bad packet length. */
+  /** Receive FIFO entry bad packet length. */
   RAIL_ASSERT_FAILED_BAD_PACKET_LENGTH = 4,
   /** Unable to configure radio for IR calibration. */
   RAIL_ASSERT_FAILED_SYNTH_DIVCTRL_ENUM_CONVERSION_ERROR = 5,
-  /** Reached unexpected state while handling Rx fifo events. */
+  /** Reached unexpected state while handling RX FIFO events. */
   RAIL_ASSERT_FAILED_UNEXPECTED_STATE_RX_FIFO = 6,
-  /** Reached unexpected state while handling RXLEN fifo events. */
+  /** Reached unexpected state while handling RXLEN FIFO events. */
   RAIL_ASSERT_FAILED_UNEXPECTED_STATE_RXLEN_FIFO = 7,
-  /** Reached unexpected state while handling Tx fifo events. */
+  /** Reached unexpected state while handling TX FIFO events. */
   RAIL_ASSERT_FAILED_UNEXPECTED_STATE_TX_FIFO = 8,
-  /** Reached unexpected state while handling Tx ACK fifo events. */
+  /** Reached unexpected state while handling TX ACK FIFO events. */
   RAIL_ASSERT_FAILED_UNEXPECTED_STATE_TXACK_FIFO = 9,
-  /** No memory to store receive packet. */
-  RAIL_ASSERT_FAILED_PBUFFER_NOT_DEFINED = 10,
-  /** Packet length longer than the receive FIFO size. */
-  RAIL_ASSERT_FAILED_INSUFFICIENT_BYTES_IN_RX_PACKET = 11,
-  /** Invalid radio clock prescaler. */
-  RAIL_ASSERT_FAILED_CLOCK_PRESCALER = 12,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_10 = 10,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_11 = 11,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_12 = 12,
   /** Error synchronizing the RAIL timebase after sleep. */
   RAIL_ASSERT_FAILED_RTCC_POST_WAKEUP = 13,
   /** VCO frequency outside supported range. */
@@ -87,62 +87,62 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
   RAIL_ASSERT_FAILED_NESTED_SEQUENCER_LOCK = 17,
   /** RSSI averaging enabled without a valid callback. */
   RAIL_ASSERT_FAILED_RSSI_AVERAGE_DONE = 18,
-  /** Invalid dynamic frame length setting provided (dflBits). */
-  RAIL_ASSERT_FAILED_DFL_BITS_SIZE = 19,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_19 = 19,
   /** Unable to seed radio pseudo random number generator. */
   RAIL_ASSERT_FAILED_PROTIMER_RANDOM_SEED = 20,
   /** Timeout exceeds EFR32XG1 register size. */
   RAIL_ASSERT_FAILED_EFR32XG1_REGISTER_SIZE = 21,
   /** Invalid timer channel specified. */
   RAIL_ASSERT_FAILED_PROTIMER_CHANNEL = 22,
-  /** Timer value larger than RAIL timebase. */
-  RAIL_ASSERT_FAILED_TIMER_REQUIRES_WRAP = 23,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_23 = 23,
   /** LBT config exceeds EFR32XG1 register size. */
   RAIL_ASSERT_FAILED_BASECNTTOP = 24,
-  /** @deprecated CSMA/LBT retry callback unexpectedly called. */
-  RAIL_ASSERT_FAILED_DEPRECATED_LBTRETRY = 25,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_25 = 25,
   /** Could not synchronize RAIL timebase with the RTC. */
   RAIL_ASSERT_FAILED_RTCC_SYNC_MISSED = 26,
   /** Clock source not ready. */
   RAIL_ASSERT_FAILED_CLOCK_SOURCE_NOT_READY = 27,
-  /** Attempted to set RAIL timings to invalid value. */
-  RAIL_ASSERT_FAILED_TIMINGS_INVALID = 28,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_28 = 28,
   /** NULL was supplied as a RAIL_Handle_t argument. */
   RAIL_ASSERT_NULL_HANDLE = 29,
-  /** Scheduled timer not running. */
-  RAIL_ASSERT_FAILED_SCHED_TIMER_NOT_RUNNING = 30,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_30 = 30,
   /** API improperly called while protocol inactive. */
   RAIL_ASSERT_FAILED_NO_ACTIVE_CONFIG = 31,
-  /** No active handle after switch. */
-  RAIL_ASSERT_FAILED_NO_ACTIVE_HANDLE_SWITCH = 32,
-  /** Reserved for future use. */
-  RAIL_ASSERT_FAILED_RESERVED33 = 33,
-  /** No active handle for scheduled rx. */
-  RAIL_ASSERT_FAILED_NO_ACTIVE_HANDLE_SCHEDRX = 34,
-  /** Invalid handle for scheduled tx. */
-  RAIL_ASSERT_FAILED_INVALID_HANDLE_SCHEDTX = 35,
-  /** Inactive handle for scheduled tx. */
-  RAIL_ASSERT_FAILED_INACTIVE_HANDLE_SCHEDTX = 36,
-  /** Invalid config index to switch to. */
-  RAIL_ASSERT_FAILED_CONFIG_INDEX_INVALID = 37,
-  /** No active handle for single protocol. */
-  RAIL_ASSERT_FAILED_NO_ACTIVE_HANDLE_SINGLEPROTOCOL = 38,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_32 = 32,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_33 = 33,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_34 = 34,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_35 = 35,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_36 = 36,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_37 = 37,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_38 = 38,
   /** This function is deprecated and must not be called. */
   RAIL_ASSERT_DEPRECATED_FUNCTION = 39,
   /** Multiprotocol task started with no event to run. */
   RAIL_ASSERT_MULTIPROTOCOL_NO_EVENT = 40,
   /** Invalid interrupt enabled. */
   RAIL_ASSERT_FAILED_INVALID_INTERRUPT_ENABLED = 41,
-  /** Power conversion functions called before curves were initialized. */
-  RAIL_ASSERT_CONVERSION_CURVES_NOT_INITIALIZED = 42,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_42 = 42,
   /** Division by zero. */
   RAIL_ASSERT_DIVISION_BY_ZERO = 43,
   /** Function cannot be called without access to the hardware. */
   RAIL_ASSERT_CANT_USE_HARDWARE = 44,
   /** Pointer parameter was passed as NULL. */
   RAIL_ASSERT_NULL_PARAMETER = 45,
-  /** Invalid task type passed to RAIL_SetTaskPriority. */
-  RAIL_ASSERT_INVALID_TASK_TYPE = 46,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_46 = 46,
   /** Synth radio config buffer for channel hopping too small. */
   RAIL_ASSERT_SMALL_SYNTH_RADIO_CONFIG_BUFFER = 47,
   /** Buffer provided for RX Channel Hopping is too small. */
@@ -155,8 +155,8 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
   RAIL_ASSERT_CHANNEL_CHANGE_FAILED = 51,
   /** Attempted to read invalid register. */
   RAIL_ASSERT_INVALID_REGISTER = 52,
-  /** Can't read register value from NULL state. */
-  RAIL_ASSERT_FAILED_LO_DIV_NULL_STATE = 53,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_53 = 53,
   /** DMP radio config caching failed. */
   RAIL_ASSERT_CACHE_CONFIG_FAILED = 54,
   /** NULL was supplied as a RAIL_StateTransitions_t argument. */
@@ -181,12 +181,12 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
   RAIL_ASSERT_SEQ_INVALID_PA_SELECTED = 64,
   /** Invalid/unsupported channel config. */
   RAIL_ASSERT_FAILED_INVALID_CHANNEL_CONFIG = 65,
-  /** The dynamic frame length configuration is invalid. */
-  RAIL_ASSERT_INVALID_DYNAMIC_FRAME_LENGTH = 66,
-  /** Failed to enable EM1P energy mode. */
-  RAIL_ASSERT_FAILED_EM1P_ENTRY = 67,
-  /** Failed to disable EM1P energy mode. */
-  RAIL_ASSERT_FAILED_EM1P_EXIT = 68,
+  /** Radio Calculator configuration HFXO frequency mismatch with chip */
+  RAIL_ASSERT_INVALID_XTAL_FREQUENCY = 66,
+  /** Invalid assert, no longer used. */
+  RAIL_ASSERT_UNUSED_67 = 67,
+  /** Software modem image does not support requested modulation  */
+  RAIL_ASSERT_UNSUPPORTED_SOFTWARE_MODEM_MODULATION = 68,
   /** Failed to disable RTCC synchronization. */
   RAIL_ASSERT_FAILED_RTCC_SYNC_STOP = 69,
   /** Multitimer linked list corrupted. */
@@ -213,13 +213,21 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
   RAIL_ASSERT_INVALID_LOG2X4_CLEAR_CONDITION = 80,
   /** Failed to complete DMA write */
   RAIL_ASSERT_FAILED_DMA_WRITE_INCOMPLETE = 81,
+  /** RAIL does not support this Radio Calculator configuration */
+  RAIL_ASSERT_CALCULATOR_NOT_SUPPORTED = 82,
+  /** Invalid binary image was loaded onto the sequencer */
+  RAIL_ASSERT_INVALID_SEQUENCER_IMAGE = 83,
+  /** No common or protocol image selected to be loaded onto the sequencer */
+  RAIL_ASSERT_MISSING_SEQUENCER_IMAGE = 84,
+  /** Software modem image invalid or missing */
+  RAIL_ASSERT_INVALID_OR_MISSING_SOFTWARE_MODEM_IMAGE = 85,
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 // Self-referencing defines minimize compiler complaints when using RAIL_ENUM
 #define RAIL_ASSERT_FAILED_APPENDED_INFO_MISSING               ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_APPENDED_INFO_MISSING)
 #define RAIL_ASSERT_FAILED_RX_FIFO_BYTES                       ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_RX_FIFO_BYTES)
-#define RAIL_ASSERT_FAILED_RX_FIFO_ZERO_BYTES_READ             ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_RX_FIFO_ZERO_BYTES_READ)
+#define RAIL_ASSERT_UNUSED_2                                   ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_2)
 #define RAIL_ASSERT_FAILED_ILLEGAL_RXLEN_ENTRY_STATUS          ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_ILLEGAL_RXLEN_ENTRY_STATUS)
 #define RAIL_ASSERT_FAILED_BAD_PACKET_LENGTH                   ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_BAD_PACKET_LENGTH)
 #define RAIL_ASSERT_FAILED_SYNTH_DIVCTRL_ENUM_CONVERSION_ERROR ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_SYNTH_DIVCTRL_ENUM_CONVERSION_ERROR)
@@ -227,50 +235,50 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
 #define RAIL_ASSERT_FAILED_UNEXPECTED_STATE_RXLEN_FIFO         ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_UNEXPECTED_STATE_RXLEN_FIFO)
 #define RAIL_ASSERT_FAILED_UNEXPECTED_STATE_TX_FIFO            ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_UNEXPECTED_STATE_TX_FIFO)
 #define RAIL_ASSERT_FAILED_UNEXPECTED_STATE_TXACK_FIFO         ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_UNEXPECTED_STATE_TXACK_FIFO)
-#define RAIL_ASSERT_FAILED_PBUFFER_NOT_DEFINED                 ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_PBUFFER_NOT_DEFINED)
-#define RAIL_ASSERT_FAILED_INSUFFICIENT_BYTES_IN_RX_PACKET     ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_INSUFFICIENT_BYTES_IN_RX_PACKET)
-#define RAIL_ASSERT_FAILED_CLOCK_PRESCALER                     ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_CLOCK_PRESCALER)
+#define RAIL_ASSERT_UNUSED_10                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_10)
+#define RAIL_ASSERT_UNUSED_11                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_11)
+#define RAIL_ASSERT_UNUSED_12                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_12)
 #define RAIL_ASSERT_FAILED_RTCC_POST_WAKEUP                    ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_RTCC_POST_WAKEUP)
 #define RAIL_ASSERT_FAILED_SYNTH_VCO_FREQUENCY                 ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_SYNTH_VCO_FREQUENCY)
 #define RAIL_ASSERT_FAILED_RAC_STATE                           ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_RAC_STATE)
 #define RAIL_ASSERT_FAILED_SYNTH_INVALID_VCOCTRL               ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_SYNTH_INVALID_VCOCTRL)
 #define RAIL_ASSERT_FAILED_NESTED_SEQUENCER_LOCK               ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_NESTED_SEQUENCER_LOCK)
 #define RAIL_ASSERT_FAILED_RSSI_AVERAGE_DONE                   ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_RSSI_AVERAGE_DONE)
-#define RAIL_ASSERT_FAILED_DFL_BITS_SIZE                       ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_DFL_BITS_SIZE)
+#define RAIL_ASSERT_UNUSED_19                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_19)
 #define RAIL_ASSERT_FAILED_PROTIMER_RANDOM_SEED                ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_PROTIMER_RANDOM_SEED)
 #define RAIL_ASSERT_FAILED_EFR32XG1_REGISTER_SIZE              ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_EFR32XG1_REGISTER_SIZE)
 #define RAIL_ASSERT_FAILED_PROTIMER_CHANNEL                    ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_PROTIMER_CHANNEL)
-#define RAIL_ASSERT_FAILED_TIMER_REQUIRES_WRAP                 ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_TIMER_REQUIRES_WRAP)
+#define RAIL_ASSERT_UNUSED_23                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_23)
 #define RAIL_ASSERT_FAILED_BASECNTTOP                          ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_BASECNTTOP)
-#define RAIL_ASSERT_FAILED_DEPRECATED_LBTRETRY                 ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_DEPRECATED_LBTRETRY)
+#define RAIL_ASSERT_UNUSED_25                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_25)
 #define RAIL_ASSERT_FAILED_RTCC_SYNC_MISSED                    ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_RTCC_SYNC_MISSED)
 #define RAIL_ASSERT_FAILED_CLOCK_SOURCE_NOT_READY              ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_CLOCK_SOURCE_NOT_READY)
-#define RAIL_ASSERT_FAILED_TIMINGS_INVALID                     ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_TIMINGS_INVALID)
+#define RAIL_ASSERT_UNUSED_28                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_28)
 #define RAIL_ASSERT_NULL_HANDLE                                ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_NULL_HANDLE)
-#define RAIL_ASSERT_FAILED_SCHED_TIMER_NOT_RUNNING             ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_SCHED_TIMER_NOT_RUNNING)
+#define RAIL_ASSERT_UNUSED_30                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_30)
 #define RAIL_ASSERT_FAILED_NO_ACTIVE_CONFIG                    ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_NO_ACTIVE_CONFIG)
-#define RAIL_ASSERT_FAILED_NO_ACTIVE_HANDLE_SWITCH             ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_NO_ACTIVE_HANDLE_SWITCH)
-#define RAIL_ASSERT_FAILED_RESERVED33                          ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_RESERVED33)
-#define RAIL_ASSERT_FAILED_NO_ACTIVE_HANDLE_SCHEDRX            ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_NO_ACTIVE_HANDLE_SCHEDRX)
-#define RAIL_ASSERT_FAILED_INVALID_HANDLE_SCHEDTX              ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_INVALID_HANDLE_SCHEDTX)
-#define RAIL_ASSERT_FAILED_INACTIVE_HANDLE_SCHEDTX             ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_INACTIVE_HANDLE_SCHEDTX)
-#define RAIL_ASSERT_FAILED_CONFIG_INDEX_INVALID                ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_CONFIG_INDEX_INVALID)
-#define RAIL_ASSERT_FAILED_NO_ACTIVE_HANDLE_SINGLEPROTOCOL     ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_NO_ACTIVE_HANDLE_SINGLEPROTOCOL)
+#define RAIL_ASSERT_UNUSED_32                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_32)
+#define RAIL_ASSERT_UNUSED_33                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_33)
+#define RAIL_ASSERT_UNUSED_34                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_34)
+#define RAIL_ASSERT_UNUSED_35                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_35)
+#define RAIL_ASSERT_UNUSED_36                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_36)
+#define RAIL_ASSERT_UNUSED_37                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_37)
+#define RAIL_ASSERT_UNUSED_38                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_38)
 #define RAIL_ASSERT_DEPRECATED_FUNCTION                        ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_DEPRECATED_FUNCTION)
 #define RAIL_ASSERT_MULTIPROTOCOL_NO_EVENT                     ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_MULTIPROTOCOL_NO_EVENT)
 #define RAIL_ASSERT_FAILED_INVALID_INTERRUPT_ENABLED           ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_INVALID_INTERRUPT_ENABLED)
-#define RAIL_ASSERT_CONVERSION_CURVES_NOT_INITIALIZED          ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_CONVERSION_CURVES_NOT_INITIALIZED)
+#define RAIL_ASSERT_UNUSED_42                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_42)
 #define RAIL_ASSERT_DIVISION_BY_ZERO                           ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_DIVISION_BY_ZERO)
 #define RAIL_ASSERT_CANT_USE_HARDWARE                          ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_CANT_USE_HARDWARE)
 #define RAIL_ASSERT_NULL_PARAMETER                             ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_NULL_PARAMETER)
-#define RAIL_ASSERT_INVALID_TASK_TYPE                          ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_INVALID_TASK_TYPE)
+#define RAIL_ASSERT_UNUSED_46                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_46)
 #define RAIL_ASSERT_SMALL_SYNTH_RADIO_CONFIG_BUFFER            ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_SMALL_SYNTH_RADIO_CONFIG_BUFFER)
 #define RAIL_ASSERT_CHANNEL_HOPPING_BUFFER_TOO_SHORT           ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_CHANNEL_HOPPING_BUFFER_TOO_SHORT)
 #define RAIL_ASSERT_INVALID_MODULE_ACTION                      ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_INVALID_MODULE_ACTION)
 #define RAIL_ASSERT_CHANNEL_HOPPING_INVALID_RADIO_CONFIG       ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_CHANNEL_HOPPING_INVALID_RADIO_CONFIG)
 #define RAIL_ASSERT_CHANNEL_CHANGE_FAILED                      ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_CHANNEL_CHANGE_FAILED)
 #define RAIL_ASSERT_INVALID_REGISTER                           ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_INVALID_REGISTER)
-#define RAIL_ASSERT_FAILED_LO_DIV_NULL_STATE                   ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_LO_DIV_NULL_STATE)
+#define RAIL_ASSERT_UNUSED_53                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_53)
 #define RAIL_ASSERT_CACHE_CONFIG_FAILED                        ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_CACHE_CONFIG_FAILED)
 #define RAIL_ASSERT_NULL_TRANSITIONS                           ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_NULL_TRANSITIONS)
 #define RAIL_ASSERT_BAD_LDMA_TRANSFER                          ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_BAD_LDMA_TRANSFER)
@@ -283,9 +291,9 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
 #define RAIL_ASSERT_INVALID_PA_OPERATION                       ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_INVALID_PA_OPERATION)
 #define RAIL_ASSERT_SEQ_INVALID_PA_SELECTED                    ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_SEQ_INVALID_PA_SELECTED)
 #define RAIL_ASSERT_FAILED_INVALID_CHANNEL_CONFIG              ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_INVALID_CHANNEL_CONFIG)
-#define RAIL_ASSERT_INVALID_DYNAMIC_FRAME_LENGTH               ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_INVALID_DYNAMIC_FRAME_LENGTH)
-#define RAIL_ASSERT_FAILED_EM1P_ENTRY                          ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_EM1P_ENTRY)
-#define RAIL_ASSERT_FAILED_EM1P_EXIT                           ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_EM1P_EXIT)
+#define RAIL_ASSERT_INVALID_XTAL_FREQUENCY                     ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_INVALID_XTAL_FREQUENCY)
+#define RAIL_ASSERT_UNUSED_67                                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNUSED_67)
+#define RAIL_ASSERT_UNSUPPORTED_SOFTWARE_MODEM_MODULATION      ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_UNSUPPORTED_SOFTWARE_MODEM_MODULATION)
 #define RAIL_ASSERT_FAILED_RTCC_SYNC_STOP                      ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_RTCC_SYNC_STOP)
 #define RAIL_ASSERT_FAILED_MULTITIMER_CORRUPT                  ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_MULTITIMER_CORRUPT)
 #define RAIL_ASSERT_FAILED_TEMPCAL_ERROR                       ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_TEMPCAL_ERROR)
@@ -299,6 +307,10 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
 #define RAIL_ASSERT_FAILED_RTCC_SYNC_STALE_DATA                ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_RTCC_SYNC_STALE_DATA)
 #define RAIL_ASSERT_INVALID_LOG2X4_CLEAR_CONDITION             ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_INVALID_LOG2X4_CLEAR_CONDITION)
 #define RAIL_ASSERT_FAILED_DMA_WRITE_INCOMPLETE                ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_FAILED_DMA_WRITE_INCOMPLETE)
+#define RAIL_ASSERT_CALCULATOR_NOT_SUPPORTED                   ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_CALCULATOR_NOT_SUPPORTED)
+#define RAIL_ASSERT_INVALID_SEQUENCER_IMAGE                    ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_INVALID_SEQUENCER_IMAGE)
+#define RAIL_ASSERT_MISSING_SEQUENCER_IMAGE                    ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_MISSING_SEQUENCER_IMAGE)
+#define RAIL_ASSERT_INVALID_OR_MISSING_SOFTWARE_MODEM_IMAGE    ((RAIL_AssertErrorCodes_t) RAIL_ASSERT_INVALID_OR_MISSING_SOFTWARE_MODEM_IMAGE)
 #endif//DOXYGEN_SHOULD_SKIP_THIS
 
 /// Use this define to create an array of error messages that map to the codes
@@ -326,60 +338,60 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
 /// @endcode
 ///
 #define RAIL_ASSERT_ERROR_MESSAGES {                                                   \
-    /* 0*/ "Appended info missing from Rx packet",                                     \
+    /* 0*/ "Appended info missing from RX packet",                                     \
     /* 1*/ "Receive FIFO too small for IR calibration",                                \
-    /* 2*/ "Error reading back packet payload",                                        \
-    /* 3*/ "Receive fifo entry has invalid status",                                    \
-    /* 4*/ "Receive fifo entry bad packet length",                                     \
+    /* 2*/ "Invalid assert, no longer used",                                           \
+    /* 3*/ "Receive FIFO entry has invalid status",                                    \
+    /* 4*/ "Receive FIFO entry bad packet length",                                     \
     /* 5*/ "Unable to configure radio for IR calibration",                             \
-    /* 6*/ "Reached unexpected state while handling Rx fifo events",                   \
-    /* 7*/ "Reached unexpected state while handling RXLEN fifo events",                \
-    /* 8*/ "Reached unexpected state while handling Tx fifo events",                   \
-    /* 9*/ "Reached unexpected state while handling Tx ACK fifo events",               \
-    /*10*/ "No memory to store receive packet",                                        \
-    /*11*/ "Packet length longer than the receive FIFO size",                          \
-    /*12*/ "Invalid radio clock prescaler",                                            \
+    /* 6*/ "Reached unexpected state while handling RX FIFO events",                   \
+    /* 7*/ "Reached unexpected state while handling RXLEN FIFO events",                \
+    /* 8*/ "Reached unexpected state while handling TX FIFO events",                   \
+    /* 9*/ "Reached unexpected state while handling TX ACK FIFO events",               \
+    /*10*/ "Invalid assert, no longer used",                                           \
+    /*11*/ "Invalid assert, no longer used",                                           \
+    /*12*/ "Invalid assert, no longer used",                                           \
     /*13*/ "Error synchronizing the RAIL timebase after sleep",                        \
     /*14*/ "VCO frequency outside supported range",                                    \
     /*15*/ "Radio active while changing channels",                                     \
     /*16*/ "Invalid Synth VCOCTRL field calculation",                                  \
     /*17*/ "Nested attempt to lock the sequencer",                                     \
     /*18*/ "RSSI averaging enabled without a valid callback",                          \
-    /*19*/ "Invalid dynamic frame length setting provided (dflBits)",                  \
+    /*19*/ "Invalid assert, no longer used",                                           \
     /*20*/ "Unable to seed radio pseudo random number generator",                      \
     /*21*/ "Timeout exceeds EFR32XG1 register size",                                   \
     /*22*/ "Invalid timer channel specified",                                          \
-    /*23*/ "Timer value larger than RAIL timebase",                                    \
+    /*23*/ "Invalid assert, no longer used",                                           \
     /*24*/ "LBT config exceeds EFR32XG1 register size",                                \
-    /*25*/ "Deprecated CSMA/LBT retry callback unexpectedly called",                   \
+    /*25*/ "Invalid assert, no longer used",                                           \
     /*26*/ "Could not synchronize RAIL timebase with the RTC",                         \
     /*27*/ "Clock source not ready",                                                   \
-    /*28*/ "Attempted to set RAIL timings to invalid value",                           \
+    /*28*/ "Invalid assert, no longer used",                                           \
     /*29*/ "NULL was supplied as a RAIL_Handle_t argument",                            \
-    /*30*/ "Scheduled timer not running",                                              \
+    /*30*/ "Invalid assert, no longer used",                                           \
     /*31*/ "API improperly called while protocol inactive",                            \
-    /*32*/ "No active handle after switch",                                            \
-    /*33*/ "Reserved for future use",                                                  \
-    /*34*/ "No active handle for scheduled rx",                                        \
-    /*35*/ "Invalid handle for scheduled tx",                                          \
-    /*36*/ "Inactive handle for scheduled tx",                                         \
-    /*37*/ "Invalid config index to switch to",                                        \
-    /*38*/ "No active handle for single protocol",                                     \
+    /*32*/ "Invalid assert, no longer used",                                           \
+    /*33*/ "Invalid assert, no longer used",                                           \
+    /*34*/ "Invalid assert, no longer used",                                           \
+    /*35*/ "Invalid assert, no longer used",                                           \
+    /*36*/ "Invalid assert, no longer used",                                           \
+    /*37*/ "Invalid assert, no longer used",                                           \
+    /*38*/ "Invalid assert, no longer used",                                           \
     /*39*/ "This function is deprecated and must not be called",                       \
     /*40*/ "Multiprotocol task started with no event to run",                          \
     /*41*/ "Invalid interrupt enabled",                                                \
-    /*42*/ "Power conversion functions called before curves were initialized",         \
+    /*42*/ "Invalid assert, no longer used",                                           \
     /*43*/ "Division by zero",                                                         \
     /*44*/ "Function cannot be called without access to the hardware",                 \
     /*45*/ "Pointer parameter was passed as NULL",                                     \
-    /*46*/ "Invalid task type passed to RAIL_SetTaskPriority",                         \
+    /*46*/ "Invalid assert, no longer used",                                           \
     /*47*/ "Synth radio config buffer for channel hopping too small",                  \
     /*48*/ "Buffer provided for RX Channel Hopping is too small",                      \
     /*49*/ "Invalid action was attempted on a module",                                 \
     /*50*/ "The radio config for this channel is not compatible with channel hopping", \
     /*51*/ "Channel change failed",                                                    \
     /*52*/ "Attempted to read invalid register",                                       \
-    /*53*/ "Can't read register value from NULL state",                                \
+    /*53*/ "Invalid assert, no longer used",                                           \
     /*54*/ "DMP radio config caching failed",                                          \
     /*55*/ "NULL was supplied as a RAIL_StateTransitions_t argument",                  \
     /*56*/ "LDMA transfer failed",                                                     \
@@ -392,9 +404,9 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
     /*63*/ "The current PA config does not allow for this operation",                  \
     /*64*/ "The sequencer selected an invalid PA",                                     \
     /*65*/ "Invalid/unsupported channel config",                                       \
-    /*66*/ "The dynamic frame length configuration is invalid",                        \
-    /*67*/ "Failed to enable EM1P energy mode",                                        \
-    /*68*/ "Failed to disable EM1P energy mode",                                       \
+    /*66*/ "Radio Calculator configuration HFXO frequency mismatch with chip",         \
+    /*67*/ "Invalid assert, no longer used",                                           \
+    /*68*/ "Software modem image does not support requested modulation",               \
     /*69*/ "Failed to disable RTCC synchronization",                                   \
     /*70*/ "Multitimer linked list corrupted",                                         \
     /*71*/ "Unable to configure radio for temperature calibration",                    \
@@ -408,6 +420,10 @@ RAIL_ENUM_GENERIC(RAIL_AssertErrorCodes_t, uint32_t)
     /*79*/ "Attempted to sleep with stale RTCC synchronization data",                  \
     /*80*/ "Attempted to clear LOG2X4 with a DEC1 value not equal to 0",               \
     /*81*/ "Failed to complete DMA write",                                             \
+    /*82*/ "RAIL does not support this Radio Calculator configuration",                \
+    /*83*/ "Invalid binary image loaded on sequencer",                                 \
+    /*84*/ "No common or protocol image selected to be loaded onto the sequencer",     \
+    /*85*/ "Software modem image invalid or missing",                                  \
 }
 
 /**

--- a/gecko/platform/radio/rail_lib/common/rail_features.h
+++ b/gecko/platform/radio/rail_lib/common/rail_features.h
@@ -183,6 +183,14 @@ extern "C" {
 #define RAIL_SUPPORTS_TX_TO_TX 0
 #endif
 
+/// Boolean to indicate whether the selected chip supports \ref RAIL_TX_REPEAT_OPTION_START_TO_START.
+/// See also runtime refinement \ref RAIL_SupportsTxRepeatStartToStart().
+#if (_SILICON_LABS_32B_SERIES_2_CONFIG >= 2)
+#define RAIL_SUPPORTS_TX_REPEAT_START_TO_START RAIL_SUPPORTS_TX_TO_TX
+#else
+#define RAIL_SUPPORTS_TX_REPEAT_START_TO_START 0
+#endif
+
 /// Boolean to indicate whether the selected chip supports thermistor measurements.
 /// See also runtime refinement \ref RAIL_SupportsExternalThermistor().
 #if ((_SILICON_LABS_32B_SERIES_2_CONFIG == 2) \
@@ -269,7 +277,7 @@ extern "C" {
 
 /// Boolean to indicate whether the selected chip supports BLE.
 /// See also runtime refinement \ref RAIL_SupportsProtocolBLE().
-#if 1
+#if (_SILICON_LABS_32B_SERIES_1_CONFIG != 4)
 #define RAIL_SUPPORTS_PROTOCOL_BLE RAIL_SUPPORTS_2P4GHZ_BAND
 #else
 #define RAIL_SUPPORTS_PROTOCOL_BLE 0
@@ -325,7 +333,8 @@ extern "C" {
 /// Antenna Switching needed for Angle-of-Arrival receives or
 /// Angle-of-Departure transmits.
 /// See also runtime refinement \ref RAIL_BLE_SupportsAntennaSwitching().
-#if ((_SILICON_LABS_32B_SERIES_2_CONFIG == 2) || (_SILICON_LABS_32B_SERIES_2_CONFIG == 4) || (_SILICON_LABS_32B_SERIES_2_CONFIG == 7))
+#if ((_SILICON_LABS_32B_SERIES_2_CONFIG == 2) \
+  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 4))
 #define RAIL_BLE_SUPPORTS_ANTENNA_SWITCHING RAIL_SUPPORTS_PROTOCOL_BLE
 #else
 #define RAIL_BLE_SUPPORTS_ANTENNA_SWITCHING 0
@@ -382,8 +391,7 @@ extern "C" {
 /// IQ Sampling needed for Angle-of-Arrival/Departure receives.
 /// See also runtime refinement \ref RAIL_BLE_SupportsIQSampling().
 #if ((_SILICON_LABS_32B_SERIES_2_CONFIG == 2) \
-  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 4) \
-  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 7))
+  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 4))
 #define RAIL_BLE_SUPPORTS_IQ_SAMPLING RAIL_SUPPORTS_PROTOCOL_BLE
 #else
 #define RAIL_BLE_SUPPORTS_IQ_SAMPLING 0
@@ -398,6 +406,19 @@ extern "C" {
 
 /// Backwards-compatible synonym of \ref RAIL_BLE_SUPPORTS_AOX
 #define RAIL_FEAT_BLE_AOX_SUPPORTED RAIL_BLE_SUPPORTS_AOX
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/// Boolean to indicate whether the selected chip supports BLE
+/// HADM (high accuracy distance measurements).
+#if (_SILICON_LABS_32B_SERIES_2_CONFIG == 4)
+#define RAIL_BLE_SUPPORTS_HADM RAIL_SUPPORTS_PROTOCOL_BLE
+#else
+#define RAIL_BLE_SUPPORTS_HADM 0
+#endif
+
+/// Backwards-compatible synonym of \ref RAIL_BLE_SUPPORTS_HADM.
+#define RAIL_FEAT_BLE_HADM_SUPPORTED RAIL_BLE_SUPPORTS_HADM
+#endif
 
 /// Boolean to indicate whether the selected chip supports BLE PHY switch to RX
 /// functionality, which is used to switch BLE PHYs at a specific time
@@ -437,7 +458,7 @@ extern "C" {
 /// Boolean to indicate whether the selected chip supports
 /// the IEEE 802.15.4 2.4 GHz band variant.
 /// See also runtime refinement \ref RAIL_SupportsIEEE802154Band2P4().
-#if (_SILICON_LABS_32B_SERIES_2_CONFIG != 3) && (_SILICON_LABS_32B_SERIES_2_CONFIG != 8)
+#if (_SILICON_LABS_32B_SERIES_2_CONFIG != 3)
 #define RAIL_SUPPORTS_IEEE802154_BAND_2P4 (RAIL_SUPPORTS_PROTOCOL_IEEE802154 && RAIL_SUPPORTS_2P4GHZ_BAND)
 #else
 #define RAIL_SUPPORTS_IEEE802154_BAND_2P4 0
@@ -446,7 +467,8 @@ extern "C" {
 /// Boolean to indicate whether the selected chip supports
 /// the IEEE 802.15.4 2.4 RX channel switching.
 /// See also runtime refinement \ref RAIL_IEEE802154_SupportsRxChannelSwitching().
-#if (_SILICON_LABS_32B_SERIES_2_CONFIG == 4)
+#if ((_SILICON_LABS_32B_SERIES_2_CONFIG == 1) \
+  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 4))
 #define RAIL_IEEE802154_SUPPORTS_RX_CHANNEL_SWITCHING (RAIL_SUPPORTS_IEEE802154_BAND_2P4)
 #else
 #define RAIL_IEEE802154_SUPPORTS_RX_CHANNEL_SWITCHING 0
@@ -454,7 +476,11 @@ extern "C" {
 
 /// Boolean to indicate whether the selected chip supports a front end module.
 /// See also runtime refinement \ref RAIL_IEEE802154_SupportsFemPhy().
+#if (_SILICON_LABS_32B_SERIES_2_CONFIG != 8)
 #define RAIL_IEEE802154_SUPPORTS_FEM_PHY (RAIL_SUPPORTS_IEEE802154_BAND_2P4)
+#else
+#define RAIL_IEEE802154_SUPPORTS_FEM_PHY 0
+#endif
 
 /// Boolean to indicate whether the selected chip supports
 /// IEEE 802.15.4E-2012 feature subset needed for Zigbee R22 GB868.
@@ -528,7 +554,8 @@ extern "C" {
 /// Wi-SUN mode switching
 /// See also runtime refinement \ref
 /// RAIL_IEEE802154_SupportsGModeSwitch().
-#if (_SILICON_LABS_32B_SERIES_2_CONFIG == 5)
+#if ((_SILICON_LABS_32B_SERIES_2_CONFIG == 5) \
+  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 8))
 #define RAIL_IEEE802154_SUPPORTS_G_MODESWITCH \
   RAIL_IEEE802154_SUPPORTS_G_SUBSET_GB868  // limit to SUBGHZ for now
 #else
@@ -626,12 +653,50 @@ extern "C" {
 #define RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE 0
 #endif
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/// Boolean to indicate whether the selected chip supports
+/// IEEE802.15.4 2.4 GHz at 2 Mbps
+/// See also runtime refinement \ref
+/// RAIL_IEEE802154_Supports2MbpsPhy().
+#if (_SILICON_LABS_32B_SERIES_1_CONFIG == 3) || (_SILICON_LABS_32B_SERIES_2_CONFIG == 1)
+#define RAIL_IEEE802154_SUPPORTS_2MBPS_PHY \
+  (RAIL_SUPPORTS_PROTOCOL_IEEE802154 && RAIL_SUPPORTS_2P4GHZ_BAND)
+#else
+#define RAIL_IEEE802154_SUPPORTS_2MBPS_PHY 0
+#endif
+#endif //DOXYGEN_SHOULD_SKIP_THIS
+
 /// Boolean to indicate whether the selected chip supports IEEE 802.15.4 PHY
 /// with custom settings
 #if ((_SILICON_LABS_32B_SERIES_1_CONFIG == 2) || (_SILICON_LABS_32B_SERIES_1_CONFIG == 3))
 #define RAIL_IEEE802154_SUPPORTS_CUSTOM1_PHY (RAIL_SUPPORTS_PROTOCOL_IEEE802154 && RAIL_SUPPORTS_2P4GHZ_BAND)
 #else
 #define RAIL_IEEE802154_SUPPORTS_CUSTOM1_PHY 0
+#endif
+
+// Wi_SUN features
+
+/// Boolean to indicate whether the selected chip supports
+/// Wi-SUN
+/// See also runtime refinement \ref
+/// RAIL_SupportsProtocolWiSUN().
+#if ((_SILICON_LABS_32B_SERIES_2_CONFIG == 5) \
+  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 8))
+#define RAIL_SUPPORTS_PROTOCOL_WI_SUN 1
+#else
+#define RAIL_SUPPORTS_PROTOCOL_WI_SUN 0
+#endif
+
+// WMBUS features
+
+/// Boolean to indicate whether the selected chip supports WMBUS simultaneous
+/// M2O RX of T and C modes set by \ref RAIL_WMBUS_Config().
+/// See also runtime refinement \ref RAIL_WMBUS_SupportsSimultaneousTCRx().
+#if ((_SILICON_LABS_32B_SERIES_2_CONFIG == 3) \
+  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 8))
+#define RAIL_WMBUS_SUPPORTS_SIMULTANEOUS_T_C_RX 1
+#else
+#define RAIL_WMBUS_SUPPORTS_SIMULTANEOUS_T_C_RX 0
 #endif
 
 // Z-Wave features
@@ -668,10 +733,8 @@ extern "C" {
 
 /// Boolean to indicate whether the selected chip supports SQ-based PHY.
 /// See also runtime refinement \ref RAIL_SupportsSQPhy().
-#if (_SILICON_LABS_32B_SERIES_2_CONFIG == 3)  \
-  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 4) \
-  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 5) \
-  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 8)
+#if ((_SILICON_LABS_32B_SERIES_2_CONFIG >= 3) && (_SILICON_LABS_32B_SERIES_2_CONFIG != 7))
+
 #define RAIL_SUPPORTS_SQ_PHY 1
 #else
 #define RAIL_SUPPORTS_SQ_PHY 0
@@ -760,6 +823,33 @@ extern "C" {
   #define RAIL_SUPPORTS_THERMAL_PROTECTION  (1U)
 #else
   #define RAIL_SUPPORTS_THERMAL_PROTECTION  (0U)
+#endif
+
+/// Boolean to indicate whether the selected chip supports fast RX2RX enabled by
+/// \ref RAIL_RX_OPTION_FAST_RX2RX.
+/// See also runtime refinement \ref RAIL_SupportsFastRx2Rx().
+#if (_SILICON_LABS_32B_SERIES_2_CONFIG >= 2)
+  #define RAIL_SUPPORTS_FAST_RX2RX  (1U)
+#else
+  #define RAIL_SUPPORTS_FAST_RX2RX  (0U)
+#endif
+
+/// Boolean to indicate whether the selected chip supports collision detection
+/// enabled by RAIL_RX_OPTION_ENABLE_COLLISION_DETECTION
+/// See also runtime refinement \ref RAIL_SupportsCollisionDetection().
+#if (_SILICON_LABS_32B_SERIES_2_CONFIG == 5)
+  #define RAIL_SUPPORTS_COLLISION_DETECTION  (1U)
+#else
+  #define RAIL_SUPPORTS_COLLISION_DETECTION  (0U)
+#endif
+
+/// Boolean to indicate whether the selected chip supports Sidewalk protocol.
+/// See also runtime refinement \ref RAIL_SupportsProtocolSidewalk().
+#if (_SILICON_LABS_32B_SERIES_2_CONFIG == 3) \
+  || (_SILICON_LABS_32B_SERIES_2_CONFIG == 8)
+  #define RAIL_SUPPORTS_PROTOCOL_SIDEWALK (1U)
+#else
+  #define RAIL_SUPPORTS_PROTOCOL_SIDEWALK (0U)
 #endif
 
 /** @} */ // end of group Features

--- a/gecko/platform/radio/rail_lib/common/rail_types.h
+++ b/gecko/platform/radio/rail_lib/common/rail_types.h
@@ -102,6 +102,16 @@ typedef struct RAIL_Version {
 typedef void *RAIL_Handle_t;
 
 /**
+ * A placeholder for a chip-specific RAIL handle. Using NULL as a RAIL handle
+ * is not recommended. As a result, another value that can't be de-referenced
+ * is used.
+ *
+ * This generic handle can and should be used for RAIL APIs that are called
+ * prior to RAIL initialization.
+ */
+#define RAIL_EFR32_HANDLE ((RAIL_Handle_t)0xFFFFFFFFUL)
+
+/**
  * @enum RAIL_Status_t
  * @brief A status returned by many RAIL API calls indicating their success or
  *   failure.
@@ -141,6 +151,20 @@ typedef void (*RAIL_InitCompleteCallbackPtr_t)(RAIL_Handle_t railHandle);
 
 /** A value to signal that RAIL should not use DMA. */
 #define RAIL_DMA_INVALID (0xFFU)
+
+/**
+ * @struct RAILSched_Config_t
+ * @brief Provided for backwards compatibility.
+ */
+typedef struct RAILSched_Config {
+  uint8_t buffer[1]; /**< Dummy buffer no longer used. */
+} RAILSched_Config_t;
+
+/**
+ * @typedef RAIL_StateBuffer_t
+ * @brief Provided for backwards compatibility.
+ */
+typedef uint8_t RAIL_StateBuffer_t[1];
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -367,16 +391,27 @@ typedef struct RAIL_PacketTimeStamp {
    */
   RAIL_PacketTimePosition_t timePosition;
   /**
+   * In RX for EFR32xG25 only  :
    * A value specifying the on-air duration of the data packet,
    * starting with the first bit of the PHR (i.e. end of sync word).
    * Preamble and sync word duration are hence excluded.
-   * Only valid for receive packets at the present time on EFR32xG25 only.
+   *
+   * In Tx for all EFR32 Series 2 except EFR32xG21 :
+   * A value specifying the on-air duration of the data packet,
+   * starting at the preamble (i.e. includes preamble, sync word, PHR, payload and FCS).
+   * This value can be use to compute duty cycles.
+   *
+   * At the present time, this field is set to zero for all EFR32 Series 1 and EFR32xG21,
+   * and also for transmission of auto-ack.
    */
   RAIL_Time_t packetDurationUs;
 } RAIL_PacketTimeStamp_t;
 
 /** @} */ // end of group System_Timing
 
+/******************************************************************************
+ * Sleep Structures
+ *****************************************************************************/
 /**
  * @addtogroup Sleep
  * @{
@@ -894,12 +929,19 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
 #define RAIL_EVENT_RX_ACK_TIMEOUT (1ULL << RAIL_EVENT_RX_ACK_TIMEOUT_SHIFT)
 
 /**
- * Occurs when the number of bytes in the receive FIFO exceeds the configured
- * threshold value.
+ * Keeps occurring as long as the number of bytes in the receive FIFO
+ * exceeds the configured threshold value.
  *
  * Call RAIL_GetRxFifoBytesAvailable() to get the number of
  * bytes available. When using this event, the threshold should be set via
  * RAIL_SetRxFifoThreshold().
+ *
+ * How to avoid sticking in the event handler (even in idle state):
+ * 1. Disable the event (via the config events API or the
+ *    \ref RAIL_FIFO_THRESHOLD_DISABLED parameter)
+ * 2. Increase FIFO threshold
+ * 3. Read the FIFO (that's not an option in
+ *    \ref RAIL_DataMethod_t::PACKET_MODE) in the event handler
  */
 #define RAIL_EVENT_RX_FIFO_ALMOST_FULL (1ULL << RAIL_EVENT_RX_FIFO_ALMOST_FULL_SHIFT)
 
@@ -921,6 +963,8 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
  * times while searching for a packet and is generally used for diagnostic
  * purposes. It can only occur after a
  * \ref RAIL_EVENT_RX_PREAMBLE_DETECT event has already occurred.
+ *
+ * @note See warning for \ref RAIL_EVENT_RX_PREAMBLE_DETECT.
  */
 #define RAIL_EVENT_RX_PREAMBLE_LOST (1ULL << RAIL_EVENT_RX_PREAMBLE_LOST_SHIFT)
 
@@ -931,6 +975,13 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
  * times while searching for a packet and is generally used for diagnostic
  * purposes. It can only occur after a \ref RAIL_EVENT_RX_TIMING_DETECT
  * event has already occurred.
+ *
+ * @warning This event, along with \ref RAIL_EVENT_RX_PREAMBLE_LOST,
+ *   may not work on some demodulators. Some demodulators usurped the signals
+ *   on which these events are based for another purpose. These demodulators
+ *   in particular are available on the EFR32xG23, EFR32xG25, and the EFR32xG28
+ *   platforms. Enabling these events on these platforms may cause the
+ *   events to fire infinitely and possibly freeze the application.
  */
 #define RAIL_EVENT_RX_PREAMBLE_DETECT (1ULL << RAIL_EVENT_RX_PREAMBLE_DETECT_SHIFT)
 
@@ -1021,7 +1072,7 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
 #define RAIL_EVENT_RX_TIMEOUT (1ULL << RAIL_EVENT_RX_TIMEOUT_SHIFT)
 
 /**
- * Occurs when a scheduled RX begins turning on the transmitter.
+ * Occurs when a scheduled RX begins turning on the receiver.
  * This event has the same numerical value as RAIL_EVENT_SCHEDULED_TX_STARTED
  * because one cannot schedule both RX and TX simultaneously.
  */
@@ -1096,6 +1147,8 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
  * while searching for a packet and is generally used for diagnostic purposes.
  * It can only occur after a \ref RAIL_EVENT_RX_TIMING_DETECT event has
  * already occurred.
+ *
+ * @note See warning for \ref RAIL_EVENT_RX_TIMING_DETECT.
  */
 #define RAIL_EVENT_RX_TIMING_LOST (1ULL << RAIL_EVENT_RX_TIMING_LOST_SHIFT)
 
@@ -1104,6 +1157,13 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
  *
  * This event can occur multiple times
  * while searching for a packet and is generally used for diagnostic purposes.
+ *
+ * @warning This event, along with \ref RAIL_EVENT_RX_TIMING_LOST,
+ *   may not work on some demodulators. Some demodulators usurped the signals
+ *   on which these events are based for another purpose. These demodulators
+ *   in particular are available on the EFR32xG23, EFR32xG25, and the EFR32xG28
+ *   platforms. Enabling these events on these platforms may cause the
+ *   events to fire infinitely and possibly freeze the application.
  */
 #define RAIL_EVENT_RX_TIMING_DETECT (1ULL << RAIL_EVENT_RX_TIMING_DETECT_SHIFT)
 
@@ -1118,6 +1178,11 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
  * through the channels again. If this event is left on indefinitely and not
  * handled it will likely be a fairly noisy event, as it continues to fire
  * each time the hopping algorithm cycles through the channel sequence.
+ *
+ * @warning This event currently does not occur when using \ref
+ *   RAIL_RxChannelHoppingMode_t::RAIL_RX_CHANNEL_HOPPING_MODE_MANUAL.
+ *   As a workaround, an application can monitor the current hop channel
+ *   with \ref RAIL_GetChannelAlt().
  */
 #define RAIL_EVENT_RX_CHANNEL_HOPPING_COMPLETE (1ULL << RAIL_EVENT_RX_CHANNEL_HOPPING_COMPLETE_SHIFT)
 
@@ -1344,7 +1409,7 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
  *
  * This event generally precedes the actual start of a CCA check by roughly
  * the \ref RAIL_StateTiming_t::idleToRx time (subject to
- * \ref RAIL_MINIMUM_TRANSITION_US).  It can
+ * \ref RAIL_MINIMUM_TRANSITION_US). It can
  * occur multiple times based on the configuration of the ongoing CSMA or LBT
  * transmission. It can only happen after calling RAIL_StartCcaCsmaTx()
  * or RAIL_StartCcaLbtTx().
@@ -1537,7 +1602,8 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
  * Occurs when a Tx has been blocked because of temperature exceeding
  * the safety threshold.
  *
- * Only occurs on platforms where \ref RAIL_SUPPORTS_EFF is true.
+ * Only occurs on platforms where \ref RAIL_SUPPORTS_EFF is true,
+ * and only when also reporting \ref RAIL_EVENT_TX_BLOCKED.
  */
 #define RAIL_EVENT_TX_BLOCKED_TOO_HOT (1ULL << RAIL_EVENT_TX_BLOCKED_TOO_HOT_SHIFT)
 
@@ -1566,6 +1632,47 @@ RAIL_ENUM_GENERIC(RAIL_Events_t, uint64_t) {
 
 /** @} */ // end of group Events
 
+/******************************************************************************
+ * General Structures (part 2)
+ *****************************************************************************/
+/**
+ * @addtogroup General
+ * @{
+ */
+
+/**
+ * @struct RAIL_Config_t
+ * @brief RAIL configuration structure.
+ */
+typedef struct RAIL_Config {
+  /**
+   * A pointer to a function, which is called whenever a RAIL event occurs.
+   *
+   * @param[in] railHandle A handle for a RAIL instance.
+   * @param[in] events A bit mask of RAIL events.
+   *
+   * See the \ref RAIL_Events_t documentation for the list of RAIL events.
+   */
+  void (*eventsCallback)(RAIL_Handle_t railHandle, RAIL_Events_t events);
+  /**
+   * Provided for backwards compatibility. Ignored.
+   */
+  void *protocol;
+  /**
+   * Provided for backwards compatibility. Ignored.
+   */
+  RAILSched_Config_t *scheduler;
+  /**
+   * Provided for backwards compatibility. Ignored.
+   */
+  RAIL_StateBuffer_t buffer;
+} RAIL_Config_t;
+
+/** @} */ // end of group General
+
+/******************************************************************************
+ * PA Power Amplifier Structures
+ *****************************************************************************/
 /**
  * @addtogroup PA Power Amplifier (PA)
  * @ingroup Transmit
@@ -1598,6 +1705,247 @@ typedef int16_t RAIL_TxPower_t;
 /// All dBm inputs to TX power functions take dBm power times this factor.
 #define RAIL_TX_POWER_DBM_SCALING_FACTOR 10
 
+/**
+ * Raw power levels used directly by the RAIL_Get/SetTxPower API where a higher
+ * numerical value corresponds to a higher output power. These are referred to
+ * as 'raw (values/units)'. On EFR32, they can range from one of \ref
+ * RAIL_TX_POWER_LEVEL_2P4_LP_MIN, \ref RAIL_TX_POWER_LEVEL_2P4_HP_MIN, or
+ * \ref RAIL_TX_POWER_LEVEL_SUBGIG_HP_MIN to one of \ref
+ * RAIL_TX_POWER_LEVEL_2P4_LP_MAX, \ref RAIL_TX_POWER_LEVEL_2P4_HP_MAX, and \ref
+ * RAIL_TX_POWER_LEVEL_SUBGIG_HP_MAX, respectively, depending on the selected \ref
+ * RAIL_TxPowerMode_t.
+ */
+typedef uint8_t RAIL_TxPowerLevel_t;
+
+/**
+ * Invalid RAIL_TxPowerLevel_t value returned when an error occurs
+ * with RAIL_GetTxPower.
+ */
+#define RAIL_TX_POWER_LEVEL_INVALID (255U)
+
+/**
+ * Sentinel value that can be passed to RAIL_SetTxPower to set
+ * the highest power level available on the current PA, regardless
+ * of which one is selected.
+ */
+#define RAIL_TX_POWER_LEVEL_MAX (254U)
+
+/**
+ * PA power setting used directly by the \ref RAIL_GetPaPowerSetting() and
+ * \ref RAIL_SetPaPowerSetting() APIs which is decoded to the actual
+ * hardware register value(s).
+ */
+typedef uint32_t RAIL_PaPowerSetting_t;
+
+/**
+ * Returned by \ref RAIL_GetPaPowerSetting when the device does
+ * not support the dBm to power setting mapping table.
+ */
+#define RAIL_TX_PA_POWER_SETTING_UNSUPPORTED     (0U)
+
+/**
+ * @enum RAIL_TxPowerMode_t
+ * @brief An enumeration of the EFR32 power modes.
+ *
+ * The power modes on the EFR32 correspond to the different on-chip PAs that
+ * are available. For more information about the power and performance
+ * characteristics of a given amplifier, see the data sheet.
+ */
+RAIL_ENUM(RAIL_TxPowerMode_t) {
+  /**
+   *  High-power 2.4 GHz amplifier
+   *  EFR32xG1X: up to 20 dBm, raw values: 0-252
+   *  EFR32xG21: up to 20 dBm, raw values: 1-180
+   *  EFR32xG22: up to  6 dBm, raw values: 1-128
+   *  EFR32xG24: up to 20 dBm, raw values: 0-180, or
+   *             up to 10 dBm, raw values: 0-90
+   *  EFR32xG26: same as EFR32xG24
+   *  EFR32xG27: up to  6 dBm, raw values: 1-128
+   *  EFR32xG28: up to 10 dBm, raw values: 0-240
+   *  Not supported on other platforms.
+   */
+  RAIL_TX_POWER_MODE_2P4GIG_HP = 0U,
+  /** @deprecated Please use \ref RAIL_TX_POWER_MODE_2P4GIG_HP instead. */
+  RAIL_TX_POWER_MODE_2P4_HP = RAIL_TX_POWER_MODE_2P4GIG_HP,
+  /**
+   *  Mid-power 2.4 GHz amplifier
+   *  EFR32xG21: up to 10 dBm, raw values: 1-90
+   *  Not supported on other platforms.
+   */
+  RAIL_TX_POWER_MODE_2P4GIG_MP = 1U,
+  /** @deprecated Please use \ref RAIL_TX_POWER_MODE_2P4GIG_MP instead. */
+  RAIL_TX_POWER_MODE_2P4_MP = RAIL_TX_POWER_MODE_2P4GIG_MP,
+  /**
+   *  Low-power 2.4 GHz amplifier
+   *  EFR32xG1x: up to 0 dBm, raw values: 1-7
+   *  EFR32xG21: up to 0 dBm, raw values: 1-64
+   *  EFR32xG22: up to 0 dBm, raw values: 1-16
+   *  EFR32xG24: up to 0 dBm, raw values: 1-16
+   *  EFR32xG26: same as EFR32xG24
+   *  EFR32xG27: up to 0 dBm, raw values: 1-16
+   *  Not supported on other platforms.
+   */
+  RAIL_TX_POWER_MODE_2P4GIG_LP = 2U,
+  /** @deprecated Please use \ref RAIL_TX_POWER_MODE_2P4GIG_LP instead. */
+  RAIL_TX_POWER_MODE_2P4_LP = RAIL_TX_POWER_MODE_2P4GIG_LP,
+  /**
+   *  Low-Low-power 2.4 GHz amplifier
+   *  Not currently supported on any EFR32 platform.
+   */
+  RAIL_TX_POWER_MODE_2P4GIG_LLP = 3U,
+  /**
+   *  Select the highest 2.4 GHz power PA available on the current chip.
+   *  Only supported on EFR32 Series-2 platforms and not Series-1.
+   */
+  RAIL_TX_POWER_MODE_2P4GIG_HIGHEST = 4U,
+  /** @deprecated Please use \ref RAIL_TX_POWER_MODE_2P4GIG_HIGHEST instead. */
+  RAIL_TX_POWER_MODE_2P4_HIGHEST = RAIL_TX_POWER_MODE_2P4GIG_HIGHEST,
+  /**
+   *  PA for all Sub-GHz dBm values in range, using \ref
+   *  RAIL_PaPowerSetting_t table.
+   *  Only supported on platforms with \ref
+   *  RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE (e.g. EFR32xG25).
+   */
+  RAIL_TX_POWER_MODE_SUBGIG_POWERSETTING_TABLE = 5U,
+  /**
+   *  High-power Sub-GHz amplifier (Class D mode)
+   *  EFR32xG1x: up to 20 dBm, raw values: 0-248
+   *  Also supported on FR32xG23 and EFR32xG28.
+   *  Not supported other Sub-GHz-incapable platforms or those with \ref
+   *  RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE.
+   */
+  RAIL_TX_POWER_MODE_SUBGIG_HP = 6U,
+  /** @deprecated Please use \ref RAIL_TX_POWER_MODE_SUBGIG_HP instead. */
+  RAIL_TX_POWER_MODE_SUBGIG = RAIL_TX_POWER_MODE_SUBGIG_HP,
+  /**
+   *  Mid-power Sub-GHz amplifier
+   *  Supported only on EFR32xG23 and EFR32xG28.
+   *  Not supported other Sub-GHz-incapable platforms or those with \ref
+   *  RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE.
+   */
+  RAIL_TX_POWER_MODE_SUBGIG_MP = 7U,
+  /**
+   *  Low-power Sub-GHz amplifier
+   *  Supported only on EFR32xG23 and EFR32xG28.
+   *  Not supported other Sub-GHz-incapable platforms or those with \ref
+   *  RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE.
+   */
+  RAIL_TX_POWER_MODE_SUBGIG_LP = 8U,
+  /**
+   *  Low-Low-power Sub-GHz amplifier
+   *  Supported only on EFR32xG23 and EFR32xG28.
+   *  Not supported other Sub-GHz-incapable platforms or those with \ref
+   *  RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE.
+   */
+  RAIL_TX_POWER_MODE_SUBGIG_LLP = 9U,
+  /**
+   *  Select the highest Sub-GHz power PA available on the current chip.
+   *  Only supported on EFR32 Series-2 platforms and not Series-1.
+   */
+  RAIL_TX_POWER_MODE_SUBGIG_HIGHEST = 10U,
+  /**
+   *  PA for all OFDM Sub-GHz dBm values in range, using \ref
+   *  RAIL_PaPowerSetting_t table.
+   *  Supported only on platforms with both \ref
+   *  RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE and \ref
+   *  RAIL_SUPPORTS_OFDM_PA (e.g. EFR32xG25).
+   */
+  RAIL_TX_POWER_MODE_OFDM_PA_POWERSETTING_TABLE = 11U,
+  /** @deprecated Please use \ref RAIL_TX_POWER_MODE_OFDM_PA_POWERSETTING_TABLE instead. */
+  RAIL_TX_POWER_MODE_OFDM_PA = RAIL_TX_POWER_MODE_OFDM_PA_POWERSETTING_TABLE,
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+  /**
+   *  PA for all Sub-GHz dBm values in range for Front-End-Module, using \ref
+   *  RAIL_PaPowerSetting_t table.
+   *  Supported only on platforms with both
+   *  RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE and \ref
+   *  RAIL_SUPPORTS_EFF.
+   */
+  RAIL_TX_POWER_MODE_SUBGIG_EFF_POWERSETTING_TABLE = 12U,
+  /**
+   *  PA for all OFDM Sub-GHz dBm values in range for Front-End-Module, using \ref
+   *  RAIL_PaPowerSetting_t table.
+   *  Supported only on platforms with all of \ref
+   *  RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE, \ref
+   *  RAIL_SUPPORTS_OFDM_PA, and \ref
+   *  RAIL_SUPPORTS_EFF.
+   */
+  RAIL_TX_POWER_MODE_OFDM_PA_EFF_POWERSETTING_TABLE = 13U,
+#endif//DOXYGEN_SHOULD_SKIP_THIS
+  /** Invalid amplifier Selection */
+  RAIL_TX_POWER_MODE_NONE // Must be last
+};
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+// Self-referencing defines minimize compiler complaints when using RAIL_ENUM
+// Refer to rail_chip_specific.h for per-platform defines of supported ones.
+#define RAIL_TX_POWER_MODE_NONE ((RAIL_TxPowerMode_t) RAIL_TX_POWER_MODE_NONE)
+#endif//DOXYGEN_SHOULD_SKIP_THIS
+
+/**
+ * @def RAIL_TX_POWER_MODE_NAMES
+ * @brief The names of the TX power modes
+ *
+ * A list of the names for the TX power modes on EFR32 parts. This
+ * macro is useful for test applications and debugging output.
+ */
+#define RAIL_TX_POWER_MODE_NAMES {                       \
+    "RAIL_TX_POWER_MODE_2P4GIG_HP",                      \
+    "RAIL_TX_POWER_MODE_2P4GIG_MP",                      \
+    "RAIL_TX_POWER_MODE_2P4GIG_LP",                      \
+    "RAIL_TX_POWER_MODE_2P4GIG_LLP",                     \
+    "RAIL_TX_POWER_MODE_2P4GIG_HIGHEST",                 \
+    "RAIL_TX_POWER_MODE_SUBGIG_POWERSETTING_TABLE",      \
+    "RAIL_TX_POWER_MODE_SUBGIG_HP",                      \
+    "RAIL_TX_POWER_MODE_SUBGIG_MP",                      \
+    "RAIL_TX_POWER_MODE_SUBGIG_LP",                      \
+    "RAIL_TX_POWER_MODE_SUBGIG_LLP",                     \
+    "RAIL_TX_POWER_MODE_SUBGIG_HIGHEST",                 \
+    "RAIL_TX_POWER_MODE_OFDM_PA_POWERSETTING_TABLE",     \
+    "RAIL_TX_POWER_MODE_SUBGIG_EFF_POWERSETTING_TABLE",  \
+    "RAIL_TX_POWER_MODE_OFDM_PA_EFF_POWERSETTING_TABLE", \
+    "RAIL_TX_POWER_MODE_NONE"                            \
+}
+
+/**
+ * @struct RAIL_TxPowerConfig_t
+ *
+ * @brief A structure containing values used to initialize the power amplifiers.
+ */
+typedef struct RAIL_TxPowerConfig {
+  /** TX power mode */
+  RAIL_TxPowerMode_t mode;
+  /** Power amplifier supply voltage in mV, generally:
+   *  DCDC supply ~ 1800 mV (1.8 V)
+   *  Battery supply ~ 3300 mV (3.3 V)
+   */
+  uint16_t voltage;
+  /** The amount of time to spend ramping for TX in uS. */
+  uint16_t rampTime;
+} RAIL_TxPowerConfig_t;
+
+/** Convenience macro for any EFF power mode. */
+#define RAIL_POWER_MODE_IS_ANY_EFF(x)                         \
+  (((x) == RAIL_TX_POWER_MODE_OFDM_PA_EFF_POWERSETTING_TABLE) \
+   || ((x) == RAIL_TX_POWER_MODE_SUBGIG_EFF_POWERSETTING_TABLE))
+/** Convenience macro for any OFDM mapping table mode. */
+#define RAIL_POWER_MODE_IS_DBM_POWERSETTING_MAPPING_TABLE_OFDM(x) \
+  (((x) == RAIL_TX_POWER_MODE_OFDM_PA_POWERSETTING_TABLE)         \
+   || ((x) == RAIL_TX_POWER_MODE_OFDM_PA_EFF_POWERSETTING_TABLE))
+/** Convenience macro for any Sub-GHz mapping table mode. */
+#define RAIL_POWER_MODE_IS_DBM_POWERSETTING_MAPPING_TABLE_SUBGIG(x) \
+  (((x) == RAIL_TX_POWER_MODE_SUBGIG_EFF_POWERSETTING_TABLE)        \
+   || ((x) == RAIL_TX_POWER_MODE_SUBGIG_POWERSETTING_TABLE))
+/** Convenience macro for any mapping table mode. */
+#define RAIL_POWER_MODE_IS_ANY_DBM_POWERSETTING_MAPPING_TABLE(x) \
+  (((x) == RAIL_TX_POWER_MODE_OFDM_PA_POWERSETTING_TABLE)        \
+   || ((x) == RAIL_TX_POWER_MODE_OFDM_PA_EFF_POWERSETTING_TABLE) \
+   || ((x) == RAIL_TX_POWER_MODE_SUBGIG_POWERSETTING_TABLE)      \
+   || ((x) == RAIL_TX_POWER_MODE_SUBGIG_EFF_POWERSETTING_TABLE))
+/** Convenience macro for any OFDM mode. */
+#define RAIL_POWER_MODE_IS_ANY_OFDM(x) \
+  RAIL_POWER_MODE_IS_DBM_POWERSETTING_MAPPING_TABLE_OFDM(x)
+
 /** @} */ // PA Power Amplifier (PA)
 
 /******************************************************************************
@@ -1607,6 +1955,15 @@ typedef int16_t RAIL_TxPower_t;
  * @addtogroup Radio_Configuration
  * @{
  */
+
+/**
+ * @brief Pointer to a radio configuration array.
+ *
+ * The radio configuration properly configures the
+ * radio for operation on a protocol. These configurations are very
+ * chip-specific should not be created or edited by hand.
+ */
+typedef const uint32_t *RAIL_RadioConfig_t;
 
 /**
  * @struct RAIL_FrameType_t
@@ -1707,6 +2064,7 @@ typedef struct RAIL_AlternatePhy {
   uint16_t minIf_kHz; /**< minimum IF for the alternate PHY in kHz. */
   uint16_t minBaseIf_kHz; /**< minimum IF for the base PHY in kHz. */
   bool isOfdmModem; /**< Indicates that OFDM modem is used by this alternate PHY. */
+  uint32_t rateInfo; /**< rate Info of the alternate PHY. */
 } RAIL_AlternatePhy_t;
 
 /**
@@ -1718,8 +2076,8 @@ typedef struct RAIL_AlternatePhy {
  *   + channelSpacing * (channel - physicalChannelOffset);
  */
 typedef struct RAIL_ChannelConfigEntry {
-  const uint32_t *phyConfigDeltaAdd; /**< The minimum radio configuration to apply to the base
-                                          configuration for this channel set. */
+  RAIL_RadioConfig_t phyConfigDeltaAdd; /**< The minimum radio configuration to apply to the base
+                                           configuration for this channel set. */
   uint32_t baseFrequency; /**< A base frequency in Hz of this channel set. */
   uint32_t channelSpacing; /**< A channel spacing in Hz of this channel set. */
   uint16_t physicalChannelOffset; /**< The offset to subtract from the logical
@@ -1953,16 +2311,17 @@ typedef struct RAIL_ChannelConfigEntry {
 /// @endcode
 
 typedef struct RAIL_ChannelConfig {
-  const uint32_t *phyConfigBase; /**< Base radio configuration for the corresponding
-                                      channel configuration entries. */
-  const uint32_t *phyConfigDeltaSubtract; /**< Minimum radio configuration to restore
-                                               channel entries back to base
-                                               configuration. */
+  RAIL_RadioConfig_t phyConfigBase; /**< Base radio configuration for the corresponding
+                                       channel configuration entries. */
+  RAIL_RadioConfig_t phyConfigDeltaSubtract; /**< Minimum radio configuration to restore
+                                                channel entries back to base
+                                                configuration. */
   const RAIL_ChannelConfigEntry_t *configs; /**< Pointer to an array of
                                                  RAIL_ChannelConfigEntry_t
                                                  entries. */
   uint32_t length; /**< Number of RAIL_ChannelConfigEntry_t entries. */
   uint32_t signature; /**< Signature for this structure. Only used on modules. */
+  uint32_t xtalFrequencyHz; /**< Crystal Frequency for the channel config. */
 } RAIL_ChannelConfig_t;
 
 /**
@@ -2002,7 +2361,63 @@ typedef void (*RAIL_RadioConfigChangedCallback_t)(RAIL_Handle_t railHandle,
 /**
  * @addtogroup PTI
  * @{
+ *
+ * These enumerations and structures are used with RAIL PTI API. EFR32 supports
+ * SPI and UART PTI and is configurable in terms of baud rates and PTI
+ * pin locations.
  */
+
+/** A channel type enumeration. */
+RAIL_ENUM(RAIL_PtiMode_t) {
+  /** Turn PTI off entirely. */
+  RAIL_PTI_MODE_DISABLED,
+  /** 8-bit SPI mode. */
+  RAIL_PTI_MODE_SPI,
+  /** 8-bit UART mode. */
+  RAIL_PTI_MODE_UART,
+  /** 9-bit UART mode. */
+  RAIL_PTI_MODE_UART_ONEWIRE,
+};
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+// Self-referencing defines minimize compiler complaints when using RAIL_ENUM
+#define RAIL_PTI_MODE_DISABLED     ((RAIL_PtiMode_t) RAIL_PTI_MODE_DISABLED)
+#define RAIL_PTI_MODE_SPI          ((RAIL_PtiMode_t) RAIL_PTI_MODE_SPI)
+#define RAIL_PTI_MODE_UART         ((RAIL_PtiMode_t) RAIL_PTI_MODE_UART)
+#define RAIL_PTI_MODE_UART_ONEWIRE ((RAIL_PtiMode_t) RAIL_PTI_MODE_UART_ONEWIRE)
+#endif//DOXYGEN_SHOULD_SKIP_THIS
+
+/**
+ * @struct RAIL_PtiConfig_t
+ * @brief A configuration for PTI.
+ */
+typedef struct RAIL_PtiConfig {
+  /** Packet Trace mode (UART or SPI). */
+  RAIL_PtiMode_t mode;
+  /** Output baudrate for PTI in Hz. */
+  uint32_t baud;
+  /** Data output (DOUT) location for doutPort/Pin.
+   *  Only needed on EFR32 Series 1; ignored on other platforms. */
+  uint8_t doutLoc;
+  /** Data output (DOUT) GPIO port. */
+  uint8_t doutPort;
+  /** Data output (DOUT) GPIO pin. */
+  uint8_t doutPin;
+  /** Data clock (DCLK) location for dclkPort/Pin. Only used in SPI mode.
+   *  Only needed on EFR32 Series 1; ignored on other platforms. */
+  uint8_t dclkLoc;
+  /** Data clock (DCLK) GPIO port. Only used in SPI mode. */
+  uint8_t dclkPort;
+  /** Data clock (DCLK) GPIO pin. Only used in SPI mode. */
+  uint8_t dclkPin;
+  /** Data frame (DFRAME) location for dframePort/Pin.
+   *  Only needed on EFR32 Series 1; ignored on other platforms. */
+  uint8_t dframeLoc;
+  /** Data frame (DFRAME) GPIO port. */
+  uint8_t dframePort;
+  /** Data frame (DFRAME) GPIO pin. */
+  uint8_t dframePin;
+} RAIL_PtiConfig_t;
 
 /**
  * @enum RAIL_PtiProtocol_t
@@ -2017,17 +2432,19 @@ RAIL_ENUM(RAIL_PtiProtocol_t) {
   RAIL_PTI_PROTOCOL_ZWAVE = 6, /**< PTI output for the Z-Wave protocol. */
   RAIL_PTI_PROTOCOL_WISUN = 7, /**< PTI output for the Wi-SUN protocol. */
   RAIL_PTI_PROTOCOL_802154 = 8, /**< PTI output for a custom protocol using a built-in 802.15.4 radio config. */
+  RAIL_PTI_PROTOCOL_SIDEWALK = 9, /** < PTI output for Sidewalk protocol. */
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 // Self-referencing defines minimize compiler complaints when using RAIL_ENUM
-#define RAIL_PTI_PROTOCOL_CUSTOM  ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_CUSTOM)
-#define RAIL_PTI_PROTOCOL_THREAD  ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_THREAD)
-#define RAIL_PTI_PROTOCOL_BLE     ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_BLE)
-#define RAIL_PTI_PROTOCOL_CONNECT ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_CONNECT)
-#define RAIL_PTI_PROTOCOL_ZIGBEE  ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_ZIGBEE)
-#define RAIL_PTI_PROTOCOL_ZWAVE   ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_ZWAVE)
-#define RAIL_PTI_PROTOCOL_802154  ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_802154)
+#define RAIL_PTI_PROTOCOL_CUSTOM    ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_CUSTOM)
+#define RAIL_PTI_PROTOCOL_THREAD    ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_THREAD)
+#define RAIL_PTI_PROTOCOL_BLE       ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_BLE)
+#define RAIL_PTI_PROTOCOL_CONNECT   ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_CONNECT)
+#define RAIL_PTI_PROTOCOL_ZIGBEE    ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_ZIGBEE)
+#define RAIL_PTI_PROTOCOL_ZWAVE     ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_ZWAVE)
+#define RAIL_PTI_PROTOCOL_802154    ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_802154)
+#define RAIL_PTI_PROTOCOL_SIDEWALK  ((RAIL_PtiProtocol_t) RAIL_PTI_PROTOCOL_SIDEWALK)
 #endif//DOXYGEN_SHOULD_SKIP_THIS
 
 /** @} */ // end of group PTI
@@ -2039,6 +2456,12 @@ RAIL_ENUM(RAIL_PtiProtocol_t) {
  * @addtogroup Data_Management
  * @{
  */
+
+/// Fixed-width type indicating the needed alignment for RX and TX FIFOs.
+#define RAIL_FIFO_ALIGNMENT_TYPE uint32_t
+
+/// Alignment that is needed for the RX and TX FIFOs.
+#define RAIL_FIFO_ALIGNMENT (sizeof(RAIL_FIFO_ALIGNMENT_TYPE))
 
 /**
  * @enum RAIL_TxDataSource_t
@@ -2079,9 +2502,22 @@ RAIL_ENUM(RAIL_RxDataSource_t) {
   RX_IQDATA_FILTMSB, /**< Gets highest 16 bits of I/Q data provided to the
                          demodulator. */
   RX_DIRECT_MODE_DATA, /**< Gets RX direct mode data output from the demodulator.
+                            BCRDEMOD captures bcr_dmod_rawd at the sample rate
+                            (faster than the bit rate by the OSR), specifically
+                            the demod_samp_rate trigger.
                             Only supported if
                             \ref RAIL_SUPPORTS_RX_DIRECT_MODE_DATA_TO_FIFO
                             is true. */
+  RX_DIRECT_SYNCHRONOUS_MODE_DATA,  /**< Gets synchronous RX direct mode data
+                                         output from the demodulator.
+                                         BCRDEMOD_SYNCHRONOUS captures
+                                         bcr_dmod_rxd_ext at the bit
+                                         rate (bcr_dmod_bitclk_ext trigger).
+                                         Only supported if
+                                         \ref RAIL_SUPPORTS_RX_DIRECT_MODE_DATA_TO_FIFO
+                                         is true.
+                                         Only efr32xg23, efr32xg25, or efr32xg28
+                                         have this mode.*/
   /** A count of the choices in this enumeration. */
   RAIL_RX_DATA_SOURCE_COUNT // Must be last
 };
@@ -2093,6 +2529,7 @@ RAIL_ENUM(RAIL_RxDataSource_t) {
 #define RX_IQDATA_FILTLSB         ((RAIL_RxDataSource_t) RX_IQDATA_FILTLSB)
 #define RX_IQDATA_FILTMSB         ((RAIL_RxDataSource_t) RX_IQDATA_FILTMSB)
 #define RX_DIRECT_MODE_DATA       ((RAIL_RxDataSource_t) RX_DIRECT_MODE_DATA)
+#define RX_DIRECT_SYNCHRONOUS_MODE_DATA ((RAIL_RxDataSource_t) RX_DIRECT_SYNCHRONOUS_MODE_DATA)
 #define RAIL_RX_DATA_SOURCE_COUNT ((RAIL_RxDataSource_t) RAIL_RX_DATA_SOURCE_COUNT)
 #endif//DOXYGEN_SHOULD_SKIP_THIS
 
@@ -2158,6 +2595,57 @@ typedef struct {
  */
 
 /**
+ * @typedef RAIL_TransitionTime_t
+ * @brief Suitable type for the supported transition time range.
+ *
+ * Refer to platform-specific \ref RAIL_MINIMUM_TRANSITION_US and
+ * \ref RAIL_MAXIMUM_TRANSITION_US for the valid range of this type.
+ */
+typedef uint32_t RAIL_TransitionTime_t;
+
+/**
+ * @def RAIL_TRANSITION_TIME_KEEP
+ * @brief A value to use in \ref RAIL_StateTiming_t fields when
+ *   calling \ref RAIL_SetStateTiming() to keep that timing
+ *   parameter at it current setting.
+ */
+#define RAIL_TRANSITION_TIME_KEEP ((RAIL_TransitionTime_t) -1)
+
+/**
+ * @struct RAIL_StateTiming_t
+ * @brief A timing configuration structure for the RAIL State Machine.
+ *
+ * Configure the timings of the radio state transitions for common situations.
+ * All of the listed timings are in microseconds. Transitions from an active
+ * radio state to idle are not configurable, and will always happen as fast
+ * as possible.
+ * No timing value can exceed platform-specific \ref RAIL_MAXIMUM_TRANSITION_US.
+ * Use \ref RAIL_TRANSITION_TIME_KEEP to keep an existing setting.
+ *
+ * For idleToRx, idleToTx, rxToTx, txToRx, and txToTx a value of 0 for the
+ * transition time means that the specified transition should happen as fast
+ * as possible, even if the timing cannot be as consistent. Otherwise, the
+ * timing value cannot be below the platform-specific \ref RAIL_MINIMUM_TRANSITION_US.
+ *
+ * For idleToTx, rxToTx, and txToTx setting a longer \ref
+ * RAIL_TxPowerConfig_t::rampTime may result in a larger minimum value.
+ *
+ * For rxSearchTimeout and txToRxSearchTimeout, there is no minimum value. A
+ * value of 0 disables the feature, functioning as an infinite timeout.
+ */
+typedef struct RAIL_StateTiming {
+  RAIL_TransitionTime_t idleToRx; /**< Transition time from IDLE to RX. */
+  RAIL_TransitionTime_t txToRx; /**< Transition time from TX to RX. */
+  RAIL_TransitionTime_t idleToTx; /**< Transition time from IDLE to TX. */
+  RAIL_TransitionTime_t rxToTx; /**< Transition time from RX packet to TX. */
+  RAIL_TransitionTime_t rxSearchTimeout; /**< Length of time the radio will search for a
+                                            packet when coming from idle or RX. */
+  RAIL_TransitionTime_t txToRxSearchTimeout; /**< Length of time the radio will search for a
+                                                packet when coming from TX. */
+  RAIL_TransitionTime_t txToTx; /**< Transition time from TX packet to TX. */
+} RAIL_StateTiming_t;
+
+/**
  * @enum RAIL_RadioState_t
  * @brief The state of the radio.
  */
@@ -2184,6 +2672,58 @@ RAIL_ENUM(RAIL_RadioState_t) {
 #define RAIL_RF_STATE_IDLE      ((RAIL_RadioState_t) RAIL_RF_STATE_IDLE)
 #define RAIL_RF_STATE_RX_ACTIVE ((RAIL_RadioState_t) RAIL_RF_STATE_RX_ACTIVE)
 #define RAIL_RF_STATE_TX_ACTIVE ((RAIL_RadioState_t) RAIL_RF_STATE_TX_ACTIVE)
+#endif//DOXYGEN_SHOULD_SKIP_THIS
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * @enum RAIL_RadioStateEfr32_t
+ * @brief Detailed EFR32 Radio state machine statuses.
+ */
+RAIL_ENUM(RAIL_RadioStateEfr32_t) {
+  RAIL_RAC_STATE_OFF,         /**< Radio is off. */
+  RAIL_RAC_STATE_RXWARM,      /**< Radio is enabling the receiver. */
+  RAIL_RAC_STATE_RXSEARCH,    /**< Radio is listening for incoming frames. */
+  RAIL_RAC_STATE_RXFRAME,     /**< Radio is receiving a frame. */
+  RAIL_RAC_STATE_RXPD,        /**< Radio is powering down receiver and going to
+                                   OFF state. */
+  RAIL_RAC_STATE_RX2RX,       /**< Radio is going back to receive mode after
+                                   receiving a frame. */
+  RAIL_RAC_STATE_RXOVERFLOW,  /**< Received data was lost due to full receive
+                                   buffer. */
+  RAIL_RAC_STATE_RX2TX,       /**< Radio is disabling receiver and enabling
+                                   transmitter. */
+  RAIL_RAC_STATE_TXWARM,      /**< Radio is enabling transmitter. */
+  RAIL_RAC_STATE_TX,          /**< Radio is transmitting data. */
+  RAIL_RAC_STATE_TXPD,        /**< Radio is powering down transmitter and going
+                                   to OFF state. */
+  RAIL_RAC_STATE_TX2RX,       /**< Radio is disabling transmitter and enabling
+                                   reception. */
+  RAIL_RAC_STATE_TX2TX,       /**< Radio is preparing a transmission after the
+                                   previous transmission was ended. */
+  RAIL_RAC_STATE_SHUTDOWN,    /**< Radio is powering down receiver and going to
+                                   OFF state. */
+  RAIL_RAC_STATE_POR,         /**< Radio power-on-reset state (EFR32xG22 and later) */
+  RAIL_RAC_STATE_NONE         /**< Invalid Radio state, must be the last entry. */
+};
+#endif//DOXYGEN_SHOULD_SKIP_THIS
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+// Self-referencing defines minimize compiler complaints when using RAIL_ENUM
+#define RAIL_RAC_STATE_OFF          ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_OFF)
+#define RAIL_RAC_STATE_RXWARM       ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXWARM)
+#define RAIL_RAC_STATE_RXSEARCH     ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXSEARCH)
+#define RAIL_RAC_STATE_RXFRAME      ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXFRAME)
+#define RAIL_RAC_STATE_RXPD         ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXPD)
+#define RAIL_RAC_STATE_RX2RX        ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RX2RX)
+#define RAIL_RAC_STATE_RXOVERFLOW   ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RXOVERFLOW)
+#define RAIL_RAC_STATE_RX2TX        ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_RX2TX)
+#define RAIL_RAC_STATE_TXWARM       ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TXWARM)
+#define RAIL_RAC_STATE_TX           ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TX)
+#define RAIL_RAC_STATE_TXPD         ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TXPD)
+#define RAIL_RAC_STATE_TX2RX        ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TX2RX)
+#define RAIL_RAC_STATE_TX2TX        ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_TX2TX)
+#define RAIL_RAC_STATE_SHUTDOWN     ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_SHUTDOWN)
+#define RAIL_RAC_STATE_NONE         ((RAIL_RadioStateEfr32_t) RAIL_RAC_STATE_NONE)
 #endif//DOXYGEN_SHOULD_SKIP_THIS
 
 /**
@@ -2354,22 +2894,23 @@ typedef struct RAIL_TxChannelHoppingConfig {
    * data anywhere in this buffer.
    *
    * @note the size of this buffer must be at least as large as
-   * 3 + 30 * numberOfChannels, plus the sum of the sizes of the
+   * 3 + \ref RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL * numberOfChannels,
+   * plus the sum of the sizes of the
    * radioConfigDeltaAdd's of the required channels, plus the size of the
    * radioConfigDeltaSubtract. In the case that one channel
    * appears two or more times in your channel sequence
    * (e.g., 1, 2, 3, 2), you must account for the radio configuration
    * size that number of times (i.e., need to count channel 2's
-   * radio configuration size twice for the given example). The overall
-   * 3 words and 30 words per channel needed in this buffer are
+   * radio configuration size twice for the given example). The buffer is
    * for internal use to the library.
    */
   uint32_t *buffer;
   /**
-   * This parameter must be set to the length of the buffer array. This way,
-   * during configuration, the software can confirm it's writing within the
-   * range of the buffer. The configuration API will return an error
-   * if bufferLength is insufficient.
+   * This parameter must be set to the length of the buffer array, in 32 bit
+   * words. This way, during configuration, the software can confirm it's
+   * writing within the bounds of the buffer. The configuration API will return
+   * an error or trigger \ref RAIL_ASSERT_CHANNEL_HOPPING_BUFFER_TOO_SHORT if
+   * bufferLength is insufficient.
    */
   uint16_t bufferLength;
   /**
@@ -2389,6 +2930,11 @@ typedef struct RAIL_TxChannelHoppingConfig {
    */
   RAIL_TxChannelHoppingConfigEntry_t *entries;
 } RAIL_TxChannelHoppingConfig_t;
+
+/// The worst-case platform-agnostic static amount of memory needed per
+/// channel for channel hopping, measured in 32 bit words, regardless of
+/// the size of radio configuration structures.
+#define RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL_WORST_CASE (65U)
 
 /** @} */ // end of group Tx_Channel_Hopping
 
@@ -2501,9 +3047,9 @@ RAIL_ENUM_GENERIC(RAIL_TxOptions_t, uint32_t) {
  */
 #define RAIL_TX_OPTION_ANTENNA1 (1UL << RAIL_TX_OPTION_ANTENNA1_SHIFT)
 /**
- * An option to dynamically set an alternate preamble length for the
- * transmission. If this option is not set, the pre-configured
- * channel preamble length will be used.
+ * An option to use the alternate preamble length established
+ * by \ref RAIL_SetTxAltPreambleLength() for the transmission.
+ * When not set, the PHY configuration's preamble length is used.
  */
 #define RAIL_TX_OPTION_ALT_PREAMBLE_LEN (1UL << RAIL_TX_OPTION_ALT_PREAMBLE_LEN_SHIFT)
 /**
@@ -2920,6 +3466,25 @@ typedef struct RAIL_LbtConfig {
 }
 
 /**
+ * @def RAIL_LBT_CONFIG_ETSI_EN_300_220_1_V3_1_0
+ * @brief RAIL_LbtConfig_t initializer configuring LBT per ETSI 300 220-1
+ *   V3.1.0 for a typical Sub-GHz band. To be practical, users should override
+ *   lbtTries and/or lbtTimeout so channel access failure will be reported in a
+ *   reasonable time frame rather than the unbounded time frame ETSI defined.
+ */
+#define RAIL_LBT_CONFIG_ETSI_EN_300_220_1_V3_1_0 {                             \
+    /* LBT per ETSI 300 220-1 V3.1.0                                        */ \
+    /* LBT time = random backoff of 160-4960 us in 160 us increments        */ \
+    /* lbtMinBoRand */ 1,    /*                                             */ \
+    /* lbtMaxBoRand */ 31,   /* app-chosen; 31*lbtBackoff = 4960 us         */ \
+    /* lbtTries     */ RAIL_MAX_LBT_TRIES, /* the maximum supported         */ \
+    /* lbtThreshold */ -85,  /* 15 dB above Rx sensitivity per Table 45     */ \
+    /* lbtBackoff   */ 160,  /* 160 us per Table 48 Minimum CCA interval    */ \
+    /* lbtDuration  */ 160,  /* 160 us per Table 48 Minimum deferral period */ \
+    /* lbtTimeout   */ 0,    /* No timeout (recommend user override)        */ \
+}
+
+/**
  * @struct RAIL_SyncWordConfig_t
  * @brief RAIL sync words and length configuration.
  *
@@ -2939,8 +3504,84 @@ typedef struct RAIL_SyncWordConfig {
   uint32_t syncWord2;
 } RAIL_SyncWordConfig_t;
 
+/**
+ * @enum RAIL_TxRepeatOptions_t
+ * @brief Transmit repeat options, in reality a bitmask.
+ */
+RAIL_ENUM_GENERIC(RAIL_TxRepeatOptions_t, uint16_t) {
+  /** Shift position of \ref RAIL_TX_REPEAT_OPTION_HOP bit */
+  RAIL_TX_REPEAT_OPTION_HOP_SHIFT = 0,
+  /** Shift position of the \ref RAIL_TX_REPEAT_OPTION_START_TO_START bit */
+  RAIL_TX_REPEAT_OPTION_START_TO_START_SHIFT = 1,
+};
+
+/** A value representing no repeat options enabled. */
+#define RAIL_TX_REPEAT_OPTIONS_NONE 0U
+/** All repeat options disabled by default. */
+#define RAIL_TX_REPEAT_OPTIONS_DEFAULT RAIL_TX_REPEAT_OPTIONS_NONE
+/**
+ * An option to configure whether or not to channel-hop before each
+ * repeated transmit.
+ */
+#define RAIL_TX_REPEAT_OPTION_HOP (1U << RAIL_TX_REPEAT_OPTION_HOP_SHIFT)
+
+/**
+ * An option to configure the delay between transmissions to be from start to start
+ * instead of end to start. Delay must be long enough to cover the prior transmit's time.
+ */
+#define RAIL_TX_REPEAT_OPTION_START_TO_START (1 << RAIL_TX_REPEAT_OPTION_START_TO_START_SHIFT)
+
+/// @struct RAIL_TxRepeatConfig_t
+/// @brief A configuration structure for repeated transmits
+///
+/// @note The PA will always be ramped down and up in between transmits so
+/// there will always be some minimum delay between transmits depending on the
+/// ramp time configuration.
+typedef struct RAIL_TxRepeatConfig {
+  /**
+   * The number of repeated transmits to run. A total of (iterations + 1)
+   * transmits will go on-air in the absence of errors.
+   */
+  uint16_t iterations;
+  /**
+   * Repeat option(s) to apply.
+   */
+  RAIL_TxRepeatOptions_t repeatOptions;
+  /**
+   * Per-repeat delay or hopping configuration, depending on repeatOptions.
+   */
+  union {
+    /**
+     * When \ref RAIL_TX_REPEAT_OPTION_HOP is not set, specifies
+     * the delay time between each repeated transmit. Specify \ref
+     * RAIL_TRANSITION_TIME_KEEP to use the current \ref
+     * RAIL_StateTiming_t::txToTx transition time setting.
+     * When using \ref RAIL_TX_REPEAT_OPTION_START_TO_START the delay
+     * must be long enough to cover the prior transmit's time.
+     */
+    RAIL_TransitionTime_t delay;
+    /**
+     * When \ref RAIL_TX_REPEAT_OPTION_HOP is set, this specifies
+     * the channel hopping configuration to use when hopping between
+     * repeated transmits. Per-hop delays are configured within each
+     * \ref RAIL_TxChannelHoppingConfigEntry_t::delay rather than
+     * this union's delay field.
+     * When using \ref RAIL_TX_REPEAT_OPTION_START_TO_START the hop delay
+     * must be long enough to cover the prior transmit's time.
+     */
+    RAIL_TxChannelHoppingConfig_t channelHopping;
+  } delayOrHop;
+} RAIL_TxRepeatConfig_t;
+
+/// RAIL_TxRepeatConfig_t::iterations initializer configuring infinite
+/// repeated transmissions.
+#define RAIL_TX_REPEAT_INFINITE_ITERATIONS (0xFFFFU)
+
 /** @} */ // end of group Transmit
 
+/******************************************************************************
+ * Receive Structures
+ *****************************************************************************/
 /**
  * @addtogroup Receive
  * @{
@@ -3070,6 +3711,10 @@ RAIL_ENUM_GENERIC(RAIL_RxOptions_t, uint32_t) {
   #endif //DOXYGEN_SHOULD_SKIP_THIS
   /** Shift position of \ref RAIL_RX_OPTION_CHANNEL_SWITCHING bit. */
   RAIL_RX_OPTION_CHANNEL_SWITCHING_SHIFT,
+  /** Shift position of \ref RAIL_RX_OPTION_FAST_RX2RX bit. */
+  RAIL_RX_OPTION_FAST_RX2RX_SHIFT,
+  /** Shift position of \ref RAIL_RX_OPTION_ENABLE_COLLISION_DETECTION bit. */
+  RAIL_RX_OPTION_ENABLE_COLLISION_DETECTION_SHIFT,
 };
 
 /** A value representing no options enabled. */
@@ -3196,8 +3841,7 @@ RAIL_ENUM_GENERIC(RAIL_RxOptions_t, uint32_t) {
 
 /**
  * An option to enable IEEE 802.15.4 RX channel switching.
- * \ref RAIL_IEEE802154_ConfigRxChannelSwitching() must be called to configure the
- * feature before enabling it via this option.
+ * See \ref RAIL_IEEE802154_ConfigRxChannelSwitching() for more information.
  * Defaults to false.
  *
  * @note This option is only supported on specific chips where
@@ -3208,6 +3852,30 @@ RAIL_ENUM_GENERIC(RAIL_RxOptions_t, uint32_t) {
  *   selection options.
  */
 #define RAIL_RX_OPTION_CHANNEL_SWITCHING (1U << RAIL_RX_OPTION_CHANNEL_SWITCHING_SHIFT)
+
+/**
+ * An option to enable fast RX2RX state transition.
+ *
+ * Once enabled, the sequencer will send the radio to RXSEARCH and get ready to
+ * receive the next packet while still processing the previous one. This will
+ * reduce RX to RX state transition time but risks impacting receive capability.
+ *
+ * @note This option is only supported on specific chips where
+ * \ref RAIL_SUPPORTS_FAST_RX2RX is true.
+ */
+#define RAIL_RX_OPTION_FAST_RX2RX (1U << RAIL_RX_OPTION_FAST_RX2RX_SHIFT)
+
+/**
+ * An option to enable collision detection.
+ *
+ * Once enabled, when a collision with a strong enough packet is detected, the demod
+ * will stop the current packet decoding and try to detect the preamble of the incoming
+ * packet.
+ *
+ * @note This option is only supported on specific chips where
+ * \ref RAIL_SUPPORTS_COLLISION_DETECTION is true.
+ */
+#define RAIL_RX_OPTION_ENABLE_COLLISION_DETECTION (1U << RAIL_RX_OPTION_ENABLE_COLLISION_DETECTION_SHIFT)
 
 /** A value representing all possible options. */
 #define RAIL_RX_OPTIONS_ALL 0xFFFFFFFFUL
@@ -3549,6 +4217,10 @@ typedef struct RAIL_RxPacketDetails {
    * chapter 20.3, table 20-10.
    * Ex: Packet bitrate for OFDM option 1 MCS0 is 100kb/s and 2400kb/s for MCS6.
    *
+   * In WMBUS cases, when using PHY_wMbus_ModeTC_M2O_100k_frameA with simultaneous
+   * RX of T and C modes enabled (\ref RAIL_WMBUS_Config()), the value corresponds
+   * to \ref RAIL_WMBUS_Phy_t.
+   *
    * It is always available.
    */
   uint8_t subPhyId;
@@ -3585,8 +4257,29 @@ typedef struct RAIL_RxPacketDetails {
   uint16_t channel;
 } RAIL_RxPacketDetails_t;
 
+/**
+ * @typedef RAIL_ConvertLqiCallback_t
+ * @brief A pointer to a function called before LQI is copied into the
+ *   \ref RAIL_RxPacketDetails_t structure.
+ *
+ * @param[in] lqi The LQI value obtained by hardware and being readied for
+ *   application consumption. This LQI value is in integral units ranging from
+ *   0 to 255.
+ * @param[in] rssi The RSSI value corresponding to the packet from which the
+ *   hardware LQI value was obtained. This RSSI value is in integral dBm units.
+ * @return uint8_t The converted LQI value that will be loaded into the
+ *   \ref RAIL_RxPacketDetails_t structure in preparation for application
+ *   consumption. This value should likewise be in integral units ranging from
+ *   0 to 255.
+ */
+typedef uint8_t (*RAIL_ConvertLqiCallback_t)(uint8_t lqi,
+                                             int8_t rssi);
+
 /** @} */ // end of group Receive
 
+/******************************************************************************
+ * Auto-ACK Structures
+ *****************************************************************************/
 /**
  * @addtogroup Auto_Ack
  * @{
@@ -3646,6 +4339,80 @@ typedef struct RAIL_AutoAckConfig {
 /** @} */ // end of group Auto_Ack
 
 /******************************************************************************
+ * Antenna Control
+ *****************************************************************************/
+/**
+ * @addtogroup Antenna_Control
+ * @{
+ *
+ * These enumerations and structures are used with RAIL Antenna Control API.
+ * EFR32 supports up to two antennas with configurable pin locations.
+ */
+
+/** Antenna path Selection enumeration. */
+RAIL_ENUM(RAIL_AntennaSel_t) {
+  /** Enum for antenna path 0. */
+  RAIL_ANTENNA_0 = 0,
+  /** Enum for antenna path 1. */
+  RAIL_ANTENNA_1 = 1,
+  /** Enum for antenna path auto. */
+  RAIL_ANTENNA_AUTO = 255,
+};
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+// Self-referencing defines minimize compiler complaints when using RAIL_ENUM
+#define RAIL_ANTENNA_0    ((RAIL_AntennaSel_t) RAIL_ANTENNA_0)
+#define RAIL_ANTENNA_1    ((RAIL_AntennaSel_t) RAIL_ANTENNA_1)
+#define RAIL_ANTENNA_AUTO ((RAIL_AntennaSel_t) RAIL_ANTENNA_AUTO)
+#endif//DOXYGEN_SHOULD_SKIP_THIS
+
+/**
+ * @struct RAIL_AntennaConfig_t
+ * @brief A configuration for antenna selection.
+ */
+typedef struct RAIL_AntennaConfig {
+  /** Antenna 0 Pin Enable */
+  bool ant0PinEn;
+  /** Antenna 1 Pin Enable */
+  bool ant1PinEn;
+  /**
+   *  Antenna 0 location for ant0Port/Pin on EFR32 Series 1
+   *  and on EFR32 Series 2 this field is called \ref defaultPath
+   *  (see define and usage below).
+   */
+  uint8_t ant0Loc;
+  /** Antenna 0 output GPIO port */
+  uint8_t ant0Port;
+  /** Antenna 0 output GPIO pin */
+  uint8_t ant0Pin;
+  /** Antenna 1 location for ant1Port/Pin.
+   *  Only needed on EFR32 Series 1; ignored on other platforms. */
+  uint8_t ant1Loc;
+  /** Antenna 1 output GPIO port */
+  uint8_t ant1Port;
+  /** Antenna 1 output GPIO pin */
+  uint8_t ant1Pin;
+} RAIL_AntennaConfig_t;
+
+/**
+ * Maps EFR32 Series 2 defaultPath onto Series 1 ant0Loc field.
+ * For EFR32 Series 2, defaultPath should be a \ref RAIL_AntennaSel_t
+ * value specifying the internal default RF path. It is ignored
+ * on EFR32 Series 2 parts that have only one RF path bonded
+ * out and on EFR32xG28 dual-band OPNs where the appropriate
+ * RF path is automatically set by RAIL to 0 for 2.4GHZ band
+ * and 1 for SubGHz band PHYs. On EFR32xG23 and EFR32xG28
+ * single-band OPNs where both RF paths are bonded out this can
+ * be set to \ref RAIL_ANTENNA_AUTO to effect internal RF path
+ * diversity on PHYs supporting diversity. This avoids the need
+ * for an external RF switch and the associated GPIO(s) needed
+ * to control its antenna selection.
+ */
+#define defaultPath ant0Loc
+
+/** @} */ // end of group Antenna_Control
+
+/******************************************************************************
  * External_Thermistor Structures
  *****************************************************************************/
 /**
@@ -3676,7 +4443,7 @@ typedef struct RAIL_HFXOThermistorConfig {
 
 /**
  * @struct RAIL_HFXOCompensationConfig_t
- * @brief Set compensation spepcific parameters
+ * @brief Set compensation specific parameters
  */
 typedef struct RAIL_HFXOCompensationConfig {
   /**
@@ -3707,6 +4474,22 @@ typedef struct RAIL_HFXOCompensationConfig {
 /**
  * @addtogroup Calibration
  * @{
+ *
+ * The EFR32 supports the Image Rejection (IR)
+ * calibration and a temperature-dependent calibration. The IR calibration
+ * can be computed once and stored off or computed each time at
+ * startup. Because it is PHY-specific and provides sensitivity improvements,
+ * it is highly recommended. The IR calibration should only be run when the
+ * radio is IDLE.
+ *
+ * The temperature-dependent calibrations are used to recalibrate the synth if
+ * the temperature crosses 0C or the temperature delta since the last
+ * calibration exceeds 70C while in receive. RAIL will run the VCO calibration
+ * automatically upon entering receive or transmit states, so the application
+ * can omit this calibration if the stack re-enters receive or transmit with
+ * enough frequency to avoid reaching the temperature delta. If the application
+ * does not calibrate for temperature, it's possible to miss receive packets due
+ * to a drift in the carrier frequency.
  */
 
 /**
@@ -3718,35 +4501,152 @@ typedef struct RAIL_HFXOCompensationConfig {
  */
 typedef uint32_t RAIL_CalMask_t;
 
-/** @} */ // end of group Calibration
+/** EFR32-specific temperature calibration bit. */
+#define RAIL_CAL_TEMP_VCO         (0x00000001U)
+/** EFR32-specific HFXO temperature check bit.
+ *  (Ignored if platform lacks \ref RAIL_SUPPORTS_HFXO_COMPENSATION.) */
+#define RAIL_CAL_TEMP_HFXO        (0x00000002U)
+/** EFR32-specific HFXO compensation bit.
+ *  (Ignored if platform lacks \ref RAIL_SUPPORTS_HFXO_COMPENSATION.) */
+#define RAIL_CAL_COMPENSATE_HFXO  (0x00000004U)
+/** EFR32-specific IR calibration bit */
+#define RAIL_CAL_RX_IRCAL         (0x00010000U)
+/** EFR32-specific Tx IR calibration bit.
+ *  (Ignored if platform lacks \ref RAIL_SUPPORTS_OFDM_PA.) */
+#define RAIL_CAL_OFDM_TX_IRCAL    (0x00100000U)
 
-/******************************************************************************
- * LQI Structures
- *****************************************************************************/
+/** A mask to run EFR32-specific IR calibrations. */
+#define RAIL_CAL_ONETIME_IRCAL    (RAIL_CAL_RX_IRCAL | RAIL_CAL_OFDM_TX_IRCAL)
+/** A mask to run temperature-dependent calibrations. */
+#define RAIL_CAL_TEMP             (RAIL_CAL_TEMP_VCO | RAIL_CAL_TEMP_HFXO | RAIL_CAL_COMPENSATE_HFXO)
+/** A mask to run one-time calibrations. */
+#define RAIL_CAL_ONETIME          (RAIL_CAL_ONETIME_IRCAL)
+/** A mask to run optional performance calibrations. */
+#define RAIL_CAL_PERF             (0)
+/** A mask for calibrations that require the radio to be off. */
+#define RAIL_CAL_OFFLINE          (RAIL_CAL_ONETIME_IRCAL)
+/** A mask to run all possible calibrations for this chip. */
+#define RAIL_CAL_ALL              (RAIL_CAL_TEMP | RAIL_CAL_ONETIME)
+/** A mask to run all pending calibrations. */
+#define RAIL_CAL_ALL_PENDING      (0x00000000U)
+/** An invalid calibration value. */
+#define RAIL_CAL_INVALID_VALUE    (0xFFFFFFFFU)
+
 /**
- * @addtogroup Receive
- * @{
+ * @def RAIL_MAX_RF_PATHS
+ * @brief Indicates the maximum number of RF Paths supported across all
+ *   platforms.
  */
+#define RAIL_MAX_RF_PATHS 2
 
 /**
- * @typedef RAIL_ConvertLqiCallback_t
- * @brief A pointer to a function called before LQI is copied into the
- *   \ref RAIL_RxPacketDetails_t structure.
+ * RAIL_RxIrCalValues_t
+ * @brief RX IR calibration values.
  *
- * @param[in] lqi The LQI value obtained by hardware and being readied for
- *   application consumption. This LQI value is in integral units ranging from
- *   0 to 255.
- * @param[in] rssi The RSSI value corresponding to the packet from which the
- *   hardware LQI value was obtained. This RSSI value is in integral dBm units.
- * @return uint8_t The converted LQI value that will be loaded into the
- *   \ref RAIL_RxPacketDetails_t structure in preparation for application
- *   consumption. This value should likewise be in integral units ranging from
- *   0 to 255.
+ * Platforms with fewer \ref RAIL_RF_PATHS than \ref RAIL_MAX_RF_PATHS
+ * will only respect and update \ref RAIL_RF_PATHS indices and ignore
+ * the rest.
  */
-typedef uint8_t (*RAIL_ConvertLqiCallback_t)(uint8_t lqi,
-                                             int8_t rssi);
+typedef uint32_t RAIL_RxIrCalValues_t[RAIL_MAX_RF_PATHS];
 
-/** @} */ // end of group Receive
+/**
+ * A define to set all RAIL_RxIrCalValues_t values to uninitialized.
+ *
+ * This define can be used when you have no data to pass to the calibration
+ * routines but wish to compute and save all possible calibrations.
+ */
+#define RAIL_IRCALVALUES_RX_UNINIT {                        \
+    [0 ... RAIL_MAX_RF_PATHS - 1] = RAIL_CAL_INVALID_VALUE, \
+}
+
+/**
+ * @struct RAIL_TxIrCalValues_t
+ * @brief A Tx IR calibration value structure.
+ *
+ * This definition contains the set of persistent calibration values for
+ * OFDM on EFR32. You can set these beforehand and apply them at startup
+ * to save the time required to compute them. Any of these values may be
+ * set to RAIL_IRCAL_INVALID_VALUE to force the code to compute that
+ * calibration value.
+ *
+ * Only supported on platforms with \ref RAIL_SUPPORTS_OFDM_PA enabled.
+ */
+typedef struct RAIL_TxIrCalValues {
+  uint32_t dcOffsetIQ;    /**< TXIRCAL result */
+  uint32_t phiEpsilon;    /**< TXIRCAL result */
+} RAIL_TxIrCalValues_t;
+
+/**
+ * A define to set all RAIL_TxIrCalValues_t values to uninitialized.
+ *
+ * This define can be used when you have no data to pass to the calibration
+ * routines but wish to compute and save all possible calibrations.
+ */
+#define RAIL_IRCALVALUES_TX_UNINIT  { \
+    RAIL_CAL_INVALID_VALUE,           \
+    RAIL_CAL_INVALID_VALUE,           \
+}
+
+/**
+ * @struct RAIL_IrCalValues_t
+ * @brief An IR calibration value structure.
+ *
+ * This definition contains the set of persistent calibration values for
+ * EFR32. You can set these beforehand and apply them at startup to save the
+ * time required to compute them. Any of these values may be set to
+ * RAIL_IRCAL_INVALID_VALUE to force the code to compute that calibration value.
+ */
+typedef struct RAIL_IrCalValues {
+  RAIL_RxIrCalValues_t rxIrCalValues; /**< RX Image Rejection (IR) calibration value */
+  RAIL_TxIrCalValues_t txIrCalValues; /**< TX Image Rejection (IR) calibration value for OFDM */
+} RAIL_IrCalValues_t;
+
+/**
+ * A define to set all RAIL_IrCalValues_t values to uninitialized.
+ *
+ * This define can be used when you have no data to pass to the calibration
+ * routines but wish to compute and save all possible calibrations.
+ */
+#define RAIL_IRCALVALUES_UNINIT { \
+    RAIL_IRCALVALUES_RX_UNINIT,   \
+    RAIL_IRCALVALUES_TX_UNINIT,   \
+}
+
+/**
+ * A define allowing Rx calibration value access compatibility
+ * between non-OFDM and OFDM platforms.
+ */
+#define RAIL_IRCALVAL(irCalStruct, rfPath) \
+  (((RAIL_IrCalValues_t *)(&(irCalStruct)))->rxIrCalValues[(rfPath)])
+
+/**
+ * @typedef RAIL_CalValues_t
+ * @brief A calibration value structure.
+ *
+ * This structure contains the set of persistent calibration values for
+ * EFR32. You can set these beforehand and apply them at startup to save the
+ * time required to compute them. Any of these values may be set to
+ * RAIL_CAL_INVALID_VALUE to force the code to compute that calibration value.
+ */
+typedef RAIL_IrCalValues_t RAIL_CalValues_t;
+
+/**
+ * A define to set all RAIL_CalValues_t values to uninitialized.
+ *
+ * This define can be used when you have no data to pass to the calibration
+ * routines but wish to compute and save all possible calibrations.
+ */
+#define RAIL_CALVALUES_UNINIT RAIL_IRCALVALUES_UNINIT
+
+/// Use this value with either TX or RX values in RAIL_SetPaCTune
+/// to use whatever value is already set and do no update. This
+/// value is provided to provide consistency across EFR32 chips,
+/// but technically speaking, all PA capacitance tuning values are
+/// invalid on EFR32XG21 parts, as RAIL_SetPaCTune is not supported
+/// on those parts.
+#define RAIL_PACTUNE_IGNORE (255U)
+
+/** @} */ // end of group Calibration
 
 /******************************************************************************
  * RF Sense Structures
@@ -3845,7 +4745,16 @@ typedef struct RAIL_RfSenseSelectiveOokConfig {
  */
 RAIL_ENUM(RAIL_RxChannelHoppingMode_t) {
   /**
-   * Switch to the next channel each time the radio enters RX.
+   * Switch to the next channel each time the radio re-enters RX after
+   * packet reception or a transmit based on the corresponding \ref
+   * State_Transitions. A hop can also be manually triggered by calling
+   * \ref RAIL_CalibrateTemp() while the radio is listening.
+   *
+   * @warning This mode currently does not issue \ref
+   *   RAIL_EVENT_RX_CHANNEL_HOPPING_COMPLETE when hopping out of
+   *   the last channel in the hop sequence.
+   *   As a workaround, an application can monitor the current hop channel
+   *   with \ref RAIL_GetChannelAlt().
    */
   RAIL_RX_CHANNEL_HOPPING_MODE_MANUAL,
   /**
@@ -4180,7 +5089,7 @@ typedef struct RAIL_RxChannelHoppingConfigMultiMode {
    * lost after this time, in microseconds, measured from entry
    * to Rx -- unless preamble had been sensed in which case any
    * switching is deferred to timingReSense and, if timing is
-   * regained, to syncDetect.  This must be greater than timingSense
+   * regained, to syncDetect. This must be greater than timingSense
    * and less than \ref RAIL_RX_CHANNEL_HOPPING_MAX_SENSE_TIME_US.
    */
   uint32_t preambleSense;
@@ -4265,22 +5174,23 @@ typedef struct RAIL_RxChannelHoppingConfig {
    * data anywhere in this buffer.
    *
    * @note the size of this buffer must be at least as large as
-   * 3 + 30 * numberOfChannels, plus the sum of the sizes of the
+   * 3 + \ref RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL * numberOfChannels,
+   * plus the sum of the sizes of the
    * radioConfigDeltaAdd's of the required channels, plus the size of the
    * radioConfigDeltaSubtract. In the case that one channel
    * appears two or more times in your channel sequence
-   * (e.g., 1, 2, 1, 3), you must account for the radio configuration
-   * size that number of times (i.e., need to count channel 1's
-   * radio configuration size twice for the given example). The overall
-   * 3 words and 30 words per channel needed in this buffer are
+   * (e.g., 1, 2, 3, 2), you must account for the radio configuration
+   * size that number of times (i.e., need to count channel 2's
+   * radio configuration size twice for the given example). The buffer is
    * for internal use to the library.
    */
   uint32_t *buffer;
   /**
    * This parameter must be set to the length of the buffer array, in 32 bit
    * words. This way, during configuration, the software can confirm it's
-   * writing within the range of the buffer. The configuration API will return
-   * an error if bufferLength is insufficient.
+   * writing within the bounds of the buffer. The configuration API will return
+   * an error or trigger \ref RAIL_ASSERT_CHANNEL_HOPPING_BUFFER_TOO_SHORT if
+   * bufferLength is insufficient.
    */
   uint16_t bufferLength;
   /**
@@ -4351,6 +5261,72 @@ typedef struct RAIL_RxDutyCycleConfig {
  */
 
 /**
+ * @typedef RAIL_FrequencyOffset_t
+ * @brief Type that represents the number of Frequency Offset
+ *   units. It is used with \ref RAIL_GetRxFreqOffset() and
+ *   \ref RAIL_SetFreqOffset().
+ *
+ * The units are chip-specific. For EFR32 they are radio synthesizer
+ * resolution steps (synthTicks) and is limited to 15 bits.
+ * A value of \ref RAIL_FREQUENCY_OFFSET_INVALID
+ * means that this value is invalid.
+ */
+typedef int16_t RAIL_FrequencyOffset_t;
+
+/**
+ * The maximum frequency offset value supported.
+ */
+#define RAIL_FREQUENCY_OFFSET_MAX ((RAIL_FrequencyOffset_t) 0x3FFF)
+
+/**
+ * The minimum frequency offset value supported.
+ */
+#define RAIL_FREQUENCY_OFFSET_MIN ((RAIL_FrequencyOffset_t) -RAIL_FREQUENCY_OFFSET_MAX)
+
+/**
+ * Specify an invalid frequency offset value. This will be returned if you
+ * call \ref RAIL_GetRxFreqOffset() at an invalid time.
+ */
+#define RAIL_FREQUENCY_OFFSET_INVALID ((RAIL_FrequencyOffset_t) 0x8000)
+
+/**
+ * @struct RAIL_DirectModeConfig_t
+ * @brief Allows the user to specify direct mode
+ *   parameters using \ref RAIL_ConfigDirectMode().
+ */
+typedef struct RAIL_DirectModeConfig {
+  /** Enable synchronous RX DOUT using DCLK vs. asynchronous RX DOUT. */
+  bool syncRx;
+  /** Enable synchronous TX DIN using DCLK vs. asynchronous TX DIN. */
+  bool syncTx;
+
+  /** RX Data output (DOUT) GPIO port */
+  uint8_t doutPort;
+  /** RX Data output (DOUT) GPIO pin */
+  uint8_t doutPin;
+
+  /** Data clock (DCLK) GPIO port. Only used in synchronous mode */
+  uint8_t dclkPort;
+  /** Data clock (DCLK) GPIO pin. Only used in synchronous mode */
+  uint8_t dclkPin;
+
+  /** TX Data input (DIN) GPIO port */
+  uint8_t dinPort;
+  /** TX Data input (DIN) GPIO pin */
+  uint8_t dinPin;
+
+  /** RX Data output (DOUT) location for doutPort/Pin.
+   *  Only needed on EFR32 Series 1; ignored on other platforms. */
+  uint8_t doutLoc;
+  /** Data clock (DCLK) location for dclkPort/Pin.
+   *  Only needed on EFR32 Series 1; ignored on other platforms. */
+  uint8_t dclkLoc;
+  /** TX Data input (DIN) location for tdinPort/Pin.
+   *  Only needed on EFR32 Series 1; ignored on other platforms. */
+  uint8_t dinLoc;
+} RAIL_DirectModeConfig_t;
+
+/**
  * @enum RAIL_StreamMode_t
  * @brief Possible stream output modes.
  */
@@ -4358,7 +5334,7 @@ RAIL_ENUM(RAIL_StreamMode_t) {
   RAIL_STREAM_CARRIER_WAVE = 0, /**< An unmodulated carrier wave. */
   RAIL_STREAM_PN9_STREAM = 1,   /**< PN9 byte sequence. */
   RAIL_STREAM_10_STREAM = 2, /**< 101010 sequence. */
-  RAIL_STREAM_CARRIER_WAVE_PHASENOISE = 3, /**< An unmodulated carrier wave with no change to PLL BW. For series-2, same as RAIL_STREAM_CARRIER_WAVE */
+  RAIL_STREAM_CARRIER_WAVE_PHASENOISE = 3, /**< An unmodulated carrier wave with no change to PLL BW. For EFR32 Series 2, same as RAIL_STREAM_CARRIER_WAVE */
   RAIL_STREAM_RAMP_STREAM = 4, /**< ramp sequence starting at a different offset for consecutive packets. Only available for some modulations. Fall back to RAIL_STREAM_PN9_STREAM if not available. */
   RAIL_STREAM_CARRIER_WAVE_SHIFTED = 5, /**< An unmodulated carrier wave not centered on DC but shifted roughly by channel_bandwidth/6 allowing an easy check of the residual DC. Only available for OFDM PA. Fall back to RAIL_STREAM_CARRIER_WAVE_PHASENOISE if not available. */
   RAIL_STREAM_MODES_COUNT   /**< A count of the choices in this enumeration. Must be last. */
@@ -4423,7 +5399,7 @@ typedef struct RAIL_VerifyConfig {
   /** Internal verification tracking information. */
   uint32_t nextIndexToVerify;
   /** Internal verification tracking information. */
-  const uint32_t *override;
+  RAIL_RadioConfig_t override;
   /** Internal verification tracking information. */
   RAIL_VerifyCallbackPtr_t cb;
 } RAIL_VerifyConfig_t;
@@ -4566,7 +5542,7 @@ RAIL_ENUM(RAIL_EffModeSensor_t) {
 #define RAIL_EFF_MODE_SENSOR_FSK_SAW2 ((RAIL_EffModeSensor_t) RAIL_EFF_MODE_SENSOR_FSK_SAW2)
 #define RAIL_EFF_MODE_SENSOR_OFDM_ANTV ((RAIL_EffModeSensor_t) RAIL_EFF_MODE_SENSOR_OFDM_ANTV)
 #define RAIL_EFF_MODE_SENSOR_OFDM_SAW2 ((RAIL_EffModeSensor_t) RAIL_EFF_MODE_SENSOR_OFDM_SAW2)
-#define RAIL_EFF_MODE_SENSOR_COUNT ((RAIL_EffModeSensor_t) RAIL_EFF_CAL_COUNT)
+#define RAIL_EFF_MODE_SENSOR_COUNT ((RAIL_EffModeSensor_t) RAIL_EFF_MODE_SENSOR_COUNT)
 #endif//DOXYGEN_SHOULD_SKIP_THIS
 
 /**
@@ -4578,6 +5554,22 @@ RAIL_ENUM(RAIL_EffModeSensor_t) {
     "RAIL_EFF_MODE_SENSOR_FSK_SAW2",      \
     "RAIL_EFF_MODE_SENSOR_OFDM_ANTV",     \
     "RAIL_EFF_MODE_SENSOR_OFDM_SAW2",     \
+}
+
+/**
+ * @def RAIL_EFF_CLPC_ENABLE_ENUM_NAMES
+ * @brief A macro that is string versions of the calibration enums.
+ */
+#define RAIL_EFF_CLPC_ENABLE_ENUM_NAMES { \
+    "RAIL_EFF_CLPC_DISABLED",             \
+    "RAIL_EFF_CLPC_MODE_CHANGE",          \
+    "RAIL_EFF_CLPC_POWER_SLOW",           \
+    "RAIL_EFF_CLPC_POWER_FAST",           \
+    "RAIL_EFF_CLPC_POWER_BOTH",           \
+    "RAIL_EFF_CLPC_POWER_SLOW_STOPPED",   \
+    "RAIL_EFF_CLPC_POWER_FAST_STOPPED",   \
+    "RAIL_EFF_CLPC_POWER_BOTH_STOPPED",   \
+    "RAIL_EFF_CLPC_COUNT",                \
 }
 
 /** @struct RAIL_EffCalConfig_t
@@ -4617,6 +5609,20 @@ typedef struct RAIL_EffClpcConfig {
   RAIL_EffClpcSensorConfig_t antv; /**< ANTV sensor configuration */
   RAIL_EffClpcSensorConfig_t saw2; /**< SAW2 sensor configuration */
 } RAIL_EffClpcConfig_t;
+
+/** @struct RAIL_EffClpcResults_t
+ *
+ * @brief Structure for passing information from the CLPC.
+ *
+ * A structure of type \ref RAIL_EffClpcResults_t returns the measurements and decisions from the
+ * Closed Loop Power Control back to the application side.
+ */
+typedef struct RAIL_EffClpcResults {
+  int8_t rawShift;  /**< CLPC shift directly from formula */
+  int8_t clampedShift;  /**< Shift after clamping to maximum allowed for this pass */
+  uint8_t currIndex;  /**< Powersetting table index before shifting */
+  uint8_t newIndex;  /**< Power table index after shifting */
+} RAIL_EffClpcResults_t;
 
 /**
  * @struct RAIL_EffConfig_t
@@ -4697,6 +5703,105 @@ typedef struct RAIL_ChipTempMetrics {
 
 /** @} */ // end of group Thermal_Protection
 
+// -----------------------------------------------------------------------------
+// Retiming
+// -----------------------------------------------------------------------------
+/**
+ * @addtogroup Retiming Retiming
+ * @{
+ * @brief EFR32-specific retiming capability.
+ * @ingroup RAIL_API
+ *
+ * The EFR product families have many digital and analog modules that can run
+ * in parallel with a radio. These combinations can cause interference and
+ * degradation on the radio RX sensitivity. Retiming can
+ * modify the clocking of the digital modules to reduce the interference.
+ */
+
+/**
+ * @enum RAIL_RetimeOptions_t
+ * @brief Retiming options bit shifts.
+ */
+RAIL_ENUM(RAIL_RetimeOptions_t) {
+  /** Shift position of \ref RAIL_RETIME_OPTION_HFXO bit. */
+  RAIL_RETIME_OPTION_HFXO_SHIFT = 0,
+  /** Shift position of \ref RAIL_RETIME_OPTION_HFRCO bit. */
+  RAIL_RETIME_OPTION_HFRCO_SHIFT,
+  /** Shift position of \ref RAIL_RETIME_OPTION_DCDC bit. */
+  RAIL_RETIME_OPTION_DCDC_SHIFT,
+  /** Shift position of \ref RAIL_RETIME_OPTION_LCD bit. */
+  RAIL_RETIME_OPTION_LCD_SHIFT,
+};
+
+// RAIL_RetimeOptions_t bitmasks
+/**
+ * An option to configure HFXO retiming.
+ */
+#define RAIL_RETIME_OPTION_HFXO \
+  (1U << RAIL_RETIME_OPTION_HFXO_SHIFT)
+
+/**
+ * An option to configure HFRCO retiming.
+ */
+#define RAIL_RETIME_OPTION_HFRCO \
+  (1U << RAIL_RETIME_OPTION_HFRCO_SHIFT)
+
+/**
+ * An option to configure DCDC retiming.
+ * Ignored on platforms that lack DCDC.
+ */
+#define RAIL_RETIME_OPTION_DCDC \
+  (1U << RAIL_RETIME_OPTION_DCDC_SHIFT)
+
+/**
+ * An option to configure LCD retiming.
+ * Ignored on platforms that lack LCD.
+ */
+#define RAIL_RETIME_OPTION_LCD \
+  (1U << RAIL_RETIME_OPTION_LCD_SHIFT)
+
+/** A value representing no retiming options. */
+#define RAIL_RETIME_OPTIONS_NONE 0x0U
+
+/** A value representing all retiming options. */
+#define RAIL_RETIME_OPTIONS_ALL 0xFFU
+
+/**
+ * Configure retiming options.
+ *
+ * @param[in] railHandle A handle of RAIL instance.
+ * @param[in] mask A bitmask containing which options should be modified.
+ * @param[in] options A bitmask containing desired configuration settings.
+ *   Bit positions for each option are found in the \ref RAIL_RetimeOptions_t.
+ * @return Status code indicating success of the function call.
+ */
+RAIL_Status_t RAIL_ConfigRetimeOptions(RAIL_Handle_t railHandle,
+                                       RAIL_RetimeOptions_t mask,
+                                       RAIL_RetimeOptions_t options);
+
+/**
+ * Get the currently configured retiming option.
+ *
+ * @param[in] railHandle A handle of RAIL instance.
+ * @param[out] pOptions A pointer to configured retiming options
+                        bitmask indicating which are enabled.
+ * @return Status code indicating success of the function call.
+ */
+RAIL_Status_t RAIL_GetRetimeOptions(RAIL_Handle_t railHandle,
+                                    RAIL_RetimeOptions_t *pOptions);
+
+/**
+ * Indicate that the DCDC peripheral bus clock enable has changed allowing
+ * RAIL to react accordingly.
+ *
+ * @note This should be called after DCDC has been enabled or disabled.
+ *
+ * @return Status code indicating success of the function call.
+ */
+RAIL_Status_t RAIL_ChangedDcdc(void);
+
+/** @} */ // end of group Retiming_EFR32
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 /******************************************************************************
@@ -4731,140 +5836,31 @@ typedef struct RAIL_ChipTempMetrics {
 }
 #endif
 
-// Include appropriate chip-specific types and APIs *after* common types, and
-// *before* types that require chip-specific abstractions.
-#include "rail_chip_specific.h"
+// Define SLI_LIBRARY_BUILD to build a library that does not include
+// chip-dependent defines. This may limit functionality but allows building
+// generic libraries that are not tied to any given chip.
+#ifdef  SLI_LIBRARY_BUILD
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+// Platform-agnostic worst-case settings and types
 
-/**
- * @addtogroup RAIL_API
- * @{
- */
+#define RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL \
+  RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL_WORST_CASE
 
-/**
- * @addtogroup State_Transitions
- * @{
- */
-
-/**
- * @def RAIL_TRANSITION_TIME_KEEP
- * @brief A value to use in \ref RAIL_StateTiming_t fields when
- *   calling \ref RAIL_SetStateTiming() to keep that timing
- *   parameter at it current setting.
- */
-#define RAIL_TRANSITION_TIME_KEEP ((RAIL_TransitionTime_t) -1)
-
-/**
- * @struct RAIL_StateTiming_t
- * @brief A timing configuration structure for the RAIL State Machine.
- *
- * Configure the timings of the radio state transitions for common situations.
- * All of the listed timings are in microseconds. Transitions from an active
- * radio state to idle are not configurable, and will always happen as fast
- * as possible.
- * No timing value can exceed \ref RAIL_MAXIMUM_TRANSITION_US.
- * Use \ref RAIL_TRANSITION_TIME_KEEP to keep an existing setting.
- *
- * For idleToRx, idleToTx, rxToTx, txToRx, and txToTx a value of 0 for the
- * transition time means that the specified transition should happen as fast
- * as possible, even if the timing cannot be as consistent. Otherwise, the
- * timing value cannot be below \ref RAIL_MINIMUM_TRANSITION_US.
- *
- * For idleToTx, rxToTx, and txToTx setting a longer \ref
- * RAIL_TxPowerConfig_t::rampTime may result in a larger minimum value.
- *
- * For rxSearchTimeout and txToRxSearchTimeout, there is no minimum value. A
- * value of 0 disables the feature, functioning as an infinite timeout.
- */
-typedef struct RAIL_StateTiming {
-  RAIL_TransitionTime_t idleToRx; /**< Transition time from IDLE to RX. */
-  RAIL_TransitionTime_t txToRx; /**< Transition time from TX to RX. */
-  RAIL_TransitionTime_t idleToTx; /**< Transition time from IDLE to RX. */
-  RAIL_TransitionTime_t rxToTx; /**< Transition time from RX packet to TX. */
-  RAIL_TransitionTime_t rxSearchTimeout; /**< Length of time the radio will search for a
-                                            packet when coming from idle or RX. */
-  RAIL_TransitionTime_t txToRxSearchTimeout; /**< Length of time the radio will search for a
-                                                packet when coming from TX. */
-  RAIL_TransitionTime_t txToTx; /**< Transition time from TX packet to TX. */
-} RAIL_StateTiming_t;
-
-/** @} */ // end of group State_Transitions
-
-/**
- * @addtogroup Transmit
- * @{
- */
-
-/**
- * @enum RAIL_TxRepeatOptions_t
- * @brief Transmit repeat options, in reality a bitmask.
- */
-RAIL_ENUM_GENERIC(RAIL_TxRepeatOptions_t, uint16_t) {
-  /** Shift position of \ref RAIL_TX_REPEAT_OPTION_HOP bit */
-  RAIL_TX_REPEAT_OPTION_HOP_SHIFT = 0,
+struct RAIL_ChannelConfigEntryAttr {
+  RAIL_RxIrCalValues_t calValues;
+  RAIL_TxIrCalValues_t txCalValues; // placeholder for size
 };
 
-/** A value representing no repeat options enabled. */
-#define RAIL_TX_REPEAT_OPTIONS_NONE 0U
-/** All repeat options disabled by default. */
-#define RAIL_TX_REPEAT_OPTIONS_DEFAULT RAIL_TX_REPEAT_OPTIONS_NONE
-/**
- * An option to configure whether or not to channel-hop before each
- * repeated transmit.
- */
-#define RAIL_TX_REPEAT_OPTION_HOP (1U << RAIL_TX_REPEAT_OPTION_HOP_SHIFT)
+#endif//DOXYGEN_SHOULD_SKIP_THIS
+#else//!SLI_LIBRARY_BUILD
 
-/// @struct RAIL_TxRepeatConfig_t
-/// @brief A configuration structure for repeated transmits
-///
-/// @note The PA will always be ramped down and up in between transmits so
-/// there will always be some minimum delay between transmits depending on the
-/// ramp time configuration.
-typedef struct RAIL_TxRepeatConfig {
-  /**
-   * The number of repeated transmits to run. A total of (iterations + 1)
-   * transmits will go on-air in the absence of errors.
-   */
-  uint16_t iterations;
-  /**
-   * Repeat option(s) to apply.
-   */
-  RAIL_TxRepeatOptions_t repeatOptions;
-  /**
-   * Per-repeat delay or hopping configuration, depending on repeatOptions.
-   */
-  union {
-    /**
-     * When \ref RAIL_TX_REPEAT_OPTION_HOP is not set, specifies
-     * the delay time between each repeated transmit. Specify \ref
-     * RAIL_TRANSITION_TIME_KEEP to use the current \ref
-     * RAIL_StateTiming_t::txToTx transition time setting.
-     */
-    RAIL_TransitionTime_t delay;
-    /**
-     * When \ref RAIL_TX_REPEAT_OPTION_HOP is set, this specifies
-     * the channel hopping configuration to use when hopping between
-     * repeated transmits. Per-hop delays are configured within each
-     * \ref RAIL_TxChannelHoppingConfigEntry_t::delay rather than
-     * this union's delay field.
-     */
-    RAIL_TxChannelHoppingConfig_t channelHopping;
-  } delayOrHop;
-} RAIL_TxRepeatConfig_t;
+// Include appropriate chip-specific types and APIs *after* common types, and
+// *before* types that depend on chip-specific types.
+#include "rail_chip_specific.h"
 
-/// RAIL_TxRepeatConfig_t::iterations initializer configuring infinite
-/// repeated transmissions.
-#define RAIL_TX_REPEAT_INFINITE_ITERATIONS (0xFFFFU)
+// (Currently no types depend on chip-specific types.)
 
-/** @} */ // end of group Transmit
-
-/** @} */ // end of RAIL_API
-
-#ifdef __cplusplus
-}
-#endif
+#endif //SLI_LIBRARY_BUILD
 
 #endif  // __RAIL_TYPES_H__

--- a/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c
+++ b/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c
@@ -30,6 +30,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  *
  ******************************************************************************/
+// For details on how to use this plugin, see
+//   https://www.silabs.com/documents/public/application-notes/an1127-power-amplifier-power-conversion-functions.pdf
 
 #include "em_device.h"
 #include "em_cmu.h"
@@ -40,13 +42,106 @@
 
 static RAIL_TxPowerCurvesConfigAlt_t powerCurvesState;
 
-#if defined(_SILICON_LABS_32B_SERIES_1) || defined(_SILICON_LAS_32B_SERIES_2_CONFIG_1)
+// Make sure SUPPORTED_PA_INDICES match the per-platform PA curves
+// provided by RAIL_DECLARE_TX_POWER_CURVES_CONFIG_ALT and resulting
+// RAIL_TxPowerCurvesConfigAlt_t!
+#ifndef SUPPORTED_PA_INDICES
+#if defined(_SILICON_LABS_32B_SERIES_1)
+#define SUPPORTED_PA_INDICES {                   \
+    0U,        /* 2P4GIG_HP  */                  \
+    RAIL_NUM_PA, /* 2P4GIG_MP  */                \
+    1U,        /* 2P4GIG_LP  */                  \
+    RAIL_NUM_PA, /* 2P4GIG_LLP */                \
+    RAIL_NUM_PA, /* 2P4GIG_HIGHEST */            \
+    RAIL_NUM_PA, /* SUBGIG_POWERSETTING_TABLE */ \
+    2U,        /* SUBGIG_HP */                   \
+    /* The rest are unsupported */               \
+}
+#elif (_SILICON_LABS_32B_SERIES_2_CONFIG == 1)
+#define SUPPORTED_PA_INDICES {     \
+    0U,        /* 2P4GIG_HP  */    \
+    1U,        /* 2P4GIG_MP  */    \
+    2U,        /* 2P4GIG_LP  */    \
+    /* The rest are unsupported */ \
+}
+#elif (_SILICON_LABS_32B_SERIES_2_CONFIG == 2)
+#define SUPPORTED_PA_INDICES {     \
+    0U,        /* 2P4GIG_HP  */    \
+    RAIL_NUM_PA, /* 2P4GIG_MP  */  \
+    1U,        /* 2P4GIG_LP  */    \
+    /* The rest are unsupported */ \
+}
+#elif (_SILICON_LABS_32B_SERIES_2_CONFIG == 3)
+#define SUPPORTED_PA_INDICES {                   \
+    RAIL_NUM_PA, /* 2P4GIG_HP  */                \
+    RAIL_NUM_PA, /* 2P4GIG_MP  */                \
+    RAIL_NUM_PA, /* 2P4GIG_LP  */                \
+    RAIL_NUM_PA, /* 2P4GIG_LLP */                \
+    RAIL_NUM_PA, /* 2P4GIG_HIGHEST */            \
+    RAIL_NUM_PA, /* SUBGIG_POWERSETTING_TABLE */ \
+    0U,        /* SUBGIG_HP */                   \
+    1U,        /* SUBGIG_MP */                   \
+    2U,        /* SUBGIG_LP */                   \
+    3U,        /* SUBGIG_LLP */                  \
+    /* The rest are unsupported */               \
+}
+#elif (_SILICON_LABS_32B_SERIES_2_CONFIG == 4)
+#define SUPPORTED_PA_INDICES {     \
+    0U,        /* 2P4GIG_HP  */    \
+    RAIL_NUM_PA, /* 2P4GIG_MP  */  \
+    1U,        /* 2P4GIG_LP  */    \
+    /* The rest are unsupported */ \
+}
+#elif (_SILICON_LABS_32B_SERIES_2_CONFIG == 5)
+#define SUPPORTED_PA_INDICES {                      \
+    RAIL_NUM_PA, /* 2P4GIG_HP  */                   \
+    RAIL_NUM_PA, /* 2P4GIG_MP  */                   \
+    RAIL_NUM_PA, /* 2P4GIG_LP  */                   \
+    RAIL_NUM_PA, /* 2P4GIG_LLP */                   \
+    RAIL_NUM_PA, /* 2P4GIG_HIGHEST */               \
+    0U,        /* SUBGIG_POWERSETTING_TABLE */      \
+    RAIL_NUM_PA, /* SUBGIG_HP */                    \
+    RAIL_NUM_PA, /* SUBGIG_MP */                    \
+    RAIL_NUM_PA, /* SUBGIG_LP */                    \
+    RAIL_NUM_PA, /* SUBGIG_LLP */                   \
+    RAIL_NUM_PA, /* SUBGIG_HIGHEST */               \
+    1U,        /* OFDM_PA_POWERSETTING_TABLE */     \
+    2U,        /* SUBGIG_EFF_POWERSETTING_TABLE */  \
+    3U,        /* OFDM_PA_EFF_POWERSETTING_TABLE */ \
+}
+#elif (_SILICON_LABS_32B_SERIES_2_CONFIG == 7)
+#define SUPPORTED_PA_INDICES {     \
+    0U,        /* 2P4GIG_HP  */    \
+    RAIL_NUM_PA, /* 2P4GIG_MP  */  \
+    1U,        /* 2P4GIG_LP  */    \
+    /* The rest are unsupported */ \
+}
+#elif (_SILICON_LABS_32B_SERIES_2_CONFIG == 8)
+#define SUPPORTED_PA_INDICES {                   \
+    0U,        /* 2P4GIG_HP  */                  \
+    RAIL_NUM_PA, /* 2P4GIG_MP  */                \
+    RAIL_NUM_PA, /* 2P4GIG_LP  */                \
+    RAIL_NUM_PA, /* 2P4GIG_LLP */                \
+    RAIL_NUM_PA, /* 2P4GIG_HIGHEST */            \
+    RAIL_NUM_PA, /* SUBGIG_POWERSETTING_TABLE */ \
+    1U,        /* SUBGIG_HP */                   \
+    2U,        /* SUBGIG_MP */                   \
+    3U,        /* SUBGIG_LP */                   \
+    4U,        /* SUBGIG_LLP */                  \
+    /* The rest are unsupported */               \
+}
+#else
+#error "unknown platform"
+#endif
+#endif
+
+static const uint8_t supportedPaIndices[] = SUPPORTED_PA_INDICES;
+
+#if defined(_SILICON_LABS_32B_SERIES_1) || defined(_SILICON_LABS_32B_SERIES_2_CONFIG_1)
   #define PA_CONVERSION_MINIMUM_PWRLVL 1U
 #else
   #define PA_CONVERSION_MINIMUM_PWRLVL 0U
 #endif
-// For details on how to use this plugin, see
-//   https://www.silabs.com/documents/public/application-notes/an1127-power-amplifier-power-conversion-functions.pdf
 
 //   This macro is defined when Silicon Labs builds this into the library as WEAK
 //   to ensure it can be overriden by customer versions of these functions. The macro
@@ -57,43 +152,36 @@ __WEAK
 const RAIL_TxPowerCurves_t *RAIL_GetTxPowerCurve(RAIL_TxPowerMode_t mode)
 {
   static RAIL_TxPowerCurves_t powerCurves;
-
-  // Check for an invalid Tx power mode
-  if (mode >= RAIL_TX_POWER_MODE_NONE) {
-    return NULL;
-  }
-  RAIL_Handle_t railHandle = RAIL_EFR32_HANDLE;
   RAIL_TxPowerLevel_t maxPowerLevel, minPowerLevel;
-  if (RAIL_SupportsTxPowerModeAlt(railHandle,
+  if (RAIL_SupportsTxPowerModeAlt(RAIL_EFR32_HANDLE,
                                   &mode,
                                   &maxPowerLevel,
-                                  &minPowerLevel) == false) {
-    return NULL;
-  }
-
-  RAIL_TxPowerCurveAlt_t const *curve =
-    powerCurvesState.curves[mode].conversion.powerCurve;
-
-  // Check for an invalid power curve
-  if (curve == NULL) {
-    return NULL;
-  }
+                                  &minPowerLevel)
+      && (mode < sizeof(supportedPaIndices))
+      && (supportedPaIndices[mode] < RAIL_NUM_PA)) {
+    const RAIL_PaDescriptor_t *modeInfo = &powerCurvesState.curves[supportedPaIndices[mode]];
+    const RAIL_TxPowerCurveAlt_t *curve = modeInfo->conversion.powerCurve;
+    // Check for an invalid power curve
+    if (curve == NULL) {
+      return NULL;
+    }
 
 #if RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE
-  RAIL_PaDescriptor_t const *modeInfo = &powerCurvesState.curves[mode];
-  if (modeInfo->algorithm == RAIL_PA_ALGORITHM_DBM_POWERSETTING_MAPPING_TABLE) {
-    powerCurves.maxPower = modeInfo->maxPowerDbm;
-    powerCurves.minPower = modeInfo->minPowerDbm;
-    // Mapping table does not have RAIL_TxPowerCurveSegment_t segments
-    powerCurves.powerParams = NULL;
-  } else
+    if (modeInfo->algorithm == RAIL_PA_ALGORITHM_DBM_POWERSETTING_MAPPING_TABLE) {
+      powerCurves.maxPower = modeInfo->maxPowerDbm;
+      powerCurves.minPower = modeInfo->minPowerDbm;
+      // Mapping table does not have RAIL_TxPowerCurveSegment_t segments
+      powerCurves.powerParams = NULL;
+    } else
 #endif
-  {
-    powerCurves.maxPower = curve->maxPower;
-    powerCurves.minPower = curve->minPower;
-    powerCurves.powerParams = &curve->powerParams[0];
+    {
+      powerCurves.maxPower = curve->maxPower;
+      powerCurves.minPower = curve->minPower;
+      powerCurves.powerParams = &curve->powerParams[0];
+    }
+    return &powerCurves;
   }
-  return &powerCurves;
+  return NULL;
 }
 
 // This function will not be supported for any parts after efr32xg1x
@@ -104,8 +192,7 @@ RAIL_Status_t RAIL_InitTxPowerCurves(const RAIL_TxPowerCurvesConfig_t *config)
 {
 #ifdef _SILICON_LABS_32B_SERIES_1
   // First PA is 2.4 GHz high power, using a piecewise fit
-  RAIL_PaDescriptor_t *current =
-    &powerCurvesState.curves[RAIL_TX_POWER_MODE_2P4_HP];
+  RAIL_PaDescriptor_t *current = &powerCurvesState.curves[0];
   current->algorithm = RAIL_PA_ALGORITHM_PIECEWISE_LINEAR;
   current->segments = config->piecewiseSegments;
   current->min = RAIL_TX_POWER_LEVEL_2P4_HP_MIN;
@@ -126,7 +213,7 @@ RAIL_Status_t RAIL_InitTxPowerCurves(const RAIL_TxPowerCurvesConfig_t *config)
   current->conversion.powerCurve = &txPower2p4;
 
   // Second PA is 2.4 GHz low power, using a mapping table
-  current = &powerCurvesState.curves[RAIL_TX_POWER_MODE_2P4_LP];
+  current = &powerCurvesState.curves[1];
   current->algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE;
   current->segments = 0U;
   current->min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN;
@@ -134,7 +221,7 @@ RAIL_Status_t RAIL_InitTxPowerCurves(const RAIL_TxPowerCurvesConfig_t *config)
   current->conversion.mappingTable = config->txPower24LpCurves;
 
   // Third and final PA is Sub-GHz, using a piecewise fit
-  current = &powerCurvesState.curves[RAIL_TX_POWER_MODE_SUBGIG];
+  current = &powerCurvesState.curves[2];
   current->algorithm = RAIL_PA_ALGORITHM_PIECEWISE_LINEAR;
   current->segments = config->piecewiseSegments;
   current->min = RAIL_TX_POWER_LEVEL_SUBGIG_MIN;
@@ -182,22 +269,15 @@ const RAIL_PaPowerSetting_t *RAIL_GetPowerSettingTable(RAIL_Handle_t railHandle,
 {
   (void)railHandle;
 #if RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE
-  // Check for an invalid Tx power mode
-  if ((mode >= RAIL_NUM_PA)
-   #ifdef RAIL_TX_POWER_MODE_2P4GIG_HIGHEST
-      || (mode == RAIL_TX_POWER_MODE_2P4GIG_HIGHEST)
-   #endif
-   #ifdef RAIL_TX_POWER_MODE_SUBGIG_HIGHEST
-      || (mode == RAIL_TX_POWER_MODE_SUBGIG_HIGHEST)
-   #endif
-      ) {
-    return NULL;
+  if ((mode < sizeof(supportedPaIndices))
+      && (supportedPaIndices[mode] < RAIL_NUM_PA)) {
+    RAIL_PaDescriptor_t *modeInfo = &powerCurvesState.curves[supportedPaIndices[mode]];
+    *minPower = modeInfo->minPowerDbm;
+    *maxPower = modeInfo->maxPowerDbm;
+    *step = modeInfo->step;
+    return (RAIL_PaPowerSetting_t*)(modeInfo->conversion.mappingTable);
   }
-  RAIL_PaDescriptor_t *modeInfo = &powerCurvesState.curves[mode];
-  *minPower = modeInfo->minPowerDbm;
-  *maxPower = modeInfo->maxPowerDbm;
-  *step = modeInfo->step;
-  return (RAIL_PaPowerSetting_t*)(modeInfo->conversion.mappingTable);
+  return NULL;
 #else
   (void)mode;
   (void)minPower;
@@ -214,9 +294,6 @@ RAIL_TxPowerLevel_t RAIL_ConvertDbmToRaw(RAIL_Handle_t railHandle,
                                          RAIL_TxPowerMode_t mode,
                                          RAIL_TxPower_t power)
 {
-  uint32_t powerLevel;
-  uint32_t minPowerLevel;
-
   (void)railHandle;
   // This function is called internally from the RAIL library,
   // so if the user never calls RAIL_InitTxPowerCurves - even
@@ -234,140 +311,133 @@ RAIL_TxPowerLevel_t RAIL_ConvertDbmToRaw(RAIL_Handle_t railHandle,
     return 255U;
   }
 
-  // Check for an invalid Tx power mode
-  if ((mode >= RAIL_NUM_PA)
-   #ifdef RAIL_TX_POWER_MODE_2P4GIG_HIGHEST
-      || (mode == RAIL_TX_POWER_MODE_2P4GIG_HIGHEST)
-   #endif
-   #ifdef RAIL_TX_POWER_MODE_SUBGIG_HIGHEST
-      || (mode == RAIL_TX_POWER_MODE_SUBGIG_HIGHEST)
-   #endif
-      ) {
-    return 0U;
-  }
-
-  RAIL_PaDescriptor_t const *modeInfo = &powerCurvesState.curves[mode];
-  minPowerLevel = MAX(modeInfo->min, PA_CONVERSION_MINIMUM_PWRLVL);
-
+  if ((mode < sizeof(supportedPaIndices))
+      && (supportedPaIndices[mode] < RAIL_NUM_PA)) {
+    RAIL_PaDescriptor_t const *modeInfo = &powerCurvesState.curves[supportedPaIndices[mode]];
+    uint32_t minPowerLevel = MAX(modeInfo->min, PA_CONVERSION_MINIMUM_PWRLVL);
 #if RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE
-  if (modeInfo->algorithm == RAIL_PA_ALGORITHM_DBM_POWERSETTING_MAPPING_TABLE) {
-    RAIL_TxPower_t minPower = modeInfo->minPowerDbm;
-    RAIL_TxPower_t maxPower = modeInfo->maxPowerDbm;
-    RAIL_TxPowerLevel_t step = modeInfo->step;
+    if (modeInfo->algorithm == RAIL_PA_ALGORITHM_DBM_POWERSETTING_MAPPING_TABLE) {
+      RAIL_TxPower_t minPower = modeInfo->minPowerDbm;
+      RAIL_TxPower_t maxPower = modeInfo->maxPowerDbm;
+      RAIL_TxPowerLevel_t step = modeInfo->step;
 
-    // Cap the power to within the range of the mapping table
-    if (power < minPower) {
-      power = minPower;
-    } else if (power > maxPower) {
-      power = maxPower;
-    } else {
-      // Power level is within bounds (MISRA required else)
+      // Cap the power to within the range of the mapping table
+      if (power < minPower) {
+        power = minPower;
+      } else if (power > maxPower) {
+        power = maxPower;
+      } else {
+        // Power level is within bounds (MISRA required else)
+      }
+
+      uint32_t powerIndex = (power - minPower) / step;
+      RAIL_SetPaPowerSetting(railHandle, modeInfo->conversion.mappingTable[powerIndex], minPower, maxPower, power);
+      return 0U;
     }
-
-    uint32_t powerIndex = (power - minPower) / step;
-    RAIL_SetPaPowerSetting(railHandle, modeInfo->conversion.mappingTable[powerIndex], minPower, maxPower, power);
-    return 0U;
-  }
 #endif
 
-  // If we're in low power mode, just use the simple lookup table
-  if (modeInfo->algorithm == RAIL_PA_ALGORITHM_MAPPING_TABLE) {
-    // Binary search through the lookup table to find the closest power level
-    // without going over.
-    uint32_t lower = 0U;
-    // Track the high side of the estimate
-    uint32_t powerIndex = modeInfo->max - minPowerLevel;
+    // If we're in low power mode, just use the simple lookup table
+    if (modeInfo->algorithm == RAIL_PA_ALGORITHM_MAPPING_TABLE) {
+      // Binary search through the lookup table to find the closest power level
+      // without going over.
+      uint32_t lower = 0U;
+      // Track the high side of the estimate
+      uint32_t powerIndex = modeInfo->max - minPowerLevel;
 
-    while (lower < powerIndex) {
-      // Calculate the midpoint of the current range
-      uint32_t index = powerIndex - (powerIndex - lower) / 2U;
-      if (power < modeInfo->conversion.mappingTable[index]) {
-        powerIndex = index - 1U;
-      } else {
-        lower = index;
+      while (lower < powerIndex) {
+        // Calculate the midpoint of the current range
+        uint32_t index = powerIndex - (powerIndex - lower) / 2U;
+        if (power < modeInfo->conversion.mappingTable[index]) {
+          powerIndex = index - 1U;
+        } else {
+          lower = index;
+        }
       }
+      return (RAIL_TxPowerLevel_t)(powerIndex + minPowerLevel);
     }
-    return (RAIL_TxPowerLevel_t)(powerIndex + minPowerLevel);
-  }
 
-  // Here we know we're using the piecewise linear conversion
-  RAIL_TxPowerCurveAlt_t const *paParams = modeInfo->conversion.powerCurve;
-  // Check for valid paParams before using them
-  if (paParams == NULL) {
-    return 0U;
-  }
+    // Here we know we're using the piecewise linear conversion
+    RAIL_TxPowerCurveAlt_t const *paParams = modeInfo->conversion.powerCurve;
+    // Check for valid paParams before using them
+    if (paParams == NULL) {
+      return 0U;
+    }
 
-  // Cap the power based on the PA settings.
-  if (power > paParams->maxPower) {
-    // If we go above the maximum dbm the chip supports
-    // Then provide maximum powerLevel
-    power = paParams->maxPower;
-  } else if (power < paParams->minPower) {
-    // If we go below the minimum we want included in the curve fit, force it.
-    power = paParams->minPower;
-  } else {
-    // Do nothing, power is OK
-  }
-  // Map the power value to a 0 - 7 curveIndex value
-  //There are 8 segments of step size of RAIL_TX_POWER_CURVE_INCREMENT in deci dBm
-  //starting from maximum RAIL_TX_POWER_CURVE_MAX in deci dBm
-  // These are just starting points to give the code
-  // a rough idea of which segment to use, based on
-  // how they were fit. Adjustments are made later on
-  // if this turns out to be incorrect.
-  RAIL_TxPower_t txPowerMax = RAIL_TX_POWER_CURVE_DEFAULT_MAX;
-  RAIL_TxPower_t txPowerIncrement = RAIL_TX_POWER_CURVE_DEFAULT_INCREMENT;
-  int16_t curveIndex = 0;
-  // if the first curve segment starts with RAIL_TX_POWER_LEVEL_INVALID
-  //It is an extra curve segment to depict the maxpower and increment
-  // (in deci-dBm) used while generating the curves.
-  // The extra segment is only present when curve segment is generated by
-  //using values different than the default - RAIL_TX_POWER_CURVE_DEFAULT_MAX
-  // and RAIL_TX_POWER_CURVE_DEFAULT_INCREMENT.
-  if ((paParams->powerParams[0].maxPowerLevel) == RAIL_TX_POWER_LEVEL_INVALID) {
-    curveIndex += 1;
-    txPowerMax = (RAIL_TxPower_t) paParams->powerParams[0].slope;
-    txPowerIncrement = (RAIL_TxPower_t) paParams->powerParams[0].intercept;
-  }
-
-  curveIndex += (txPowerMax - power) / txPowerIncrement;
-  if ((curveIndex > ((int16_t)modeInfo->segments - 1))
-      || (curveIndex < 0)) {
-    curveIndex = ((int16_t)modeInfo->segments - 1);
-  }
-
-  do {
-    // Select the correct piecewise segment to use for conversion.
-    RAIL_TxPowerCurveSegment_t const *powerParams =
-      &paParams->powerParams[curveIndex];
-
-    // powerLevel can only go down to 0.
-    int32_t powerLevelInt = powerParams->intercept + ((int32_t)powerParams->slope * (int32_t)power);
-    if (powerLevelInt < 0) {
-      powerLevel = 0U;
+    // Cap the power based on the PA settings.
+    if (power > paParams->maxPower) {
+      // If we go above the maximum dbm the chip supports
+      // Then provide maximum powerLevel
+      power = paParams->maxPower;
+    } else if (power < paParams->minPower) {
+      // If we go below the minimum we want included in the curve fit, force it.
+      power = paParams->minPower;
     } else {
-      powerLevel = (uint32_t) powerLevelInt;
+      // Do nothing, power is OK
     }
-    // Add 500 to do rounding correctly, as opposed to just rounding towards 0
-    powerLevel = ((powerLevel + 500U) / 1000U);
+    // Map the power value to a 0 - 7 curveIndex value
+    //There are 8 segments of step size of RAIL_TX_POWER_CURVE_INCREMENT in deci dBm
+    //starting from maximum RAIL_TX_POWER_CURVE_MAX in deci dBm
+    // These are just starting points to give the code
+    // a rough idea of which segment to use, based on
+    // how they were fit. Adjustments are made later on
+    // if this turns out to be incorrect.
+    RAIL_TxPower_t txPowerMax = RAIL_TX_POWER_CURVE_DEFAULT_MAX;
+    RAIL_TxPower_t txPowerIncrement = RAIL_TX_POWER_CURVE_DEFAULT_INCREMENT;
+    int16_t curveIndex = 0;
+    // if the first curve segment starts with RAIL_TX_POWER_LEVEL_INVALID
+    //It is an extra curve segment to depict the maxpower and increment
+    // (in deci-dBm) used while generating the curves.
+    // The extra segment is only present when curve segment is generated by
+    //using values different than the default - RAIL_TX_POWER_CURVE_DEFAULT_MAX
+    // and RAIL_TX_POWER_CURVE_DEFAULT_INCREMENT.
+    if ((paParams->powerParams[0].maxPowerLevel) == RAIL_TX_POWER_LEVEL_INVALID) {
+      curveIndex += 1;
+      txPowerMax = (RAIL_TxPower_t) paParams->powerParams[0].slope;
+      txPowerIncrement = (RAIL_TxPower_t) paParams->powerParams[0].intercept;
+    }
 
-    // In case it turns out the resultant power level was too low and we have
-    // to recalculate with the next curve...
-    curveIndex++;
-  } while ((curveIndex < (int16_t)modeInfo->segments)
-           && (powerLevel <= paParams->powerParams[curveIndex].maxPowerLevel));
+    curveIndex += (txPowerMax - power) / txPowerIncrement;
+    if ((curveIndex > ((int16_t)modeInfo->segments - 1))
+        || (curveIndex < 0)) {
+      curveIndex = ((int16_t)modeInfo->segments - 1);
+    }
 
-// We already know that curveIndex is at most modeInfo->segments
-  if (powerLevel > paParams->powerParams[curveIndex - 1].maxPowerLevel) {
-    powerLevel = paParams->powerParams[curveIndex - 1].maxPowerLevel;
+    uint32_t powerLevel;
+    do {
+      // Select the correct piecewise segment to use for conversion.
+      RAIL_TxPowerCurveSegment_t const *powerParams =
+        &paParams->powerParams[curveIndex];
+
+      // powerLevel can only go down to 0.
+      int32_t powerLevelInt = powerParams->intercept + ((int32_t)powerParams->slope * (int32_t)power);
+      if (powerLevelInt < 0) {
+        powerLevel = 0U;
+      } else {
+        powerLevel = (uint32_t) powerLevelInt;
+      }
+      // RAIL_LIB-8330: Modified from adding 500 to adding 92, this was tested on xg21 as being the highest
+      // number we can use without exceeding the requested power in dBm
+      powerLevel = ((powerLevel + 92U) / 1000U);
+
+      // In case it turns out the resultant power level was too low and we have
+      // to recalculate with the next curve...
+      curveIndex++;
+    } while ((curveIndex < (int16_t)modeInfo->segments)
+             && (powerLevel <= paParams->powerParams[curveIndex].maxPowerLevel));
+
+    // We already know that curveIndex is at most modeInfo->segments
+    if (powerLevel > paParams->powerParams[curveIndex - 1].maxPowerLevel) {
+      powerLevel = paParams->powerParams[curveIndex - 1].maxPowerLevel;
+    }
+
+    // If we go below the minimum we want included in the curve fit, force it.
+    if (powerLevel < minPowerLevel) {
+      powerLevel = minPowerLevel;
+    }
+
+    return (RAIL_TxPowerLevel_t)powerLevel;
   }
-
-// If we go below the minimum we want included in the curve fit, force it.
-  if (powerLevel < minPowerLevel) {
-    powerLevel = minPowerLevel;
-  }
-
-  return (RAIL_TxPowerLevel_t)powerLevel;
+  return 0U;
 }
 
 #ifdef RAIL_PA_CONVERSIONS_WEAK
@@ -379,96 +449,87 @@ RAIL_TxPower_t RAIL_ConvertRawToDbm(RAIL_Handle_t railHandle,
 {
   (void)railHandle;
 
-  // Check for an invalid Tx power mode
-  if ((mode >= RAIL_NUM_PA)
-   #ifdef RAIL_TX_POWER_MODE_2P4GIG_HIGHEST
-      || (mode == RAIL_TX_POWER_MODE_2P4GIG_HIGHEST)
-   #endif
-   #ifdef RAIL_TX_POWER_MODE_SUBGIG_HIGHEST
-      || (mode == RAIL_TX_POWER_MODE_SUBGIG_HIGHEST)
-   #endif
-      ) {
-    return RAIL_TX_POWER_MIN;
-  }
+  if ((mode < sizeof(supportedPaIndices))
+      && (supportedPaIndices[mode] < RAIL_NUM_PA)) {
+    RAIL_PaDescriptor_t const *modeInfo = &powerCurvesState.curves[supportedPaIndices[mode]];
+    if (modeInfo->algorithm == RAIL_PA_ALGORITHM_MAPPING_TABLE) {
+      // Limit the max power level
+      if (powerLevel > modeInfo->max) {
+        powerLevel = modeInfo->max;
+      }
 
-  RAIL_PaDescriptor_t const *modeInfo = &powerCurvesState.curves[mode];
+      // We 1-index low power PA power levels, but of course arrays are 0 indexed
+      powerLevel -= MAX(modeInfo->min, PA_CONVERSION_MINIMUM_PWRLVL);
 
-  if (modeInfo->algorithm == RAIL_PA_ALGORITHM_MAPPING_TABLE) {
-    // Limit the max power level
-    if (powerLevel > modeInfo->max) {
-      powerLevel = modeInfo->max;
-    }
-
-    // We 1-index low power PA power levels, but of course arrays are 0 indexed
-    powerLevel -= MAX(modeInfo->min, PA_CONVERSION_MINIMUM_PWRLVL);
-
-    //If the index calculation above underflowed, then provide the lowest array index.
-    if (powerLevel > (modeInfo->max - modeInfo->min)) {
-      powerLevel = 0U;
-    }
-    return modeInfo->conversion.mappingTable[powerLevel];
-  } else {
-#if defined(_SILICON_LABS_32B_SERIES_1) || defined(_SILICON_LAS_32B_SERIES_2_CONFIG_1)
-    // Although 0 is a legitimate power on non-2.4 LP PA's and can be set via
-    // "RAIL_SetTxPower(railHandle, 0)" it is MUCH lower than power
-    // level 1 (approximately -50 dBm). Including it in the piecewise
-    // linear fit would skew the curve substantially, so we exclude it
-    // from the conversion.
-    if (powerLevel == 0U) {
-      return -500;
-    }
+      //If the index calculation above underflowed, then provide the lowest array index.
+      if (powerLevel > (modeInfo->max - modeInfo->min)) {
+        powerLevel = 0U;
+      }
+      return modeInfo->conversion.mappingTable[powerLevel];
+    } else {
+#if defined(_SILICON_LABS_32B_SERIES_1) || defined(_SILICON_LABS_32B_SERIES_2_CONFIG_1)
+      // Although 0 is a legitimate power on non-2.4 LP PA's and can be set via
+      // "RAIL_SetTxPower(railHandle, 0)" it is MUCH lower than power
+      // level 1 (approximately -50 dBm). Including it in the piecewise
+      // linear fit would skew the curve substantially, so we exclude it
+      // from the conversion.
+      if (powerLevel == 0U) {
+        return -500;
+      }
 #endif
 
-    RAIL_TxPowerCurveAlt_t const *powerCurve = modeInfo->conversion.powerCurve;
-    // Check for a valid powerCurve pointer before using it
-    if (powerCurve == NULL) {
-      return RAIL_TX_POWER_MIN;
-    }
+      RAIL_TxPowerCurveAlt_t const *powerCurve = modeInfo->conversion.powerCurve;
+      // Check for a valid powerCurve pointer before using it
+      if (powerCurve == NULL) {
+        return RAIL_TX_POWER_MIN;
+      }
 
-    RAIL_TxPowerCurveSegment_t const *powerParams = powerCurve->powerParams;
+      RAIL_TxPowerCurveSegment_t const *powerParams = powerCurve->powerParams;
 
-    // Hard code the extremes (i.e. don't use the curve fit) in order
-    // to make it clear that we are reaching the extent of the chip's
-    // capabilities
-    if (powerLevel <= modeInfo->min) {
-      return powerCurve->minPower;
-    } else if (powerLevel >= modeInfo->max) {
-      return powerCurve->maxPower;
-    } else {
-      // Power level is within bounds (MISRA required else)
-    }
+      // Hard code the extremes (i.e. don't use the curve fit) in order
+      // to make it clear that we are reaching the extent of the chip's
+      // capabilities
+      if (powerLevel <= modeInfo->min) {
+        return powerCurve->minPower;
+      } else if (powerLevel >= modeInfo->max) {
+        return powerCurve->maxPower;
+      } else {
+        // Power level is within bounds (MISRA required else)
+      }
 
-    // Figure out which parameter to use based on the power level
-    uint8_t x = 0;
-    uint8_t upperBound = modeInfo->segments - 1U;
+      // Figure out which parameter to use based on the power level
+      uint8_t x = 0;
+      uint8_t upperBound = modeInfo->segments - 1U;
 
-    // If the first curve segment starts with RAIL_TX_POWER_LEVEL_INVALID,
-    // then it is an additional curve segment that stores maxpower and increment
-    // (in deci-dBm) used to generate the curves.
-    // The extra info segment is present only if the curves were generated using
-    // values other than default - RAIL_TX_POWER_CURVE_DEFAULT_MAX and
-    // RAIL_TX_POWER_CURVE_DEFAULT_INCREMENT.
-    if ((powerParams[0].maxPowerLevel) == RAIL_TX_POWER_LEVEL_INVALID) {
-      x = 1U; // skip over the first entry
-    }
+      // If the first curve segment starts with RAIL_TX_POWER_LEVEL_INVALID,
+      // then it is an additional curve segment that stores maxpower and increment
+      // (in deci-dBm) used to generate the curves.
+      // The extra info segment is present only if the curves were generated using
+      // values other than default - RAIL_TX_POWER_CURVE_DEFAULT_MAX and
+      // RAIL_TX_POWER_CURVE_DEFAULT_INCREMENT.
+      if ((powerParams[0].maxPowerLevel) == RAIL_TX_POWER_LEVEL_INVALID) {
+        x = 1U; // skip over the first entry
+      }
 
-    for (; x < upperBound; x++) {
-      if (powerParams[x + 1U].maxPowerLevel < powerLevel) {
-        break;
+      for (; x < upperBound; x++) {
+        if (powerParams[x + 1U].maxPowerLevel < powerLevel) {
+          break;
+        }
+      }
+      int32_t power;
+      power = ((1000 * (int32_t)(powerLevel)) - powerParams[x].intercept);
+      power = ((power + ((int32_t)powerParams[x].slope / 2)) / (int32_t)powerParams[x].slope);
+
+      if (power > powerCurve->maxPower) {
+        return powerCurve->maxPower;
+      } else if (power < powerCurve->minPower) {
+        return powerCurve->minPower;
+      } else {
+        return (RAIL_TxPower_t)power;
       }
     }
-    int32_t power;
-    power = ((1000 * (int32_t)(powerLevel)) - powerParams[x].intercept);
-    power = ((power + ((int32_t)powerParams[x].slope / 2)) / (int32_t)powerParams[x].slope);
-
-    if (power > powerCurve->maxPower) {
-      return powerCurve->maxPower;
-    } else if (power < powerCurve->minPower) {
-      return powerCurve->minPower;
-    } else {
-      return (RAIL_TxPower_t)power;
-    }
   }
+  return RAIL_TX_POWER_MIN;
 }
 
 #ifdef RAIL_PA_CONVERSIONS_WEAK
@@ -480,39 +541,31 @@ RAIL_Status_t RAIL_GetTxPowerCurveLimits(RAIL_Handle_t railHandle,
                                          RAIL_TxPower_t *increment)
 {
   (void)railHandle;
-  // Check for an invalid Tx power mode
-  if ((mode >= RAIL_NUM_PA)
-   #ifdef RAIL_TX_POWER_MODE_2P4GIG_HIGHEST
-      || (mode == RAIL_TX_POWER_MODE_2P4GIG_HIGHEST)
-   #endif
-   #ifdef RAIL_TX_POWER_MODE_SUBGIG_HIGHEST
-      || (mode == RAIL_TX_POWER_MODE_SUBGIG_HIGHEST)
-   #endif
-      ) {
-    return RAIL_STATUS_INVALID_PARAMETER;
-  }
-  RAIL_PaDescriptor_t const *modeInfo = &powerCurvesState.curves[mode];
-
+  if ((mode < sizeof(supportedPaIndices))
+      && (supportedPaIndices[mode] < RAIL_NUM_PA)) {
+    RAIL_PaDescriptor_t const *modeInfo = &powerCurvesState.curves[supportedPaIndices[mode]];
 #if RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE
-  if (modeInfo->algorithm == RAIL_PA_ALGORITHM_DBM_POWERSETTING_MAPPING_TABLE) {
-    *maxPower = modeInfo->maxPowerDbm;
-    *increment = modeInfo->step;
-    return RAIL_STATUS_NO_ERROR;
-  }
+    if (modeInfo->algorithm == RAIL_PA_ALGORITHM_DBM_POWERSETTING_MAPPING_TABLE) {
+      *maxPower = modeInfo->maxPowerDbm;
+      *increment = modeInfo->step;
+      return RAIL_STATUS_NO_ERROR;
+    }
 #endif
 
-  //The power max info only for available Linear fit
-  if (modeInfo->algorithm == RAIL_PA_ALGORITHM_MAPPING_TABLE) {
-    return RAIL_STATUS_INVALID_CALL;
+    //The power max info only for available Linear fit
+    if (modeInfo->algorithm == RAIL_PA_ALGORITHM_MAPPING_TABLE) {
+      return RAIL_STATUS_INVALID_CALL;
+    }
+    *maxPower = RAIL_TX_POWER_CURVE_DEFAULT_MAX;
+    *increment = RAIL_TX_POWER_CURVE_DEFAULT_INCREMENT;
+    RAIL_TxPowerCurveAlt_t const *paParams = modeInfo->conversion.powerCurve;
+    if ((paParams->powerParams[0].maxPowerLevel) == RAIL_TX_POWER_LEVEL_INVALID) {
+      *maxPower = paParams->powerParams[0].slope;
+      *increment = (RAIL_TxPower_t)paParams->powerParams[0].intercept;
+    }
+    return RAIL_STATUS_NO_ERROR;
   }
-  *maxPower = RAIL_TX_POWER_CURVE_DEFAULT_MAX;
-  *increment = RAIL_TX_POWER_CURVE_DEFAULT_INCREMENT;
-  RAIL_TxPowerCurveAlt_t const *paParams = modeInfo->conversion.powerCurve;
-  if ((paParams->powerParams[0].maxPowerLevel) == RAIL_TX_POWER_LEVEL_INVALID) {
-    *maxPower = paParams->powerParams[0].slope;
-    *increment = (RAIL_TxPower_t)paParams->powerParams[0].intercept;
-  }
-  return RAIL_STATUS_NO_ERROR;
+  return RAIL_STATUS_INVALID_PARAMETER;
 }
 
 // This macro is defined when Silicon Labs builds curves into the library as WEAK
@@ -670,6 +723,21 @@ void sl_rail_util_pa_on_channel_config_change(RAIL_Handle_t rail_handle,
       if (status != RAIL_STATUS_NO_ERROR) {
         while (true) {
         } // Error: Can't set TX Power
+      }
+      // If requested a HIGHEST setting, update it with the real one selected
+      // to short-circuit the next time through here since HIGHEST never
+      // matches the real PA returned by RAIL_GetTxPowerConfig(), causing
+      // reconfiguration of the same PA on every callback.
+      if (false
+         #ifdef  RAIL_TX_POWER_MODE_2P4GIG_HIGHEST
+          || (newTxPowerConfigPtr->mode == RAIL_TX_POWER_MODE_2P4GIG_HIGHEST)
+         #endif
+         #ifdef  RAIL_TX_POWER_MODE_SUBGIG_HIGHEST
+          || (newTxPowerConfigPtr->mode == RAIL_TX_POWER_MODE_SUBGIG_HIGHEST)
+         #endif
+          ) {
+        (void) RAIL_GetTxPowerConfig(rail_handle, &currentTxPowerConfig);
+        newTxPowerConfigPtr->mode = currentTxPowerConfig.mode;
       }
     }
 #endif

--- a/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c
+++ b/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c
@@ -38,7 +38,9 @@
 #include "pa_conversions_efr32.h"
 #include "rail.h"
 
+#ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
 
 static RAIL_TxPowerCurvesConfigAlt_t powerCurvesState;
 

--- a/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h
+++ b/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.h
@@ -165,6 +165,14 @@ RAIL_TxPowerConfig_t *sl_rail_util_pa_get_tx_power_config_2p4ghz(void);
 RAIL_TxPowerConfig_t *sl_rail_util_pa_get_tx_power_config_subghz(void);
 
 /**
+ * Get a pointer to the TX Power Config OFDM structure.
+ *
+ * @return a pointer to the TX Power Config stucture.
+ *
+ */
+RAIL_TxPowerConfig_t *sl_rail_util_pa_get_tx_power_config_ofdm(void);
+
+/**
  * Provide a channel config change callback capable of configuring the PA
  * correctly.
  *

--- a/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c
+++ b/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c
@@ -148,12 +148,12 @@ const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesVbat = {
       .max = RAIL_TX_POWER_LEVEL_2P4_HP_MAX,
       .conversion = { .powerCurve = &RAIL_piecewiseDataHpVbat },
     },
-    {                                                        \
-      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,          \
-      .segments = 0U,                                        \
-      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,                 \
-      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,                 \
-      .conversion = { .mappingTable = &RAIL_curves24Lp[0] }, \
+    {
+      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,
+      .segments = 0U,
+      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,
+      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,
+      .conversion = { .mappingTable = &RAIL_curves24Lp[0] },
     },
   }
 };
@@ -170,12 +170,12 @@ const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesDcdc = {
       .max = RAIL_TX_POWER_LEVEL_2P4_HP_MAX,
       .conversion = { .powerCurve = &RAIL_piecewiseDataHpVbat },
     },
-    {                                                        \
-      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,          \
-      .segments = 0U,                                        \
-      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,                 \
-      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,                 \
-      .conversion = { .mappingTable = &RAIL_curves24Lp[0] }, \
+    {
+      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,
+      .segments = 0U,
+      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,
+      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,
+      .conversion = { .mappingTable = &RAIL_curves24Lp[0] },
     },
   }
 };
@@ -208,8 +208,6 @@ static const int32_t RAIL_curvesSubgig[RAIL_PA_CURVES_SUBGIG_CURVES_NUM_VALUES] 
 
 static const int32_t RAIL_curvesEffSubgig[RAIL_PA_CURVES_EFF_SUBGIG_CURVES_NUM_VALUES] =
   RAIL_PA_CURVES_EFF_SUBGIG_CURVES;
-
-RAIL_DECLARE_TX_POWER_VBAT_CURVES_ALT;
 
 // This chip has the same curve for Vbat and DCDC
 #ifdef RAIL_PA_CONVERSIONS_WEAK
@@ -252,7 +250,6 @@ const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesVbat = {
       .max = RAIL_TX_POWER_LEVEL_2P4_HP_MAX,
       .conversion = { .powerCurve = &RAIL_piecewiseDataHpVbat },
     },
-#if _SILICON_LABS_32B_SERIES_2_CONFIG == 1
     {
       .algorithm = RAIL_PA_ALGORITHM_PIECEWISE_LINEAR,
       .segments = RAIL_PA_CURVES_PIECEWISE_SEGMENTS,
@@ -260,7 +257,6 @@ const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesVbat = {
       .max = RAIL_TX_POWER_LEVEL_2P4_MP_MAX,
       .conversion = { .powerCurve = &RAIL_piecewiseDataMpVbat },
     },
-#endif // _SILICON_LABS_32B_SERIES_2_CONFIG == 1
     {
       .algorithm = RAIL_PA_ALGORITHM_PIECEWISE_LINEAR,
       .segments = RAIL_PA_CURVES_PIECEWISE_SEGMENTS,
@@ -299,12 +295,21 @@ const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesDcdc = {
     },
   }
 };
-#elif defined(_SILICON_LABS_32B_SERIES_2_CONFIG_4)
+#elif defined(_SILICON_LABS_32B_SERIES_2_CONFIG_4) || defined(_SILICON_LABS_32B_SERIES_2_CONFIG_6)
 static const RAIL_TxPowerCurveAlt_t RAIL_piecewiseDataHpVbat = {
   RAIL_PA_CURVES_2P4_HP_VBAT_MAX_POWER,
   RAIL_PA_CURVES_2P4_HP_VBAT_MIN_POWER,
   RAIL_PA_CURVES_2P4_HP_VBAT_CURVES,
 };
+
+#if defined(RAIL_DECLARE_TX_POWER_DCDC_CURVES_ALT)
+static const RAIL_TxPowerCurveAlt_t RAIL_piecewiseDataHpDcdc = {
+  RAIL_PA_CURVES_2P4_HP_DCDC_MAX_POWER,
+  RAIL_PA_CURVES_2P4_HP_DCDC_MIN_POWER,
+  RAIL_PA_CURVES_2P4_HP_DCDC_CURVES,
+};
+#endif
+
 static const int16_t RAIL_curves24Lp[RAIL_PA_CURVES_LP_VALUES] =
   RAIL_PA_CURVES_2P4_LP_VBAT_CURVES;
 
@@ -320,12 +325,12 @@ const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesVbat = {
       .max = RAIL_TX_POWER_LEVEL_2P4_HP_MAX,
       .conversion = { .powerCurve = &RAIL_piecewiseDataHpVbat },
     },
-    {                                                        \
-      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,          \
-      .segments = 0U,                                        \
-      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,                 \
-      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,                 \
-      .conversion = { .mappingTable = &RAIL_curves24Lp[0] }, \
+    {
+      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,
+      .segments = 0U,
+      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,
+      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,
+      .conversion = { .mappingTable = &RAIL_curves24Lp[0] },
     },
   }
 };
@@ -340,20 +345,91 @@ const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesDcdc = {
       .segments = RAIL_PA_CURVES_PIECEWISE_SEGMENTS,
       .min = RAIL_TX_POWER_LEVEL_2P4_HP_MIN,
       .max = RAIL_TX_POWER_LEVEL_2P4_HP_MAX,
+#if defined(RAIL_DECLARE_TX_POWER_DCDC_CURVES_ALT)
+      .conversion = { .powerCurve = &RAIL_piecewiseDataHpDcdc },
+#else
       .conversion = { .powerCurve = &RAIL_piecewiseDataHpVbat },
+#endif
     },
-    {                                                        \
-      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,          \
-      .segments = 0U,                                        \
-      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,                 \
-      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,                 \
-      .conversion = { .mappingTable = &RAIL_curves24Lp[0] }, \
+    {
+      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,
+      .segments = 0U,
+      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,
+      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,
+      .conversion = { .mappingTable = &RAIL_curves24Lp[0] },
     },
   }
 };
 
 #else
+#ifdef RAIL_INTERNAL_BUILD
+static const RAIL_TxPowerCurveAlt_t RAIL_piecewiseDataHpVbat = {
+  RAIL_PA_CURVES_2P4_HP_VBAT_MAX_POWER,
+  RAIL_PA_CURVES_2P4_HP_VBAT_MIN_POWER,
+  RAIL_PA_CURVES_2P4_HP_VBAT_CURVES,
+};
+
+#if defined(RAIL_DECLARE_TX_POWER_DCDC_CURVES_ALT)
+static const RAIL_TxPowerCurveAlt_t RAIL_piecewiseDataHpDcdc = {
+  RAIL_PA_CURVES_2P4_HP_DCDC_MAX_POWER,
+  RAIL_PA_CURVES_2P4_HP_DCDC_MIN_POWER,
+  RAIL_PA_CURVES_2P4_HP_DCDC_CURVES,
+};
+#endif
+
+static const int16_t RAIL_curves24Lp[RAIL_PA_CURVES_LP_VALUES] =
+  RAIL_PA_CURVES_2P4_LP_VBAT_CURVES;
+
+#ifdef RAIL_PA_CONVERSIONS_WEAK
+__WEAK
+#endif
+const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesVbat = {
+  .curves = {
+    {
+      .algorithm = RAIL_PA_ALGORITHM_PIECEWISE_LINEAR,
+      .segments = RAIL_PA_CURVES_PIECEWISE_SEGMENTS,
+      .min = RAIL_TX_POWER_LEVEL_2P4_HP_MIN,
+      .max = RAIL_TX_POWER_LEVEL_2P4_HP_MAX,
+      .conversion = { .powerCurve = &RAIL_piecewiseDataHpVbat },
+    },
+    {
+      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,
+      .segments = 0U,
+      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,
+      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,
+      .conversion = { .mappingTable = &RAIL_curves24Lp[0] },
+    },
+  }
+};
+
+#ifdef RAIL_PA_CONVERSIONS_WEAK
+__WEAK
+#endif
+const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesDcdc = {
+  .curves = {
+    {
+      .algorithm = RAIL_PA_ALGORITHM_PIECEWISE_LINEAR,
+      .segments = RAIL_PA_CURVES_PIECEWISE_SEGMENTS,
+      .min = RAIL_TX_POWER_LEVEL_2P4_HP_MIN,
+      .max = RAIL_TX_POWER_LEVEL_2P4_HP_MAX,
+#if defined(RAIL_DECLARE_TX_POWER_DCDC_CURVES_ALT)
+      .conversion = { .powerCurve = &RAIL_piecewiseDataHpDcdc },
+#else
+      .conversion = { .powerCurve = &RAIL_piecewiseDataHpVbat },
+#endif
+    },
+    {
+      .algorithm = RAIL_PA_ALGORITHM_MAPPING_TABLE,
+      .segments = 0U,
+      .min = RAIL_TX_POWER_LEVEL_2P4_LP_MIN,
+      .max = RAIL_TX_POWER_LEVEL_2P4_LP_MAX,
+      .conversion = { .mappingTable = &RAIL_curves24Lp[0] },
+    },
+  }
+};
+#else
 #error "Unsupported platform!"
+#endif
 #endif
 
 #endif //_SILICON_LABS_MODULE

--- a/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h
+++ b/gecko/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.h
@@ -61,11 +61,17 @@ extern "C" {
 #elif (_SILICON_LABS_32B_SERIES_2_CONFIG == 8)
 #if defined(_SILICON_LABS_EFR32_SUBGHZ_HP_PA_PRESENT)
   #if (_SILICON_LABS_EFR32_SUBGHZ_HP_PA_MAX_OUTPUT_DBM == 20)
-  #include "efr32xg28/sl_rail_util_pa_curves_20dbm.h"
-  #elif (_SILICON_LABS_EFR32_SUBGHZ_HP_PA_MAX_OUTPUT_DBM == 10)
-  #include "efr32xg28/sl_rail_util_pa_curves_10dbm_434M.h"
+    #if defined(HARDWARE_BOARD_SUPPORTS_RF_BAND_868)
+      #include "efr32xg28/sl_rail_util_pa_curves_20dbm_868M.h"
+    #else
+      #include "efr32xg28/sl_rail_util_pa_curves_20dbm_915M.h"
+    #endif
   #else
-  #include "efr32xg28/sl_rail_util_pa_curves_14dbm.h"
+    #if defined(HARDWARE_BOARD_SUPPORTS_RF_BAND_868)
+      #include "efr32xg28/sl_rail_util_pa_curves_14dbm_868M.h"
+    #else
+      #include "efr32xg28/sl_rail_util_pa_curves_14dbm_915M.h"
+    #endif
   #endif
 #else
 #error "No valid PA available for selected chip."
@@ -82,9 +88,23 @@ extern "C" {
 #include "efr32xg25/sl_rail_util_pa_dbm_powersetting_mapping_table.h"
 #include "efr32xg25/sl_rail_util_pa_curves.h"
 #elif (_SILICON_LABS_32B_SERIES_2_CONFIG == 7)
-#include "efr32xg27/sl_rail_util_pa_curves.h"
+// EFR32XG27 boards come in two different packaging -- CSP and QFN
+// These packages have different matching circuits which leads
+// to different PA curves.
+// CSP packages have _SILICON_LABS_EFR32_2G4HZ_HP_PA_MAX_OUTPUT_DBM
+// = 4 whereas for QFN package it is 6 or 8dBm, so this parameter
+// is used to differentiate it.
+  #if (_SILICON_LABS_EFR32_2G4HZ_HP_PA_MAX_OUTPUT_DBM < 6)
+  #include "efr32xg27/sl_rail_util_pa_curves_CSP.h"
+  #else
+  #include "efr32xg27/sl_rail_util_pa_curves_QFN.h"
+  #endif
+#else
+#ifdef RAIL_INTERNAL_BUILD
+#include "pa_curves_efr32_internal.h"
 #else
 #error "Unsupported platform!"
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/gecko/platform/radio/rail_lib/plugin/rail_util_protocol/sl_rail_util_protocol.c
+++ b/gecko/platform/radio/rail_lib/plugin/rail_util_protocol/sl_rail_util_protocol.c
@@ -36,6 +36,7 @@
 #include "rail_ble.h"
 #include "rail_ieee802154.h"
 #include "rail_zwave.h"
+#include "rail_sidewalk.h"
 
 #include "sl_rail_util_protocol.h"
 
@@ -45,7 +46,7 @@ static RAIL_Status_t sl_rail_util_protocol_config_proprietary(RAIL_Handle_t hand
   return RAIL_STATUS_NO_ERROR;
 }
 
-#if RAIL_SUPPORTS_2P4GHZ_BAND && SL_RAIL_UTIL_PROTOCOL_BLE_ENABLE
+#if RAIL_SUPPORTS_PROTOCOL_BLE && SL_RAIL_UTIL_PROTOCOL_BLE_ENABLE
 static RAIL_Status_t sl_rail_util_protocol_config_ble(RAIL_Handle_t handle,
                                                       sl_rail_util_protocol_type_t protocol)
 {
@@ -331,6 +332,16 @@ static RAIL_Status_t sl_rail_util_protocol_config_zwave(RAIL_Handle_t handle,
         status = RAIL_ZWAVE_ConfigRegion(handle,
                                          &RAIL_ZWAVE_REGION_US_LR_END_DEVICE);
         break;
+      case SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR1: // EU, Long Range 1
+        status = RAIL_ZWAVE_ConfigRegion(handle, &RAIL_ZWAVE_REGION_EU_LR1);
+        break;
+      case SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR2: // EU, Long Range 2
+        status = RAIL_ZWAVE_ConfigRegion(handle, &RAIL_ZWAVE_REGION_EU_LR2);
+        break;
+      case SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR_END_DEVICE: // EU, LR End Device
+        status = RAIL_ZWAVE_ConfigRegion(handle,
+                                         &RAIL_ZWAVE_REGION_EU_LR_END_DEVICE);
+        break;
       default:
         status = RAIL_STATUS_INVALID_PARAMETER;
         break;
@@ -346,26 +357,43 @@ static RAIL_Status_t sl_rail_util_protocol_config_zwave(RAIL_Handle_t handle,
 }
 #endif // RAIL_FEAT_SUBGIG_RADIO
 
+#if RAIL_SUPPORTS_PROTOCOL_SIDEWALK && SL_RAIL_UTIL_PROTOCOL_SIDEWALK_ENABLE
+static RAIL_Status_t sl_rail_util_protocol_config_sidewalk(RAIL_Handle_t handle,
+                                                           sl_rail_util_protocol_type_t protocol)
+{
+  RAIL_Status_t status;
+  switch (protocol) {
+    case SL_RAIL_UTIL_PROTOCOL_SIDEWALK_2GFSK_50KBPS:
+      status = RAIL_Sidewalk_ConfigPhy2GFSK50kbps(handle);
+      break;
+    default:
+      status = RAIL_STATUS_INVALID_PARAMETER;
+      break;
+  }
+  return status;
+}
+#endif // RAIL_SUPPORTS_PROTOCOL_SIDEWALK && SL_RAIL_UTIL_PROTOCOL_SIDEWALK_ENABLE
+
 RAIL_Status_t sl_rail_util_protocol_config(RAIL_Handle_t handle,
                                            sl_rail_util_protocol_type_t protocol)
 {
   switch (protocol) {
     case SL_RAIL_UTIL_PROTOCOL_PROPRIETARY:
       return sl_rail_util_protocol_config_proprietary(handle);
-#if RAIL_SUPPORTS_2P4GHZ_BAND && SL_RAIL_UTIL_PROTOCOL_BLE_ENABLE
+#if RAIL_SUPPORTS_PROTOCOL_BLE && SL_RAIL_UTIL_PROTOCOL_BLE_ENABLE
     case SL_RAIL_UTIL_PROTOCOL_BLE_1MBPS:
     case SL_RAIL_UTIL_PROTOCOL_BLE_2MBPS:
     case SL_RAIL_UTIL_PROTOCOL_BLE_CODED_125KBPS:
     case SL_RAIL_UTIL_PROTOCOL_BLE_CODED_500KBPS:
     case SL_RAIL_UTIL_PROTOCOL_BLE_QUUPPA_1MBPS:
       return sl_rail_util_protocol_config_ble(handle, protocol);
+#endif
 #if RAIL_SUPPORTS_IEEE802154_BAND_2P4  && SL_RAIL_UTIL_PROTOCOL_IEEE802154_2P4GHZ_ENABLE
     case SL_RAIL_UTIL_PROTOCOL_IEEE802154_2P4GHZ:
     case SL_RAIL_UTIL_PROTOCOL_IEEE802154_2P4GHZ_ANTDIV:
     case SL_RAIL_UTIL_PROTOCOL_IEEE802154_2P4GHZ_COEX:
     case SL_RAIL_UTIL_PROTOCOL_IEEE802154_2P4GHZ_ANTDIV_COEX:
       return sl_rail_util_protocol_config_ieee802154_2p4ghz(handle, protocol);
-#endif
 #endif
 #if RAIL_SUPPORTS_SUBGHZ_BAND && SL_RAIL_UTIL_PROTOCOL_IEEE802154_GB868_ENABLE
     case SL_RAIL_UTIL_PROTOCOL_IEEE802154_GB868_915MHZ:
@@ -387,7 +415,14 @@ RAIL_Status_t sl_rail_util_protocol_config(RAIL_Handle_t handle,
     case SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR1: // United States, Long Range 1
     case SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR2: // United States, Long Range 2
     case SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR_END_DEVICE: // US, LR End Device
+    case SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR1: // European Union, Long Range 1
+    case SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR2: // European Union, Long Range 2
+    case SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR_END_DEVICE: // EU, LR End Device
       return sl_rail_util_protocol_config_zwave(handle, protocol);
+#endif
+#if RAIL_SUPPORTS_PROTOCOL_SIDEWALK && SL_RAIL_UTIL_PROTOCOL_SIDEWALK_ENABLE
+    case SL_RAIL_UTIL_PROTOCOL_SIDEWALK_2GFSK_50KBPS:
+      return sl_rail_util_protocol_config_sidewalk(handle, protocol);
 #endif
     default:
       return RAIL_STATUS_INVALID_PARAMETER;

--- a/gecko/platform/radio/rail_lib/plugin/rail_util_protocol/sl_rail_util_protocol_types.h
+++ b/gecko/platform/radio/rail_lib/plugin/rail_util_protocol/sl_rail_util_protocol_types.h
@@ -62,6 +62,10 @@ typedef enum sl_rail_util_protocol_type{
   SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR1,
   SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR2,
   SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR_END_DEVICE,
+  SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR1,
+  SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR2,
+  SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR_END_DEVICE,
+  SL_RAIL_UTIL_PROTOCOL_SIDEWALK_2GFSK_50KBPS,
 } sl_rail_util_protocol_type_t;
 
 #define SL_RAIL_UTIL_PROTOCOL_IS_BLE(x)              \
@@ -80,21 +84,27 @@ typedef enum sl_rail_util_protocol_type{
   ((x == SL_RAIL_UTIL_PROTOCOL_IEEE802154_GB868_915MHZ) \
    || (x == SL_RAIL_UTIL_PROTOCOL_IEEE802154_GB868_863MHZ))
 
-#define SL_RAIL_UTIL_PROTOCOL_IS_ZWAVE(x)       \
-  ((x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_ANZ)       \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_CN)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_HK)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_IN)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_IL)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_JP)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_KR)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_MY)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_RU)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_US)     \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR1) \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR2) \
-   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR_END_DEVICE))
+#define SL_RAIL_UTIL_PROTOCOL_IS_ZWAVE(x)                 \
+  ((x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_ANZ)                 \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_CN)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_HK)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_IN)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_IL)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_JP)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_KR)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_MY)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_RU)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_US)               \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR1)           \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR2)           \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_US_LR_END_DEVICE) \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR1)           \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR2)           \
+   || (x == SL_RAIL_UTIL_PROTOCOL_ZWAVE_EU_LR_END_DEVICE))
+
+#define SL_RAIL_UTIL_PROTOCOL_IS_SIDEWALK(x) \
+  ((x == SL_RAIL_UTIL_PROTOCOL_SIDEWALK_2GFSK_50KBPS))
 
 #ifdef __cplusplus
 }

--- a/gecko/platform/radio/rail_lib/plugin/rail_util_sequencer/config/efr32xg13/sl_rail_util_sequencer_config.h
+++ b/gecko/platform/radio/rail_lib/plugin/rail_util_sequencer/config/efr32xg13/sl_rail_util_sequencer_config.h
@@ -1,0 +1,60 @@
+/***************************************************************************//**
+ * @file
+ * @brief
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_RAIL_UTIL_SEQUENCER_H
+#define SL_RAIL_UTIL_SEQUENCER_H
+
+#include "rail.h"
+#if defined(SL_COMPONENT_CATALOG_PRESENT)
+#include "sl_component_catalog.h"
+#endif
+
+#if defined(SL_CATALOG_RAIL_UTIL_IEEE802154_HIGH_SPEED_PHY_PRESENT)
+#include "sl_rail_util_ieee802154_high_speed_phy_config.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SL_RAIL_UTIL_SEQUENCER_RUNTIME_IMAGE_SELECTION 0
+
+#if (defined(SL_CATALOG_RAIL_UTIL_IEEE802154_HIGH_SPEED_PHY_PRESENT) \
+  && (SL_RAIL_UTIL_IEEE802154_2P4_2MBPS_PHY_ENABLED == 1))
+#define SL_RAIL_UTIL_SEQUENCER_IMAGE RAIL_SEQ_IMAGE_HIGH_BW_PHY
+#else
+#define SL_RAIL_UTIL_SEQUENCER_IMAGE RAIL_SEQ_IMAGE_ZWAVE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SL_RAIL_UTIL_SEQUENCER_H

--- a/gecko/platform/radio/rail_lib/plugin/rail_util_sequencer/sl_rail_util_sequencer.c
+++ b/gecko/platform/radio/rail_lib/plugin/rail_util_sequencer/sl_rail_util_sequencer.c
@@ -1,0 +1,45 @@
+/***************************************************************************//**
+ * @file
+ * @brief
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#include "sl_rail_util_sequencer_config.h"
+#include "rail.h"
+
+#if !SL_RAIL_UTIL_SEQUENCER_RUNTIME_IMAGE_SELECTION \
+  && defined(SL_RAIL_UTIL_SEQUENCER_IMAGE)
+RAIL_Status_t RAILCb_RadioSequencerImageLoad(void)
+{
+#if SL_RAIL_UTIL_SEQUENCER_IMAGE == RAIL_SEQ_IMAGE_1
+  return RAIL_LoadSequencerImage1(RAIL_EFR32_HANDLE);
+#elif SL_RAIL_UTIL_SEQUENCER_IMAGE == RAIL_SEQ_IMAGE_2
+  return RAIL_LoadSequencerImage2(RAIL_EFR32_HANDLE);
+#else
+  #error "Must choose a valid sequencer image!"
+#endif
+}
+#endif

--- a/gecko/platform/radio/rail_lib/protocol/ble/rail_ble.h
+++ b/gecko/platform/radio/rail_lib/protocol/ble/rail_ble.h
@@ -206,6 +206,22 @@ extern const RAIL_ChannelConfig_t *const RAIL_BLE_Phy1MbpsViterbi;
  */
 extern const RAIL_ChannelConfig_t *const RAIL_BLE_Phy2MbpsViterbi;
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * Default PHY to use for BLE 1M Viterbi HADM. Will be NULL if
+ * \ref RAIL_BLE_SUPPORTS_HADM is 0. On EFR32XG24, this will also
+ * be NULL for non 40MHz HFXO frequencies.
+ */
+extern const RAIL_ChannelConfig_t *const RAIL_BLE_Phy1MbpsViterbiHadm;
+
+/**
+ * Default PHY to use for BLE 2M Viterbi HADM. Will be NULL if
+ * \ref RAIL_BLE_SUPPORTS_HADM is 0. On EFR32XG24, this will also
+ * be NULL for non 40MHz HFXO frequencies.
+ */
+extern const RAIL_ChannelConfig_t *const RAIL_BLE_Phy2MbpsViterbiHadm;
+#endif
+
 /**
  * PHY to use for BLE 2M with AoX functionality. Will be NULL if either
  * \ref RAIL_BLE_SUPPORTS_2MBPS_VITERBI or \ref RAIL_BLE_SUPPORTS_AOX is 0.
@@ -286,6 +302,7 @@ typedef struct RAIL_BLE_State {
   uint32_t accessAddress; /**< The access address used for the connection. */
   uint16_t channel; /**< The logical channel used. */
   bool disableWhitening; /**< Indicates whether the whitening engine should be off. */
+  uint16_t whiteInit; /**< The value used to initialize the whitening algorithm */
 } RAIL_BLE_State_t;
 
 /**
@@ -436,12 +453,42 @@ RAIL_Status_t RAIL_BLE_ConfigPhyCoded(RAIL_Handle_t railHandle,
  */
 RAIL_Status_t RAIL_BLE_ConfigPhySimulscan(RAIL_Handle_t railHandle);
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * Switch to the 1 Mbps BLE PHY for HADM.
+ *
+ * @param[in] railHandle A handle for RAIL instance.
+ * @return A status code indicating success of the function call.
+ *
+ * Use this function to switch back to the BLE 1 Mbps HADM PHY from
+ * another configuration. You may only call this
+ * function after initializing BLE and while the radio is idle.
+ *
+ * @note This PHY is only supported when \ref RAIL_BLE_SUPPORTS_HADM is not 0.
+ */
+RAIL_Status_t RAIL_BLE_ConfigPhy1MbpsHadm(RAIL_Handle_t railHandle);
+
+/**
+ * Switch to the 2 Mbps BLE PHY for HADM.
+ *
+ * @param[in] railHandle A handle for RAIL instance.
+ * @return A status code indicating success of the function call.
+ *
+ * Use this function to switch back to the BLE 2 Mbps HADM PHY from
+ * another configuration. You may only call this
+ * function after initializing BLE and while the radio is idle.
+ *
+ * @note This PHY is only supported when \ref RAIL_BLE_SUPPORTS_HADM is not 0.
+ */
+RAIL_Status_t RAIL_BLE_ConfigPhy2MbpsHadm(RAIL_Handle_t railHandle);
+#endif
+
 /**
  * Change BLE radio parameters.
  *
  * @param[in] railHandle A handle for RAIL instance.
  * @param[in] crcInit The value to use for CRC initialization.
- * @param[in] accessAddress The access address to use for the connection.  The
+ * @param[in] accessAddress The access address to use for the connection. The
  * bits of this parameter are transmitted or received LSB first.
  * @param[in] channel The logical channel that you're changing to, which
  * initializes the whitener if used.
@@ -518,7 +565,7 @@ RAIL_Status_t RAIL_BLE_ConfigSignalIdentifier(RAIL_Handle_t railHandle,
                                               RAIL_BLE_SignalIdentifierMode_t signalIdentifierMode);
 
 /**
- * Enable or Disable signal identifier interrupt for BLE signal detection.
+ * Enable or disable signal identifier interrupt for BLE signal detection.
  *
  * @param[in] railHandle A RAIL instance handle.
  * @param[in] enable Signal detection is enabled if true, disabled if false.
@@ -649,11 +696,13 @@ typedef struct RAIL_BLE_AoxConfig {
   RAIL_BLE_AoxOptions_t aoxOptions;
   /**
    * Size of the raw AoX CTE (continuous tone extension) data capture buffer in
-   * bytes.
+   * bytes. Note this value should be a multiple of 4 as each IQ sample
+   * requires 4 bytes.
    */
   uint16_t cteBuffSize;
   /**
-   * Address to where the received CTE is written.
+   * Address to where the received CTE is written. Buffer must be 32-bit
+   * aligned.
    */
   uint32_t * cteBuffAddr;
   /**
@@ -797,6 +846,603 @@ RAIL_Status_t RAIL_BLE_ConfigAoxAntenna(RAIL_Handle_t railHandle,
                                         RAIL_BLE_AoxAntennaConfig_t *antennaConfig);
 
 /** @} */  // end of group AoX
+
+ #ifndef DOXYGEN_SHOULD_SKIP_THIS
+/******************************************************************************
+ * High Accuracy Distance Measurement (HADM)
+ *****************************************************************************/
+/**
+ * @addtogroup HADM High Accuracy Distance Measurement
+ * @{
+ * @brief These APIs are to a stack implementing BLE's high accuracy distance
+ * measurement functionality.
+ *
+ * They are designed for use by the Silicon Labs BLE stack only at this time and
+ * may cause problems if accessed directly.
+ */
+
+/**
+ * @enum RAIL_BLE_HadmRole_t
+ * @brief The device role during HADM events.
+ */
+RAIL_ENUM(RAIL_BLE_HadmRole_t) {
+  /** Device cannot perform HADM events. */
+  RAIL_BLE_HADM_ROLE_UNASSIGNED = 0,
+  /** Device is an initiator during HADM events */
+  RAIL_BLE_HADM_ROLE_INITIATOR = 1,
+  /** Device is a reflector during HADM events */
+  RAIL_BLE_HADM_ROLE_REFLECTOR = 2,
+};
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+// Self-referencing defines minimize compiler complaints when using RAIL_ENUM
+#define RAIL_BLE_HADM_ROLE_UNASSIGNED ((RAIL_BLE_HadmRole_t) RAIL_BLE_HADM_ROLE_UNASSIGNED)
+#define RAIL_BLE_HADM_ROLE_INITIATOR  ((RAIL_BLE_HadmRole_t) RAIL_BLE_HADM_ROLE_INITIATOR)
+#define RAIL_BLE_HADM_ROLE_REFLECTOR  ((RAIL_BLE_HadmRole_t) RAIL_BLE_HADM_ROLE_REFLECTOR)
+#endif//DOXYGEN_SHOULD_SKIP_THIS
+
+/**
+ * @struct RAIL_BLE_HadmResults_t
+ * @brief Contains measurement results from HADM step
+ */
+typedef struct {
+  uint32_t result[7]; /**< HADM measurement data for a particular step. */
+} RAIL_BLE_HadmResults_t;
+
+/**
+ * @enum RAIL_BLE_HadmRttType_t
+ * @brief HADM RTT Types.
+ */
+RAIL_ENUM(RAIL_BLE_HadmRttType_t) {
+  /** Coarse cost function engine method RTT. */
+  RAIL_BLE_HADM_RTT_AA_ONLY = 0U,
+  /** 32 bit sounding sequence method RTT. */
+  RAIL_BLE_HADM_RTT_32B_SS = 1U,
+  /** 96 bit sounding sequence method RTT. */
+  RAIL_BLE_HADM_RTT_96B_SS = 2U,
+};
+
+/**
+ *  The minimum size in 32 bit words for the IQ buffer. This value guarantees
+ *  all IQ samples for a single 1mbps HADM step can be stored.
+ */
+#define RAIL_BLE_HADM_1MBPS_MINIMUM_IQ_BUFFER_SIZE  600
+
+/**
+ * @struct RAIL_BLE_HadmConfig_t
+ * @brief Contains arguments for \ref RAIL_BLE_ConfigHadm function.
+ */
+typedef struct RAIL_BLE_HadmConfig {
+  RAIL_BLE_HadmRole_t role; /**< The device role during HADM event. */
+  uint16_t hadmSqteSteps; /**< Number of steps in HADM event. */
+  /** Pointer to HADM measurements. Set to NULL if unused. */
+  RAIL_BLE_HadmResults_t *pHadmDataOutput;
+  uint16_t t_fcs; /**< Frequency change spacing (in us). */
+  uint16_t t_ip1; /**< Interlude period for mode 0 & 1 steps (in us). */
+  uint16_t t_ip2; /**< Interlude period for mode 2 steps (in us). */
+  uint16_t t_pm; /**< Phase measurement time (in us). */
+  /**
+   * Pointer to buffer where IQ data will be written. Buffer must be 32-bit
+   * aligned.
+   */
+  uint32_t *pIqBuffer;
+  /**
+   * Size of IQ buffer in 32 bit words. Must be at least \ref
+   * RAIL_BLE_HADM_1MBPS_MINIMUM_IQ_BUFFER_SIZE or else an error will be
+   * returned by \ref RAIL_BLE_ConfigHadm.
+   */
+  uint16_t iqBufferSize;
+  /**
+   * Step Index to perform the event calibration. This index must correspond
+   * to a mode 0 step or else the event calibration won't occur.
+   */
+  uint8_t eventCalStepIndex;
+  RAIL_BLE_HadmRttType_t rttType; /**< RTT type returned during mode 1 step. */
+  /**
+   * A pointer to the selected HADM event gain index. This field will be
+   * populated after \ref eventCalStepIndex has been reached.
+   */
+  uint8_t *pEventGainIndex;
+  /**
+   * A pointer to the selected HADM event Fractional Frequency Offset
+   * (FFO) * 100. This field will be populated after \ref eventCalStepIndex
+   * has been reached.
+   */
+  int16_t *pEventFfo;
+  bool disableRttGdComp; /**< Debug flag to disable RTT GD compensation. */
+  bool disablePbrDcComp; /**< Debug flag to disable PBR DC compensation. */
+  bool disablePbrGdComp; /**< Debug flag to disable PBR GD compensation. */
+  bool forceAgcGain;     /**< Debug flag to force event gain for calibration. */
+  uint32_t forcedAgcStatus0; /**< Equivalent AGC status0 register to force. */
+} RAIL_BLE_HadmConfig_t;
+
+/** The maximum number of HADM steps allowed during a HADM event */
+#define RAIL_BLE_HADM_MAX_SQTE_STEPS 512
+
+/**
+ * @enum RAIL_BLE_HadmStepState_t
+ * @brief The current HADM step state.
+ */
+RAIL_ENUM(RAIL_BLE_HadmStepState_t) {
+  /** HADM step state idle */
+  RAIL_BLE_HADM_STATE_IDLE = 0,
+  /** HADM step state initiator initiator transmit mode 0 */
+  RAIL_BLE_HADM_STATE_I_TX_MODE0 = 1,
+  /** HADM step state initiator reflector transmit mode 0 */
+  RAIL_BLE_HADM_STATE_R_TX_MODE0 = 2,
+  /** HADM step state initiator initiator transmit mode 1 */
+  RAIL_BLE_HADM_STATE_I_TX_MODE1 = 3,
+  /** HADM step state initiator reflector transmit mode 1 */
+  RAIL_BLE_HADM_STATE_R_TX_MODE1 = 4,
+  /** HADM step state initiator initiator transmit mode 2 */
+  RAIL_BLE_HADM_STATE_R_TX_MODE2 = 6,
+  /** HADM step state initiator reflector transmit mode 2 */
+  RAIL_BLE_HADM_STATE_I_TX_MODE2 = 7,
+};
+
+/**
+ * First step state for HADM mode 0.
+ */
+#define RAIL_BLE_HADM_STEP_MODE0             RAIL_BLE_HADM_STATE_I_TX_MODE0
+
+/**
+ * First step state for HADM mode 1.
+ */
+#define RAIL_BLE_HADM_STEP_MODE1             RAIL_BLE_HADM_STATE_I_TX_MODE1
+
+/**
+ * First step state for HADM mode 2.
+ */
+#define RAIL_BLE_HADM_STEP_MODE2             RAIL_BLE_HADM_STATE_I_TX_MODE2
+
+/**
+ * @enum RAIL_BLE_HadmStepMode_t
+ * @brief The HADM step mode.
+ */
+RAIL_ENUM(RAIL_BLE_HadmStepMode_t) {
+  RAIL_BLE_HADM_MODE_0,   /**< HADM step mode 0. */
+  RAIL_BLE_HADM_MODE_1,   /**< HADM step mode 1. */
+  RAIL_BLE_HADM_MODE_2,   /**< HADM step mode 2. */
+  RAIL_BLE_HADM_MODE_3,   /**< HADM step mode 3. */
+};
+
+/**
+ * @enum RAIL_BLE_HadmAntennaId_t
+ * @brief The HADM antenna ID.
+ */
+RAIL_ENUM(RAIL_BLE_HadmAntennaId_t) {
+  RAIL_BLE_HADM_ANTENNA_1 = 0, /**< HADM antenna ID 1. */
+  RAIL_BLE_HADM_ANTENNA_2, /**< HADM antenna ID 2. */
+  RAIL_BLE_HADM_ANTENNA_3, /**< HADM antenna ID 3. */
+  RAIL_BLE_HADM_ANTENNA_4, /**< HADM antenna ID 4. */
+};
+
+/**
+ * @enum RAIL_BLE_HadmRttPacketQuality_t
+ * @brief HADM RTT packet quality.
+ */
+RAIL_ENUM(RAIL_BLE_HadmRttPacketQuality_t) {
+  /** Access address check succeeded. */
+  RAIL_BLE_HADM_RTT_AA_SUCCESS = 0U,
+  /** Access address had one or more bit errors. */
+  RAIL_BLE_HADM_RTT_AA_BIT_ERRORS = 1U,
+  /** Access address not found. */
+  RAIL_BLE_HADM_RTT_AA_NOT_FOUND = 2U,
+};
+
+/**
+ * @struct RAIL_BLE_HadmMode0Results_t
+ * @brief Contains HADM mode 0 step measurement results.
+ */
+typedef struct RAIL_BLE_HadmMode0Results {
+  /** Mode of HADM step. */
+  uint8_t mode;
+  /** Antenna ID. */
+  RAIL_BLE_HadmAntennaId_t antenna;
+  /** RSSI during step in integer dBm. */
+  int8_t rssi;
+  /** Packet quality */
+  uint8_t packetQuality;
+  /** Reserved */
+  uint16_t reserved;
+  /** Fractional Frequency Offset (FFO) * 100 */
+  int16_t hadmFfo;
+  /** The gain setting. */
+  uint32_t stepGainSetting;
+  /** Reserved */
+  uint32_t reserved1;
+} RAIL_BLE_HadmMode0Results_t;
+
+/**
+ *  A sentinel value to indicate an invalid rtt time value in
+ *  \ref RAIL_BLE_HadmMode1Results_t::rttHalfNs
+ */
+#define RAIL_BLE_HADM_INVALID_RTT_VALUE ((int16_t)0x8000)
+
+/**
+ * @struct RAIL_BLE_HadmMode1Results_t
+ * @brief Contains HADM mode 1 step measurement results.
+ */
+typedef struct RAIL_BLE_HadmMode1Results {
+  /** Mode of HADM step. */
+  uint8_t mode;
+  /** Antenna ID. */
+  RAIL_BLE_HadmAntennaId_t antenna;
+  /** RSSI during step in integer dBm. */
+  int8_t rssi;
+  /** Packet quality */
+  uint8_t packetQuality;
+  /**
+   * For the initiator, this is the time (in 0.5 ns units) between time of
+   * departure and time of arrival excluding known offsets such as interlude
+   * period and packet length.
+   * For the reflector, this is the time (in 0.5 ns units) between time of
+   * arrival and time of departure excluding known offsets such as interlude
+   * period and packet length.
+   */
+  int16_t rttHalfNs;
+  /** Flag used to indicate whether we have missed FCAL during calibration */
+  uint8_t missedFcal;
+  /** Reserved */
+  uint8_t reserved1;
+  /** Reserved */
+  uint32_t reserved2[2];
+} RAIL_BLE_HadmMode1Results_t;
+
+/**
+ * @enum RAIL_BLE_HadmToneQuality_t
+ * @brief HADM tone quality.
+ */
+RAIL_ENUM(RAIL_BLE_HadmToneQuality_t) {
+  /** Good quality HADM mode 2 tone. */
+  RAIL_BLE_HADM_TONE_QUALITY_GOOD = 0U,
+  /** Medium quality HADM mode 2 tone. */
+  RAIL_BLE_HADM_TONE_QUALITY_MEDIUM = 1U,
+  /** Low quality HADM mode 2 tone. */
+  RAIL_BLE_HADM_TONE_QUALITY_LOW = 2U,
+  /** HADM mode 2 tone quality indication unavailable. */
+  RAIL_BLE_HADM_TONE_QUALITY_UNAVAILABLE = 3U,
+};
+
+/**
+ * @struct RAIL_BLE_HadmMode2Results_t
+ * @brief Contains HADM mode 2 step measurement results.
+ */
+typedef struct RAIL_BLE_HadmMode2Results {
+  /** Mode of HADM step. */
+  uint8_t mode;
+  /** Antenna ID. */
+  RAIL_BLE_HadmAntennaId_t antenna;
+  /** Flag used to indicate whether we have missed FCAL during calibration */
+  uint8_t missedFcal;
+  /** Reserved */
+  uint8_t reserved1;
+  /** PCT i value */
+  int16_t pctI;
+  /** PCT q value */
+  int16_t pctQ;
+  /** Tone extension PCT i value */
+  int16_t pctToneExtI;
+  /** Tone extension PCT q value */
+  int16_t pctToneExtQ;
+  /** Tone quality indicator */
+  RAIL_BLE_HadmToneQuality_t tqi;
+  /** Tone quality indicator for tone extension */
+  RAIL_BLE_HadmToneQuality_t tqiToneExt;
+  /** Reserved */
+  uint16_t reserved2;
+} RAIL_BLE_HadmMode2Results_t;
+
+/**
+ * @struct RAIL_BLE_HadmStepResults_t
+ * @brief Generic HADM step mode result structure. Based on the value of the
+ *   mode field, this structure can be type cast to the appropriate mode
+ *   specific structure \ref RAIL_BLE_HadmMode0Results_t,
+ *   \ref RAIL_BLE_HadmMode1Results_t, or RAIL_BLE_HadmMode2Results_t.
+ */
+typedef struct RAIL_BLE_HadmStepResults {
+  /** Mode of HADM step. */
+  uint8_t mode;
+  /** Reserved */
+  uint8_t reserved0;
+  /** Reserved */
+  uint16_t reserved1;
+  /** Reserved */
+  uint32_t reserved2[3];
+} RAIL_BLE_HadmStepResults_t;
+
+/**
+ * @struct RAIL_BLE_HadmMode0DebugResults_t
+ * @brief Contains HADM mode 0 step measurement debug results.
+ */
+typedef struct RAIL_BLE_HadmMode0DebugResults {
+  /** Highest recorded RSSI up to and including the current mode 0 step. */
+  int16_t highestRssi;
+  /**
+   * FFO of the Mode 0 step with the highest recorded RSSI
+   * up to and including the current Mode 0 step.
+   */
+  int16_t hadmFfo;
+  /**
+   * AGC gain value of the Mode 0 step with the highest recorded
+   * RSSI up to and including the current Mode 0 step.
+   */
+  uint32_t agcStatus0;
+  /**
+   * For devices configured as an initiator, the measured frequency offset
+   * in Hz between the two devices during a HADM mode 0 step. For devices
+   * configured as a reflector, this value will always be 0.
+   */
+  int32_t freqOffHz;
+  /**
+   * Estimated coarse frequency offset in internal units.
+   */
+  int32_t hwFreqOffEst;
+  /** Reserved */
+  uint32_t reserved[3];
+} RAIL_BLE_HadmMode0DebugResults_t;
+
+/**
+ * @struct RAIL_BLE_HadmMode1DebugResults_t
+ * @brief Contains HADM mode 1 step measurement debug results.
+ */
+typedef struct RAIL_BLE_HadmMode1DebugResults {
+  uint16_t toxClks;
+  int16_t fracRttHalfNs;
+  uint32_t coarseRttHalfNs;
+  int32_t gdCompRttHalfNs;
+  int32_t toxWithOffsetsRttHalfNs;
+  uint32_t hadmstatus3;
+  uint32_t hadmstatus4;
+  uint32_t hadmstatus5;
+} RAIL_BLE_HadmMode1DebugResults_t;
+
+/**
+ * @struct RAIL_BLE_HadmMode2DebugResults_t
+ * @brief Contains HADM mode 2 step measurement debug results.
+ */
+typedef struct RAIL_BLE_HadmMode2DebugResults {
+  /** DCCOMP i value */
+  int16_t dcCompI;
+  /** DCCOMP q value */
+  int16_t dcCompQ;
+  /** GDCOMP i value */
+  int16_t gdCompI;
+  /** GDCOMP q value */
+  int16_t gdCompQ;
+  /** Raw tone quality value */
+  uint16_t tqiRaw;
+  /** Raw tone quality tone extension value */
+  uint16_t tqiToneExtRaw;
+  /** FCAL value from SYNTH_VCOTUNING */
+  uint16_t fcal;
+  /** Reserved */
+  uint16_t reserved;
+  /** Reserved */
+  uint32_t reserved1[3];
+} RAIL_BLE_HadmMode2DebugResults_t;
+
+/**
+ * @struct RAIL_BLE_HadmStepDebugResults_t
+ * @brief Generic HADM step mode debug result structure. Based on the value of
+ *   the mode field, this structure can be type cast to the appropriate mode
+ *   specific structure \ref RAIL_BLE_HadmMode0DebugResults_t,
+ *   \ref RAIL_BLE_HadmMode1DebugResults_t, or RAIL_BLE_HadmMode2DebugResults_t.
+ */
+typedef struct RAIL_BLE_HadmStepDebugResults {
+  uint32_t reserved;
+  uint32_t reserved1;
+  uint32_t reserved2;
+  uint32_t reserved3;
+  uint32_t reserved4;
+  uint32_t reserved5;
+  uint32_t reserved6;
+} RAIL_BLE_HadmStepDebugResults_t;
+
+/**
+ * @struct RAIL_BLE_HadmStepConfig_t
+ * @brief Contains arguments for \ref RAIL_BLE_SetNextHadmStep.
+ */
+typedef struct RAIL_BLE_HadmStepConfig {
+  /** Sets the HADM step state. */
+  RAIL_BLE_HadmStepState_t stepState;
+  /** Indicates whether this is final step in HADM event. */
+  bool lastStep;
+  /**
+   * Transmit tone during tone extension slot in mode 2 packet.
+   * This field is ignored during RX and for all non mode 2 packets.
+   */
+  bool transmitToneExtension;
+  /** Sets the HADM step logical channel. */
+  uint16_t channel;
+  /**
+   * Length of packet payload in bytes. Should not include trailer, guard,
+   * or UC bits. Only used for mode 1 steps, ignored otherwise.
+   */
+  uint16_t packetLength;
+  /** The initiator (first) access address during step. */
+  uint32_t initAccessAddress;
+  /** The reflector (second) access address during step. */
+  uint32_t reflAccessAddress;
+  /** Pointer to TX data to be transmitted. Ignored for mode 0 and 2 steps. */
+  uint8_t *pTxData;
+  /** RTT marker bit position. Ignored for mode 0 and 2 steps. */
+  uint8_t rttMarkerBitPosition[2];
+  /**
+   * A pointer to an array of HADM step results. These results will be
+   * populated after the completion of the HADM step. This array can be cast to
+   * \ref RAIL_BLE_HadmMode0Results_t, \ref RAIL_BLE_HadmMode1Results_t, or
+   * \ref RAIL_BLE_HadmMode2Results_t as appropriate to read mode specific
+   * results.
+   */
+  RAIL_BLE_HadmStepResults_t *pResults;
+  /**
+   * A pointer to an array of HADM step debug results. These results will be
+   * populated after the completion of the HADM step. This array can be cast to
+   * \ref RAIL_BLE_HadmMode0DebugResults_t, \ref
+   * RAIL_BLE_HadmMode1DebugResults_t, or \ref RAIL_BLE_HadmMode2DebugResults_t
+   * as appropriate to read mode specific debug results.
+   *
+   * Setting this pointer to NULL means no debug data will be collected.
+   */
+  RAIL_BLE_HadmStepDebugResults_t *pDebugResults;
+  /**
+   * Pointer to contiguous global read-write memory that will be used
+   * by RAIL to store channel switching information.
+   * It need not be initialized and applications should never write
+   * data anywhere in this buffer.
+   *
+   * @note the size in words of this buffer must be at least as large as
+   * 3 + /ref RAIL_CHANNEL_HOPPING_BUFFER_SIZE_PER_CHANNEL. This buffer
+   * is for internal use to the library.
+   */
+  uint32_t *pBuffer;
+  /**
+   * This parameter must be set to the length of the buffer array. This way,
+   * during configuration, the software can confirm it's writing within the
+   * range of the buffer. The configuration API will return an error
+   * if bufferLength is insufficient.
+   */
+  uint16_t bufferLength;
+  /** Reserved */
+  uint16_t reserved0;
+  /**
+   * A pointer to the start of captured IQ data for this step. This pointer
+   * will be populated after the completion of the HADM step.
+   */
+  uint32_t **pIqBuffer;
+  /**
+   * A pointer to captured IQ data size in 32 bit words. This pointer will be
+   * populated after the completion of the HADM step.
+   */
+  uint16_t *pIqBufferSize;
+  /**
+   * A pointer to a boolean to indicate whether to preserve IQ data for this
+   * step. If this is the final step of the event, IQ data will automatically
+   * be preserved regardless of how this boolean is set. For other steps, if
+   * this boolean is set true, and there are at least \ref
+   * RAIL_BLE_HADM_1MBPS_MINIMUM_IQ_BUFFER_SIZE unused 32 bit words still
+   * available in the event IQ buffer, this step's IQ data will be preserved
+   * and not be overwritten by IQ data from a subsequent step. Otherwise, this
+   * step's IQ data will not be preserved and may be overwritten. This boolean
+   * will be updated after completion of the HADM step to indicate whether the
+   * IQ data from that step was actually preserved.
+   */
+  bool *pSaveIqData;
+} RAIL_BLE_HadmStepConfig_t;
+
+/**
+ * @struct RAIL_BLE_HadmAntennaConfig_t
+ * @brief Contains arguments for \ref RAIL_BLE_ConfigHadmAntenna function.
+ */
+typedef struct RAIL_BLE_HadmAntennaConfig {
+  int8_t antennaCount; /**< Total number of antenna elements. */
+  const int16_t *pAntennaOffsetCm; /**< Pointer to antenna offsets in cm units. */
+} RAIL_BLE_HadmAntennaConfig_t;
+
+/** The maximum number of antennas supported. */
+#define RAIL_BLE_HADM_MAX_ANTENNAS 4
+
+/**
+ * @struct RAIL_BLE_HadmGdCompTables_t
+ * @brief Contains pointers to HADM group delay compensation tables.
+ */
+typedef struct RAIL_BLE_HadmGdCompTables {
+  /** Pointer to PBR phase LSB group delay compensation table. */
+  const int16_t *pPbrPhaseLsb;
+  /** Pointer to RTT slope group delay compensation table. */
+  const int16_t *pRttSlope;
+  /** Pointer to RTT offset group delay compensation table. */
+  const int16_t *pRttOffset;
+  /** Common length for each table in units of int16_t. */
+  uint8_t length;
+} RAIL_BLE_HadmGdCompTables_t;
+
+/**
+ * Configure High Accuracy Distance Measurement (HADM) functionality.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in] hadmConfig Configuration options for HADM.
+ * @return RAIL_Status_t indicating success or failure of the call.
+ *
+ * @warning This API is not safe to use in a multiprotocol app.
+ */
+RAIL_Status_t RAIL_BLE_ConfigHadm(RAIL_Handle_t railHandle,
+                                  const RAIL_BLE_HadmConfig_t *hadmConfig);
+
+/**
+ * Enable High Accuracy Distance Measurement (HADM) functionality.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in] enable Enable or disable HADM functionality.
+ * @return RAIL_Status_t indicating success or failure of the call.
+ *
+ * @warning This API is not safe to use in a multiprotocol app.
+ */
+RAIL_Status_t RAIL_BLE_EnableHadm(RAIL_Handle_t railHandle,
+                                  bool enable);
+
+/**
+ * Set up the next HADM step.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in,out] hadmStepConfig Configuration options for next HADM step.
+ * @param[in] pend If true, apply configuration at next appropriate radio
+ *   transition (i.e. at Rx2Tx for an initiator, or Tx2Rx for a reflector).
+ *   Otherwise, apply configuration immediately.
+ * @return RAIL_Status_t indicating success or failure of the call.
+ *
+ * @note When the next HADM step is to be pended, the specified step in
+ *   hadmStepConfig must be the initial step state for a particular mode (e.g.
+ *   \ref RAIL_BLE_HADM_STEP_MODE0, \ref RAIL_BLE_HADM_STEP_MODE1, or \ref
+ *   RAIL_BLE_HADM_STEP_MODE2). Otherwise this API will return \ref
+ *   RAIL_STATUS_INVALID_PARAMETER.
+ *
+ * @warning This API is not safe to use in a multiprotocol app.
+ */
+RAIL_Status_t RAIL_BLE_SetNextHadmStep(RAIL_Handle_t railHandle,
+                                       const RAIL_BLE_HadmStepConfig_t *hadmStepConfig,
+                                       bool pend);
+
+/**
+ * Configure antennas for HADM event.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in] pAntennaConfig A pointer to the antenna config
+ * @return RAIL_Status_t indicating success or failure of the call.
+ */
+RAIL_Status_t RAIL_BLE_ConfigHadmAntenna(RAIL_Handle_t railHandle,
+                                         RAIL_BLE_HadmAntennaConfig_t *pAntennaConfig);
+
+/**
+ * Loads the HADM RTT and PBR group delay compensation tables for a
+ * particular PA mode.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in] pTables Pointer to group delay compensation lookup tables.
+ * @param[in] powerMode The PA mode for which to load compensation tables.
+ * @return Status code indicating success of the function call.
+ */
+RAIL_Status_t RAIL_BLE_LoadHadmCompTables(RAIL_Handle_t railHandle,
+                                          const RAIL_BLE_HadmGdCompTables_t *pTables,
+                                          RAIL_TxPowerMode_t powerMode);
+
+/**
+ * Callback used to load HADM group delay compensation tables for all PA modes
+ * supported by device during \ref RAIL_BLE_EnableHadm when enable is true.
+ * This function is optional to implement.
+ *
+ * @return Status code indicating success of the function call.
+ *
+ * @note If this callback function is not implemented, unneeded tables may not
+ * be dead stripped, resulting in larger overall code size. The API \ref
+ * RAIL_BLE_LoadHadmCompTables should be used within this callback to load the
+ * appropriate tables for each supported PA mode.
+ */
+RAIL_Status_t RAILCb_BLE_HadmGdCompTableLoad(void);
+
+/** @} */  // end of group HADM
+#endif//DOXYGEN_SHOULD_SKIP_THIS
 
 /// @addtogroup BLETX2TX BLE TX Channel Hopping
 /// @{
@@ -1007,6 +1653,26 @@ RAIL_Status_t RAIL_BLE_SetNextTxRepeat(RAIL_Handle_t railHandle,
 /** @} */  // end of group BLETX2TX
 
 /** @} */ // end of BLE
+
+/// @addtogroup Calibration
+/// @brief Bluetooth protocol-specific APIs for calibrating the radio.
+/// @{
+
+/**
+ * Calibrate image rejection for Bluetooth Low Energy.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[out] imageRejection The result of the image rejection calibration.
+ * @return A status code indicating success of the function call.
+ *
+ * Some chips have protocol-specific image rejection calibrations programmed
+ * into their flash. This function will either get the value from flash and
+ * apply it, or run the image rejection algorithm to find the value.
+ */
+RAIL_Status_t RAIL_BLE_CalibrateIr(RAIL_Handle_t railHandle,
+                                   uint32_t *imageRejection);
+
+/// @} // End of group Calibration
 
 #ifdef __cplusplus
 }

--- a/gecko/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h
+++ b/gecko/platform/radio/rail_lib/protocol/ieee802154/rail_ieee802154.h
@@ -315,7 +315,17 @@ typedef struct RAIL_IEEE802154_Config {
 } RAIL_IEEE802154_Config_t;
 
 /** RX channel switching buffer size, in bytes. */
-#define RAIL_IEEE802154_RX_CHANNEL_SWITCHING_BUF_BYTES              (640U)
+#ifdef  SLI_LIBRARY_BUILD
+#define RAIL_IEEE802154_RX_CHANNEL_SWITCHING_BUF_BYTES (704U) // largest of below
+#else//!SLI_LIBRARY_BUILD
+#if     (_SILICON_LABS_32B_SERIES_2_CONFIG == 1)
+#define RAIL_IEEE802154_RX_CHANNEL_SWITCHING_BUF_BYTES (704U)
+#elif   (_SILICON_LABS_32B_SERIES_2_CONFIG == 4)
+#define RAIL_IEEE802154_RX_CHANNEL_SWITCHING_BUF_BYTES (640U)
+#else// RX channel switching not supported
+#define RAIL_IEEE802154_RX_CHANNEL_SWITCHING_BUF_BYTES (0U)
+#endif
+#endif//SLI_LIBRARY_BUILD
 
 /** Fixed-width type indicating the needed alignment for RX channel switching buffer. */
 #define RAIL_IEEE802154_RX_CHANNEL_SWITCHING_BUF_ALIGNMENT_TYPE     uint32_t
@@ -375,6 +385,20 @@ typedef struct RAIL_IEEE802154_RxChannelSwitchingCfg {
  * is 0.
  */
 extern const RAIL_ChannelConfig_t *const RAIL_IEEE802154_Phy2p4GHz;
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * Default PHY to use for 1Mbps 2.4 GHz 802.15.4 with forward error correction.
+ * Will be NULL if \ref RAIL_IEEE802154_SUPPORTS_2MBPS_PHY is 0.
+ */
+extern const RAIL_ChannelConfig_t *const RAIL_IEEE802154_Phy2p4GHz1MbpsFec;
+
+/**
+ * Default PHY to use for 2Mbps 2.4 GHz 802.15.4. Will be NULL if
+ * \ref RAIL_IEEE802154_SUPPORTS_2MBPS_PHY is 0.
+ */
+extern const RAIL_ChannelConfig_t *const RAIL_IEEE802154_Phy2p4GHz2Mbps;
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * Default PHY to use for 2.4 GHz 802.15.4 with antenna diversity. Will be NULL
@@ -447,6 +471,12 @@ extern const RAIL_ChannelConfig_t *const RAIL_IEEE802154_PhyGB863MHz;
  */
 extern const RAIL_ChannelConfig_t *const RAIL_IEEE802154_PhyGB915MHz;
 
+/**
+ * Default PHY to use for 2.4 GHz 802.15.4 with RX channel switching. Will be
+ * NULL if \ref RAIL_IEEE802154_SUPPORTS_RX_CHANNEL_SWITCHING is 0.
+ */
+extern const RAIL_ChannelConfig_t *const RAIL_IEEE802154_Phy2p4GHzRxChSwitching;
+
 /// @} // End of group IEEE802154_PHY
 
 /**
@@ -472,6 +502,8 @@ extern const RAIL_ChannelConfig_t *const RAIL_IEEE802154_PhyGB915MHz;
  * - RAIL_SetStateTiming()
  * - RAIL_ConfigAddressFilter()
  * - RAIL_EnableAddressFilter()
+ *
+ * It must be called before most of RAIL_IEEE802154_* function.
  */
 RAIL_Status_t RAIL_IEEE802154_Init(RAIL_Handle_t railHandle,
                                    const RAIL_IEEE802154_Config_t *config);
@@ -607,6 +639,48 @@ RAIL_Status_t RAIL_IEEE802154_Config2p4GHzRadioCoexFem(RAIL_Handle_t railHandle)
  */
 RAIL_Status_t RAIL_IEEE802154_Config2p4GHzRadioAntDivCoexFem(RAIL_Handle_t railHandle);
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * Configure the radio for 2.4 GHz 802.15.4 for 250kbps/2Mbps operation.
+ *
+ * @param[in] railHandle A handle of RAIL instance.
+ * @return A status code indicating success of the function call.
+ *
+ * This initializes the radio for 2.4 GHz high speed operation.
+ * It takes the place of calling \ref RAIL_ConfigChannels.
+ * After this call, channels 11-26 will be available, giving the frequencies of
+ * those channels on channel page 0, as defined by IEEE 802.15.4-2011 section 8.1.2.2
+ * at 250kbps.
+ * Channels 11-26 will support transmitting and receiving using dual sync words.
+ * Channels 27-42 will transmit and receive on the frequency of [channel - 16] at 2Mbps.
+ * Auto-ack and address filtering are disabled when channels 27-42 are selected.
+ *
+ * @note This call implicitly disables all \ref RAIL_IEEE802154_GOptions_t.
+ */
+RAIL_Status_t RAIL_IEEE802154_Config2p4GHzRadio2Mbps(RAIL_Handle_t railHandle);
+
+/**
+ * Configure the radio for 2.4 GHz 802.15.4 for 250kbps/1Mbps forward error correction
+ * operation.
+ *
+ * @param[in] railHandle A handle of RAIL instance.
+ * @return A status code indicating success of the function call.
+ *
+ * This initializes the radio for 2.4 GHz high speed operation.
+ * It takes the place of calling \ref RAIL_ConfigChannels.
+ * After this call, channels 11-26 will be available, giving the frequencies of
+ * those channels on channel page 0, as defined by IEEE 802.15.4-2011 section 8.1.2.2
+ * at 250kbps.
+ * Channels 11-26 will support transmitting and receiving using dual sync words.
+ * Channels 27-42 will transmit and receive on the frequency of [channel - 16] at 1Mbps.
+ * Auto-ack and address filtering are disabled when channels 27-42 are selected.
+ *
+ * @note This call implicitly disables all \ref RAIL_IEEE802154_GOptions_t.
+ */
+RAIL_Status_t RAIL_IEEE802154_Config2p4GHzRadio1MbpsFec(RAIL_Handle_t railHandle);
+
+#endif //DOXYGEN_SHOULD_SKIP_THIS
+
 /**
  * Configure the radio for 2.4 GHz 802.15.4 operation with custom
  * settings. It enables better interoperability with some proprietary
@@ -686,7 +760,7 @@ bool RAIL_IEEE802154_IsEnabled(RAIL_Handle_t railHandle);
  * @enum RAIL_IEEE802154_PtiRadioConfig_t
  * @brief 802.15.4 PTI radio configuration mode
  */
-RAIL_ENUM(RAIL_IEEE802154_PtiRadioConfig_t) {
+RAIL_ENUM_GENERIC(RAIL_IEEE802154_PtiRadioConfig_t, uint16_t) {
   /**
    * Built-in 2.4 GHz 802.15.4 radio configuration.
    */
@@ -740,70 +814,6 @@ RAIL_ENUM(RAIL_IEEE802154_PtiRadioConfig_t) {
    * External 915 MHz Zigbee R23 802.15.4 NA radio configuration.
    */
   RAIL_IEEE802154_PTI_RADIO_CONFIG_915MHZ_R23_NA_EXT = 0x97U,
-  /**
-   * 863 MHz SUN OFDM Option 1 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OFDM_OPT1_863MHZ = 0x42,
-  /**
-   * 902 MHz SUN OFDM Option 1 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OFDM_OPT1_902MHZ = 0x43,
-  /**
-   * 86 3MHz SUN OFDM Option 2 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OFDM_OPT2_863MHZ = 0x52,
-  /**
-   * 902 MHz SUN OFDM Option 2 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OFDM_OPT2_902MHZ = 0x53,
-  /**
-   * 863 MHz SUN OFDM Option 3 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OFDM_OPT3_863MHZ = 0x62,
-  /**
-   * 902 MHz SUN OFDM Option 3 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OFDM_OPT3_902MHZ = 0x63,
-  /**
-   * 863 MHz SUN OFDM Option 4 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OFDM_OPT4_863MHZ = 0x72,
-  /**
-   * 902 MHz SUN OFDM Option 4 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OFDM_OPT4_902MHZ = 0x73,
-  /**
-   * 868 MHz SUN OQPSK 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OQPSK_868MHZ = 0x44,
-  /**
-   * 915 MHz SUN OQPSK 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_OQPSK_915MHZ = 0x45,
-  /**
-   * 863 MHz SUN FSK FEC 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_FSK_FEC_863MHZ = 0x46,
-  /**
-   * 902 MHz SUN FSK FEC 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_FSK_FEC_902MHZ = 0x47,
-  /**
-   * 863 MHz SUN FSK NO FEC 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_FSK_NOFEC_863MHZ = 0x56,
-  /**
-   * 902 MHz SUN FSK NO FEC 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_SUN_FSK_NOFEC_902MHZ = 0x57,
-  /**
-   * 868 MHz Legacy OQPSK 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_LEG_OQPSK_868MHZ = 0x48,
-  /**
-   * 915 MHz Legacy OQPSK 802.15.4 radio configuration.
-   */
-  RAIL_IEEE802154_PTI_RADIO_CONFIG_LEG_OQPSK_915MHZ = 0x49
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -918,7 +928,8 @@ RAIL_Status_t RAIL_IEEE802154_SetLongAddress(RAIL_Handle_t railHandle,
  *
  * If the device is a PAN Coordinator, it will accept data and command
  * frames with no destination address. This function will fail if 802.15.4
- * hardware acceleration is not currently enabled. This setting may be changed
+ * hardware acceleration is not currently enabled by calling
+ * \ref RAIL_IEEE802154_Init(). This setting may be changed
  * at any time when 802.15.4 hardware acceleration is enabled.
  */
 RAIL_Status_t RAIL_IEEE802154_SetPanCoordinator(RAIL_Handle_t railHandle,
@@ -933,8 +944,9 @@ RAIL_Status_t RAIL_IEEE802154_SetPanCoordinator(RAIL_Handle_t railHandle,
  *
  * If promiscuous mode is enabled, no frame or address filtering steps
  * will be performed other than checking the CRC. This function will fail if
- * 802.15.4 hardware acceleration is not currently enabled. This setting may be
- * changed at any time when 802.15.4 hardware acceleration is enabled.
+ * 802.15.4 hardware acceleration is not currently enabled by calling
+ * \ref RAIL_IEEE802154_Init(). This setting may be changed at any time when
+ * 802.15.4 hardware acceleration is enabled.
  */
 RAIL_Status_t RAIL_IEEE802154_SetPromiscuousMode(RAIL_Handle_t railHandle,
                                                  bool enable);
@@ -1045,7 +1057,8 @@ RAIL_ENUM_GENERIC(RAIL_IEEE802154_EOptions_t, uint32_t) {
  * @return A status code indicating success of the function call.
  *
  * This function will fail if 802.15.4 hardware acceleration is not
- * currently enabled or the platform does not support the feature(s).
+ * currently enabled by calling \ref RAIL_IEEE802154_Init() or the platform
+ * does not support the feature(s).
  * These settings may be changed at any time when 802.15.4 hardware
  * acceleration is enabled.
  */
@@ -1157,8 +1170,9 @@ RAIL_ENUM_GENERIC(RAIL_IEEE802154_GOptions_t, uint32_t) {
  * @return A status code indicating success of the function call.
  *
  * This function will fail if 802.15.4 hardware acceleration is not
- * currently enabled, the platform does not support the feature(s),
- * the radio configuration is not appropriate, or the radio is not idle.
+ * currently enabled by calling \ref RAIL_IEEE802154_Init(), the platform does
+ * not support the feature(s), the radio configuration is not appropriate,
+ * or the radio is not idle.
  */
 RAIL_Status_t RAIL_IEEE802154_ConfigGOptions(RAIL_Handle_t railHandle,
                                              RAIL_IEEE802154_GOptions_t mask,
@@ -1191,9 +1205,11 @@ typedef struct RAIL_IEEE802154_ModeSwitchPhr {
  * @param[out] pChannel A pointer to the channel to switch to.
  * @return A status code indicating success of the function call.
  *
- * This function will fail if the targeted PhyModeID is the same as the
- * current PhyMode ID, or if called on a platform that lacks
- * \ref RAIL_IEEE802154_SUPPORTS_G_MODESWITCH.
+ * This function will fail if:
+ * - the targeted PhyModeID is the same as the current PhyMode ID
+ * - called on a platform that lacks \ref RAIL_IEEE802154_SUPPORTS_G_MODESWITCH
+ * - called on a platform that doesn't have 802154G options enabled
+ *     by \ref RAIL_IEEE802154_ConfigGOptions().
  * For newPhyModeId associated with a FSK FEC_off PHY, if dynamic FEC is
  * activated (see \ref RAIL_IEEE802154_G_OPTION_DYNFEC), the returned
  * channel can correspond to the associated FSK FEC_on PHY corresponding
@@ -1203,10 +1219,8 @@ RAIL_Status_t RAIL_IEEE802154_ComputeChannelFromPhyModeId(RAIL_Handle_t railHand
                                                           uint8_t newPhyModeId,
                                                           uint16_t *pChannel);
 
-#if RAIL_IEEE802154_SUPPORTS_G_MODESWITCH
 /**
- * This function can be implemented to manage forbidden channels during mode
- * switch.
+ * Manage forbidden channels during mode switch.
  *
  * @param[in] currentBaseFreq  The current frequency of the base channel.
  * @param[in] newPhyModeId A targeted PhyMode ID.
@@ -1216,19 +1230,23 @@ RAIL_Status_t RAIL_IEEE802154_ComputeChannelFromPhyModeId(RAIL_Handle_t railHand
  *   is valid, the function must just return. If channel is forbidden, the
  *   function must update it with the closest valid channel. The highest
  *   channel must be selected in case of two valid channels being equidistant
- *   to a forbiden channel.
+ *   to a forbidden channel.
  * @return A status code indicating success of the function call. It must
  *   return RAIL_STATUS_INVALID_PARAMETER for failure or RAIL_STATUS_NO_ERROR
  *   for success.
  *
  * This function must fail if no valid channel has been found. If so, RAIL will
  * abort the mode switch.
+ *
+ * @note This callback will only be called on platforms where
+ *   \ref RAIL_IEEE802154_SUPPORTS_G_MODESWITCH is true, \ref
+ *   RAIL_IEEE802154_G_OPTION_WISUN_MODESWITCH was successfully enabled,
+ *   and a valid mode switch PHY header is received.
  */
 RAIL_Status_t RAILCb_IEEE802154_IsModeSwitchNewChannelValid(uint32_t currentBaseFreq,
                                                             uint8_t newPhyModeId,
                                                             const RAIL_ChannelConfigEntry_t *configEntryNewPhyModeId,
                                                             uint16_t *pChannel);
-#endif//RAIL_IEEE802154_SUPPORTS_G_MODESWITCH
 
 /// When receiving packets, accept 802.15.4 BEACON frame types.
 #define RAIL_IEEE802154_ACCEPT_BEACON_FRAMES       (0x01)
@@ -1261,7 +1279,8 @@ RAIL_Status_t RAILCb_IEEE802154_IsModeSwitchNewChannelValid(uint32_t currentBase
  * @return A status code indicating success of the function call.
  *
  * This function will fail if 802.15.4 hardware acceleration is not currently
- * enabled or framesMask requests an unsupported frame type.
+ * enabled by calling \ref RAIL_IEEE802154_Init() or framesMask requests an
+ * unsupported frame type.
  * This setting may be changed at any time when 802.15.4 hardware
  * acceleration is enabled. Only Beacon, Data, ACK, Command, and Multipurpose
  * (except on EFR32XG1) frames may be received.
@@ -1309,7 +1328,8 @@ RAIL_Status_t RAIL_IEEE802154_AcceptFrames(RAIL_Handle_t railHandle,
  * Enhanced ACK.
  *
  * This function will fail if 802.15.4 hardware acceleration is not
- * currently enabled, or on platforms that do not support this feature.
+ * currently enabled by calling \ref RAIL_IEEE802154_Init(),
+ * or on platforms that do not support this feature.
  * This setting may be changed at any time when 802.15.4 hardware
  * acceleration is enabled.
  */
@@ -1334,8 +1354,9 @@ RAIL_Status_t RAIL_IEEE802154_EnableEarlyFramePending(RAIL_Handle_t railHandle,
  * Data frames which require an Enhanced ACK.
  *
  * This function will fail if 802.15.4 hardware acceleration is not
- * currently enabled. This setting may be changed at any time when
- * 802.15.4 hardware acceleration is enabled.
+ * currently enabled by calling \ref RAIL_IEEE802154_Init().
+ * This setting may be changed at any time when 802.15.4 hardware acceleration
+ * is enabled.
  */
 RAIL_Status_t RAIL_IEEE802154_EnableDataFramePending(RAIL_Handle_t railHandle,
                                                      bool enable);
@@ -1404,7 +1425,13 @@ RAIL_Status_t RAIL_IEEE802154_GetAddress(RAIL_Handle_t railHandle,
  *
  * @param[in] railHandle A handle of RAIL instance.
  * @param[in] ackData Pointer to ACK data to transmit
- * @param[in] ackDataLen Length of ACK data, in bytes
+ *   This may be NULL, in which case it's assumed the data has already
+ *   been emplaced into the ACK buffer and RAIL just needs to be told
+ *   how many bytes are there.  Use \ref RAIL_GetAutoAckFifo() to get
+ *   the address of RAIL's AutoACK buffer in RAM and its size.
+ * @param[in] ackDataLen Length of ACK data, in bytes.
+ *   If this exceeds \ref RAIL_AUTOACK_MAX_LENGTH the function
+ *   will return \ref RAIL_STATUS_INVALID_PARAMETER.
  * @return A status code indicating success of the function call.
  *
  * This function sets the AutoACK data to use in acknowledging the frame
@@ -1424,6 +1451,32 @@ RAIL_Status_t RAIL_IEEE802154_GetAddress(RAIL_Handle_t railHandle,
 RAIL_Status_t RAIL_IEEE802154_WriteEnhAck(RAIL_Handle_t railHandle,
                                           const uint8_t *ackData,
                                           uint8_t ackDataLen);
+
+/**
+ * Set a separate RX packet to TX state transition turnaround time for
+ * sending an Enhanced ACK.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[in,out] pRxToEnhAckTx Pointer to the turnaround transition requested
+ *   for Enhanced ACKs.  It will be updated with the actual time set.
+ *   Requesting a time of 0 will sync the Enhanced ACK turnaround time with
+ *   that used for immediate ACKs (and output 0). Requesting a time of \ref
+ *   RAIL_TRANSITION_TIME_KEEP will output the current Enhanced ACK timing
+ *   parameter (0 if it is the same as that used for Immediate ACKs).
+ * @return Status code indicating a success of the function call.
+ *   An error will not update the pRxToEnhAckTx output parameter.
+ *
+ * Normally Immediate and Enhanced ACKs are both sent using the
+ * \ref RAIL_IEEE802154_Config_t::timings rxToTx turnaround time.
+ * If the stack needs more time to prepare an Enhanced ACK, it can
+ * call this function after \ref RAIL_IEEE802154_Init() to set a
+ * longer turnaround time used just for Enhanced ACK transmits.
+ *
+ * This function will fail on platforms that lack
+ * \ref RAIL_IEEE802154_SUPPORTS_E_ENHANCED_ACK.
+ */
+RAIL_Status_t RAIL_IEEE802154_SetRxToEnhAckTx(RAIL_Handle_t railHandle,
+                                              RAIL_TransitionTime_t *pRxToEnhAckTx);
 
 /**
  * Convert RSSI into 802.15.4 Link Quality Indication (LQI) metric
@@ -1615,33 +1668,100 @@ RAIL_Status_t RAIL_IEEE802154_ConfigCcaMode(RAIL_Handle_t railHandle,
  */
 RAIL_Status_t RAIL_IEEE802154_AllowMalformed(RAIL_Handle_t railHandle,
                                              bool allow);
-#endif//DOXYGEN_SHOULD_SKIP_THIS
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * Configure RX channel switching for 802.15.4.
  *
  * @param[in] railHandle A RAIL instance handle.
- * @param[in] pConfig A pointer to \ref RAIL_IEEE802154_RxChannelSwitchingCfg_t structure.
+ * @param[in] pConfig A pointer to \ref RAIL_IEEE802154_RxChannelSwitchingCfg_t
+ *   structure. Use NULL to disable any switching previously set up.
  * @return Status code indicating success of the function call.
  *
- * This function configures RX channel switching, allowing reception of 2.4Ghz 802.15.4
- * signals on two specified radio channels. This function must be called once before
- * \ref RAIL_StartRx and/or enabling \ref RAIL_RX_OPTION_CHANNEL_SWITCHING.
+ * This function configures RX channel switching, allowing reception of 2.4Ghz
+ * 802.15.4 signals on two different radio channels within the same PHY.
+ * (If the two channels are same, the function behaves the same as if
+ * pConfig was NULL.)
+ * This function should be
+ * called once before \ref RAIL_StartRx and/or enabling
+ * \ref RAIL_RX_OPTION_CHANNEL_SWITCHING.
  *
- * @note IEEE 802.15.4 must be enabled, \ref RAIL_IEEE802154_Init, and radio must be
- *   in idle state when configuring RX channel switching. This function requires a DMA channel,
- *   see \ref RAIL_UseDma, and one must be allocated if not done already.
+ * When \ref RAIL_RX_OPTION_CHANNEL_SWITCHING is enabled,
+ * channel switching will occur during normal listening but is suspended
+ * (and the radio is idled) when starting any kind of transmit, including
+ * scheduled or CSMA transmits. It remains suspended after a \ref
+ * RAIL_TX_OPTION_WAIT_FOR_ACK transmit until the ACK is received or
+ * times out.
  *
- * @note When RX channel switching is active, receive sensitivity and performance are
- *   slightly impacted.
+ * When \ref RAIL_RX_OPTION_CHANNEL_SWITCHING is disabled after switching
+ * has been active, the radio could be left listening on either channel,
+ * so the application should call \ref RAIL_StartRx() to put it on the
+ * desired non-switching channel.
+ *
+ * @note IEEE 802.15.4 must be enabled via \ref RAIL_IEEE802154_Init, and the
+ *   radio must be in the idle state when configuring RX channel switching.
+ *   A DMA channel must be allocated with \ref RAIL_UseDma; otherwise this API
+ *   will return \ref RAIL_STATUS_INVALID_CALL.
+ *   This feature also requires a PRS channel, internally allocated by the RAIL
+ *   library, to use and hold onto for future use. If no PRS channel is
+ *   available, the function returns \ref RAIL_STATUS_INVALID_PARAMETER.
+ *
+ * @note When RX channel switching is active, receive sensitivity and performance
+ *   are slightly impacted.
+ *
+ * @note This function internally uses \ref RAIL_EnableCacheSynthCal to
+ *   enable/disable the sequencer cache to store the synth calibration value.
+ *
+ * @note Switching is cancelled on any PHY change, so this function would
+ *   need to be re-called to reestablish switching after such a change.
  */
 RAIL_Status_t RAIL_IEEE802154_ConfigRxChannelSwitching(RAIL_Handle_t railHandle,
                                                        const RAIL_IEEE802154_RxChannelSwitchingCfg_t *pConfig);
 
 /** @} */ // end of IEEE802.15.4
 
+/// @addtogroup Calibration
+/// @brief IEEE802154 protocol-specific APIs for calibrating the radio.
+/// @{
+
+/**
+ * Calibrate image rejection for IEEE 802.15.4 2.4 GHz.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[out] imageRejection The result of the image rejection calibration.
+ * @return A status code indicating success of the function call.
+ *
+ * Some chips have protocol-specific image rejection calibrations programmed
+ * into their flash. This function will either get the value from flash and
+ * apply it, or run the image rejection algorithm to find the value.
+ */
+RAIL_Status_t RAIL_IEEE802154_CalibrateIr2p4Ghz(RAIL_Handle_t railHandle,
+                                                uint32_t *imageRejection);
+
+/**
+ * Calibrate image rejection for IEEE 802.15.4 915 MHz and 868 MHz.
+ *
+ * @param[in] railHandle A RAIL instance handle.
+ * @param[out] imageRejection The result of the image rejection calibration.
+ * @return A status code indicating success of the function call.
+ *
+ * Some chips have protocol-specific image rejection calibrations programmed
+ * into their flash. This function will either get the value from flash and
+ * apply it, or run the image rejection algorithm to find the value.
+ *
+ * @deprecated Please use \ref RAIL_CalibrateIrAlt instead.
+ */
+RAIL_Status_t RAIL_IEEE802154_CalibrateIrSubGhz(RAIL_Handle_t railHandle,
+                                                uint32_t *imageRejection);
+
+/// @} // End of group Calibration
+
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef RAIL_INTERNAL_BUILD
+#include "rail_ieee802154_internal.h"
 #endif
 
 #endif // __RAIL_IEEE802154_H__

--- a/gecko/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h
+++ b/gecko/platform/radio/rail_lib/protocol/sidewalk/rail_sidewalk.h
@@ -1,0 +1,85 @@
+/***************************************************************************//**
+ * @file
+ * @brief The Sidewalk specific header file for the RAIL library.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef RAIL_SIDEWALK_H
+#define RAIL_SIDEWALK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Get the standard include types
+#include <stdint.h>
+#include <stdbool.h>
+
+// Get the RAIL specific structures and types
+#include "rail_types.h"
+
+/// @addtogroup SIDEWALK_PHY Sidewalk Radio Configurations
+/// @ingroup Protocol_Specific
+/// Radio configurations for the RAIL Sidewalk Accelerator
+///
+/// These radio configurations are used to configure Sidewalk when a function
+/// such as \ref RAIL_Sidewalk_ConfigPhy2GFSK50kbps() is called. Each radio
+/// configuration listed below is compiled into the RAIL library as a weak
+/// symbol that will take into account per-die defaults. If the board
+/// configuration in use has different settings than the default, such as a
+/// different radio subsystem clock frequency, these radio configurations can
+/// be overriden to account for those settings.
+/// @{
+
+/**
+ * Default PHY to use for Sidewalk 2GFSK 50kbps. Will be NULL if
+ * \ref RAIL_SUPPORTS_PROTOCOL_SIDEWALK is 0.
+ */
+extern const RAIL_ChannelConfig_t *const RAIL_Sidewalk_Phy2GFSK50kbps;
+
+/**
+ * Switch to the 2GFSK 50kbps Sidewalk PHY.
+ *
+ * @param[in] railHandle A handle for RAIL instance.
+ * @return A status code indicating success of the function call.
+ *
+ * Use this function to switch to the 2GFSK 50kbps Sidewalk PHY.
+ *
+ * @note The Sidewalk PHY is supported only on some parts.
+ * The preprocessor symbol \ref RAIL_SUPPORTS_PROTOCOL_SIDEWALK and the
+ * runtime function \ref RAIL_SupportsProtocolSidewalk() may be used to
+ * test for support of the Sidewalk PHY.
+ */
+RAIL_Status_t RAIL_Sidewalk_ConfigPhy2GFSK50kbps(RAIL_Handle_t railHandle);
+
+/// @} // End of group SIDEWALK_PHY
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RAIL_SIDEWALK_H

--- a/gecko/platform/radio/rail_lib/protocol/zwave/rail_zwave.h
+++ b/gecko/platform/radio/rail_lib/protocol/zwave/rail_zwave.h
@@ -198,7 +198,7 @@ RAIL_ENUM_GENERIC(RAIL_ZWAVE_NodeId_t, uint16_t) {
 #define RAIL_ZWAVE_NODE_ID_NONE      ((RAIL_ZWAVE_NodeId_t) RAIL_ZWAVE_NODE_ID_NONE)
 #define RAIL_ZWAVE_NODE_ID_BROADCAST ((RAIL_ZWAVE_NodeId_t) RAIL_ZWAVE_NODE_ID_BROADCAST)
 #define RAIL_ZWAVE_NODE_ID_DEFAULT   ((RAIL_ZWAVE_NodeId_t) RAIL_ZWAVE_NODE_ID_DEFAULT)
-#endif//DOXYGEN_SHOULD_SKIP_THIS
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 /** Defines for subPhyID field in RAIL_RxPacketDetails_t */
@@ -206,7 +206,7 @@ RAIL_ENUM_GENERIC(RAIL_ZWAVE_NodeId_t, uint16_t) {
 #define RAIL_ZWAVE_RX_SUBPHY_ID_1     (1U)
 #define RAIL_ZWAVE_RX_SUBPHY_ID_2     (2U)
 #define RAIL_ZWAVE_RX_SUBPHY_ID_3     (3U)
-#endif//DOXYGEN_SHOULD_SKIP_THIS
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * @enum RAIL_ZWAVE_HomeId_t
@@ -223,7 +223,7 @@ RAIL_ENUM_GENERIC(RAIL_ZWAVE_HomeId_t, uint32_t) {
 // Self-referencing defines minimize compiler complaints when using RAIL_ENUM
 #define RAIL_ZWAVE_HOME_ID_UNKNOWN ((RAIL_ZWAVE_HomeId_t) RAIL_ZWAVE_HOME_ID_UNKNOWN)
 #define RAIL_ZWAVE_HOME_ID_DEFAULT ((RAIL_ZWAVE_HomeId_t) RAIL_ZWAVE_HOME_ID_DEFAULT)
-#endif//DOXYGEN_SHOULD_SKIP_THIS
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * @enum RAIL_ZWAVE_HomeIdHash_t
@@ -250,7 +250,7 @@ RAIL_ENUM(RAIL_ZWAVE_HomeIdHash_t) {
 #define RAIL_ZWAVE_HOME_ID_HASH_ILLEGAL_3 ((RAIL_ZWAVE_HomeIdHash_t) RAIL_ZWAVE_HOME_ID_HASH_ILLEGAL_3)
 #define RAIL_ZWAVE_HOME_ID_HASH_DONT_CARE ((RAIL_ZWAVE_HomeIdHash_t) RAIL_ZWAVE_HOME_ID_HASH_DONT_CARE)
 #define RAIL_ZWAVE_HOME_ID_HASH_DEFAULT   ((RAIL_ZWAVE_HomeIdHash_t) RAIL_ZWAVE_HOME_ID_HASH_DEFAULT)
-#endif//DOXYGEN_SHOULD_SKIP_THIS
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * @struct RAIL_ZWAVE_Config_t
@@ -284,6 +284,35 @@ RAIL_ENUM(RAIL_ZWAVE_Baud_t) {
   RAIL_ZWAVE_BAUD_INVALID   /**< Sentinel value for invalid baud rate*/
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/**
+ * @enum RAIL_ZWAVE_RegionOptions_t
+ * @brief Region Specific Physical
+ */
+
+RAIL_ENUM(RAIL_ZWAVE_RegionOptions_t)
+{
+  /** Bit shift for US Long Range End Devices */
+  RAIL_ZWAVE_REGION_LONG_RANGE_END_SHIFT = 0,
+  /** Bit shift for special low side config, mostly for Japan and Korea */
+  RAIL_ZWAVE_REGION_LOW_SIDE_SHIFT = 1,
+  /** Bit shift for US long range range configurations */
+  RAIL_ZWAVE_REGION_LONG_RANGE_SHIFT = 2,
+};
+
+/**
+ * RAIL_ZWAVE_RegionOptions_t bitmasks
+ */
+/** A value representing US Long Range regions  */
+#define RAIL_ZWAVE_REGION_LONG_RANGE_MASK  (1u << RAIL_ZWAVE_REGION_LONG_RANGE_SHIFT)
+/** A value representing lowside configurations: For Series 2: JP and KR, for Series 1: KR */
+#define RAIL_ZWAVE_REGION_LOW_SIDE_MASK (1u << RAIL_ZWAVE_REGION_LOW_SIDE_SHIFT)
+/** A value representing Long Range End Device region */
+#define RAIL_ZWAVE_REGION_LONG_RANGE_END_MASK (1u << RAIL_ZWAVE_REGION_LONG_RANGE_END_SHIFT)
+/** A value representing No bit to be enabled */
+#define RAIL_ZWAVE_REGION_SPECIFIC_NONE 0u
+#endif // DOXYGEN SHOULD SKIP THIS
+
 /**
  * Sentinel value to indicate that a channel (and thus its frequency)
  * are invalid.
@@ -298,7 +327,7 @@ RAIL_ENUM(RAIL_ZWAVE_Baud_t) {
 #define RAIL_ZWAVE_LR             ((RAIL_ZWAVE_Baud_t) RAIL_ZWAVE_LR)
 #define RAIL_ZWAVE_ENERGY_DETECT  ((RAIL_ZWAVE_Baud_t) RAIL_ZWAVE_ENERGY_DETECT)
 #define RAIL_ZWAVE_INVALID        ((RAIL_ZWAVE_Baud_t) RAIL_ZWAVE_INVALID)
-#endif//DOXYGEN_SHOULD_SKIP_THIS
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * @enum RAIL_ZWAVE_RegionId_t
@@ -320,6 +349,9 @@ RAIL_ENUM(RAIL_ZWAVE_RegionId_t) {
   RAIL_ZWAVE_REGIONID_US_LR1,  /**< United States, with first long range PHY*/
   RAIL_ZWAVE_REGIONID_US_LR2,  /**< United States, with second long range PHY*/
   RAIL_ZWAVE_REGIONID_US_LR_END_DEVICE, /**< United States long range end device PHY for both LR frequencies*/
+  RAIL_ZWAVE_REGIONID_EU_LR1,  /**< European Union, with first long range PHY*/
+  RAIL_ZWAVE_REGIONID_EU_LR2,  /**< European Union, with second long range PHY*/
+  RAIL_ZWAVE_REGIONID_EU_LR_END_DEVICE, /**< European Union long range end device PHY for both LR frequencies*/
   RAIL_ZWAVE_REGIONID_COUNT    /**< Count of known regions, must be last*/
 };
 
@@ -340,8 +372,11 @@ RAIL_ENUM(RAIL_ZWAVE_RegionId_t) {
 #define RAIL_ZWAVE_REGIONID_US_LR1 ((RAIL_ZWAVE_RegionId_t) RAIL_ZWAVE_REGIONID_US_LR1)
 #define RAIL_ZWAVE_REGIONID_US_LR2 ((RAIL_ZWAVE_RegionId_t) RAIL_ZWAVE_REGIONID_US_LR2)
 #define RAIL_ZWAVE_REGIONID_US_LR_END_DEVICE ((RAIL_ZWAVE_RegionId_t) RAIL_ZWAVE_REGIONID_US_LR_END_DEVICE)
+#define RAIL_ZWAVE_REGIONID_EU_LR1 ((RAIL_ZWAVE_RegionId_t) RAIL_ZWAVE_REGIONID_EU_LR1)
+#define RAIL_ZWAVE_REGIONID_EU_LR2 ((RAIL_ZWAVE_RegionId_t) RAIL_ZWAVE_REGIONID_EU_LR2)
+#define RAIL_ZWAVE_REGIONID_EU_LR_END_DEVICE ((RAIL_ZWAVE_RegionId_t) RAIL_ZWAVE_REGIONID_EU_LR_END_DEVICE)
 #define RAIL_ZWAVE_REGIONID_COUNT ((RAIL_ZWAVE_RegionId_t) RAIL_ZWAVE_REGIONID_COUNT)
-#endif//DOXYGEN_SHOULD_SKIP_THIS
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 // Largest ACK timeout period based on
@@ -355,7 +390,7 @@ RAIL_ENUM(RAIL_ZWAVE_RegionId_t) {
 #define RAIL_ZWAVE_TIME_IDLE_TO_TX_US        (0U)
 #define RAIL_ZWAVE_TIME_RX_TO_TX_US          (1000U)
 
-#endif//DOXYGEN_SHOULD_SKIP_THIS
+#endif //DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * Invalid beam TX power value returned when \ref RAIL_ZWAVE_GetLrBeamTxPower
@@ -408,6 +443,7 @@ typedef struct RAIL_ZWAVE_RegionConfig {
   RAIL_TxPower_t maxPower[RAIL_NUM_ZWAVE_CHANNELS];                   /**< The maximum power allowed on the channel*/
   RAIL_ZWAVE_Baud_t baudRate[RAIL_NUM_ZWAVE_CHANNELS];                /**< Channel baud rate index*/
   RAIL_ZWAVE_RegionId_t regionId;                                     /**< Identification number for the region*/
+  RAIL_ZWAVE_RegionOptions_t regionSpecific;                                             /**< Encapsulates region specific data*/
 } RAIL_ZWAVE_RegionConfig_t;
 
 /**
@@ -891,6 +927,15 @@ extern const RAIL_ZWAVE_RegionConfig_t RAIL_ZWAVE_REGION_US_LR2;
 
 /** US-Long Range End Device, RAIL_ZWAVE_REGION_US_LR_END_DEVICE */
 extern const RAIL_ZWAVE_RegionConfig_t RAIL_ZWAVE_REGION_US_LR_END_DEVICE;
+
+/** EU-Long Range 1, RAIL_ZWAVE_REGION_EU_LR1 */
+extern const RAIL_ZWAVE_RegionConfig_t RAIL_ZWAVE_REGION_EU_LR1;
+
+/** EU-Long Range 2, RAIL_ZWAVE_REGION_EU_LR2 */
+extern const RAIL_ZWAVE_RegionConfig_t RAIL_ZWAVE_REGION_EU_LR2;
+
+/** EU-Long Range End Device, RAIL_ZWAVE_REGION_EU_LR_END_DEVICE */
+extern const RAIL_ZWAVE_RegionConfig_t RAIL_ZWAVE_REGION_EU_LR_END_DEVICE;
 
 /** Invalid Region */
 extern const RAIL_ZWAVE_RegionConfig_t RAIL_ZWAVE_REGION_INVALID;

--- a/gecko/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto.h
+++ b/gecko/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto.h
@@ -1,0 +1,205 @@
+/***************************************************************************//**
+ * @file
+ * @brief Accelerated cryptographic primitives using the CRYPTO and RADIOAES
+ *        peripherals, for series-1 and series-2 respectively.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#ifndef SLI_PROTOCOL_CRYPTO_H
+#define SLI_PROTOCOL_CRYPTO_H
+
+/// @cond DO_NOT_INCLUDE_WITH_DOXYGEN
+
+/***************************************************************************//**
+ * @addtogroup sli_protocol_crypto
+ * @brief Accelerated cryptographic primitives using the CRYPTO and RADIOAES
+ *        peripherals, for series-1 and series-2 respectively.
+ * @{
+ ******************************************************************************/
+
+#include "sl_status.h"
+#include "em_device.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************************************************//**
+ * @brief          AES-CTR block encryption/decryption optimized for radio
+ *
+ * @param key      AES key
+ * @param keybits  must be 128 or 256
+ * @param input    16-byte input block
+ * @param iv_in    16-byte counter/IV starting value
+ * @param iv_out   16-byte counter/IV output after block round
+ * @param output   16-byte output block
+ *
+ * @return         SL_STATUS_OK if successful, relevant status code on error
+ ******************************************************************************/
+sl_status_t sli_aes_crypt_ctr_radio(const unsigned char    *key,
+                                    unsigned int           keybits,
+                                    const unsigned char    input[16],
+                                    const unsigned char    iv_in[16],
+                                    volatile unsigned char iv_out[16],
+                                    volatile unsigned char output[16]);
+
+/***************************************************************************//**
+ * @brief          AES-ECB block encryption/decryption optimized for radio
+ *
+ * @param encrypt  true for encryption, false for decryption
+ * @param key      AES key
+ * @param keybits  must be 128 or 256
+ * @param input    16-byte input block
+ * @param output   16-byte output block
+ *
+ * @return         SL_STATUS_OK if successful, relevant status code on error
+ ******************************************************************************/
+sl_status_t sli_aes_crypt_ecb_radio(bool                   encrypt,
+                                    const unsigned char    *key,
+                                    unsigned int           keybits,
+                                    const unsigned char    input[16],
+                                    volatile unsigned char output[16]);
+
+#if defined(RADIOAES_PRESENT)
+/***************************************************************************//**
+ * @brief          AES-CMAC calculation optimized for radio
+ *
+ * @param key      AES key
+ * @param keybits  Must be 128 or 256
+ * @param input    Input buffer containing the message to be signed
+ * @param length   Amount of bytes in the input buffer
+ * @param output   16-byte output block for calculated CMAC
+ *
+ * @return         SL_STATUS_OK if successful, relevant status code on error
+ ******************************************************************************/
+sl_status_t sli_aes_cmac_radio(const unsigned char    *key,
+                               unsigned int           keybits,
+                               const unsigned char    *input,
+                               unsigned int           length,
+                               volatile unsigned char output[16]);
+
+/***************************************************************************//**
+ * @brief         Seeds the AES mask. It is recommended to call this function
+                  during initialization in order to avoid taking the potential
+                  hit of requesting RNG output in an IRQ context.
+ ******************************************************************************/
+void sli_aes_seed_mask(void);
+#endif
+
+/***************************************************************************//**
+ * @brief          CCM buffer authenticated decryption optimized for BLE
+ *
+ * @param data     Input/output buffer of payload data of BLE packet
+ * @param length   length of input data
+ * @param iv       nonce (initialization vector)
+ *                 must be 13 bytes
+ * @param header   header of BLE packet (1 byte)
+ * @param tag      authentication tag of BLE packet (4 bytes)
+ *
+ * @return         SL_STATUS_OK if successful and authenticated,
+ *                 SL_STATUS_INVALID_SIGNATURE if tag does not match payload,
+ *                 relevant status code on other error
+ ******************************************************************************/
+sl_status_t sli_ccm_auth_decrypt_ble(unsigned char       *data,
+                                     size_t              length,
+                                     const unsigned char *key,
+                                     const unsigned char *iv,
+                                     unsigned char       header,
+                                     unsigned char       *tag);
+
+/***************************************************************************//**
+ * @brief          CCM buffer encryption optimized for BLE
+ *
+ * @param data     Input/output buffer of payload data of BLE packet
+ * @param length   length of input data
+ * @param iv       nonce (initialization vector)
+ *                 must be 13 bytes
+ * @param header   header of BLE packet (1 byte)
+ * @param tag      buffer where the BLE packet tag (4 bytes) will be written
+ *
+ * @return         SL_STATUS_OK if successful, relevant status code on error
+ ******************************************************************************/
+sl_status_t sli_ccm_encrypt_and_tag_ble(unsigned char       *data,
+                                        size_t              length,
+                                        const unsigned char *key,
+                                        const unsigned char *iv,
+                                        unsigned char       header,
+                                        unsigned char       *tag);
+
+/***************************************************************************//**
+ * @brief          CCM buffer authenticated decryption optimized for Zigbee
+ *
+ * @param data     Input/output buffer of payload data (decrypt-in-place)
+ * @param length   length of input data
+ * @param iv       nonce (initialization vector)
+ *                 must be 13 bytes
+ * @param aad      Input buffer of Additional Authenticated Data
+ * @param aad_len  Length of buffer @p aad
+ * @param tag      authentication tag
+ * @param tag_len  Length of authentication tag
+ *
+ * @return         SL_STATUS_OK if successful and authenticated,
+ *                 SL_STATUS_INVALID_SIGNATURE if tag does not match payload,
+ *                 relevant status code on other error
+ ******************************************************************************/
+sl_status_t sli_ccm_zigbee(bool encrypt,
+                           const unsigned char *data_in,
+                           unsigned char       *data_out,
+                           size_t              length,
+                           const unsigned char *key,
+                           const unsigned char *iv,
+                           const unsigned char *aad,
+                           size_t              aad_len,
+                           unsigned char       *tag,
+                           size_t              tag_len);
+
+/***************************************************************************//**
+ * @brief          Process a table of BLE RPA device keys and look for a
+ *                 match against the supplied hash
+ *
+ * @param keytable Pointer to an array of AES-128 keys, corresponding to the
+ *                 per-device key in the BLE RPA process
+ * @param keymask  Bitmask indicating with key indices in keytable are valid
+ * @param prand    24-bit BLE nonce to encrypt with each key and match against hash
+ * @param hash     BLE RPA hash to match against (last 24 bits of AES result)
+ *
+ * @return         0-based index of matching key if a match is found, -1 for no match.
+ ******************************************************************************/
+int sli_process_ble_rpa(const unsigned char keytable[],
+                        uint32_t            keymask,
+                        uint32_t            prand,
+                        uint32_t            hash);
+
+#ifdef __cplusplus
+}
+#endif
+
+/// @} (end addtogroup sli_protocol_crypto)
+/// @endcond
+#endif // SLI_PROTOCOL_CRYPTO_H

--- a/gecko/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_crypto.c
+++ b/gecko/platform/security/sl_component/sl_protocol_crypto/src/sli_protocol_crypto_crypto.c
@@ -1,0 +1,568 @@
+/***************************************************************************//**
+ * @file
+ * @brief Proprietary crypto primitivies optimized for Silicon Labs devices
+ *        with a CRYPTO peripheral.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "em_device.h"
+
+#if defined(CRYPTO_PRESENT)
+
+#include "sli_protocol_crypto.h"
+#include "crypto_management.h"
+#include "em_crypto.h"
+
+// CCM (and CCM-star) implementation optimized for radio protocol usecases
+static sl_status_t aes_ccm_radio(bool                encrypt,
+                                 const unsigned char *add_data,
+                                 size_t              add_length,
+                                 const unsigned char *data_in,
+                                 unsigned char       *data_out,
+                                 size_t              length,
+                                 const unsigned char *key,
+                                 uint32_t            *header,
+                                 size_t              header_length_over_16,
+                                 unsigned char       *tag,
+                                 size_t              tag_length)
+{
+  // Assumptions:
+  // * There is always header input, and the header buffer is 32 bytes and word-aligned
+  // * The actual data content in the header is at least 16 bytes (full block) and
+  //   at maximum 32 bytes (precalculated B0_B1 in BLE). The remainder of the header buffer
+  //   is passed in zero-initialized.
+  // * Input parameter header_length_over_16 reflects this: it says how much larger than 16 bytes the
+  //   header input buffer is.
+  // * The header is always word-aligned
+  // * There may not always be ADD input (e.g. BLE-CCM)
+  // * There may not always be data input (e.g. CCM in authenticated-only mode)
+  // * The header input is pre-calculated by the caller of this function
+  // * Data output may be NULL (in which case it is discarded)
+  // * Tag length may be 0 (CCM-star), in which case the tag pointer is also allowed to be NULL
+
+  size_t L = (((uint8_t*)header)[0] & 0x7) + 1;
+
+  // Mangling DDATA1 (KEY), DDATA2 (= DATA0/DATA1), DDATA3 (=DATA2/DATA3),
+  // DDATA4 (KEYBUF). Max execution sequence length = 20
+  CRYPTO_TypeDef   *device =
+    crypto_management_acquire_preemption(CRYPTO_MANAGEMENT_SAVE_DDATA1
+                                         | CRYPTO_MANAGEMENT_SAVE_DDATA2
+                                         | CRYPTO_MANAGEMENT_SAVE_DDATA3
+                                         | CRYPTO_MANAGEMENT_SAVE_DDATA4
+                                         | CRYPTO_MANAGEMENT_SAVE_UPTO_SEQ4);
+
+  // Setup CRYPTO for AES-128 mode (256 not implemented here)
+  device->CTRL      = CRYPTO_CTRL_AES_AES128;
+  device->WAC       = 0UL;
+
+  CRYPTO_KeyBufWriteUnaligned(device, key, cryptoKey128Bits);
+
+  // Store CBC IV in device->DATA0
+  CRYPTO_DataWrite(&device->DATA0, header);
+
+  // Calculate Counter IV for encryption, which is basically
+  // the CBC IV with the flags byte masked with 0x7, and zeroing
+  // out the length field.
+  ((uint8_t*)header)[0] &= 0x07;
+  for (size_t i = 16 - L; i < 16; i++) {
+    ((uint8_t*)header)[i] = 0;
+  }
+
+  // Store Counter IV in crypto->DATA1
+  CRYPTO_DataWrite(&device->DATA1, header);
+
+  // Start the CBC-MAC by encrypting the IV and storing the result in DATA
+  device->CMD = CRYPTO_CMD_INSTR_AESENC;
+
+  // Update the CBC-MAC with the remainder of the header and
+  // the full AAD, up until block boundary
+  if (header_length_over_16 + add_length > 0) {
+    if (header_length_over_16 < 16) {
+      // Fill up the remainder taking from the ADD (if any) and into the
+      // second header block (guaranteed to have a 32-byte writeable buffer)
+      if (add_length > 0) {
+        size_t injected_add = add_length > (16 - header_length_over_16) ? 16 - header_length_over_16 : add_length;
+
+        for (size_t i = 0; i < injected_add; i++) {
+          (&((uint8_t*)&header[4])[header_length_over_16])[i] = add_data[i];
+        }
+
+        header_length_over_16 += injected_add;
+        add_data += injected_add;
+        add_length -= injected_add;
+      }
+    }
+
+    // Accumulate the second header block into the CBC-MAC
+    CRYPTO_DataWrite(&device->DATA3, &header[4]);
+
+    // Accumulate: XOR the input block into the previously accumulated value in DATA0
+    // and encrypt the result to get the updated accumulator in DATA0
+    device->CMD = CRYPTO_CMD_INSTR_DATA3TODATA0XOR;
+    device->CMD = CRYPTO_CMD_INSTR_AESENC;
+    device->CMD = CRYPTO_CMD_INSTR_DATA0TODATA3;
+
+    // Run the remainder of the ADD through the CBC-MAC accumulator
+    if (add_length > 0) {
+      // Set the iteration count
+      device->SEQCTRL  = add_length;
+      device->SEQCTRLB = 0;
+
+      CRYPTO_EXECUTE_4(device,
+                       CRYPTO_CMD_INSTR_DMA0TODATA,      // Load new block of data into DATA0
+                       CRYPTO_CMD_INSTR_DATA3TODATA0XOR, // XOR the accumulated tag with the new block
+                       CRYPTO_CMD_INSTR_AESENC,          // Encrypt the XOR result
+                       CRYPTO_CMD_INSTR_DATA0TODATA3     // Store the new accumulated tag to DATA3
+                       );
+      while (add_length) {
+        if (add_length < 16) {
+          // Use writeable header buffer for zero padding
+          header[0] = 0;
+          header[1] = 0;
+          header[2] = 0;
+          header[3] = 0;
+          // Since add_data is potentially unaligned, do a byte copy
+          for (size_t i = 0; i < add_length; i++) {
+            ((uint8_t*)header)[i] = add_data[i];
+          }
+          CRYPTO_DataWrite(&device->DATA0, header);
+          add_length = 0;
+        } else {
+          CRYPTO_DataWriteUnaligned(&device->DATA0, add_data);
+          add_length  -= 16;
+          add_data    += 16;
+        }
+      }
+    }
+  } else {
+    // Move the CBC-MAC accumulator to DATA3
+    device->CMD = CRYPTO_CMD_INSTR_DATA0TODATA3;
+  }
+
+  // Set the iteration count
+  device->SEQCTRL  = length;
+  device->SEQCTRLB = 0;
+
+  if (encrypt) {
+    CRYPTO_EXECUTE_16(device,
+                      CRYPTO_CMD_INSTR_EXECIFA,
+
+                      // Read data input into DATA2
+                      CRYPTO_CMD_INSTR_DMA0TODATA,
+                      CRYPTO_CMD_INSTR_DATA0TODATA2,
+
+                      // Accumulate the plaintext into the CBC-MAC
+                      CRYPTO_CMD_INSTR_DATA3TODATA0XOR,
+                      CRYPTO_CMD_INSTR_AESENC,
+                      CRYPTO_CMD_INSTR_DATA0TODATA3,
+
+                      // Calculate key stream block
+                      CRYPTO_CMD_INSTR_DATA1INC,
+                      CRYPTO_CMD_INSTR_DATA1TODATA0,
+                      CRYPTO_CMD_INSTR_AESENC,
+
+                      // XOR plaintext with key stream and output the result
+                      CRYPTO_CMD_INSTR_DATA2TODATA0XOR,
+                      CRYPTO_CMD_INSTR_DATATODMA0,
+
+                      // Calculate tag into DATA0 when all data has been processed
+                      CRYPTO_CMD_INSTR_EXECIFLAST,
+                      CRYPTO_CMD_INSTR_DATA1INCCLR,
+                      CRYPTO_CMD_INSTR_DATA1TODATA0,
+                      CRYPTO_CMD_INSTR_AESENC,
+                      CRYPTO_CMD_INSTR_DATA3TODATA0XOR
+                      );
+  } else {
+    CRYPTO_EXECUTE_18(device,
+                      CRYPTO_CMD_INSTR_EXECIFA,
+
+                      // Calculate key stream block into DATA0
+                      CRYPTO_CMD_INSTR_DATA1INC,
+                      CRYPTO_CMD_INSTR_DATA1TODATA0,
+                      CRYPTO_CMD_INSTR_AESENC,
+
+                      // XOR data input with key stream and output the result
+                      CRYPTO_CMD_INSTR_DATA0TODATA2,
+                      CRYPTO_CMD_INSTR_DMA0TODATA,
+                      CRYPTO_CMD_INSTR_DATA2TODATA0XORLEN,
+                      CRYPTO_CMD_INSTR_DATATODMA0,
+
+                      // Accumulate the plaintext into the CBC-MAC
+                      CRYPTO_CMD_INSTR_DATA0TODATA2,
+                      CRYPTO_CMD_INSTR_DATA3TODATA0,
+                      CRYPTO_CMD_INSTR_DATA2TODATA0XORLEN,
+
+                      CRYPTO_CMD_INSTR_AESENC,
+                      CRYPTO_CMD_INSTR_DATA0TODATA3,
+
+                      // Calculate tag into DATA0 when all data has been processed
+                      CRYPTO_CMD_INSTR_EXECIFLAST,
+                      CRYPTO_CMD_INSTR_DATA1INCCLR,
+                      CRYPTO_CMD_INSTR_DATA1TODATA0,
+                      CRYPTO_CMD_INSTR_AESENC,
+                      CRYPTO_CMD_INSTR_DATA3TODATA0XOR
+                      );
+  }
+
+  while (length) {
+    if (length < 16) {
+      // Use writeable header buffer for zero padding
+      header[0] = 0;
+      header[1] = 0;
+      header[2] = 0;
+      header[3] = 0;
+      // Since input data is potentially unaligned, do a byte copy
+      for (size_t i = 0; i < length; i++) {
+        ((uint8_t*)header)[i] = data_in[i];
+      }
+      CRYPTO_DataWrite(&device->DATA0, header);
+      CRYPTO_DataRead(&device->DATA0, header);
+      if (data_out) {
+        // Data output can be unaligned, too
+        for (size_t i = 0; i < length; i++) {
+          data_out[i] = ((uint8_t*)header)[i];
+        }
+        // In this case, we're guaranteed it is the last part of
+        // the data and don't need to adjust the pointer anymore.
+      }
+      length = 0;
+    } else {
+      CRYPTO_DataWriteUnaligned(&device->DATA0, data_in);
+      length  -= 16;
+      data_in += 16;
+      if (data_out) {
+        CRYPTO_DataReadUnaligned(&device->DATA0, data_out);
+        data_out += 16;
+      } else {
+        CRYPTO_DataRead(&device->DATA0, header);
+      }
+    }
+  }
+
+  // Read calculated authentication tag from DATA0 register
+  CRYPTO_DataRead(&device->DATA0, header);
+  crypto_management_release_preemption(device);
+
+  if (encrypt) {
+    // For encryption, return the requested amount of tag
+    for (size_t i = 0; i < tag_length; i++) {
+      tag[i] = ((uint8_t*)header)[i];
+    }
+  } else {
+    // For decryption, verify the requested amount of tag
+    uint32_t accumulator = 0;
+    for (size_t i = 0; i < tag_length; i++) {
+      accumulator |= ((uint8_t*)header)[i] ^ tag[i];
+    }
+    if (accumulator != 0) {
+      return SL_STATUS_INVALID_SIGNATURE;
+    }
+  }
+
+  return SL_STATUS_OK;
+}
+
+// Perform a CCM encrypt/decrypt operation with BLE parameters and input.
+// This means:
+// * 13 bytes IV
+// * 1 byte AAD (parameter 'header')
+// * AES-128 key (16 byte key)
+// * in-place encrypt/decrypt with variable length plain/ciphertext
+//   (up to 64 kB, uint16 overflow)
+// * 4 byte tag
+static sl_status_t aes_ccm_ble(bool                encrypt,
+                               unsigned char       *data,
+                               size_t              length,
+                               const unsigned char *key,
+                               const unsigned char *iv,
+                               unsigned char       header,
+                               unsigned char       *tag)
+
+{
+  // Use 32-byte word aligned buffer to bypass some time-consuming logic in aes_ccm_radio
+  uint32_t b0b1_words[32 / sizeof(uint32_t)];
+  uint8_t* b0b1_bytes = (uint8_t*)b0b1_words;
+
+  // Fill in B0 block according to BLE spec
+  b0b1_bytes[0] = 0x49U;
+
+  // Copy in the 13 bytes of nonce
+  for (size_t i = 0; i < 13; i++) {
+    b0b1_bytes[i + 1] = iv[i];
+  }
+
+  b0b1_bytes[14] = (uint8_t) length >> 8;
+  b0b1_bytes[15] = (uint8_t) length;
+  b0b1_bytes[16] = 0; // upper octet of AAD length
+  b0b1_bytes[17] = 1; // lower octet of AAD length (BLE CCM always has only one byte of AAD)
+  b0b1_bytes[18] = header; // AAD
+  b0b1_bytes[19] = 0;
+  b0b1_words[5] = 0;
+  b0b1_words[6] = 0;
+  b0b1_words[7] = 0;
+
+  return aes_ccm_radio(encrypt,
+                       NULL, 0,
+                       data, data, length,
+                       key,
+                       b0b1_words, 32 - 16,
+                       tag, 4);
+}
+
+//
+// CCM buffer authenticated decryption optimized for BLE
+//
+sl_status_t sli_ccm_auth_decrypt_ble(unsigned char       *data,
+                                     size_t              length,
+                                     const unsigned char *key,
+                                     const unsigned char *iv,
+                                     unsigned char       header,
+                                     unsigned char       *tag)
+{
+  return aes_ccm_ble(false,
+                     data,
+                     length,
+                     key,
+                     iv,
+                     header,
+                     (uint8_t *) tag);
+}
+
+//
+// CCM buffer encryption optimized for BLE
+//
+sl_status_t sli_ccm_encrypt_and_tag_ble(unsigned char       *data,
+                                        size_t              length,
+                                        const unsigned char *key,
+                                        const unsigned char *iv,
+                                        unsigned char       header,
+                                        unsigned char       *tag)
+{
+  return aes_ccm_ble(true,
+                     data,
+                     length,
+                     key,
+                     iv,
+                     header,
+                     tag);
+}
+
+sl_status_t sli_ccm_zigbee(bool encrypt,
+                           const unsigned char *data_in,
+                           unsigned char       *data_out,
+                           size_t              length,
+                           const unsigned char *key,
+                           const unsigned char *iv,
+                           const unsigned char *aad,
+                           size_t              aad_len,
+                           unsigned char       *tag,
+                           size_t              tag_len)
+{
+  // Validated assumption: for ZigBee, the authenticated data
+  // length will always fit into a 16-bit length field (up to
+  // 64 kB of data), meaning the header data size will always
+  // be either 16 (no ciphertext) or 18 bytes long.
+
+  // Use 32-byte word aligned buffer to bypass some time-consuming logic in aes_ccm_radio
+  uint32_t header_words[32 / sizeof(uint32_t)];
+  uint8_t* header_bytes = (uint8_t*)header_words;
+
+  // Start with the 'flags' byte. It encodes whether there is AAD,
+  // and the length of the tag fields
+  header_bytes[0] = 0x01 // always 2 bytes of message length
+                    | ((aad_len > 0) ? 0x40 : 0x00) // Set 'aflag' bit if there is AAD
+                    | ((tag_len >= 4) ? (((tag_len - 2) / 2) << 3) : 0); // Encode tag length
+
+  for (size_t i = 0; i < 13; i++) {
+    header_bytes[i + 1] = iv[i];
+  }
+
+  header_bytes[14] = (uint8_t) length >> 8;
+  header_bytes[15] = (uint8_t) length;
+  header_words[4] = 0;
+  header_words[5] = 0;
+  header_words[6] = 0;
+  header_words[7] = 0;
+  if (aad_len > 0) {
+    header_bytes[16] = (uint8_t) aad_len >> 8; // upper octet of AAD length
+    header_bytes[17] = (uint8_t) aad_len; // lower octet of AAD length
+  }
+
+  return aes_ccm_radio(encrypt,
+                       aad,
+                       aad_len,
+                       data_in,
+                       data_out,
+                       length,
+                       key,
+                       header_words,
+                       (aad_len > 0 ? 2 : 0),
+                       tag,
+                       tag_len);
+}
+
+/*
+ * Process a table of BLE RPA device keys and look for a
+ * match against the supplied hash
+ */
+int sli_process_ble_rpa(const unsigned char   keytable[],
+                        uint32_t              keymask,
+                        uint32_t              prand,
+                        uint32_t              hash)
+{
+  size_t index;
+  uint32_t data_register[4] = { 0 };
+  data_register[3] = __REV(prand);
+
+  /* Mangling DDATA1 (KEY) and DDATA2 (= DATA0/DATA1). Max execution length = 2 */
+  CRYPTO_TypeDef *device =
+    crypto_management_acquire_preemption(CRYPTO_MANAGEMENT_SAVE_DDATA1
+                                         | CRYPTO_MANAGEMENT_SAVE_DDATA2
+                                         | CRYPTO_MANAGEMENT_SAVE_UPTO_SEQ0);
+  /* Set up CRYPTO to do AES, and load prand */
+  device->CTRL     = CRYPTO_CTRL_AES_AES128 | CRYPTO_CTRL_KEYBUFDIS;
+  device->WAC      = 0UL;
+
+  CRYPTO_DataWrite(&device->DATA1, (uint32_t*)data_register);
+
+  /* For each key, execute AES encrypt operation and compare w hash */
+  /* Read result of previous iteration first to minimize stall while waiting
+     for AES to finish */
+  int currentindex = -1;
+  for ( index = 0; index < 32; index++ ) {
+    if ( (keymask & (1U << index)) == 0 ) {
+      continue;
+    }
+
+    CRYPTO_DataRead(&device->DATA0, data_register);
+    CRYPTO_DataWrite(&device->KEY, (uint32_t*)(&keytable[index * 16]));
+    CRYPTO_EXECUTE_2(device,
+                     CRYPTO_CMD_INSTR_DATA1TODATA0,
+                     CRYPTO_CMD_INSTR_AESENC);
+
+    if ( (currentindex >= 0)
+         && ( (data_register[3] & 0xFFFFFF00UL) == __REV(hash) ) ) {
+      crypto_management_release_preemption(device);
+      return currentindex;
+    }
+
+    currentindex = index;
+  }
+
+  /* Read result of last encryption and check for hash */
+  CRYPTO_DataRead(&device->DATA0, data_register);
+  crypto_management_release_preemption(device);
+
+  if ( (data_register[3] & 0xFFFFFF00UL) == __REV(hash) ) {
+    return currentindex;
+  }
+
+  return -1;
+}
+
+sl_status_t sli_aes_crypt_ecb_radio(bool                   encrypt,
+                                    const unsigned char    *key,
+                                    unsigned int           keybits,
+                                    const unsigned char    input[16],
+                                    volatile unsigned char output[16])
+{
+  /* process one ore more blocks of data */
+  CRYPTO_TypeDef *device =
+    crypto_management_acquire_preemption(CRYPTO_MANAGEMENT_SAVE_DDATA1
+                                         | CRYPTO_MANAGEMENT_SAVE_DDATA2
+                                         | CRYPTO_MANAGEMENT_SAVE_DDATA4);
+  device->WAC = 0;
+  device->CTRL = 0;
+
+  CRYPTO_KeyBufWriteUnaligned(device, key,
+                              (keybits == 128UL
+                               ? cryptoKey128Bits : cryptoKey256Bits));
+
+  if (!encrypt) {
+    // Transform encryption to decryption key
+    device->CMD = CRYPTO_CMD_INSTR_AESENC;
+    device->CMD = CRYPTO_CMD_INSTR_DDATA1TODDATA4;
+  }
+
+  CRYPTO_DataWriteUnaligned(&device->DATA0, (const uint8_t *)input);
+
+  if ( encrypt ) {
+    device->CMD = CRYPTO_CMD_INSTR_AESENC;
+  } else {
+    device->CMD = CRYPTO_CMD_INSTR_AESDEC;
+  }
+
+  CRYPTO_DataReadUnaligned(&device->DATA0, (uint8_t *)output);
+
+  crypto_management_release_preemption(device);
+
+  return SL_STATUS_OK;
+}
+
+sl_status_t sli_aes_crypt_ctr_radio(const unsigned char   *key,
+                                    unsigned int           keybits,
+                                    const unsigned char    input[16],
+                                    const unsigned char    iv_in[16],
+                                    volatile unsigned char iv_out[16],
+                                    volatile unsigned char output[16])
+{
+  /* process one ore more blocks of data */
+  CRYPTO_TypeDef *device =
+    crypto_management_acquire_preemption(CRYPTO_MANAGEMENT_SAVE_DDATA1
+                                         | CRYPTO_MANAGEMENT_SAVE_DDATA2
+                                         | CRYPTO_MANAGEMENT_SAVE_DDATA4);
+  device->WAC = 0;
+  device->CTRL = 0;
+
+  CRYPTO_KeyBufWriteUnaligned(device, key,
+                              (keybits == 128UL
+                               ? cryptoKey128Bits : cryptoKey256Bits));
+
+  if ((uint32_t)iv_in != 0) {
+    CRYPTO_DataWriteUnaligned(&device->DATA1, (uint8_t *)iv_in);
+  } else {
+    uint32_t iv[4] = { 0, 0, 0, 0 };
+    CRYPTO_DataWrite(&device->DATA1, iv);
+  }
+
+  device->CMD = CRYPTO_CMD_INSTR_DATA1TODATA0;
+  device->CMD = CRYPTO_CMD_INSTR_AESENC;
+  device->CMD = CRYPTO_CMD_INSTR_DATA1INC;
+
+  CRYPTO_DataWriteUnaligned(&device->DATA0XOR, (uint8_t *)(input));
+  CRYPTO_DataReadUnaligned(&device->DATA0, (uint8_t *)(output));
+
+  if ((uint32_t)iv_out != 0) {
+    CRYPTO_DataReadUnaligned(&device->DATA1, (uint8_t *)iv_out);
+  }
+
+  crypto_management_release_preemption(device);
+
+  return SL_STATUS_OK;
+}
+
+#endif /* CRYPTO_PRESENT */

--- a/gecko/platform/security/sl_component/sl_psa_driver/inc/crypto_management.h
+++ b/gecko/platform/security/sl_component/sl_psa_driver/inc/crypto_management.h
@@ -1,0 +1,135 @@
+/***************************************************************************//**
+ * @file
+ * @brief Silicon Labs CRYPTO device management interface.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef CRYPTO_MANAGEMENT_H
+#define CRYPTO_MANAGEMENT_H
+
+/// @cond DO_NOT_INCLUDE_WITH_DOXYGEN
+
+/***************************************************************************//**
+ * \addtogroup sl_crypto_plugins
+ * \{
+ ******************************************************************************/
+
+/***************************************************************************//**
+ * \addtogroup sl_crypto_management Peripheral Instance Management: CRYPTO
+ * \brief Resource management functions for the CRYPTO peripheral
+ *
+ * \{
+ ******************************************************************************/
+
+#include "em_device.h"
+
+#if defined(CRYPTO_PRESENT)
+#include "em_crypto.h"
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Save DDATA0 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_DDATA0 (0x1U << 3)
+/** Save DDATA1 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_DDATA1 (0x1U << 4)
+/** Save DDATA2 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_DDATA2 (0x1U << 5)
+/** Save DDATA3 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_DDATA3 (0x1U << 6)
+/** Save DDATA4 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_DDATA4 (0x1U << 7)
+/** Save SEQ0 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_UPTO_SEQ0 (0x1U)
+/** Save SEQ0 through SEQ1 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_UPTO_SEQ1 (0x2U)
+/** Save SEQ0 through SEQ2 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_UPTO_SEQ2 (0x3U)
+/** Save SEQ0 through SEQ3 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_UPTO_SEQ3 (0x4U)
+/** Save SEQ0 through SEQ4 register when preempting */
+#define CRYPTO_MANAGEMENT_SAVE_UPTO_SEQ4 (0x5U)
+
+/**
+ * \brief		   Get ownership of a CRYPTO peripheral
+ *
+ * \return         Handle of assigned CRYPTO peripheral
+ */
+CRYPTO_TypeDef *crypto_management_acquire(void);
+
+/**
+ * \brief		   Get ownership of the default CRYPTO peripheral
+ *
+ * \return         Handle of default CRYPTO peripheral
+ */
+CRYPTO_TypeDef *crypto_management_acquire_default(void);
+
+/**
+ * \brief          Release ownership of a CRYPTO peripheral
+ *
+ * \param device   Handle of CRYPTO peripheral to be released
+ */
+void crypto_management_release(CRYPTO_TypeDef *device);
+
+/**
+ * \brief          Acquire preempting ownership of a CRYPTO peripheral.
+ *                 NOTE: this function is not meant for general use, it
+ *                 is not thread-safe, and must be called form the
+ *                 highest priority thread/interrupt allowed to use mbed TLS.
+ *
+ * \param regmask  Bitmask of CRYPTO_MANAGEMENT_ defines instructing what
+ *                 parts of the device state will be clobbered during
+ *                 preemption.
+ *
+ * \return         Handle of assigned CRYPTO peripheral
+ */
+CRYPTO_TypeDef *crypto_management_acquire_preemption(uint32_t regmask);
+
+/**
+ * \brief          Releasing preempting ownership of a CRYPTO peripheral.
+ *                 NOTE: this function is not meant for general use, it
+ *                 is not thread-safe, and must be called form the
+ *                 highest priority thread/interrupt allowed to use mbed TLS.
+ *
+ * \param device   Handle of preempted CRYPTO peripheral to be released
+ */
+void crypto_management_release_preemption(CRYPTO_TypeDef *device);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CRYPTO_PRESENT */
+
+/** \} (end addtogroup sl_crypto_management) */
+/** \} (end addtogroup sl_crypto_plugins) */
+
+/// @endcond
+
+#endif /* CRYPTO_MANAGEMENT_H */

--- a/gecko/platform/security/sl_component/sl_psa_driver/src/crypto_management.c
+++ b/gecko/platform/security/sl_component/sl_psa_driver/src/crypto_management.c
@@ -1,0 +1,454 @@
+/***************************************************************************//**
+ * @file
+ * @brief Silicon Labs CRYPTO device management interface.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#include "em_device.h"
+
+#if defined(CRYPTO_PRESENT)
+
+#include "crypto_management.h"
+#include "em_core.h"
+#include "em_bus.h"
+#include "sl_assert.h"
+#include <mbedtls/build_info.h>
+
+#if defined(MBEDTLS_THREADING_C)
+#include "mbedtls/threading.h"
+
+static mbedtls_threading_mutex_t    crypto_locks[CRYPTO_COUNT] = { 0 };
+static volatile bool                crypto_locks_initialized = false;
+static unsigned int                 acquire_count = 0U;
+
+#if defined(SL_THREADING_ALT)
+  #include "cmsis_os2.h"
+#endif
+
+#endif /* MBEDTLS_THREADING_C */
+
+/* Conversion macro for compatibility with the 5.3.x release of the Gecko SDK */
+#if defined(MBEDTLS_CRYPTO_DEVICE_PREEMPTION)
+#warning "MBEDTLS_CRYPTO_DEVICE_PREEMPTION is deprecated, please define " \
+  "CRYPTO_DEVICE_PREEMPTION instead."
+#define CRYPTO_DEVICE_PREEMPTION
+#endif
+
+#if defined(CRYPTO_DEVICE_PREEMPTION)
+/** Preemptable context of CRYPTO hardware module. */
+typedef struct {
+  uint32_t CTRL;            /*!< Control Register  */
+  uint32_t WAC;             /*!< Wide Arithmetic Configuration  */
+  uint32_t SEQCTRL;         /*!< Sequence Control  */
+  uint32_t SEQCTRLB;        /*!< Sequence Control B  */
+  uint32_t IEN;             /*!< Interrupt Enable Register  */
+  uint32_t SEQ[5];          /*!< Instruction Sequence registers */
+  CRYPTO_Data260_TypeDef DDATA[5];   /*!< DDATA registers. Covers all data
+                                        registers
+                                        of CRYPTO, including DATA(128 bit),
+                                        DDATA (256bit/260bit),
+                                        QDATA (512bit) registers. */
+  uint32_t regmask;         /*!< Bitmask for which registers to save */
+  uint32_t operands;        /*!< Saving the currently selected operands */
+  bool carry;               /*!< Saving the status of the carry flag */
+} crypto_context_t;
+
+static crypto_context_t preemption_context;
+static bool             is_preempted = false;
+static CORE_DECLARE_IRQ_STATE;
+#endif /* CRYPTO_DEVICE_PREEMPTION */
+
+typedef enum {
+#if defined(CRYPTO0)
+  CRYPTO0_ID = 0,
+#elif defined(CRYPTO)
+  CRYPTO_ID = 0,
+#endif
+#if defined(CRYPTO1)
+  CRYPTO1_ID = 1,
+#endif
+} crypto_instance_number_t;
+
+typedef struct {
+  CRYPTO_TypeDef *device;
+  uint32_t clockMask;
+} crypto_device_t;
+
+static const crypto_device_t crypto_devices[CRYPTO_COUNT] =
+{
+#if defined(CRYPTO0)
+  {
+    CRYPTO0,
+    _CMU_HFBUSCLKEN0_CRYPTO0_SHIFT
+  },
+#elif defined(CRYPTO)
+  {
+    CRYPTO,
+    _CMU_HFBUSCLKEN0_CRYPTO_SHIFT
+  },
+#endif
+#if defined(CRYPTO1)
+  {
+    CRYPTO1,
+    _CMU_HFBUSCLKEN0_CRYPTO1_SHIFT
+  },
+#endif
+};
+
+static inline int crypto_management_index_by_device(CRYPTO_TypeDef *device)
+{
+#if defined(CRYPTO0)
+  if ( device == CRYPTO0 ) {
+    return 0;
+  }
+#elif defined(CRYPTO)
+  if ( device == CRYPTO ) {
+    return 0;
+  }
+#endif
+#if defined(CRYPTO1)
+  if ( device == CRYPTO1 ) {
+    return 1;
+  }
+#endif
+  return -1;
+}
+
+#if defined(MBEDTLS_THREADING_C)
+static bool crypto_management_initialize_mutex(void)
+{
+#if !defined(SL_THREADING_ALT)
+  /* Initialize mutexes if that hasn't happened yet */
+  CORE_DECLARE_IRQ_STATE;
+#endif
+
+  /* Initialize mutexes if that hasn't happened yet */
+  if ( !crypto_locks_initialized ) {
+#if defined(SL_THREADING_ALT)
+    int32_t kernel_lock_state = 0;
+    osKernelState_t kernel_state = osKernelGetState();
+    if (kernel_state != osKernelInactive && kernel_state != osKernelReady) {
+      kernel_lock_state = osKernelLock();
+      if (kernel_lock_state < 0) {
+        return false;
+      }
+    }
+#else
+    CORE_ENTER_CRITICAL();
+#endif
+    if ( !crypto_locks_initialized ) {
+      for ( int i = 0; i < CRYPTO_COUNT; i++ ) {
+        mbedtls_mutex_init(&crypto_locks[i]);
+      }
+      crypto_locks_initialized = true;
+    }
+#if defined(SL_THREADING_ALT)
+    if (kernel_state != osKernelInactive && kernel_state != osKernelReady) {
+      if (osKernelRestoreLock(kernel_lock_state) < 0) {
+        return false;
+      }
+    }
+#else
+    CORE_EXIT_CRITICAL();
+#endif
+  }
+
+  return true;
+}
+#endif
+
+/* Use bitband for clock enable/disable operations, such that they are atomic */
+#define CRYPTO_CLOCK_ENABLE(clk)  BUS_RegBitWrite(& (CMU->HFBUSCLKEN0), (clk), 1)
+#define CRYPTO_CLOCK_DISABLE(clk) BUS_RegBitWrite(& (CMU->HFBUSCLKEN0), (clk), 0)
+#define CRYPTO_CLOCK_ENABLED(clk) BUS_RegBitRead(& (CMU->HFBUSCLKEN0), (clk))
+
+/* Get ownership of an available crypto device */
+CRYPTO_TypeDef *crypto_management_acquire(void)
+{
+  CRYPTO_TypeDef *device = NULL;
+
+#if defined(MBEDTLS_THREADING_C)
+  unsigned int devno = 0;
+  bool mutex_initialized = crypto_management_initialize_mutex();
+  EFM_ASSERT(mutex_initialized);
+
+/* Wrapping this in SL_THREADING_ALT pending non-blocking mutex in official
+ * threading API. */
+#if defined(SL_THREADING_ALT)
+  /* Try to take an available crypto instance */
+  for (; devno < CRYPTO_COUNT; devno++ ) {
+    if ( 0 == THREADING_TakeMutexNonBlocking(&crypto_locks[devno]) ) {
+      device = crypto_devices[devno].device;
+      break;
+    }
+  }
+#endif /* SL_THREADING_ALT */
+
+  /* If no device immediately available, do naieve round-robin */
+  if ( device == NULL ) {
+    devno = acquire_count % CRYPTO_COUNT;
+    mbedtls_mutex_lock(&crypto_locks[devno]);
+    device = crypto_devices[devno].device;
+  }
+
+  /* Doing this outside of critical section is safe, since we own the lock
+   * and are using bitband to poke the clock enable bit */
+  CRYPTO_CLOCK_ENABLE(crypto_devices[devno].clockMask);
+
+  acquire_count++;
+#else // !MBEDTLS_THREADING_C
+  device = crypto_devices[0].device;
+  CRYPTO_CLOCK_ENABLE(crypto_devices[0].clockMask);
+#endif // MBEDTLS_THREADING_C
+
+  return device;
+}
+
+/* Get ownership of the default crypto device (CRYPTO0/CRYPTO) */
+CRYPTO_TypeDef *crypto_management_acquire_default(void)
+{
+  CRYPTO_TypeDef *device = NULL;
+
+#if defined(MBEDTLS_THREADING_C)
+  bool mutex_initialized = crypto_management_initialize_mutex();
+  EFM_ASSERT(mutex_initialized);
+
+  mbedtls_mutex_lock(&crypto_locks[0]);
+  device = crypto_devices[0].device;
+
+  /* Doing this outside of critical section is safe, since we own the lock
+   * and are using bitband to poke the clock enable bit */
+  CRYPTO_CLOCK_ENABLE(crypto_devices[0].clockMask);
+#else // !MBEDTLS_THREADING_C
+  device = crypto_devices[0].device;
+  CRYPTO_CLOCK_ENABLE(crypto_devices[0].clockMask);
+#endif // MBEDTLS_THREADING_C
+
+  return device;
+}
+
+/* Release ownership of an available crypto device */
+void crypto_management_release(CRYPTO_TypeDef *device)
+{
+  int devno = crypto_management_index_by_device(device);
+  if ( devno < 0 ) {
+    return;
+  }
+
+  /* Doing this outside of critical section is safe, since we still own the lock
+   * and are using bitband to poke the clock enable bit */
+  CRYPTO_CLOCK_DISABLE(crypto_devices[devno].clockMask);
+
+#if defined (MBEDTLS_THREADING_C)
+  mbedtls_mutex_unlock(&crypto_locks[devno]);
+#endif
+}
+
+/* Acquire a device with preemption. NOT thread-safe! */
+CRYPTO_TypeDef *crypto_management_acquire_preemption(uint32_t regmask)
+{
+#if defined(CRYPTO_DEVICE_PREEMPTION)
+  CRYPTO_TypeDef *device = NULL;
+  /* Turn off interrupts */
+  CORE_ENTER_CRITICAL();
+
+  /* Check if there is an unused CRYPTO instance */
+  for ( int i = 0; i < CRYPTO_COUNT; i++ ) {
+    if ( !CRYPTO_CLOCK_ENABLED(crypto_devices[i].clockMask) ) {
+      /* Found an unused device */
+      CRYPTO_CLOCK_ENABLE(crypto_devices[i].clockMask);
+      device = crypto_devices[i].device;
+      break;
+    }
+  }
+
+  /* If there is no unused instance, preempt the last one */
+  if ( device == NULL ) {
+    is_preempted = true;
+    device = crypto_devices[CRYPTO_COUNT - 1].device;
+
+    /* In case this instance is still working on anything */
+    CRYPTO_InstructionSequenceWait(device);
+
+    /* Store operational context */
+    preemption_context.regmask  = regmask;
+    preemption_context.WAC      = device->WAC;
+    preemption_context.CTRL     = device->CTRL;
+    preemption_context.SEQCTRL  = device->SEQCTRL;
+    preemption_context.SEQCTRLB = device->SEQCTRLB;
+    preemption_context.IEN      = device->IEN;
+    preemption_context.operands = device->CSTATUS;
+    preemption_context.carry    = (device->DSTATUS & CRYPTO_DSTATUS_CARRY) != 0;
+
+    if ( (preemption_context.WAC & _CRYPTO_WAC_RESULTWIDTH_MASK) == CRYPTO_WAC_RESULTWIDTH_260BIT) {
+      CRYPTO_DData0Read260(device, preemption_context.DDATA[0]);       /* Always save DDATA0 because it'll get clobbered in 260-bit mode*/
+
+      if ( (regmask & CRYPTO_MANAGEMENT_SAVE_DDATA1) != 0 ) {
+        device->CMD = CRYPTO_CMD_INSTR_DDATA1TODDATA0;         /* Move DDATA1 to DDATA0
+                                                                  in order to read. */
+        CRYPTO_DData0Read260(device, preemption_context.DDATA[1]);
+      }
+      if ( (regmask & CRYPTO_MANAGEMENT_SAVE_DDATA2) != 0 ) {
+        device->CMD = CRYPTO_CMD_INSTR_DDATA2TODDATA0;         /* Move DDATA2 to DDATA0
+                                                                  in order to read. */
+        CRYPTO_DData0Read260(device, preemption_context.DDATA[2]);
+      }
+      if ( (regmask & CRYPTO_MANAGEMENT_SAVE_DDATA3) != 0 ) {
+        device->CMD = CRYPTO_CMD_INSTR_DDATA3TODDATA0;         /* Move DDATA3 to DDATA0
+                                                                  in order to read. */
+        CRYPTO_DData0Read260(device, preemption_context.DDATA[3]);
+      }
+      if ( (regmask & CRYPTO_MANAGEMENT_SAVE_DDATA4) != 0 ) {
+        device->CMD = CRYPTO_CMD_INSTR_DDATA4TODDATA0;         /* Move DDATA4 to DDATA0
+                                                                  in order to read. */
+        CRYPTO_DData0Read260(device, preemption_context.DDATA[4]);
+      }
+    } else {
+      if ( (regmask & CRYPTO_MANAGEMENT_SAVE_DDATA0) != 0 ) {
+        CRYPTO_DDataRead(&device->DDATA0, preemption_context.DDATA[0]);
+      }
+      if ( (regmask & CRYPTO_MANAGEMENT_SAVE_DDATA1) != 0 ) {
+        CRYPTO_DDataRead(&device->DDATA1, preemption_context.DDATA[1]);
+      }
+      if ( (regmask & CRYPTO_MANAGEMENT_SAVE_DDATA2) != 0 ) {
+        CRYPTO_DDataRead(&device->DDATA2, preemption_context.DDATA[2]);
+      }
+      if ( (regmask & CRYPTO_MANAGEMENT_SAVE_DDATA3) != 0 ) {
+        CRYPTO_DDataRead(&device->DDATA3, preemption_context.DDATA[3]);
+      }
+      if ( (regmask & CRYPTO_MANAGEMENT_SAVE_DDATA4) != 0 ) {
+        CRYPTO_DDataRead(&device->DDATA4, preemption_context.DDATA[4]);
+      }
+    }
+
+    /* Search for possible EXEC commands and replace with END. */
+    for ( size_t j = 0; j < (regmask & 0x7U) * sizeof(uint32_t); j++ ) {
+      if ( (j & 0x03) == 0 ) {
+        preemption_context.SEQ[j / sizeof(uint32_t)] = *((&device->SEQ0) + (j / sizeof(uint32_t)));
+      }
+      if ( ((uint8_t*)preemption_context.SEQ)[j] == CRYPTO_CMD_INSTR_EXEC ) {
+        ((uint8_t*)preemption_context.SEQ)[j] = CRYPTO_CMD_INSTR_END;
+      }
+    }
+  }
+
+  return device;
+#else /* CRYPTO_DEVICE_PREEMPTION */
+  (void) regmask;
+  return crypto_management_acquire();
+#endif /* CRYPTO_DEVICE_PREEMPTION */
+}
+
+/* Release a device from preemption */
+void crypto_management_release_preemption(CRYPTO_TypeDef *device)
+{
+  if ( crypto_management_index_by_device(device) < 0 ) {
+    return;
+  }
+#if defined(CRYPTO_DEVICE_PREEMPTION)
+
+  if ( is_preempted ) {
+    /* If we preempted something, put their context back */
+    device->WAC      = preemption_context.WAC;
+    device->CTRL     = preemption_context.CTRL;
+    device->SEQCTRL  = preemption_context.SEQCTRL;
+    device->SEQCTRLB = preemption_context.SEQCTRLB;
+    device->IEN      = preemption_context.IEN;
+
+    if ( (preemption_context.WAC & _CRYPTO_WAC_RESULTWIDTH_MASK) == CRYPTO_WAC_RESULTWIDTH_260BIT) {
+      /* Start by writing the DDATA1 value to DDATA0 and move to DDATA1. */
+      if ( (preemption_context.regmask & CRYPTO_MANAGEMENT_SAVE_DDATA1) != 0 ) {
+        CRYPTO_DData0Write260(device, preemption_context.DDATA[1]);
+        device->CMD = CRYPTO_CMD_INSTR_DDATA0TODDATA1;
+      }
+
+      /* Write the DDATA2 value to DDATA0 and move to DDATA2. */
+      if ( (preemption_context.regmask & CRYPTO_MANAGEMENT_SAVE_DDATA2) != 0 ) {
+        CRYPTO_DData0Write260(device, preemption_context.DDATA[2]);
+        device->CMD = CRYPTO_CMD_INSTR_DDATA0TODDATA2;
+      }
+
+      /* Write the DDATA3 value to DDATA0 and move to DDATA3. */
+      if ( (preemption_context.regmask & CRYPTO_MANAGEMENT_SAVE_DDATA3) != 0 ) {
+        CRYPTO_DData0Write260(device, preemption_context.DDATA[3]);
+        device->CMD = CRYPTO_CMD_INSTR_DDATA0TODDATA3;
+      }
+
+      /* Write the DDATA4 value to DDATA0 and move to DDATA4. */
+      if ( (preemption_context.regmask & CRYPTO_MANAGEMENT_SAVE_DDATA4) != 0 ) {
+        CRYPTO_DData0Write260(device, preemption_context.DDATA[4]);
+        device->CMD = CRYPTO_CMD_INSTR_DDATA0TODDATA4;
+      }
+
+      /* Finally write DDATA0 */
+      CRYPTO_DData0Write260(device, preemption_context.DDATA[0]);
+    } else {
+      if ( (preemption_context.regmask & CRYPTO_MANAGEMENT_SAVE_DDATA0) != 0 ) {
+        CRYPTO_DDataWrite(&device->DDATA0, preemption_context.DDATA[0]);
+      }
+      if ( (preemption_context.regmask & CRYPTO_MANAGEMENT_SAVE_DDATA1) != 0 ) {
+        CRYPTO_DDataWrite(&device->DDATA1, preemption_context.DDATA[1]);
+      }
+      if ( (preemption_context.regmask & CRYPTO_MANAGEMENT_SAVE_DDATA2) != 0 ) {
+        CRYPTO_DDataWrite(&device->DDATA2, preemption_context.DDATA[2]);
+      }
+      if ( (preemption_context.regmask & CRYPTO_MANAGEMENT_SAVE_DDATA3) != 0 ) {
+        CRYPTO_DDataWrite(&device->DDATA3, preemption_context.DDATA[3]);
+      }
+      if ( (preemption_context.regmask & CRYPTO_MANAGEMENT_SAVE_DDATA4) != 0 ) {
+        CRYPTO_DDataWrite(&device->DDATA4, preemption_context.DDATA[4]);
+      }
+    }
+
+    if (preemption_context.carry) {
+      device->CMD = CRYPTO_CMD_INSTR_CSET;
+    } else {
+      device->CMD = CRYPTO_CMD_INSTR_CCLR;
+    }
+
+    device->CMD = (preemption_context.operands & 0x7U)
+                  | (((preemption_context.operands >> 8) & 0x7U) << 3)
+                  | 0xC0;
+
+    for (size_t i = 0; i < (preemption_context.regmask & 0x7U); i++ ) {
+      *((&device->SEQ0) + i) = preemption_context.SEQ[i];
+    }
+
+    is_preempted = false;
+  } else {
+    /* If we didn't preempt anything, turn crypto clock back off */
+    CRYPTO_CLOCK_DISABLE(crypto_devices[crypto_management_index_by_device(device)].clockMask);
+  }
+
+  /* Turn interrupts back on */
+  CORE_EXIT_CRITICAL();
+#else /* CRYPTO_DEVICE_PREEMPTION */
+  crypto_management_release(device);
+#endif /* CRYPTO_DEVICE_PREEMPTION */
+}
+
+#endif /* CRYPTO_PRESENT */

--- a/gecko/protocol/bluetooth/bgstack/ll/inc/sl_bt_ll_config.h
+++ b/gecko/protocol/bluetooth/bgstack/ll/inc/sl_bt_ll_config.h
@@ -1,0 +1,80 @@
+/***************************************************************************//**
+ * @brief Bluetooth Link Layer configuration
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_BT_BLUETOOTH_LL_PRIORITIES_DEFINED
+#define SL_BT_BLUETOOTH_LL_PRIORITIES_DEFINED
+
+typedef struct {
+  uint8_t scan_min;
+  uint8_t scan_max;
+  uint8_t adv_min;
+  uint8_t adv_max;
+  uint8_t conn_min;
+  uint8_t conn_max;
+  uint8_t init_min;
+  uint8_t init_max;
+  uint8_t rail_mapping_offset;
+  uint8_t rail_mapping_range;
+  uint8_t _reserved;
+  uint8_t adv_step;
+  uint8_t scan_step;
+  uint8_t pawr_tx_min;
+  uint8_t pawr_tx_max;
+  uint8_t pawr_rx_min;
+  uint8_t pawr_rx_max;
+} sl_bt_bluetooth_ll_priorities;
+
+//Default priority configuration
+#define SL_BT_BLUETOOTH_PRIORITIES_DEFAULT { 191, 143, 175, 127, 135, 0, 55, 15, 16, 16, 0, 4, 4, 15, 5, 20, 10 }
+
+#define SL_BT_BLUETOOTH_PA_AUTOMODE 0xff
+
+#include "sl_common.h"
+SL_PACK_START(1)
+typedef struct {
+  int8_t golden_rssi_min_1m; //<! Golden range lowest RSSI for 1M PHY.
+  int8_t golden_rssi_max_1m; //<! Golden range highest RSSI for 1M PHY.
+
+  int8_t golden_rssi_min_2m; //<! Golden range lowest RSSI for 2M PHY.
+  int8_t golden_rssi_max_2m; //<! Golden range highest RSSI for 2M PHY.
+
+  int8_t golden_rssi_min_coded_s8; //<! Golden range lowest RSSI for Coded PHY w/ S=8.
+  int8_t golden_rssi_max_coded_s8; //<! Golden range highest RSSI for Coded PHY w/ S=8.
+
+  int8_t golden_rssi_min_coded_s2; //<! Golden range lowest RSSI for Coded PHY w/ S=2.
+  int8_t golden_rssi_max_coded_s2; //<! Golden range highest RSSI for Coded PHY w/ S=2.
+
+  uint8_t activate_power_control;
+} SL_ATTRIBUTE_PACKED sl_bt_ll_power_control_config_t;
+SL_PACK_END()
+
+#define SL_BT_USE_MAX_POWER_LEVEL_SUPPORTED_BY_RADIO 0x7fff
+#define SL_BT_USE_MIN_POWER_LEVEL_SUPPORTED_BY_RADIO 0x7fff
+
+#endif

--- a/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_callbacks.h
+++ b/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_callbacks.h
@@ -1,0 +1,80 @@
+/***************************************************************************//**
+ * @brief Bluetooth controller callback API
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_BTCTRL_EVENTS_H
+#define SL_BTCTRL_EVENTS_H
+
+#include <stdbool.h>
+#include "sl_btctrl_packets.h"
+
+/**
+ * @addtogroup sl_btctrl_callbacks Bluetooth Controller Callbacks
+ *
+ * This API can be used to change the behaviour of Bluetooth controller.
+ *
+ * Example usage: RSSI based scan request transmission can be implented by
+ * adding following callback function into application code. Following
+ * examples adds logic to transmit scan request packet only to the devices
+ * which advertising packet RSSI is over -60.
+ *
+ * \code{.c}
+ *  #include <sl_btctrl_callbacks.h>
+ *  #include <sl_btctrl_packets.h>
+ *
+ *  bool sl_btctrl_filter_scan_request_transmission_cb(sl_btctrl_packet_t packet)
+ *  {
+ *    int8_t rssi = sl_btctrl_get_packet_rssi(packet);
+ *    return rssi > -60;
+ *  }
+ * \endcode
+ *
+ * \note All callback functions are called from critical section which
+ *       means that they should return immediately and should not do any
+ *       time consuming operations.
+ *
+ * \note It is NOT allowed to
+ *         - call more that few instructions, which consume less than one micro second
+ *         - call any BGAPI functions or other time consuming operations
+ *
+ * \note Only APIs from sl_btctrl_packets.h can be used in callback functions.
+ * @{
+ */
+
+/**
+ * This callback function is called before scan request transmission. The
+ * return value of callback function is used as a guidance for controller
+ * to decide whether or not to transmit scan request packet.
+ *
+ * @param packet Received advertising packet from peripheral.
+ * @return Scan request is sent if true is returned.
+ */
+bool sl_btctrl_filter_scan_request_transmission_cb(sl_btctrl_packet_t packet);
+
+/** @} sl_btctrl_callbacks */
+#endif

--- a/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_hci.h
+++ b/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_hci.h
@@ -1,0 +1,126 @@
+/***************************************************************************//**
+ * @brief Bluetooth controller HCI API.
+ *
+ * This interface is for external use.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef _SL_BTCTRL_HCI_H_
+#define _SL_BTCTRL_HCI_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "sl_status.h"
+
+//Initialize Vendor Specific Extensions
+void sl_bthci_init_vs(void);
+
+void sl_bthci_init_upper(void);
+
+void hci_enableVendorSpecificDebugging(void);
+
+void hci_debugEnable(void);
+
+sl_status_t hci_send_sleep_command_complete(void);
+
+/**
+ * The Bluetooth controller receives a HCI message fragment from the host.
+ * The HCI transport can give the HCI message in fragments.
+ * @param[in] data Pointer to the received data.
+ * @param[in] len Length of the received data.
+ * @param[in] lastFragment Indicate whether this is the last
+ *       fragment of an HCI message (true / false).
+ * @return  0 - success
+ *         -1 - out of memory
+ *         -2 - badly formatted message. */
+int16_t sl_btctrl_hci_receive(uint8_t *data, int16_t len, bool lastFragment);
+
+static inline int16_t hci_common_transport_receive(uint8_t *data, int16_t len, bool lastFragment)
+{
+  return sl_btctrl_hci_receive(data, len, lastFragment);
+}
+
+/**
+ * The HCI transport has transmitted a message.
+ * The HCI can transmit the next message after the transport
+ * has given this indication. */
+void sl_btctrl_hci_transmit_complete(uint32_t status);
+
+static inline void hci_common_transport_transmit_complete(uint32_t status)
+{
+  sl_btctrl_hci_transmit_complete(status);
+}
+
+/**
+ * The HCI transport has been reconnected with the host.
+ * The HCI can transmit the next message after this function
+ * has been called. */
+void sl_btctrl_hci_transmit_reconnected(void);
+
+static inline void hci_common_transport_transmit_reconnected(void)
+{
+  sl_btctrl_hci_transmit_reconnected();
+}
+
+/**
+ * Host has sent HCI reset command callback handler.
+ * This is implemented as weak function and can be overridden by application to perform own activities before doing reset.
+ * It is also possible to call sl_btctrl_hard_reset to start hard reset procedure
+ *
+ * @return - true to progress with normal soft reset
+ *         - false if normal reset procedure should be bypassed
+ */
+bool sl_btctrl_reset_handler(void);
+
+/**
+ * Hard reset device
+ * This is called from reset callback handler to implement hard reset
+ * If HCI packet is in middle of transmit to host, reset will be done after transmit is complete
+ */
+void sl_btctrl_request_hard_reset(void);
+
+void sl_btctrl_hci_parser_init_conn(void);
+
+void sl_btctrl_hci_parser_init_adv(void);
+
+void sl_btctrl_hci_parser_init_phy(void);
+
+void sl_btctrl_hci_parser_init_past(void);
+
+void sl_btctrl_hci_parser_init_privacy(void);
+
+void sl_btctrl_hci_parser_init_cs(void);
+
+void sl_btctrl_hci_parser_init_default(void);
+
+/**
+ * Create hardware error event and try to send it to the host.
+ * The created event shall be sent as high priority event.
+ * @param[in] errorCode Code describing the error. */
+void sl_btctrl_hci_send_hardware_error_event(uint8_t errorCode);
+
+#endif // _SL_BTCTRL_HCI_H_

--- a/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_hci_event.h
+++ b/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_hci_event.h
@@ -1,0 +1,113 @@
+/***************************************************************************//**
+ * @brief Provides API to create HCI event handler hooks to filter out events
+ *  that are passed to host stack
+ *
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SLI_BTCTRL_HCI_EVENT_H
+#define SLI_BTCTRL_HCI_EVENT_H
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <sl_status.h>
+
+enum sl_btctrl_hci_event_filter_status {
+  SL_BTCTRL_HCI_EVENT_FILTER_STATUS_EVENT_ACCEPT = 0x00,
+  SL_BTCTRL_HCI_EVENT_FILTER_STATUS_EVENT_DISCARD = 0x01
+};
+
+/**
+ * @brief Struct declaration for opaque pointer
+ * It is intentionally undefined to prevent direct manipulation.
+ */
+struct sl_btctrl_hci_event;
+
+/**
+ * @brief HCI event filter callback function
+ * @important Filtering function should only return false for advertising events or other discardable events
+ * @important Host stack might end up in deadlock if command complete or other state affecting events are discarded
+ * @param event Opaque handle to the HCI event
+ * @return sl_btctrl_hci_event_filter_status SL_BTCTRL_HCI_FILTER_STATUS_EVENT_ACCEPT continue processing event,
+ * SL_BTCTRL_HCI_FILTER_STATUS_EVENT_DISCARD discard event
+ */
+typedef enum sl_btctrl_hci_event_filter_status (*sl_btctrl_hci_event_callback)(struct sl_btctrl_hci_event *event);
+
+/**
+ * @brief Event handler structure
+ * Event handler structure must be allocated from the heap
+ * Controller will fill and use the structure members, do not modify directly
+ */
+typedef struct sl_btctrl_hci_event_handler {
+  struct sl_btctrl_hci_event_handler *next;
+  sl_btctrl_hci_event_callback handler;
+} sl_btctrl_hci_event_handler_t;
+
+/**
+ * @brief Register HCI Event handler callback function
+ *
+ * @param handler_ptr Pointer to sl_btctrl_hci_event_handler_t structure, this is fully initialized by the function
+ * @param callback function pointer to the filter callback function
+ * @return sl_status_t SL_STATUS_OK if success
+ */
+sl_status_t sl_btctrl_hci_register_event_handler(sl_btctrl_hci_event_handler_t *handler_ptr, sl_btctrl_hci_event_callback callback);
+
+/**
+ * @brief Clear all registered event handler callbacks
+ * @return sl_status_t SL_STATUS_OK if success
+ */
+sl_status_t sl_btctrl_hci_clear_event_handlers(void);
+
+/**
+ * @brief Get opcode of HCI event
+ * @param event Event handler passed to the callback function
+ * @param event_code pointer to where to place the opcode of event
+ * @param subevent_code pointer to where to place the subevent of event, only used if event code is 0x3e (LE Meta event)
+ * @return sl_status_t SL_STATUS_OK if success
+ */
+sl_status_t sl_btctrl_hci_event_get_opcode(struct sl_btctrl_hci_event *event, uint8_t *event_code, uint8_t *subevent_code);
+
+/**
+ * @brief Get length of event payload
+ * @param event Event handler passed to the callback function
+ * @param length pointer to size_t where to store the length
+ * @return sl_status_t SL_STATUS_OK if success
+ */
+sl_status_t sl_btctrl_hci_event_get_length(struct sl_btctrl_hci_event *event, size_t *length);
+
+/**
+ * @brief Get event parameters
+ * @param event Event handler passed to the callback function
+ * @param destination pointer to destination buffer
+ * @param destination_length length of the destination buffer
+ * @param offset offset of where to read the event payload
+ * @param length pointer to size_t where to store how many bytes have been copied to the buffer
+ * @return sl_status_t SL_STATUS_OK if success
+ */
+sl_status_t sl_btctrl_hci_event_get_parameters(struct sl_btctrl_hci_event *event, uint8_t *destination, size_t destination_length, size_t offset, size_t *length);
+
+#endif // SLI_BTCTRL_HCI_EVENT_H

--- a/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_hci_handler.h
+++ b/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_hci_handler.h
@@ -1,0 +1,117 @@
+/***************************************************************************//**
+ * @brief Provides API to create HCI message handling hooks to create custom
+ * hci command handlers
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_BTCTRL_VENDOR_H
+#define SL_BTCTRL_VENDOR_H
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <sl_status.h>
+
+/***************************************************************************//**
+ * @addtogroup sl_btctrl_hci_handler API create custom hci command handlers
+ * @{
+ ******************************************************************************/
+
+/**
+ * @brief Opaque message handle to identify HCI command state, this is passed back to API functions
+ *
+ */
+struct sl_btctrl_hci_message;
+
+/**
+ * @brief HCI message callback function
+ *
+ */
+typedef bool (*sl_btctrl_vendor_handler)(struct sl_btctrl_hci_message * packet);
+typedef struct sl_btctrl_command_handler {
+  struct sl_btctrl_command_handler * next;
+  sl_btctrl_vendor_handler handler;
+} sl_btctrl_command_handler_t;
+
+/**
+ * @brief Register HCI handler to be called when packet is received
+ *
+ * @param str Pointer to sl_btctrl_command_handler structure, this is fully initialized by the function
+ * @param handler function pointer to the handler to be called
+ */
+void sl_btctrl_hci_register_handler(sl_btctrl_command_handler_t * str, sl_btctrl_vendor_handler handler);
+
+/**
+ * @brief Get HCI Command opcode of the HCI message
+ *
+ * @param handle pointer to the HCI message
+ * @param opcode pointer to uint16_t where the command opcode is copied to
+ * @return sl_status_t SL_STATUS_OK if success
+ */
+sl_status_t sl_btctrl_hci_message_get_opcode(struct sl_btctrl_hci_message * handle, uint16_t * opcode);
+
+/**
+ * @brief Get Length of the parameter data of the HCI command
+ *
+ * @param handle pointer to the hci message
+ * @param length pointer to size_t data where length is to be copied to
+ * @return sl_status_t SL_STATUS_OK if success
+ */
+sl_status_t sl_btctrl_hci_message_get_length(struct sl_btctrl_hci_message * handle, size_t * length);
+
+/**
+ * @brief Get parameter data of the HCI command
+ * If buffer is too small to contain all data then it is filled with as much data as possible and SL_STATUS_FULL error is returned
+ *
+ * @param handle pointer to the HCI command
+ * @param buffer pointer to data buffer where data is to be copied to
+ * @param buffer_len length of the data buffer
+ * @return sl_status_t SL_STATUS_OK if success
+ */
+sl_status_t sl_btctrl_hci_message_get_parameters(struct sl_btctrl_hci_message * handle, uint8_t * buffer, size_t buffer_len);
+
+/**
+ * @brief Set HCI response event to the hci command,
+ * after this command pointer is an pointer to HCI eventand no other hci_message-functions can be used on it
+ * Maximum response size is currently limited to 50bytes
+ *
+ * @param handle pointer to the HCI command
+ * @param bt_status Bluetooth status code to be used in event
+ * @param buffer pointer to data buffer to be
+ * @param buffer_len length of data to be added as event parameters
+ * @return sl_status_t SL_STATUS_OK if success, SL_STATUS_INVALID_PARAMETER if data is too long
+ */
+sl_status_t sl_btctrl_hci_message_set_response(struct sl_btctrl_hci_message * handle, uint8_t bt_status, const uint8_t * buffer, size_t buffer_len);
+
+/**
+ * @brief Maximum length of HCI response supported
+ *
+ */
+#define SL_BTCTRL_MAX_HCI_RESPONSE_LENGTH 50
+
+/** @} (end addtogroup sl_btctrl_hci_handler) */
+
+#endif

--- a/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_linklayer.h
+++ b/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_linklayer.h
@@ -1,0 +1,328 @@
+/***************************************************************************//**
+ * @brief Bluetooth Link Layer configuration API
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef _SL_BTCTRL_LINKLAYER_H_
+#define _SL_BTCTRL_LINKLAYER_H_
+#include "sl_status.h"
+#include <stdint.h>
+
+void sl_bt_controller_init(void);
+
+void sl_bt_controller_deinit(void);
+
+void sl_btctrl_init(void);
+
+/**
+ * Allocate memory buffers for controller
+ *
+ * @param memsize size of memory to allocate
+ * @returns number of memory buffers allocated
+ */
+uint32_t sl_btctrl_init_mem(uint32_t memsize);
+
+/**
+ *  Configures how many maximum sized ACL data packets
+ *  can the controller store.
+ */
+void sl_btctrl_configure_le_buffer_size(uint8_t count);
+
+/**
+ * Release all memory allocated by controller
+ */
+void sli_btctrl_deinit_mem(void);
+
+void sli_btctrl_set_interrupt_priorities();
+
+sl_status_t sl_btctrl_init_ll(void);
+
+void sli_btctrl_set_address(uint8_t *address);
+
+//Initialize memory objects used by LinkLayer
+//In future these should be configured individually
+sl_status_t sl_btctrl_init_basic(uint8_t connections, uint8_t adv_sets, uint8_t whitelist);
+
+void sli_btctrl_events_init(void);
+
+enum sl_btctrl_channelmap_flags{
+  SL_BTCTRL_CHANNELMAP_FLAG_ACTIVE_ADAPTIVITY = 0x01,
+  SL_BTCTRL_CHANNELMAP_FLAG_PASSIVE_ADAPTIVITY= 0x02,
+};
+
+/**
+ * Initialize and enable adaptive frequency hopping
+ */
+sl_status_t sl_btctrl_init_afh(uint32_t flags);
+
+/**
+ * Enable high power use under appropriate conditions
+ */
+void sl_btctrl_init_highpower(void);
+
+/**
+ * @brief Initilize periodic advertiser
+ */
+void sl_btctrl_init_periodic_adv();
+
+/**
+ * @brief Initilize periodic advertiser
+ */
+void sl_btctrl_init_periodic_scan();
+
+/**
+ * Configuration for Periodic Advertising with Responses.
+ */
+struct sl_btctrl_pawr_advertiser_config {
+  /**
+   * Number of advertising sets supporting PAwR.
+   * If set to zero, previously allocated PAwR sets are only freed. */
+  uint8_t max_pawr_sets;
+  /**
+   * Hint to the controller what will be the maximum advertised data length.
+   * The value does not prevent using longer advertising data. Value zero means
+   * that maximum data length can expected to be up to the length of Periodic
+   * Advertising Delay. */
+  uint8_t max_advertised_data_length_hint;
+  /**
+   * The number of subevent advertising packets requested from the host
+   * at once. */
+  uint8_t subevent_data_request_count;
+  /**
+   * How many subevents before airing a subevent its data is requested from
+   * the host. */
+  uint8_t subevent_data_request_advance;
+};
+
+/**
+ * Configuration of synchronizer for Periodic Advertising with Responses.
+ */
+struct sl_btctrl_pawr_synchronizer_config {
+  /**
+   * Number of advertising sets supporting PArR.
+   * If set to zero, previously allocated PArR sets are only freed. */
+  uint8_t max_pawr_sets;
+};
+
+/**
+ * @brief Enable and initialize support for the PAwR advertiser.
+ * @param[in] pawr_adv_config PAwR advertiser configuration.
+ * @return SL_STATUS_OK, or an appropriate error code. */
+sl_status_t sl_btctrl_pawr_advertiser_configure(struct sl_btctrl_pawr_advertiser_config *pawr_adv_config);
+
+/**
+ * @brief Enable and initialize support for PAwR sync/receiver.
+ * @param[in] pawr_sync_config PAwR synchronizer configuration.
+ * @return SL_STATUS_OK, or an appropriate error code. */
+sl_status_t sl_btctrl_pawr_synchronizer_configure(struct sl_btctrl_pawr_synchronizer_config *pawr_sync_config);
+
+/**
+ * @brief Allocate memory for synchronized scanners
+ *
+ * @param num_scan Number of Periodic Scanners Allowed
+ * @return SL_STATUS_OK if allocation was succesfull, failure reason otherwise
+ */
+sl_status_t sl_btctrl_alloc_periodic_scan(uint8_t num_scan);
+
+/**
+ * @brief Allocate memory for periodic advertisers
+ *
+ * @param num_adv Number of advertisers to allocate
+ */
+sl_status_t sl_btctrl_alloc_periodic_adv(uint8_t num_adv);
+
+/**
+ * Call to import the conn scheduler state variables in the binary
+ */
+void sli_btctrl_enable_conn_scheduler_state(void);
+
+/**
+ * @brief Set maximum number of advertisement reports allowed to be queued
+ *
+ * @param num_adv Maximum number of advertisement reports allowed to be queued
+ */
+void sl_btctrl_configure_max_queued_adv_reports(uint8_t num_reports);
+
+/**
+ * Call to enable the even connection scheduling algorithm.
+ * This function should be called before link layer initialization.
+ */
+void sl_btctrl_enable_even_connsch();
+
+/**
+ * Call to enable the PAwR aware connection scheduling algorithm.
+ * This function should be called before link layer initialization.
+ */
+void sl_btctrl_enable_pawr_connsch();
+
+/**
+ * Call to enable the legacy connection scheduling algorithm.
+ * This function should be called before link layer initialization.
+ */
+void sl_btctrl_enable_legacy_connsch();
+
+/**
+ * Call to enable connection statistics collection.
+ */
+void sl_btctrl_init_conn_statistics(void);
+
+/**
+ * Call to initialize multiprotocol
+ * in bluetooth controller
+ */
+void sl_btctrl_init_multiprotocol();
+
+/**
+ * Link with symbol to enable radio watchdog
+ */
+void sl_btctrl_enable_radio_watchdog();
+
+/**
+ * Initialize CTE receiver
+ */
+sl_status_t sl_btctrl_init_cte_receiver();
+
+/**
+ * Initialize CTE transmitter
+ */
+sl_status_t sl_btctrl_init_cte_transmitter();
+
+/**
+ * Initialize both CTE receiver and transmitter
+ *
+ * Note: This is for backward compatibility. It is recommend to
+ * use sl_btctrl_init_cte_receiver and sl_btctrl_init_cte_transmitter
+ * functions instead.
+ */
+sl_status_t sl_btctrl_init_cte();
+
+/**
+ * Initialize Channel Sounding
+ */
+struct sl_btctrl_cs_config {
+  /** number of channel sounding configurations per connection */
+  uint8_t configs_per_connection;
+  /** number of simultaneous channel sounding procedures */
+  uint8_t procedures;
+};
+
+sl_status_t sl_btctrl_init_cs(const struct sl_btctrl_cs_config *config);
+
+/**
+ * Check if event bitmap indicates pending events
+ * @return bool pending events
+ */
+bool sli_pending_btctrl_events(void);
+
+/**
+ * Disable the support for Coded and Simulscan PHYs.
+ */
+void sl_btctrl_disable_coded_phy(void);
+
+/**
+ * Disable the support for 2M PHY.
+ */
+void sl_btctrl_disable_2m_phy(void);
+
+/**
+ * Initialize adv component
+ */
+void sl_btctrl_init_adv(void);
+
+void sl_btctrl_init_conn(void);
+
+void sl_btctrl_init_phy(void);
+
+void sl_btctrl_init_adv_ext(void);
+
+enum sl_btctrl_advertiser_config_flags {
+  SL_BTCTRL_CONFIG_FLAG_PRIMARY_EXT_PACKET_ADDRESS = 0x02,
+  SL_BTCTRL_CONFIG_FLAG_PRIMARY_EXT_PACKET_TX_POWER = 0x04,
+};
+
+struct sl_btctrl_adv_config {
+  enum sl_btctrl_advertiser_config_flags flags;
+};
+
+/**
+ * Set the advertiser address or tx power to be used for all advertisers
+ * @param adv_config The advertiser configuration.
+ * @return sl_status_ok, or an appropriate status.
+ */
+sl_status_t sl_btctrl_config_adv(struct sl_btctrl_adv_config *adv_config);
+
+void sl_btctrl_init_privacy(void);
+
+sl_status_t sl_btctrl_allocate_resolving_list_memory(uint8_t resolvingListSize);
+
+/**
+ * @brief Initialize extended scanner state
+ *
+ */
+void sl_btctrl_init_scan_ext(void);
+
+void sl_btctrl_init_scan(void);
+
+/**
+ * @brief return true if controller is initialized
+ *
+ */
+bool sl_btctrl_is_initialized();
+
+/**
+ * @brief Sets PAST initiator feature bit,
+ * and links in PAST sender and ll_adv_sync symbols to the project.
+ */
+void sl_btctrl_init_past_local_sync_transfer(void);
+
+/**
+ * @brief Sets PAST initiator feature bit,
+ * and links in PAST sender, ll_scan_sync and ll_scan_sync_registry symbols to the project.
+ */
+void sl_btctrl_init_past_remote_sync_transfer(void);
+
+/**
+ * @brief Sets PAST receiver feature bit,
+ * and links in PAST receiver, ll_scan_sync and ll_scan_sync_registry symbols to the project.
+ */
+void sl_btctrl_init_past_receiver(void);
+
+/**
+ * @brief Configure how often to send the Number Of Completed Packets HCI event.
+ * @param[in] packets When the controller has transmitted this number of ACL data packets it will send
+ * the Number Of Completed Packets HCI event to the host.
+ * @param[in] events When this number of connection events have passed and the controller did not yet report
+ * all the transmitted packets, then it will send the Number Of Completed Packets HCI event to the host.
+ */
+void sl_btctrl_configure_completed_packets_reporting(uint8_t packets, uint8_t events);
+
+/**
+ * @brief Initializes event info reporting vendor specific feature.
+ */
+void sl_btctrl_init_event_info_reporting(void);
+
+#endif

--- a/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_packets.h
+++ b/gecko/protocol/bluetooth/bgstack/ll/inc/sl_btctrl_packets.h
@@ -1,0 +1,54 @@
+/***************************************************************************//**
+ * @brief Packet API provides several functions to read detailed information from
+ * the received packet.
+ *
+ * Currently only RSSI reading is supported.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef SL_BTCTRL_PACKETS_H
+#define SL_BTCTRL_PACKETS_H
+
+#include <stdint.h>
+
+typedef const void * sl_btctrl_packet_t;
+
+/***************************************************************************//**
+ * @addtogroup sl_btctrl_packets API to get detailed information of received packet
+ * @{
+ ******************************************************************************/
+
+/**
+ * Get RSSI of received packet
+ *
+ * @param packet Packet where the RSSI value is read from.
+ * @return Signed RSSI value of the given packet in dBm.
+ */
+int8_t sl_btctrl_get_packet_rssi(sl_btctrl_packet_t packet);
+
+/** @} sl_btctrl_packets */
+#endif

--- a/gecko/protocol/bluetooth/bgstack/ll/inc/sl_hci_common_transport.h
+++ b/gecko/protocol/bluetooth/bgstack/ll/inc/sl_hci_common_transport.h
@@ -1,0 +1,73 @@
+/***************************************************************************//**
+ * @brief The API between HCI and common HCI transport.
+ *
+ * The interface configuration shall be done using UC configuration.
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef _HCI_COMMON_TRANSPORT_H_
+#define _HCI_COMMON_TRANSPORT_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "sl_btctrl_hci.h"
+
+/**
+ * The HCI receives a message from currently selected transport layer.
+ * The HCI transport calls this function implemented in the HCI
+ * once it has received a complete HCI message. If the HCI does not
+ * manage to process the message, the transport may drop the message.
+ * @param[in] data Pointer to the received data.
+ * @param[in] len Length of the received data.
+ * @param[in] lastFragment Indicates if this is the last fragment of
+ *       a complete HCI message.
+ * @return  0 - success
+ *         -1 - out of memory
+ *         -2 - badly formatted message. */
+int16_t hci_common_transport_receive(uint8_t *data, int16_t len, bool lastFragment);
+
+/**
+ * Transmit HCI message using the currently used transport layer.
+ * The HCI calls this function to transmit a full HCI message.
+ * @param[in] data Data buffer to be transmitted.
+ * @param[in] len Length of the data.
+ * @return 0 - on success, or non-zero on failure. */
+uint32_t hci_common_transport_transmit(uint8_t *data, int16_t len);
+
+/**
+ * The HCI transport indicates a message has been transmitted. */
+void hci_common_transport_transmit_complete(uint32_t status);
+
+/**
+ * The HCI transport has been reconnected with the host. */
+void hci_common_transport_transmit_reconnected(void);
+
+/**
+ * Initialize the currently selected transport layer. */
+void hci_common_transport_init(void);
+
+#endif // _COMMON_TRANSPORT_H_

--- a/gecko/protocol/bluetooth/bgstack/ll/src/hci/hci_reset.h
+++ b/gecko/protocol/bluetooth/bgstack/ll/src/hci/hci_reset.h
@@ -1,0 +1,10 @@
+#ifndef HCI_RESET_H
+#define HCI_RESET_H
+
+#include <stdint.h>
+
+bool sl_hci_reset_events_pending(void);
+bool sl_hci_reset_reason_is_sys_reset(void);
+void sl_hci_reset(void);
+
+#endif // HCI_RESET_H

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -614,66 +614,82 @@ blobs:
 
   # librail for gecko_sdk (series 1)
   - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg1_gcc_release.a
-    sha256: 776969fe3e98fc1099e31fad92f74d8791ca2069e568e079ad9bce73c9096a3e
+    sha256: b66ed307910d17bde12f8a74471e6fc7ca466421a16b8ca46180246fb6621050
     type: lib
-    version: "4.1.4"
+    version: "4.5.0"
     license-path: zephyr/blobs/license/Zlib.txt
-    url: https://github.com/SiliconLabs/gecko_sdk/raw/v4.1.4/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg1_gcc_release.a
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 478098
+    fetcher: lfs
   - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg1_gcc_release.a
-    sha256: 6199ef8287d6d998e7be364acec447636bd0f72eed1112888d7f843eff9d74ce
+    sha256: d34be1b8d8a956d2e2f6f56f9b93b15a5e0ddea0d40b7b82e840d772b989edc8
     type: lib
-    version: "4.1.4"
+    version: "4.5.0"
     license-path: zephyr/blobs/license/Zlib.txt
-    url: https://github.com/SiliconLabs/gecko_sdk/raw/v4.1.4/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg1_gcc_release.a
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 507764
+    fetcher: lfs
   - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg12_gcc_release.a
-    sha256: 33c6de9113787aa87baff8443aad00601d2831ade2bbd605f246a5b02ea3fa77
+    sha256: 81d7aa38a83c536bd5ada8e7592fa872676c45c6ddc385da4b064fe098dba2c2
     type: lib
-    version: "4.1.4"
+    version: "4.5.0"
     license-path: zephyr/blobs/license/Zlib.txt
-    url: https://github.com/SiliconLabs/gecko_sdk/raw/v4.1.4/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg12_gcc_release.a
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 508474
+    fetcher: lfs
   - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg12_gcc_release.a
-    sha256: 884f6c023fb1ea91ceca3d0f16d8833af70565353cf8df2a68989eeb06150d8a
+    sha256: 6cb66933ed76f770b591d49b3ea94d3b9b2d879a76985ddc67e262d400e3e94a
     type: lib
-    version: "4.1.4"
+    version: "4.5.0"
     license-path: zephyr/blobs/license/Zlib.txt
-    url: https://github.com/SiliconLabs/gecko_sdk/raw/v4.1.4/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg12_gcc_release.a
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 539242
+    fetcher: lfs
   - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg13_gcc_release.a
-    sha256: 25af46964d0373c561ffd8cbabe6c7b0f58cd93d30ae476d60ac84cc52ff1573
+    sha256: e7ceb1e2bdabf081bf3d6b20442cdc0a40d8aebbf2169fb374186a42ad09ee2f
     type: lib
-    version: "4.1.4"
+    version: "4.5.0"
     license-path: zephyr/blobs/license/Zlib.txt
-    url: https://github.com/SiliconLabs/gecko_sdk/raw/v4.1.4/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg13_gcc_release.a
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 563146
+    fetcher: lfs
   - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg13_gcc_release.a
-    sha256: 31bccef93cf0cee65bd221e9bdbb24c9f0957632d9a91436c5a2910607bee0c5
+    sha256: b1c2e2c85e54821d82ae2bac5189bb868278b68d373c410d24c796e4d344ed35
     type: lib
-    version: "4.1.4"
+    version: "4.5.0"
     license-path: zephyr/blobs/license/Zlib.txt
-    url: https://github.com/SiliconLabs/gecko_sdk/raw/v4.1.4/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg13_gcc_release.a
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 594740
+    fetcher: lfs
   - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg14_gcc_release.a
-    sha256: d1f4fd4e2ed814158384e8328fb6807453bae5e263bf78d6ede38889040b5381
+    sha256: 8deaacd1499fd52e3379c1c52d1940ae037b8dec6f7265874eaad448a13e85db
     type: lib
-    version: "4.1.4"
+    version: "4.5.0"
     license-path: zephyr/blobs/license/Zlib.txt
-    url: https://github.com/SiliconLabs/gecko_sdk/raw/v4.1.4/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg14_gcc_release.a
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 518620
+    fetcher: lfs
   - path: gecko/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg14_gcc_release.a
-    sha256: ef6e618f544d65d21b278ba7eee8c8c89846c6dbdd8ae3144f9acc166805f18d
+    sha256: e08ce0d9c0664edf14215dd33e26a4ccbf05cd9399dfaec2258241743acb8550
     type: lib
-    version: "4.1.4"
+    version: "4.5.0"
     license-path: zephyr/blobs/license/Zlib.txt
-    url: https://github.com/SiliconLabs/gecko_sdk/raw/v4.1.4/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg14_gcc_release.a
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
     description: "Binary libraries supporting EFR32 RF subsystems"
     doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 549350
+    fetcher: lfs

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -24,7 +24,8 @@ blobs:
     doc-url: https://github.com/SiliconLabsSoftware/sisdk-release
     size: 1234
     fetcher: lfs
-  # libbluetooth_controller
+
+  # libbluetooth_controller (series 2)
   - path: simplicity_sdk/protocol/bluetooth/bgstack/ll/build/gcc/xg21/release/liblinklayer.a
     sha256: b530be82244c59b32d05073925d7a47c73926d76ba9633ae61007de528b7a4a5
     type: lib
@@ -96,7 +97,7 @@ blobs:
     size: 3410446
     fetcher: lfs
 
-  # libbgcommon
+  # libbgcommon (series 2)
   - path: simplicity_sdk/protocol/bluetooth/bgcommon/lib/build/gcc/cortex-m33/bgcommon/release/libbgcommon.a
     sha256: f35e23133d1ae0e66c76cd62beb285a7b34525e520a531477dc023ff6d5441ac
     type: lib
@@ -610,6 +611,90 @@ blobs:
     description: "Radio Abstraction Interface Library (RAIL) module configuration"
     doc-url: https://github.com/SiliconLabsSoftware/sisdk-release
     size: 63044
+    fetcher: lfs
+
+  # libbluetooth_controller (series 1)
+  - path: gecko/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg1_gcc_release.a
+    sha256: 80691cd1ea7ad08b8e719b2fbae9a9c87a9462da63e183ba8c6357bed6cc915f
+    type: lib
+    version: "4.5.0"
+    license-path: zephyr/blobs/license/Zlib.txt
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
+    description: "Bluetooth Controller library (Link Layer) for EFR32"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 9618682
+    fetcher: lfs
+  - path: gecko/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg12_gcc_release.a
+    sha256: 2d60a9f529fd233d6f8db856079a98c209f96ba0c6fe91730f0adc58e9d65797
+    type: lib
+    version: "4.5.0"
+    license-path: zephyr/blobs/license/Zlib.txt
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
+    description: "Bluetooth Controller library (Link Layer) for EFR32"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 9621114
+    fetcher: lfs
+  - path: gecko/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg13_gcc_release.a
+    sha256: e4baa6c64de2c7340159fbdd2aa44d78a39aef4495487cb4e4044c4e20004347
+    type: lib
+    version: "4.5.0"
+    license-path: zephyr/blobs/license/Zlib.txt
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
+    description: "Bluetooth Controller library (Link Layer) for EFR32"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 9620666
+    fetcher: lfs
+  - path: gecko/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg14_gcc_release.a
+    sha256: 40201df51d965832d62b0fe8af334a926d2e4d4a8b7474d9e9664d8a8b605337
+    type: lib
+    version: "4.5.0"
+    license-path: zephyr/blobs/license/Zlib.txt
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
+    description: "Bluetooth Controller library (Link Layer) for EFR32"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 9620070
+    fetcher: lfs
+
+  # libbgcommon (series 1)
+  - path: gecko/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32xg1_gcc_release.a
+    sha256: 7ad90aecd4450e7f74c7fab342ae662eeb5b132f468d4ab83e931df27a5bbb83
+    type: lib
+    version: "4.5.0"
+    license-path: zephyr/blobs/license/Zlib.txt
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
+    description: "Bluetooth Utility library for EFR32"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 270258
+    fetcher: lfs
+  - path: gecko/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32xg12_gcc_release.a
+    sha256: 20a27d4b6b303d360e22287b872826dd384cfa33775977d192b113fe57d7d75b
+    type: lib
+    version: "4.5.0"
+    license-path: zephyr/blobs/license/Zlib.txt
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
+    description: "Bluetooth Utility library for EFR32"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 270282
+    fetcher: lfs
+  - path: gecko/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32xg13_gcc_release.a
+    sha256: 6fba8494d4e9a4c1f7a30ab9eb59edbc1c7629131a58f745d2802ed50cee82e9
+    type: lib
+    version: "4.5.0"
+    license-path: zephyr/blobs/license/Zlib.txt
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
+    description: "Bluetooth Utility library for EFR32"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 270282
+    fetcher: lfs
+  - path: gecko/protocol/bluetooth/bgcommon/lib/libbgcommon_efr32xg14_gcc_release.a
+    sha256: e090c4ef549651e43f69d80a7f60471f1c6ab6b64d3313d49db86a47c663ae16
+    type: lib
+    version: "4.5.0"
+    license-path: zephyr/blobs/license/Zlib.txt
+    url: https://artifacts.silabs.net/artifactory/api/lfs/gsdk
+    description: "Bluetooth Utility library for EFR32"
+    doc-url: https://github.com/SiliconLabs/gecko_sdk
+    size: 270282
     fetcher: lfs
 
   # librail for gecko_sdk (series 1)


### PR DESCRIPTION
About `gecko: pa-conversions: fix duplicate definition of MAX`: I know that patching imported code is not ideal, but doing this was actually [recommended by a Silabs employee](https://community.silabs.com/s/question/0D5Vm00001GDLzrKAH/how-to-contribute-to-gecko-sdk?language=en_US). I just hope that we don't accidentally revert such changes when updating these files to a newer version.

Required by: https://github.com/zephyrproject-rtos/zephyr/pull/113102